### PR TITLE
Fix bug in teacherreg listclasses template.

### DIFF
--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -85,6 +85,7 @@ class TeacherClassRegModule(ProgramModuleObj, module_ext.ClassRegModuleInfo):
         context['can_edit'] = self.deadline_met('/Classes/Edit')
         context['can_create'] = self.deadline_met('/Classes/Create')
         context['teacherclsmodule'] = self # ...
+        context['clslist'] = self.clslist(get_current_request().user)
         context['friendly_times_with_date'] = (Tag.getProgramTag(key='friendly_times_with_date',program=self.program,default=False) == "True")
         return context
 

--- a/esp/templates/program/modules/teacherclassregmodule/listclasses.html
+++ b/esp/templates/program/modules/teacherclassregmodule/listclasses.html
@@ -59,7 +59,7 @@ If you have any questions regarding the program, <br /> please email the
   <tr>
     <td colspan="6">Below is a summary of the classes you have registered to teach for {{ program.niceName }}.  Please look through the information carefully; e-mail the directors if you believe there is a problem with your time or room assignment.  Also, e-mail the directors immediately if you need to cancel a class.</td>
    </tr>
-  {% for cls in teacherclsmodule.clslist %}
+  {% for cls in clslist %}
   <tr>
     <td class="clsleft classname bordertop2">
       <span title="{{cls}}">


### PR DESCRIPTION
Previously, when you went to teach/<program>/<instance>/teacherreg, no
classes appeared at the bottom of the page, even if you had registered
classes.

The method TeacherClassRegModule.clslist() takes two arguments, not
one. Therefore, this method can't be called in the listclasses
template.

I'm guessing that this was changed when user was removed as an
attribute from all of the modules. Presumbably, clslist() used to be a
one-argument function, because user was built into self. But now that
this isn't the case, user is needed as a second argument.

This commit fixes this by manually adding clslist as context in the
prepare() method. However, its possible that a more elegant fix is
called for.
