### PR TITLE
Default grade in profile creator is now null.

### DIFF
--- a/esp/esp/users/forms/user_profile.py
+++ b/esp/esp/users/forms/user_profile.py
@@ -263,7 +263,7 @@ class StudentInfoForm(FormUnrestrictedOtherUser):
         custom_grade_options = Tag.getTag('student_grade_options')
         if custom_grade_options:
             custom_grade_options = json.loads(custom_grade_options)
-            self.fields['graduation_year'].choices = [(str(ESPUser.YOGFromGrade(x)), str(x)) for x in custom_grade_options]
+            self.fields['graduation_year'].choices = [('','')]+[(str(ESPUser.YOGFromGrade(x)), str(x)) for x in custom_grade_options]
 
         if Tag.getTag('show_student_graduation_years_not_grades'):            
             current_grad_year = self.ESPUser.current_schoolyear()


### PR DESCRIPTION
There was a bug where, if you set the
student_grade_options, the default grade would
be the smallest grade option. Many users missed
this box, and accidentally chose the wrong grade
(which required manual fixing in the admin panel).
Fixed the bug by supplying an initial null value.

This resolves issue #9
https://github.com/learning-unlimited/ESP-Website/issues/9.
