### PR TITLE
Removes csrf_token tags from the templates

### DIFF
--- a/esp/templates/admin/cache_flush.html
+++ b/esp/templates/admin/cache_flush.html
@@ -20,7 +20,7 @@
 {% if error %}<p><font color="red">{{ error }}</font></p>{% endif %}
 {% if success %}<p><font color="blue">{{ success }}</font></p>{% endif %}
 <p>
-<form action="." method="POST">{% csrf_token %}
+<form action="." method="POST">
 <textarea name="reason">?</textarea>
 <input type="submit" value="Flush Cache" />
 </form>

--- a/esp/templates/contact.html
+++ b/esp/templates/contact.html
@@ -26,11 +26,11 @@ If you would like, we can e-mail you a link to reset your password.
 The e-mail will remind you of your username.
 </p>
 {% end_inline_qsd_block %}
-<form action="/myesp/passwdrecover/" method="post">{% csrf_token %}
+<form action="/myesp/passwdrecover/" method="post">
 	<input type="hidden" name="email" value="{{contact_form.cleaned_data.sender}}" />
 	<input type="submit" name="recoverpassword" value="Reset my password" />
 </form>
-<form action="{{ request.path }}" method="post">{% csrf_token %}
+<form action="{{ request.path }}" method="post">
 <input type="submit" name="sendanyway" value="I want to send this message anyway" />
 {% else %}
 {% inline_qsd_block Q/Web contact_header_text request.user %}
@@ -52,7 +52,7 @@ We really do appreciate your interest, but we're an all-volunteer organization s
 
 </p>
 {% end_inline_qsd_block %}
-<form action="{{ request.path }}" method="post">{% csrf_token %}
+<form action="{{ request.path }}" method="post">
 {% endif %}
 
 <table class="contact">

--- a/esp/templates/customforms/form.html
+++ b/esp/templates/customforms/form.html
@@ -12,7 +12,7 @@
 	<em class="step_count">Step {{ step }} of {{ step_count }}</em>
 	<em class="req_text">(Fields in blue are required)</em>
 	
-	<form action="." method="post" id="cstform" class="form-stacked">{% csrf_token %}
+	<form action="." method="post" id="cstform" class="form-stacked">
     {% include "customforms/single_form_fragment.html" %}
 	<input type="hidden" name="{{ step_field }}" value="{{ step0 }}" />
 	{{ previous_fields|safe }}

--- a/esp/templates/customforms/playing.html
+++ b/esp/templates/customforms/playing.html
@@ -7,7 +7,7 @@
 		<p>{{form_description}}</p>
 		<p>Step {{ step }} of {{ step_count }}</p>
 		
-		<form action="." method="post">{% csrf_token %}
+		<form action="." method="post">
 		{% if form.non_field_errors %}{{ form.non_field_errors }}{% endif %}
 		{% for fieldset in form.fieldsets %}
 		  <fieldset class="{{ fieldset.classes }}">

--- a/esp/templates/dataviews/forms/wizard.html
+++ b/esp/templates/dataviews/forms/wizard.html
@@ -39,7 +39,7 @@ function showInstructions() {
 {% endblock %}
 {% endblock %}
 {% block form %}
-<form action="." method="post" id="id_{{ step }}-form">{% csrf_token %}
+<form action="." method="post" id="id_{{ step }}-form">
 {% block form_begin %}{% endblock %}
 {% block form_div %}<div id="id_{{ step0 }}-form_div">{% endblock %}
 {% block form_as %}{{ form.as_p }}{% endblock %}

--- a/esp/templates/events/create_update
+++ b/esp/templates/events/create_update
@@ -17,7 +17,7 @@
 <h2>Please correct the error(s) in the form.</h2>
 {% endif %}
 
-<form method="post" action=".">{% csrf_token %}
+<form method="post" action=".">
     {{ form.as_p }}
 <p><input type="submit" /></p>
 </form>

--- a/esp/templates/inclusion/miniblog/single_comments.html
+++ b/esp/templates/inclusion/miniblog/single_comments.html
@@ -21,7 +21,7 @@ Comment by {{ comment.author.first_name }} {{ comment.author.last_name }} &mdash
 {% if user.is_authenticated %}
 <div id="form_spacing">&nbsp;</div>
 
-<form action="{{ path }}" method="post" name="comments">{% csrf_token %}
+<form action="{{ path }}" method="post" name="comments">
 <table>
 <thead>
 <tr>

--- a/esp/templates/inclusion/program/class_catalog.html
+++ b/esp/templates/inclusion/program/class_catalog.html
@@ -14,7 +14,7 @@
                 <p class="addbutton_error">{{ errormsg }}</p>
                 {% if user.onsite_local %}
                     <br />
-                    <form name="prereg_{{ section.id }}" onsubmit="return submit_override_prereg('{{ section.id }}');" method="post" action="{{ prereg_url }}">{% csrf_token %}
+                    <form name="prereg_{{ section.id }}" onsubmit="return submit_override_prereg('{{ section.id }}');" method="post" action="{{ prereg_url }}">
                     <input type="hidden" name="class_id" value="{{ class.id }}" />
                     <input type="hidden" name="section_id" value="{{ section.id }}" />
                     <input type="submit" class="addbutton" name="action" value="Add this class anyway!"

--- a/esp/templates/inclusion/program/class_catalog_swap.html
+++ b/esp/templates/inclusion/program/class_catalog_swap.html
@@ -12,7 +12,7 @@
 <span class="error" style="font-size: 16px;">{{ errormsg }}</span> 
 {% if user.onsite_local %}
 <br />
-<form name="prereg_submitform" onsubmit="return submit_override_prereg('{{ class.id }}');" method="post" action="{{ prereg_url }}">{% csrf_token %}
+<form name="prereg_submitform" onsubmit="return submit_override_prereg('{{ class.id }}');" method="post" action="{{ prereg_url }}">
 	  <input type="hidden" name="class_id" value="{{ class.id }}" />
   	  <input type="submit" class="addbutton" name="action" value="Switch into this class anyway!"
                  id="submitbutton{{ class.id }}" />
@@ -20,7 +20,7 @@
 {% endif %}
 
 {% else %}
-	<form name="prereg_submitform" onsubmit="return submit_prereg('{{ class.id }}');" method="post" action="{{ prereg_url }}">{% csrf_token %}
+	<form name="prereg_submitform" onsubmit="return submit_prereg('{{ class.id }}');" method="post" action="{{ prereg_url }}">
 	  <input type="hidden" name="class_id" value="{{ class.id }}" />
   	  <input type="submit" class="addbutton" name="action" value="Switch into this class"
                  id="submitbutton{{ class.id }}" />

--- a/esp/templates/membership/alumnicontact.html
+++ b/esp/templates/membership/alumnicontact.html
@@ -41,7 +41,7 @@ Use the following form to create a discussion thread, then (if you want) you can
 {% endif %}
 
 <div id="alumni_form">
- <form action="{{ request.path }}" method="post">{% csrf_token %}
+ <form action="{{ request.path }}" method="post">
   <table align="center" width="600">
 
   <thead>

--- a/esp/templates/membership/alumniform.html
+++ b/esp/templates/membership/alumniform.html
@@ -37,7 +37,7 @@ if you can join us for our anniversary weekend!
 </p>
 
 <div id="alumni_form">
-  <form action="{{ request.path }}" method="post">{% csrf_token %}
+  <form action="{{ request.path }}" method="post">
   <table class="contact" align="center" width="500">
   
   

--- a/esp/templates/membership/alumniform_perfield.html
+++ b/esp/templates/membership/alumniform_perfield.html
@@ -21,7 +21,7 @@
  The ESP 50th anniversary event will be on September 14-15, 2007.  Fill out this form to inform ESP of your status as an alumni.  What do you remember about ESP, and how would you like to be involved in the future? <br /> <br />
 </p>
 
-<form action="{{ request.path }}" method="post">{% csrf_token %}
+<form action="{{ request.path }}" method="post">
 <table class="contact" align="center" width="500">
 <thead>
 <tr>

--- a/esp/templates/membership/alumnilookup.html
+++ b/esp/templates/membership/alumnilookup.html
@@ -63,7 +63,7 @@
 {% endif %}
 
 <div id="alumniform">
- <form action="{{ request.path }}" method="post">{% csrf_token %}
+ <form action="{{ request.path }}" method="post">
   <table class="contact" align="center" width="500">
  <thead>
     <tr>
@@ -142,7 +142,7 @@ If you have an account on the ESP web site, please use the box in the first row 
 </p>
 
 <div id="alumniform">
- <form action="{{ request.path }}" method="post">{% csrf_token %}
+ <form action="{{ request.path }}" method="post">
   <table class="contact" align="center" width="500">
 
   <thead>

--- a/esp/templates/membership/alumnirsvp.html
+++ b/esp/templates/membership/alumnirsvp.html
@@ -26,7 +26,7 @@ Please confirm whether or not you will be coming.  You are invited to bring your
 </p>
 
 <div id="alumni_form">
-  <form action="{{ request.path }}" method="post">{% csrf_token %}
+  <form action="{{ request.path }}" method="post">
   <table class="contact" align="center" width="500">
   <thead>
     <tr>

--- a/esp/templates/membership/thread_view.html
+++ b/esp/templates/membership/thread_view.html
@@ -52,7 +52,7 @@ This thread was originally created on {{ thread.timestamp|date:"M. j, Y" }}.
 
 <br />
 <div id="alumniform">
-  <form action="{{ request.path }}" method="post">{% csrf_token %}
+  <form action="{{ request.path }}" method="post">
   <table class="contact" align="center" width="500">
   <thead>
     <tr>

--- a/esp/templates/miniblog.html
+++ b/esp/templates/miniblog.html
@@ -17,8 +17,8 @@
 {% endfor %}
 
 {% if canpost %}
-<form action='/blog/{{ webnode }}/post.scm' method='post'>{% csrf_token %}
-<form method="POST" action="the-plan.html">{% csrf_token %}
+<form action='/blog/{{ webnode }}/post.scm' method='post'>
+<form method="POST" action="the-plan.html">
   <h1>Title</h1>
   <input type="text" name="title" value="New Blog Entry" size="64" /><br><br>
   <h1>Content</h1>

--- a/esp/templates/money/reimbursement_request.html
+++ b/esp/templates/money/reimbursement_request.html
@@ -13,7 +13,7 @@
 <br /><br />
 {% endif %}
 
-<form method="post" action=".">{% csrf_token %}
+<form method="post" action=".">
 
 <p>
     <label for="id_amount">Amount Paid:</label> {{ form.amount }}

--- a/esp/templates/program/archives.html
+++ b/esp/templates/program/archives.html
@@ -44,7 +44,7 @@ Old sort params:
 <br />
 
 <a name="top"></a>
-<form method="post" action="{{request.path}}">{% csrf_token %}
+<form method="post" action="{{request.path}}">
 
 <table cellspacing="0" cellpadding="4" class="fullwidth" align="center">
 <tr><th colspan="2">
@@ -114,7 +114,7 @@ Archive Viewing Options
 <tr><td>
 <h3>Browse current set of results</h3></td>
 <td>
-<form method="post" action="{{request.path}}">{% csrf_token %}
+<form method="post" action="{{request.path}}">
 <input type="hidden" name="max_num_results" value="{{ max_num_results }}" />
 <input type="hidden" name="results_end" value="{{ results_range.start }}" />
 <input type="hidden" name="newparam" value="{{ sortorder.0 }}" />
@@ -129,7 +129,7 @@ disabled
 {% endifequal %}
 />
 </form>
-<form method="post" action="{{request.path}}">{% csrf_token %}
+<form method="post" action="{{request.path}}">
 <input type="hidden" name="max_num_results" value="{{ max_num_results }}" />
 <input type="hidden" name="results_start" value="{{ results_range.end }}" />
 <input type="hidden" name="newparam" value="{{ sortorder.0 }}" />

--- a/esp/templates/program/class_form.html
+++ b/esp/templates/program/class_form.html
@@ -12,7 +12,7 @@
 </p>
 {% endif %}
 
-<form method="post" action=".">{% csrf_token %}
+<form method="post" action=".">
 <p><label for="id_title">Title:</label> {{ orig_class.anchor.friendly_name }}
 {% if form.title.errors %}*** {{ form.title.errors|join:", " }}{% endif %}</p>
 <p><label for="id_category">Category:</label> {{ form.category }}

--- a/esp/templates/program/classchangerequest.html
+++ b/esp/templates/program/classchangerequest.html
@@ -21,7 +21,7 @@ None
 </ol>
 <h3>Class Change Request Form</h3>
 <p>You can request a change into any class without application questions, or into any application question class that you originally applied for, and were accepted to.</p>
-<form action="classchangerequest" method="post">{% csrf_token %}
+<form action="classchangerequest" method="post">
 {{ form.as_p }}
 {% if user.isStudent %}
 <input type="submit" value="Submit" />

--- a/esp/templates/program/modules/adminclass/attendees_enter_users.html
+++ b/esp/templates/program/modules/adminclass/attendees_enter_users.html
@@ -15,7 +15,7 @@
 <p>Enter attendance for {% if is_program %}{{ prog }}{% else %}{{ cls }}{% endif %} (enter either usernames or user ID's, one per line):</p>
 
 <p>
-<form action="" method="POST">{% csrf_token %}
+<form action="" method="POST">
 <input type="hidden" name="class_id" value="{% if is_program %}program{% else %}{{ class_id }}{% endif %}" />
 <textarea name="ids_to_enter" rows="30" cols="15">
 {% for stu in registered_students %}{{ stu.username }}

--- a/esp/templates/program/modules/adminclass/classedit.html
+++ b/esp/templates/program/modules/adminclass/classedit.html
@@ -20,7 +20,7 @@ Thank you for teaching for {{ one }}. Please fill out/update the form below.
 <h2 style="color:red">Please fix the error{{ form.error_dict|pluralize }} in the form.</h2>
 {% endif %}
 
-<form action="{{request.path}}" name="clsform" method="post">{% csrf_token %}
+<form action="{{request.path}}" name="clsform" method="post">
 
 <label for="id_title" class="header">
 Course Title:

--- a/esp/templates/program/modules/adminclass/coteachers.html
+++ b/esp/templates/program/modules/adminclass/coteachers.html
@@ -39,7 +39,7 @@
 {% if not coteachers|length %}
 There are currently no teachers associated with this class.
 {% else %}
-<form action="{{request.path}}" method="post" name="manage_coteachers">{% csrf_token %}
+<form action="{{request.path}}" method="post" name="manage_coteachers">
 <table align="center" width="400">
     <tr>
         <th colspan="2">Current Teachers</th>
@@ -68,7 +68,7 @@ There are currently no teachers associated with this class.
 </table>
 </form>
 {% endif %}
-<form action="{{request.path}}" method="post" name="addteacher">{% csrf_token %}
+<form action="{{request.path}}" method="post" name="addteacher">
 <table align="center" width="400">
     <tr>
         <th colspan="2">Add More Teachers</th>
@@ -97,7 +97,7 @@ There are currently no teachers associated with this class.
     </tr>
     <tr>
         <td align="center" colspan="2">
-            <form action="{{request.path}}" method="post" name="submit">{% csrf_token %}
+            <form action="{{request.path}}" method="post" name="submit">
             <input type="hidden" name="op" value="save" />
             <input type="hidden" name="clsid" value="{{ class.id }}" />
             <input type="hidden" name="coteachers" value="{{ txtTeachers }}" />

--- a/esp/templates/program/modules/adminclass/delete_confirm.html
+++ b/esp/templates/program/modules/adminclass/delete_confirm.html
@@ -42,13 +42,13 @@
     <tr>
         <td colspan="1">&nbsp;</td>
         <td>
-            <form action="/manage/{{ module.program.getUrlBase }}/deletesection/{{ sec.parent_class.id }}?sec_id={{ sec.id }}" method="post">{% csrf_token %}
+            <form action="/manage/{{ module.program.getUrlBase }}/deletesection/{{ sec.parent_class.id }}?sec_id={{ sec.id }}" method="post">
                 <input type="hidden" name="sure" value="False" />
                 <input class="fancybutton" type="submit" value="Cancel" />
             </form>
         </td>
         <td>
-            <form action="/manage/{{ module.program.getUrlBase }}/deletesection/{{ sec.parent_class.id }}?sec_id={{ sec.id }}" method="post">{% csrf_token %}
+            <form action="/manage/{{ module.program.getUrlBase }}/deletesection/{{ sec.parent_class.id }}?sec_id={{ sec.id }}" method="post">
                 <input type="hidden" name="sure" value="True" />
                 <input class="fancybutton" type="submit" value="Confirm Deletion" />
             </form>

--- a/esp/templates/program/modules/adminclass/listclasses.html
+++ b/esp/templates/program/modules/adminclass/listclasses.html
@@ -311,7 +311,7 @@ and <tt>M100-class@{{ EMAIL_HOST }}</tt> will email everyone in the class.
 <div id="classmanager">
 <div class="hd"><!--Please enter your information--></div>
   <div class="bd">
-    <form method="POST" action="../assets/post.php">{% csrf_token %}
+    <form method="POST" action="../assets/post.php">
     </form>
   </div>
 </div>

--- a/esp/templates/program/modules/adminclass/manageclass.html
+++ b/esp/templates/program/modules/adminclass/manageclass.html
@@ -114,7 +114,7 @@
 <p>The table below allows you to cancel the class or any one of its sections.  Cancelling the class will cancel all of its sections.  It is recommended that you enter an explanation (which can be brief, such as "Teacher schedule conflict" or "No appropriate rooms available") to be included in an e-mail to the students.</p>
 
 {% if cls_cancel_form %}
-<form name="class_cancel" action="{{ request.path }}?action=cancel_cls" method="POST">{% csrf_token %}
+<form name="class_cancel" action="{{ request.path }}?action=cancel_cls" method="POST">
 <table align="center" width="500">
     <tr>
         <th colspan="2" align="center">Cancel class {{ class.emailcode }}: {{ class.title }}</th>
@@ -144,7 +144,7 @@
     </tr>
     </table>
 {% else %}
-    <form name="sec{{ forloop.counter }}_cancel" action="{{ request.path }}?action=cancel_sec_{{ forloop.counter }}" method="POST">{% csrf_token %}
+    <form name="sec{{ forloop.counter }}_cancel" action="{{ request.path }}?action=cancel_sec_{{ forloop.counter }}" method="POST">
     <table align="center" width="500">
     <tr>
         <th colspan="2" align="center">Cancel section {{ class.emailcode }}s{{ forloop.counter }}: {{ class.title }}</th>
@@ -168,7 +168,7 @@
 Please use the form below to alter {{ class.title }}.  Note that changes made to the class will propagate to each of the sections, but you can later change each section independently.
 </p>
 
-<form name="classmanage" action="{{ request.path }}?action=modify" method="POST">{% csrf_token %}
+<form name="classmanage" action="{{ request.path }}?action=modify" method="POST">
 <table align="center" width="500">
 
 <tr>

--- a/esp/templates/program/modules/adminclass/manageclass_ajax.html
+++ b/esp/templates/program/modules/adminclass/manageclass_ajax.html
@@ -1,4 +1,4 @@
-<form name="classmanage" action="/manage/{{program.getUrlBase}}/manageclass_ajaxpost/" method="POST">{% csrf_token %}
+<form name="classmanage" action="/manage/{{program.getUrlBase}}/manageclass_ajaxpost/" method="POST">
 <input type="hidden" name="manage_post" value="" />
 <input type="hidden" name="clsid" value="{{class.id}}" />
 <input type="hidden" name="ajax" value="true" />

--- a/esp/templates/program/modules/adminclass/mass_approve_form.html
+++ b/esp/templates/program/modules/adminclass/mass_approve_form.html
@@ -17,7 +17,7 @@ the text box below, each separated by a newline.<br />
 
 <br />
 
-<form action="./bulkapproval" method="post" />{% csrf_token %}
+<form action="./bulkapproval" method="post" />
 <textarea name="clslist" rows="20" cols="50"></textarea><br />
 <br />
 <input type="submit" value="Submit List" />

--- a/esp/templates/program/modules/admincore/deadlines.html
+++ b/esp/templates/program/modules/admincore/deadlines.html
@@ -161,7 +161,7 @@
 
 <h3>Edit Deadlines</h3>
 
-<form method="post" action="/manage/{{ program.getUrlBase }}/deadlines" id="manage_form">{% csrf_token %}
+<form method="post" action="/manage/{{ program.getUrlBase }}/deadlines" id="manage_form">
 {% autoescape off %}
 {{ manage_form }}
 {% for bit in bits %}

--- a/esp/templates/program/modules/admincore/registrationtype_management.html
+++ b/esp/templates/program/modules/admincore/registrationtype_management.html
@@ -14,7 +14,7 @@
     </ul>
     <p>When in doubt, contact <a href="mailto:{{ support }}">{{ support }}</a> for assistance.</p>
     <p>You may also select All to have all registration types display (which was the original default behavior). Only select this if you are sure that you want students to be able to see everything (something which has caused confusion in the past).</p>
-    <form action="/manage/{{ one }}/{{ two }}/registrationtype_management/" method="post">{% csrf_token %}
+    <form action="/manage/{{ one }}/{{ two }}/registrationtype_management/" method="post">
     {{ form.as_p }}
     <input type="submit" value="Submit" />
     </form>

--- a/esp/templates/program/modules/adminmaterials/listmaterials.html
+++ b/esp/templates/program/modules/adminmaterials/listmaterials.html
@@ -55,7 +55,7 @@ From this page, you can view documents related to the program (in the first sect
 	<tr>
             <td class="class_stuff"><a href="{{ doc.target_file.url }}">{{ doc.friendly_name }}</a></td>
 		<td class="clsmiddle">
-			<form method="post" action="/manage/{{ prog.url }}/get_materials">{% csrf_token %}
+			<form method="post" action="/manage/{{ prog.url }}/get_materials">
 				<input type="hidden" name="docid" value="{{ doc.id }}">
 				<input type="hidden" name="command" value="delete">
 				<input class="button" type="submit" value="Delete">
@@ -81,7 +81,7 @@ From this page, you can view documents related to the program (in the first sect
 			<tr>
 				<td class="class_stuff"><a href="{{ doc.target_file.url }}">{{ doc.friendly_name }}</a></td>
 				<td class="clsmiddle">
-					<form method="post" action="/manage/{{ program.url }}/get_materials">{% csrf_token %}
+					<form method="post" action="/manage/{{ program.url }}/get_materials">
 						<input type="hidden" name="docid" value="{{ doc.id }}">
 						<input type="hidden" name="command" value="delete">
 						<input class="button" type="submit" value="Delete">
@@ -96,7 +96,7 @@ From this page, you can view documents related to the program (in the first sect
 <br />
 <br />
 
-<form method="post" action="/manage/{{ prog.url }}/get_materials" enctype="multipart/form-data">{% csrf_token %}
+<form method="post" action="/manage/{{ prog.url }}/get_materials" enctype="multipart/form-data">
 <input type="hidden" name="command" value="add">
 <table cellpadding="12" cellspacing="0" align="center" width="450">
 	<tr>

--- a/esp/templates/program/modules/adminreviewapps/review.html
+++ b/esp/templates/program/modules/adminreviewapps/review.html
@@ -40,7 +40,7 @@ Added your class: {{ student.added_class|date:"m/d/Y @ h:i:s" }}
 </tbody>
 </table>
 <br />
-<form action="{{ request.path }}" method="post" name="review">{% csrf_token %}
+<form action="{{ request.path }}" method="post" name="review">
 <input type="hidden" name="student" value="{{student.id}}" />
 <table>
 <thead>

--- a/esp/templates/program/modules/availabilitymodule/availability_form.html
+++ b/esp/templates/program/modules/availabilitymodule/availability_form.html
@@ -38,7 +38,7 @@ We have detected that you are currently signed up to teach more hours of class t
 
 <br />
 
-<form method="post" action="{{ request.path }}">{% csrf_token %}
+<form method="post" action="{{ request.path }}">
 <table cellpadding="4" cellspacing="0" align="center" width="300">
     <tr>
         <th colspan="2" align="center">Time Slots for {{ prog.niceName }}</th>

--- a/esp/templates/program/modules/classroommodule/managerooms.html
+++ b/esp/templates/program/modules/classroommodule/managerooms.html
@@ -21,7 +21,7 @@ Using this tool you can add rooms for use in your program.
 </p>
 
 <br />
-<form action="./addroom" method="post">{% csrf_token %}
+<form action="./addroom" method="post">
 <fieldset>
 <label for="name"><strong>Long Name:</strong></label>
 <input type="text" name="name" value="" size="30" />

--- a/esp/templates/program/modules/commmodule/commmodulefront.html
+++ b/esp/templates/program/modules/commmodule/commmodulefront.html
@@ -91,7 +91,7 @@ function switchnot(not, title) {
 <h2>Step 1:</h2>
 
 
-<form action="/manage/{{program.getUrlBase}}/commstep2" method="post" name="comm">{% csrf_token %}
+<form action="/manage/{{program.getUrlBase}}/commstep2" method="post" name="comm">
 <p>
 <em>(If you feel there's a list omitted from this list or this interface is too hard to use, please email <tt>{{ DEFAULT_EMAIL_ADDRESSES.support }}</tt> with questions!)</em>
 <br />

--- a/esp/templates/program/modules/commmodule/preview.html
+++ b/esp/templates/program/modules/commmodule/preview.html
@@ -65,7 +65,7 @@ users to whom you are sending this email.
 
 <br />
 <br />
-<form action="/manage/{{program.getUrlBase}}/maincomm2" method="post" name="mainback">{% csrf_token %}
+<form action="/manage/{{program.getUrlBase}}/maincomm2" method="post" name="mainback">
 <input type="hidden" name="filterid" value="{{filterid}}" />
 <input type="hidden" name="from" value="{{from}}" />
 <input type="hidden" name="replyto" value="{{replyto}}" />
@@ -74,7 +74,7 @@ users to whom you are sending this email.
 <input type="hidden" name="listcount" value="{{listcount}}" />
 <input type="submit" value="Edit Your Email" id="submitform" />
 </form>
-<form action="/manage/{{program.getUrlBase}}/commfinal" method="post" name="mainback">{% csrf_token %}
+<form action="/manage/{{program.getUrlBase}}/commfinal" method="post" name="mainback">
 <input type="hidden" name="filterid" value="{{filterid}}" />
 <input type="hidden" name="from" value="{{from}}" />
 <input type="hidden" name="replyto" value="{{replyto}}" />

--- a/esp/templates/program/modules/commmodule/step2.html
+++ b/esp/templates/program/modules/commmodule/step2.html
@@ -40,7 +40,7 @@ into the text of the message&mdash;the parameters are listed below.
 
 <p><b>Tip:</b> If you would like to send your message in HTML format, wrap your HTML code in &lt;html&gt; and &lt;/html&gt; tags.</p>
 
-<form action="/manage/{{program.getUrlBase}}/commprev" method="post" name="comm2">{% csrf_token %}
+<form action="/manage/{{program.getUrlBase}}/commprev" method="post" name="comm2">
 <table border="0" cellspacing="0" width="100%">
 <tr>
   <td>

--- a/esp/templates/program/modules/creditcardmodule/cardpay.html
+++ b/esp/templates/program/modules/creditcardmodule/cardpay.html
@@ -139,8 +139,8 @@ function testCreditCard() {
 <h1>Credit Card Payment for {{ program.niceName }} </h1>
 <br />
 <p>Required fields are boxed in a red border and marked with an asterisk.</p>
-<form onsubmit="return formTest();" action="https://shopmit.mit.edu/payment/esp_form" method="post" autocomplete="off">{% csrf_token %} 
-<!--<form onsubmit="return formTest();" action="https://shopmit.mit.edu/bin/cgiemail2/esp/www/creditcard_email.txt" method="post" autocomplete="off">-->{% csrf_token %}
+<form onsubmit="return formTest();" action="https://shopmit.mit.edu/payment/esp_form" method="post" autocomplete="off"> 
+<!--<form onsubmit="return formTest();" action="https://shopmit.mit.edu/bin/cgiemail2/esp/www/creditcard_email.txt" method="post" autocomplete="off">-->
 <input type="hidden" name="OrderComments" value="ESP__{{program.id }}-{{module.payment.id}}" />
 
 <!-- Defaults -->

--- a/esp/templates/program/modules/creditcardmodule_cybersource/cardpay.html
+++ b/esp/templates/program/modules/creditcardmodule_cybersource/cardpay.html
@@ -144,7 +144,7 @@ function formTest() {
 
 <p>If you would like to cancel at this time, you can <a href="/learn/{{ program.getUrlBase }}/studentreg" title="Return to main registration page">return to the main registration page</a>.</p>
 
-<form onsubmit="return formTest();" action="https://shopmitprd.mit.edu/controller/index.php?auto_submit=Y" method="post" autocomplete="off">{% csrf_token %} 
+<form onsubmit="return formTest();" action="https://shopmitprd.mit.edu/controller/index.php?auto_submit=Y" method="post" autocomplete="off"> 
 
 <br />
 <p>Please fill out the form below.  Required fields are boxed in a red border and marked with an asterisk.</p>

--- a/esp/templates/program/modules/creditcardmodule_firstdata/cardpay.html
+++ b/esp/templates/program/modules/creditcardmodule_firstdata/cardpay.html
@@ -168,7 +168,7 @@ Please review the costs below. If you are concerned that there is a problem, ple
 
 {% comment %}{% end_inline_qsd_block %}{% endcomment %}
 
-<form onsubmit="return formTest();" action="{{ module.post_url }}" method="post" autocomplete="off">{% csrf_token %} 
+<form onsubmit="return formTest();" action="{{ module.post_url }}" method="post" autocomplete="off"> 
 
 <input type="hidden" name="storename" value="{{ module.store_id }}" />
 <input type="hidden" name="oid" value="{{ module.invoice_prefix }}-{{ invoice.get_locator }}" />

--- a/esp/templates/program/modules/financialaidappmodule/application.html
+++ b/esp/templates/program/modules/financialaidappmodule/application.html
@@ -67,7 +67,7 @@
 <p>Please complete this form to request financial aid for {{ program.niceName }}.  You can always <strong>Save Progress</strong> to keep your work and return to this page at any time to continue filling it out.  Once you're finished, please let us know by clicking <strong>Complete</strong>.  If you've finished filling out the form, but you discover that information on the form is inaccurate or you wish to cancel the application, click <strong>Mark as Incomplete</strong>.</p>
 <p>All information is completely optional.  However, the better we can understand your current need, the easier it is for us to grant financial aid when necessary (and determine an appropriate amount).</p>
 
-<form action="{{ request.path }}" method="post" name="application_form">{% csrf_token %}
+<form action="{{ request.path }}" method="post" name="application_form">
 <table id="appform" cellspacing="0" cellpadding="4">
 <tr style="background-color: #c6def7">
 <th colspan="2" style="text-align: center;">

--- a/esp/templates/program/modules/listgenmodule/options.html
+++ b/esp/templates/program/modules/listgenmodule/options.html
@@ -18,7 +18,7 @@
 You can use this to get a list of users for a specific purpose.
 </p>
 
-<form action="{{ request.path }}?filterid={{ filterid }}" method="POST">{% csrf_token %}
+<form action="{{ request.path }}?filterid={{ filterid }}" method="POST">
 <center>
 <table width="400" cellpadding="5">
 

--- a/esp/templates/program/modules/mailinglabels/mailinglabel_badzips.html
+++ b/esp/templates/program/modules/mailinglabels/mailinglabel_badzips.html
@@ -24,7 +24,7 @@ For example:
 </pre>
 </p>
 
-<form action="{{ request.path }}" method="post">{% csrf_token %}
+<form action="{{ request.path }}" method="post">
 <table>
 {{ form }}
 <tr>

--- a/esp/templates/program/modules/mailinglabels/schools_confirm.html
+++ b/esp/templates/program/modules/mailinglabels/schools_confirm.html
@@ -19,7 +19,7 @@ According to our records, there are <strong style="font-size: 140%;">{{ num }}
   </strong> schools that
  match your request.
 </p>
-<form name="confirmform" action="{{ request.path }}" method="post">{% csrf_token %}
+<form name="confirmform" action="{{ request.path }}" method="post">
 <p>
   Would you like to <a href="javascript:history.go(-1);">go back</a> or
   <input type="submit" value="continue" />?

--- a/esp/templates/program/modules/mailinglabels/selectschools.html
+++ b/esp/templates/program/modules/mailinglabels/selectschools.html
@@ -21,7 +21,7 @@
 
 <br />
 <br />
-<form name="selectschool" action="{{ request.path }}" method="post">{% csrf_token %}
+<form name="selectschool" action="{{ request.path }}" method="post">
 <table class="newform" id="appform">
  {{form}}
 <tr>

--- a/esp/templates/program/modules/nametagmodule/selectoptions.html
+++ b/esp/templates/program/modules/nametagmodule/selectoptions.html
@@ -46,7 +46,7 @@ To have good quality IDs:<br />
    <li>That's all!</li>
 </ol>
 <br />
-<form action="./generatetags" method="post">{% csrf_token %}
+<form action="./generatetags" method="post">
 <fieldset>
 <strong>ID Type</strong>
 <ul>

--- a/esp/templates/program/modules/onsitecheckinmodule/ajaxcheckin.html
+++ b/esp/templates/program/modules/onsitecheckinmodule/ajaxcheckin.html
@@ -28,7 +28,7 @@ Welcome to student check-in for {{program.niceName}}.  Make sure that the studen
 <p align="center">{{ message }}</p>
 {% endif %}
 
-<form id="checkinform" name="checkinform" method="POST" action="{{ request.path }}">{% csrf_token %}
+<form id="checkinform" name="checkinform" method="POST" action="{{ request.path }}">
 <table>
 <tr>
     <th colspan="2">

--- a/esp/templates/program/modules/onsitecheckinmodule/checkin.html
+++ b/esp/templates/program/modules/onsitecheckinmodule/checkin.html
@@ -24,7 +24,7 @@ Welcome to student check-in for {{module.student.name}}.  Make sure that the stu
 </ul>
 <br />
 <br />
-<form name="checkin" method="POST" action="{{request.path}}">{% csrf_token %}
+<form name="checkin" method="POST" action="{{request.path}}">
 <input type="hidden" name="Attended" id="attended" value="True">
 <input type="hidden" name="MedicalFiled" id="medical" value="True">
 <input type="hidden" name="LiabilityFiled" id="liability" value="True">
@@ -35,7 +35,7 @@ Welcome to student check-in for {{module.student.name}}.  Make sure that the stu
 Welcome to the student check-in for {{module.student.name}}. Please checkoff that the following has been completed:
 </p>
 <br />
-<form name="checkin" method="POST" action="{{request.path}}">{% csrf_token %}
+<form name="checkin" method="POST" action="{{request.path}}">
 <label for="attended"><strong>Attending? (i.e. here right now?)</strong></label> &nbsp;&nbsp;
    <input type="checkbox" name="Attended" id="attended" {% if module.hasAttended %}checked="checked"{% endif %} />
   <br />

--- a/esp/templates/program/modules/onsiteclasslist/status.html
+++ b/esp/templates/program/modules/onsiteclasslist/status.html
@@ -93,7 +93,7 @@ form {
 {% for section in timeslot.sections %}
 <tr class="narrow">
 <td class="narrow">
-<form method="POST" action="{{ request.path }}?op=add&sec_id={{ section.id }}">{% csrf_token %}
+<form method="POST" action="{{ request.path }}?op=add&sec_id={{ section.id }}">
 <table bgcolor="#{{ section.color }}" border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td> <!-- width="50px" -->

--- a/esp/templates/program/modules/onsitecore/checkin.html
+++ b/esp/templates/program/modules/onsitecore/checkin.html
@@ -20,7 +20,7 @@
 Welcome to the student check-in for {{module.student.name}}. Please checkoff that hte following has been completed:
 </p>
 <br />
-<form name="checkin" method="POST" action="{{request.path}}">{% csrf_token %}
+<form name="checkin" method="POST" action="{{request.path}}">
 <label for="medical"><strong>Medical Form?</strong></label> &nbsp;&nbsp;
    <input type="checkbox" name="medical" id="medical" {% if module.hasMedical %}checked="checked"{% endif %} />
   <br />

--- a/esp/templates/program/modules/onsitecore/checkin_search.html
+++ b/esp/templates/program/modules/onsitecore/checkin_search.html
@@ -25,14 +25,14 @@ Please use this to search for a user to "check in".
 {% endif %}
 
 <br />
-<form action="{{ request.path }}" method="get">{% csrf_token %}
+<form action="{{ request.path }}" method="get">
 <label for="userid"><strong>User ID:</strong></label>
 <input type="text" size="6" name="userid" id="userid" />
 <input type="submit" name="submitid" value="Search by ID" />
 </form>
 <br />
 <br />
-<form action="{{ request.path }}" method="get">{% csrf_token %}
+<form action="{{ request.path }}" method="get">
 <label for="lastname"><strong>Last Name:</strong></label>
 <input type="text" size="20" name="lastname" id="lastname" />
 <input type="submit" name="submitid" value="Search by Last Name" />

--- a/esp/templates/program/modules/onsitecore/reg_info.html
+++ b/esp/templates/program/modules/onsitecore/reg_info.html
@@ -20,7 +20,7 @@
 Please enter the information for the new student:
 </p>
 <br />
-<form autocomplete="off" name="reg" method="POST" action="{{request.path}}">{% csrf_token %}
+<form autocomplete="off" name="reg" method="POST" action="{{request.path}}">
 <table cellpadding="2" align="center" border="0">
 
 <tr>

--- a/esp/templates/program/modules/onsiteregister/reg_info.html
+++ b/esp/templates/program/modules/onsiteregister/reg_info.html
@@ -20,7 +20,7 @@
 Please enter the information for the new student:
 </p>
 <br />
-<form autocomplete="off" name="reg" method="POST" action="{{request.path}}">{% csrf_token %}
+<form autocomplete="off" name="reg" method="POST" action="{{request.path}}">
 <table cellpadding="2" align="center" border="0">
 
 <tr>

--- a/esp/templates/program/modules/programprintables/catalog_order.html
+++ b/esp/templates/program/modules/programprintables/catalog_order.html
@@ -35,7 +35,7 @@ Get Catalog:
 <a href="/manage/{{program.getUrlBase}}/coursecatalog/log?sort_name_list={{ sort_name_list }}&clsids={{clsids}}">log</a>)
 
 <div id="program_form">
-<form action="" method="get">{% csrf_token %}
+<form action="" method="get">
 <table cellspacing="0" cellpadding="0">
 
 <tr>

--- a/esp/templates/program/modules/programprintables/paid_list_filter.html
+++ b/esp/templates/program/modules/programprintables/paid_list_filter.html
@@ -8,7 +8,7 @@
 
 <h1>Filter List of Paid Students</h1>
 
-<form method="get" action="paid_list">{% csrf_token %}
+<form method="get" action="paid_list">
 <p>
 <select multiple size="{{ lineitemtypes.count }}" name="filter">
 {% for lineitemtype in lineitemtypes %}

--- a/esp/templates/program/modules/programprintables/refund_receipt_form.html
+++ b/esp/templates/program/modules/programprintables/refund_receipt_form.html
@@ -27,7 +27,7 @@ Transaction Type: {{ transaction.payment_type }}
 Transaction Amount: {{ transaction.amount }}
 </pre>
 
-<form action="{{ request.path }}" method="get" name="payer_info">{% csrf_token %}
+<form action="{{ request.path }}" method="get" name="payer_info">
 <table>
 {{ form }}
 <input type="hidden" name="payer_post" value="true" />

--- a/esp/templates/program/modules/remoteteacherprofile/editprofile.html
+++ b/esp/templates/program/modules/remoteteacherprofile/editprofile.html
@@ -21,7 +21,7 @@ Please fill out the form below to help us better organize {{ program.niceName }}
 
 <br />
 
-<form action="{{request.path}}" name="profileform" method="post">{% csrf_token %}
+<form action="{{request.path}}" name="profileform" method="post">
 <div id="catalog">
 <table align="center" width="500">
 <tr>

--- a/esp/templates/program/modules/resourcemodule/classroom_delete.html
+++ b/esp/templates/program/modules/resourcemodule/classroom_delete.html
@@ -22,7 +22,7 @@ You have chosen to delete the classroom: {{ classroom }}.  Please confirm this b
 <p>Pay special attention to the <b>classes that will be unscheduled</b> below.</p>
 
 <div id="program_form">
-<form method="post" action="{{ request.path }}">{% csrf_token %}
+<form method="post" action="{{ request.path }}">
 <input type="hidden" name="command" value="reallyremove" />
 <input type="hidden" name="id" value="{{ classroom.id }}" />
 <table align="center" width="550" cellpadding="4" cellspacing="0">

--- a/esp/templates/program/modules/resourcemodule/classroom_import.html
+++ b/esp/templates/program/modules/resourcemodule/classroom_import.html
@@ -23,7 +23,7 @@ You have chosen to import the classrooms from {{ past_program.niceName }} to {{ 
 {% end_inline_qsd_block %}
 
 <div id="program_form">
-<form method="post" action="{{ request.path }}">{% csrf_token %}
+<form method="post" action="{{ request.path }}">
 <input type="hidden" name="import_confirm" value="yes" />
 <input type="hidden" name="program" value="{{ past_program.id }}" />
 <table align="center" cellpadding="0" cellspacing="0" width="550">

--- a/esp/templates/program/modules/resourcemodule/classrooms.html
+++ b/esp/templates/program/modules/resourcemodule/classrooms.html
@@ -42,14 +42,14 @@
     {% endfor %}
     </table></td></tr>
 </table>
-<form method="post" action="/manage/{{ prog.url }}/resources/classroom_import">{% csrf_token %}
+<form method="post" action="/manage/{{ prog.url }}/resources/classroom_import">
 <table align="center" cellpadding="0" cellspacing="0" width="550">
     <tr><th colspan="2" class="small">Import classrooms from a previous program</th></tr>
     {{ import_form }}
     <tr><td colspan="2" align="center"><input class="fancybutton" type="submit" value="Start" /></td></tr>
 </table>
 </form>
-<form method="post" action="/manage/{{ prog.url }}/resources/classroom">{% csrf_token %}
+<form method="post" action="/manage/{{ prog.url }}/resources/classroom">
 <input type="hidden" name="command" value="addedit" />
 <table align="center" cellpadding="0" cellspacing="0" width="550">
     <tr><th colspan="2" class="small">Add a new classroom</th></tr>

--- a/esp/templates/program/modules/resourcemodule/equipment.html
+++ b/esp/templates/program/modules/resourcemodule/equipment.html
@@ -14,7 +14,7 @@
 <p>The following are resources that ESP administrators or teachers can carry from room to room (LCD projectors, art supplies, etc).</p>
 
 <div id="program_form">
-<form method="post" action="/manage/{{ prog.url }}/resources/equipment">{% csrf_token %}
+<form method="post" action="/manage/{{ prog.url }}/resources/equipment">
 <input type="hidden" name="command" value="addedit" />
 <table align="center" cellpadding="0" cellspacing="0" width="450">
     <tr><th colspan="2">Floating Resources for {{ prog.niceName }}</th></tr>

--- a/esp/templates/program/modules/resourcemodule/equipment_delete.html
+++ b/esp/templates/program/modules/resourcemodule/equipment_delete.html
@@ -20,7 +20,7 @@ You have chosen to delete the equipment resource: {{ equipment }}, for {{ prog.n
 </p>
 
 <div id="program_form">
-<form method="post" action="{{ request.path }}">{% csrf_token %}
+<form method="post" action="{{ request.path }}">
 <input type="hidden" name="command" value="reallyremove" />
 <input type="hidden" name="id" value="{{ equipment.id }}" />
 <table align="center" width="550" cellpadding="4" cellspacing="0">

--- a/esp/templates/program/modules/resourcemodule/resource_types.html
+++ b/esp/templates/program/modules/resourcemodule/resource_types.html
@@ -14,7 +14,7 @@
 <p>The following types of resources will be available for teachers to select on the teacher registration page.  Don't feel obligated to give them every possible option - we do ask teachers to make special requests in the "Message for Directors" that gets e-mailed to you.  However, covering the most commonly needed things would be a good idea.</p>
 
 <div id="program_form">
-<form method="post" action="/manage/{{ prog.url }}/resources/restype">{% csrf_token %}
+<form method="post" action="/manage/{{ prog.url }}/resources/restype">
 <input type="hidden" name="command" value="addedit" />
 <table align="center" cellpadding="0" cellspacing="0" width="550">
     <tr><th colspan="2">Resource Types for {{ prog.niceName }}</th></tr>

--- a/esp/templates/program/modules/resourcemodule/restype_delete.html
+++ b/esp/templates/program/modules/resourcemodule/restype_delete.html
@@ -20,7 +20,7 @@ You have chosen to delete the resource type: {{ restype }}.  Please confirm this
 </p>
 
 <div id="program_form">
-<form method="post" action="{{ request.path }}">{% csrf_token %}
+<form method="post" action="{{ request.path }}">
 <input type="hidden" name="command" value="reallyremove" />
 <input type="hidden" name="id" value="{{ restype.id }}" />
 <table align="center" width="550" cellpadding="4" cellspacing="0">

--- a/esp/templates/program/modules/resourcemodule/timeslot_delete.html
+++ b/esp/templates/program/modules/resourcemodule/timeslot_delete.html
@@ -20,7 +20,7 @@ You have chosen to delete the timeslot: {{ timeslot }}.  Please confirm this bel
 </p>
 
 <div id="program_form">
-<form method="post" action="{{ request.path }}">{% csrf_token %}
+<form method="post" action="{{ request.path }}">
 <input type="hidden" name="command" value="reallyremove" />
 <input type="hidden" name="id" value="{{ timeslot.id }}" />
 <table align="center" width="550" cellpadding="4" cellspacing="0">

--- a/esp/templates/program/modules/resourcemodule/timeslots.html
+++ b/esp/templates/program/modules/resourcemodule/timeslots.html
@@ -16,7 +16,7 @@
 <p>Keep in mind that classes generally begin 5 minutes after the hour (or half hour) and end 5 minuts before the hour (or half hour), allowing 10 minutes between classes.  So, for example, a 9 - 10 AM time block really should start at 09:05 and be 50 minutes long.  Please put the approximate time in the 'name' field (i.e. 9 - 10 AM) and the exact times in the 'description' field (i.e. 9:05 - 9:55 AM).</p>
 
 <div id="program_form">
-<form method="post" action="/manage/{{ prog.url }}/resources/timeslot">{% csrf_token %}
+<form method="post" action="/manage/{{ prog.url }}/resources/timeslot">
 <input type="hidden" name="command" value="addedit" />
 <table align="center" cellpadding="0" cellspacing="0" width="450"> 
     <tr><th colspan="2">Timeslots for {{ prog.niceName }}</th></tr>

--- a/esp/templates/program/modules/satprep_reg.html
+++ b/esp/templates/program/modules/satprep_reg.html
@@ -27,7 +27,7 @@ label.groupheader { font-size: 1.2em; font-weight: bold; }
 {% endif %}
 
 
-<form action="{{request.path}}" method="post">{% csrf_token %}
+<form action="{{request.path}}" method="post">
 <table cellpadding="2" align="center" border="0">
 
 {% include "users/profiles/usercontact.html" %}

--- a/esp/templates/program/modules/satprep_stureg.html
+++ b/esp/templates/program/modules/satprep_stureg.html
@@ -22,7 +22,7 @@ While none of this information is required, it will greatly enhance our ability 
 {% endif %}
 
 
-<form action="{{request.path}}" method="post">{% csrf_token %}
+<form action="{{request.path}}" method="post">
 <table cellpadding="2" align="center" border="0">
 
 <tr>

--- a/esp/templates/program/modules/satprepadminschedule/newclass_confirm.html
+++ b/esp/templates/program/modules/satprepadminschedule/newclass_confirm.html
@@ -25,7 +25,7 @@ Please fill in the form below and press the "Submit" button to create all the cl
 </p>
 
 <div id="program_form">
-<form method="post" action="{{ request.path }}" name="confirm">{% csrf_token %}
+<form method="post" action="{{ request.path }}" name="confirm">
 <table width="400">
 <tr><th colspan="4">Scheduling Options for {{ program.niceName }}</th></tr>
 <tr>

--- a/esp/templates/program/modules/satprepadminschedule/room_setup.html
+++ b/esp/templates/program/modules/satprepadminschedule/room_setup.html
@@ -26,7 +26,7 @@
 <p>Then, click "Submit" and wait.  It will take some time (a few minutes) for all of the rooms and their student lists to be saved.  You will be taken to a confirmation page showing which students were assigned to each section.  You may also want to print the <a href="/manage/{{ prog.getUrlBase }}/classchecklists/">class checklists</a> for all confirmed students.</p>
 
 <div id="program_form">
-<form method="post" action="/manage/{{ prog.getUrlBase }}/create_rooms/">{% csrf_token %}
+<form method="post" action="/manage/{{ prog.getUrlBase }}/create_rooms/">
 <table align="center" width="350">
 <tr>
     <th colspan="2">Diagnostic Setup for {{ prog.niceName }}</th>

--- a/esp/templates/program/modules/satprepadminschedule/schedule_confirm.html
+++ b/esp/templates/program/modules/satprepadminschedule/schedule_confirm.html
@@ -24,7 +24,7 @@ This is a magic button to schedule all of the students into their remaining SAT 
 </p>
 
 <div id="program_form">
-<form method="post" action="{{ request.path }}?{{ request.GET.urlencode }}" name="confirm">{% csrf_token %}
+<form method="post" action="{{ request.path }}?{{ request.GET.urlencode }}" name="confirm">
 <table>
 <tr>
     <th>Section Assignments for {{ program.niceName }}</th>

--- a/esp/templates/program/modules/satprepadminschedule/score_entry.html
+++ b/esp/templates/program/modules/satprepadminschedule/score_entry.html
@@ -86,7 +86,7 @@ Please save the spreadsheet in a comma-separated variable (CSV) format and uploa
 <br />
 
 <div id="program_form">
-<form method="post" action="/manage/{{ prog.getUrlBase }}/enter_scores/" enctype="multipart/form-data">{% csrf_token %}
+<form method="post" action="/manage/{{ prog.getUrlBase }}/enter_scores/" enctype="multipart/form-data">
 <table align="center" width="400">
 <tr>
     <th colspan="2">Diagnostic Score Entry for {{ prog.niceName }}</th>

--- a/esp/templates/program/modules/satprepadminschedule/setteachers.html
+++ b/esp/templates/program/modules/satprepadminschedule/setteachers.html
@@ -26,7 +26,7 @@ Please assign each teacher to the appropriate section below:
 </p>
 
 <div id="program_form">
-<form action="{{ request.path }}" method="post" name="teachersections">{% csrf_token %}
+<form action="{{ request.path }}" method="post" name="teachersections">
 <table cellspacing="0" cellpadding="2" width="300" >
 <thead>
 <tr>

--- a/esp/templates/program/modules/satpreponsiteregister/reg_info.html
+++ b/esp/templates/program/modules/satpreponsiteregister/reg_info.html
@@ -20,7 +20,7 @@
 Please enter the information for the new student:
 </p>
 <br />
-<form autocomplete="off" name="reg" method="POST" action="{{request.path}}">{% csrf_token %}
+<form autocomplete="off" name="reg" method="POST" action="{{request.path}}">
 <table cellpadding="2" align="center" border="0">
 
 <tr>

--- a/esp/templates/program/modules/satprepteacherinput/satprep_diag.html
+++ b/esp/templates/program/modules/satprepteacherinput/satprep_diag.html
@@ -26,7 +26,7 @@ label.groupheader { font-size: 1.2em; font-weight: bold; }
 {% endif %}
 
 
-<form action="{{request.path}}?userid={{user.id}}" method="post">{% csrf_token %}
+<form action="{{request.path}}?userid={{user.id}}" method="post">
 <table cellpadding="2" align="center" border="0">
 
 <tr>

--- a/esp/templates/program/modules/satprepteachermodule/satprep_info.html
+++ b/esp/templates/program/modules/satprepteachermodule/satprep_info.html
@@ -28,7 +28,7 @@ label.groupheader { font-size: 1.2em; font-weight: bold; }
 {% endif %}
 
 
-<form action="{{request.path}}" method="post">{% csrf_token %}
+<form action="{{request.path}}" method="post">
 <table cellpadding="2" align="center" border="0">
 
 <tr>

--- a/esp/templates/program/modules/schedulingmodule/class_list.html
+++ b/esp/templates/program/modules/schedulingmodule/class_list.html
@@ -17,7 +17,7 @@
 </ol>
 </p>
 
-<form method="post" action="{{ request.path }}">{% csrf_token %}
+<form method="post" action="{{ request.path }}">
 <table cellpadding="2" cellspacing="0" align="center">
 <tr>
     <th colspan="8">Class Schedule List for {{ prog.niceName }}</th>

--- a/esp/templates/program/modules/schedulingmodule/force_prompt.html
+++ b/esp/templates/program/modules/schedulingmodule/force_prompt.html
@@ -32,13 +32,13 @@ However, in order to schedule classes the teachers' availability will need to be
 </tr>
 <tr>
     <td align="center">
-        <form method="post" action="/manage/{{ prog.getUrlBase }}/force_availability">{% csrf_token %}
+        <form method="post" action="/manage/{{ prog.getUrlBase }}/force_availability">
         <input type="hidden" name="sure" value="False" />
         <input class="fancybutton" type="submit" value="Return to Scheduling" />
         </form>
     </td>
     <td align="center">
-        <form method="post" action="/manage/{{ prog.getUrlBase }}/force_availability">{% csrf_token %}
+        <form method="post" action="/manage/{{ prog.getUrlBase }}/force_availability">
         <input type="hidden" name="sure" value="True" />
         <input class="fancybutton" type="submit" value="Mark Teachers Available" />
         </form>

--- a/esp/templates/program/modules/splashinfomodule/splashinfo.html
+++ b/esp/templates/program/modules/splashinfomodule/splashinfo.html
@@ -27,7 +27,7 @@
 </p>
 {% end_inline_qsd_block %}
 
-<form action="{{ request.path }}" method="post">{% csrf_token %}
+<form action="{{ request.path }}" method="post">
 {% if form.lunchsat %}
 <table cellpadding="1" align="center" border="0">
 <tr>

--- a/esp/templates/program/modules/studentextracosts/extracosts.html
+++ b/esp/templates/program/modules/studentextracosts/extracosts.html
@@ -35,7 +35,7 @@ td>ul { list-style-type: none; padding: 0px }
 {% if errors %}<div class="formerror">Please fill out the entire form</div>{% endif %}
   
 <div id="program_form">
-<form action="" method="post">{% csrf_token %}
+<form action="" method="post">
 <center>
 <table width="400" cellpadding="2" cellspacing="0">
 <tr><th colspan="{% if select_qty %}3{% else %}2{% endif %}">Additional Items for {{ program.niceName }}</th></tr>

--- a/esp/templates/program/modules/studentjunctionappmodule/application.html
+++ b/esp/templates/program/modules/studentjunctionappmodule/application.html
@@ -31,7 +31,7 @@
 <br />
 
 <div id="program_form">
-<form action="{{ request.path }}" method="post" name="application_form">{% csrf_token %}
+<form action="{{ request.path }}" method="post" name="application_form">
 <table align="center" id="appform" class="fullwidth">
 {% load smartypants %}
 {% load markdown %}

--- a/esp/templates/program/modules/studentregcore/mainpage.html
+++ b/esp/templates/program/modules/studentregcore/mainpage.html
@@ -71,7 +71,7 @@
 {% load render_qsd %}
 {% render_inline_qsd program.anchor "learn:studentreg" request.user %}
 
-<form action="/learn/{{one}}/{{two}}/confirmreg" method="post">{% csrf_token %}
+<form action="/learn/{{one}}/{{two}}/confirmreg" method="post">
 
 {% for module in modules %}
 {% if module.useTemplate %}
@@ -106,13 +106,13 @@
     <a name="confirmreg"></a>
     {% if program.isFull and program.program_allow_waitlist and not isConfirmed %}
         </form>
-        <form action="/learn/{{one}}/{{two}}/waitlist_subscribe" method="post">{% csrf_token %}
+        <form action="/learn/{{one}}/{{two}}/waitlist_subscribe" method="post">
         <input class="button" type="submit" value="Join Waiting List"/>
         </form>
     {% else %}
         <input id="confirmbutton" class="button" type="submit" value="{% if not isConfirmed %}{{ scrmi.confirm_button_text }}{% else %}{{ scrmi.view_button_text }}{% endif %}" {% if not completedAll %}disabled{% endif %} {% if program.isFull and not canRegToFullProgram and not isConfirmed %}disabled{% endif %}/></form>
         {% if isConfirmed or scrmi.cancel_button_dereg %}{% if not have_paid %}
-           <form action="/learn/{{one}}/{{two}}/cancelreg" method="get" onsubmit="return submit_cancel();" >{% csrf_token %}
+           <form action="/learn/{{one}}/{{two}}/cancelreg" method="get" onsubmit="return submit_cancel();" >
            <input id="cancelbutton" class="button" type="submit" value="{{ scrmi.cancel_button_text }}" />
             </form>
         {% endif %}{% endif %}

--- a/esp/templates/program/modules/teacheracknowledgementmodule/acknowledgement.html
+++ b/esp/templates/program/modules/teacheracknowledgementmodule/acknowledgement.html
@@ -7,7 +7,7 @@
 {{ prog.niceName }} will be on {{ prog.date_range }}! Please acknowledge that you are aware of this and commit to teaching at one of the times you have specified for your availability. You may not cancel your classes after student registration opens. In the case of extenuating circumstances like illness or serious emergency, you must notify the directors ASAP at <a href="mailto:{{ prog.director_email }}">{{ prog.director_email }}</a> and assist in finding a substitute for your classes. If you do not meet these expectations, it is unfair for the students who registered for your class and makes organization difficult for us. Note that not being responsible with respect to your classes will affect your ability to teach for us in the future.
 </p>
 <br />
-<form action="acknowledgement" method="post">{% csrf_token %}
+<form action="acknowledgement" method="post">
 {{ form.as_p }}
 <input type="submit" value="Submit" />
 </form>

--- a/esp/templates/program/modules/teacherclassregmodule/class_docs.html
+++ b/esp/templates/program/modules/teacherclassregmodule/class_docs.html
@@ -48,7 +48,7 @@ We would like you, as a teacher, to upload all documents and other materials rel
 	<tr>
 		<td class="clsmiddle"><a href="{{ doc.target_file.url }}">{{ doc.friendly_name }}</a></td>
 		<td class="clsmiddle">
-			<form method="post" action="./{{ cls.id }}">{% csrf_token %}
+			<form method="post" action="./{{ cls.id }}">
 				<input type="hidden" name="docid" value="{{ doc.id }}">
 				<input type="hidden" name="command" value="delete">
 				<input class="button" type="submit" value="Delete">
@@ -61,7 +61,7 @@ We would like you, as a teacher, to upload all documents and other materials rel
 <br />
 <br />
 
-<form method="post" action="./{{ cls.id }}" enctype="multipart/form-data">{% csrf_token %}
+<form method="post" action="./{{ cls.id }}" enctype="multipart/form-data">
 <input type="hidden" name="command" value="add">
 <table cellpadding="12" cellspacing="0" align="center" width="450">
 	<tr>

--- a/esp/templates/program/modules/teacherclassregmodule/classedit.html
+++ b/esp/templates/program/modules/teacherclassregmodule/classedit.html
@@ -34,7 +34,7 @@ sections of the
 same class, <b>do not submit this form multiple times.</b>  Instead, select the desired number of sections next to "Number of Sections" (the second field from the top).</div>
 </p>
 
-<form action="{{request.path}}" id="clsform" name="clsform" method="post" {% if grade_range_popup %}onsubmit="return check_grade_range($j(this), {{ program.grade_min }}, {{ program.grade_max }});"{% endif %}>{% csrf_token %}
+<form action="{{request.path}}" id="clsform" name="clsform" method="post" {% if grade_range_popup %}onsubmit="return check_grade_range($j(this), {{ program.grade_min }}, {{ program.grade_max }});"{% endif %}>
 
 {% if form.errors %}
 <p align="center">

--- a/esp/templates/program/modules/teacherclassregmodule/coteachers.html
+++ b/esp/templates/program/modules/teacherclassregmodule/coteachers.html
@@ -39,7 +39,7 @@
 {% if not coteachers|length %}
 You currently have no coteachers for this class.
 {% else %}
-<form action="{{request.path}}" method="post" name="manage_coteachers">{% csrf_token %}
+<form action="{{request.path}}" method="post" name="manage_coteachers">
 <table align="center" width="400">
     <tr>
         <th colspan="2">Current Coteachers</th>
@@ -68,7 +68,7 @@ You currently have no coteachers for this class.
 </table>
 </form>
 {% endif %}
-<form action="{{request.path}}" method="post" name="addteacher">{% csrf_token %}
+<form action="{{request.path}}" method="post" name="addteacher">
 <table align="center" width="400">
     <tr>
         <th colspan="2">Add More Coteachers</th>
@@ -97,7 +97,7 @@ You currently have no coteachers for this class.
     </tr>
     <tr>
         <td align="center" colspan="2">
-            <form action="{{request.path}}" method="post" name="submit">{% csrf_token %}
+            <form action="{{request.path}}" method="post" name="submit">
             <input type="hidden" name="op" value="save" />
             <input type="hidden" name="clsid" value="{{ class.id }}" />
             <input type="hidden" name="coteachers" value="{{ txtTeachers }}" />

--- a/esp/templates/program/modules/teacherclassregmodule/listclasses.html
+++ b/esp/templates/program/modules/teacherclassregmodule/listclasses.html
@@ -68,12 +68,12 @@ If you have any questions regarding the program, <br /> please email the
       </span>
     </td>
     <td class="clsmiddle bordertop2">
-       <form method="post" action="/teach/{{program.getUrlBase}}/deleteclass/{{cls.id }}" onsubmit="return deleteClass();">{% csrf_token %}
+       <form method="post" action="/teach/{{program.getUrlBase}}/deleteclass/{{cls.id }}" onsubmit="return deleteClass();">
          <input class="button" type="submit" value="Delete" {% if cls.num_students or not module.deadline_met %}disabled {% endif %} />
        </form>
     </td>
     <td class="clsmiddle bordertop2">
-       <form method="post" action="/teach/{{program.getUrlBase}}/editclass/{{cls.id }}">{% csrf_token %}
+       <form method="post" action="/teach/{{program.getUrlBase}}/editclass/{{cls.id }}">
          <input type="hidden" name="command" value="edit_class_{{cls.id}}">
 {% if can_edit %}
          <input class="button" type="submit" value="Edit">
@@ -83,7 +83,7 @@ If you have any questions regarding the program, <br /> please email the
        </form>
     </td>
    <td class="clsmiddle bordertop2">
-      <form method="get" action="/teach/{{program.getUrlBase}}/class_status/{{cls.id}}">{% csrf_token %}
+      <form method="get" action="/teach/{{program.getUrlBase}}/class_status/{{cls.id}}">
          <input class="button" type="submit" value="View Status" />
       </form>
    </td>
@@ -118,7 +118,7 @@ If you have any questions regarding the program, <br /> please email the
     <td class="clsleft"><b>(Co-)Teachers: </b></td>
     <td class="clsmiddle" colspan="4">{% for t in cls.teachers %}{% ifnotequal t request.user %}{{ t.first_name }} {{ t.last_name }}{% if not forloop.last %}, {% endif %}{% endifnotequal %}{% endfor %}</td>
     <td class="clsright">
-       <form method="post" action="/teach/{{program.getUrlBase}}/coteachers">{% csrf_token %}
+       <form method="post" action="/teach/{{program.getUrlBase}}/coteachers">
          <input type="hidden" name="command" value="edit_class_{{cls.id}}" />
 	 <input type="hidden" name="clsid"   value="{{cls.id }}" />
          <input class="button" type="submit" value="Modify Coteachers">

--- a/esp/templates/program/modules/teacherclassregmodule/select_students.html
+++ b/esp/templates/program/modules/teacherclassregmodule/select_students.html
@@ -70,7 +70,7 @@ Student list (with school) sorted by registration status
 </ul>
 </p>
 <div id="program_form">
-<form method="POST" action="/teach/{{ prog.getUrlBase }}/select_students/{{ sec.id }}">{% csrf_token %}
+<form method="POST" action="/teach/{{ prog.getUrlBase }}/select_students/{{ sec.id }}">
 <table class="roster">
 <thead>
 <tr>

--- a/esp/templates/program/modules/teachereventsmodule/event_signup.html
+++ b/esp/templates/program/modules/teachereventsmodule/event_signup.html
@@ -19,7 +19,7 @@ Please let us know which events you will attend.
 {% load render_qsd %}
 {% render_inline_qsd prog.anchor "teach:eventsignupheader" request.user %}
 
-<form method="post" action="{{ request.path }}">{% csrf_token %}
+<form method="post" action="{{ request.path }}">
 <table cellpadding="4" cellspacing="0" align="center" width="300">
     {{ form }}
     <tr>

--- a/esp/templates/program/modules/teacherquizmodule/quiz.html
+++ b/esp/templates/program/modules/teacherquizmodule/quiz.html
@@ -19,7 +19,7 @@
 Some of your responses are incorrect!  Please consult our instructions and fill in the right answers.
 {% endif %}
 
-<form method="post" action="{{ request.path }}" class="form-stacked">{% csrf_token %}
+<form method="post" action="{{ request.path }}" class="form-stacked">
 {% include "customforms/single_form_fragment.html" %}
 <div style="text-align: center;"><input type="submit" value="Done!" /></div>
 

--- a/esp/templates/program/modules/teacherreviewapps/questions.html
+++ b/esp/templates/program/modules/teacherreviewapps/questions.html
@@ -23,7 +23,7 @@ The directors would like you to specify up to {{ clrmi.num_teacher_questions }} 
 </p>
 
 <div id="program_form">
-<form method="post" action="{{ request.path }}">{% csrf_token %}
+<form method="post" action="{{ request.path }}">
 <table align="center" width="500">
 {% for f in forms %}
     <th colspan="2">App Question for {{ f.app_question.subject }}</th>

--- a/esp/templates/program/modules/teacherreviewapps/review.html
+++ b/esp/templates/program/modules/teacherreviewapps/review.html
@@ -21,7 +21,7 @@ Please review the student's biographical information and responses to our questi
 </p>
 
 <div id="program_form">
-<form action="{{ request.path }}" method="post" name="review">{% csrf_token %}
+<form action="{{ request.path }}" method="post" name="review">
 <table class="application" class="fullwidth">
 <tr>
   <th colspan="2">Student Application for {{ student.name }}</th>

--- a/esp/templates/program/modules/volunteermanage/main.html
+++ b/esp/templates/program/modules/volunteermanage/main.html
@@ -55,7 +55,7 @@ You may request groups of volunteers for your program here.  At the <a href="/vo
 
 <br />
 
-<form method="POST" action="{{ request.path }}">{% csrf_token %}
+<form method="POST" action="{{ request.path }}">
 <center>
 <table width="400">
 <tr>

--- a/esp/templates/program/modules/volunteersignup/signup.html
+++ b/esp/templates/program/modules/volunteersignup/signup.html
@@ -29,7 +29,7 @@ Thank you, {{ complete_name }}, for volunteering! You will receive reminder emai
 {% endif %}
 
 <div id="program_form">
-<form method="POST" action="{{ request.path }}">{% csrf_token %}
+<form method="POST" action="{{ request.path }}">
 <center>
 <table width="500">
 <tr>

--- a/esp/templates/program/newprogram.html
+++ b/esp/templates/program/newprogram.html
@@ -59,7 +59,7 @@ Use a past program as a template:
 </p>
 
 <div id="alumni_form">
-  <form action="{{ request.path }}" method="post">{% csrf_token %}
+  <form action="{{ request.path }}" method="post">
   {% autoescape off %}
   {% if form.non_field_errors %}{{ form.non_field_errors }}{% endif %}
 {% for fieldset in form.fieldsets %}

--- a/esp/templates/program/newprogram_review.html
+++ b/esp/templates/program/newprogram_review.html
@@ -73,7 +73,7 @@ The program you are trying to create is: <b>{{ prog.anchor.name }} {{ datatrees.
 <div class="info"><b>Warning</b>: it is difficult to undo the changes made by this function.  If you would like to change anything, please go back and re-submit.</div>
 
 <div id="program_form">
-<form method="POST" action="{{ request.path }}?checked=1">{% csrf_token %}
+<form method="POST" action="{{ request.path }}?checked=1">
 
 <input type="submit" class="button" value="Make Program Happen">
 </form>

--- a/esp/templates/program/statistics.html
+++ b/esp/templates/program/statistics.html
@@ -48,7 +48,7 @@ The default form rendering takes care of this, but the below might be a starting
 {% endcomment %}
 
 <form dojoType="dijit.form.Form" id="statistics_form" method="POST" action="/manage/statistics/">
-{% csrf_token %}
+
 <div id="statistics_form_contents">
 {% include "program/statistics/form.html" %}
 </div>

--- a/esp/templates/program/studentreg.html
+++ b/esp/templates/program/studentreg.html
@@ -41,7 +41,7 @@
 {% endif %}
 {% endfor %}
 <br />
-<form action="/learn/{{one}}/{{two}}/finishedStudent" method="post">{% csrf_token %}
+<form action="/learn/{{one}}/{{two}}/finishedStudent" method="post">
 <p style="text-align: center">
 <input type="submit" value="Save!" {% if not completedAll %}disabled{% endif %}/><br />
 {% if not completedAll %}<em>(Please complete the above steps first!)</em>{% endif %}

--- a/esp/templates/qsd/bulk_move.html
+++ b/esp/templates/qsd/bulk_move.html
@@ -27,7 +27,7 @@ With the form below, you can reassign those components in order to move the page
 </p>
 
 <div id="program_form">
-<form method="post" action="{{ request.path }}?cmd=bulk_move">{% csrf_token %}
+<form method="post" action="{{ request.path }}?cmd=bulk_move">
 <input type="hidden" name="confirm" value="True" />
 <table align="center" cellpadding="0" cellspacing="0" width="450"> 
     <tr><th colspan="2">Options for bulk move</th></tr>

--- a/esp/templates/qsd/delete_confirm.html
+++ b/esp/templates/qsd/delete_confirm.html
@@ -36,12 +36,12 @@
 
 <tr>
     <td colspan="2" align="center">
-        <form method="post" action="{{ request.path }}?cmd=delete&id={{ qsd.id }}">{% csrf_token %}
+        <form method="post" action="{{ request.path }}?cmd=delete&id={{ qsd.id }}">
         <input type="hidden" name="sure" value="False" />
         <input class="fancybutton" type="submit" value="Return" />
         </form>
         &nbsp;&nbsp;&nbsp;&nbsp;
-        <form method="post" action="{{ request.path }}?cmd=delete&id={{ qsd.id }}">{% csrf_token %}
+        <form method="post" action="{{ request.path }}?cmd=delete&id={{ qsd.id }}">
         <input type="hidden" name="sure" value="True" />
         <input class="fancybutton" type="submit" value="Delete Page" />
         </form>

--- a/esp/templates/qsd/list.html
+++ b/esp/templates/qsd/list.html
@@ -18,7 +18,7 @@
 <div id="program_form">
 
 <center>
-<form method="post" action="{{ request.path }}?cmd=bulk_move">{% csrf_token %}
+<form method="post" action="{{ request.path }}?cmd=bulk_move">
 <table class="fullwidth" style="table-layout: fixed;">
 <tr>
     <th colspan="6">List of Pages</th>

--- a/esp/templates/qsd/move.html
+++ b/esp/templates/qsd/move.html
@@ -27,7 +27,7 @@ With the form below, you can reassign those components in order to move the page
 </p>
 
 <div id="program_form">
-<form method="post" action="{{ request.path }}?cmd=move&id={{ qsd.id }}">{% csrf_token %}
+<form method="post" action="{{ request.path }}?cmd=move&id={{ qsd.id }}">
 <table align="center" cellpadding="0" cellspacing="0" width="450"> 
     <tr><th colspan="2">Options for {{ qsd.url }}</th></tr>
     {{ form }}

--- a/esp/templates/qsd/qsd_edit.html
+++ b/esp/templates/qsd/qsd_edit.html
@@ -37,7 +37,7 @@
 
 
 {% block content %}
-<form method="post" action="{{ request.path }}" enctype="multipart/form-data">{% csrf_token %}
+<form method="post" action="{{ request.path }}" enctype="multipart/form-data">
 
 <h1>Static Page Editing</h1>
 <p>Current URL path: <tt>{{ qsdrec.url }}</tt> <br />

--- a/esp/templates/registration/emailuser.html
+++ b/esp/templates/registration/emailuser.html
@@ -26,7 +26,7 @@ Note: By creating an account, you will automatically
 be in our mailing list.
 </div>
 
-<form action="{{ request.path }}" method="post" name="emaillist_form">{% csrf_token %}
+<form action="{{ request.path }}" method="post" name="emaillist_form">
 <table>
 <thead>
 <tr>

--- a/esp/templates/registration/login.html
+++ b/esp/templates/registration/login.html
@@ -31,7 +31,7 @@ Please log in below.
 
 
 <div id="login_form">
-<form action="{{ request.action }}" method="post">{% csrf_token %}
+<form action="{{ request.action }}" method="post">
 <table cellpadding="2" align="center">
 <thead>
 <tr>

--- a/esp/templates/registration/login_by_bday.html
+++ b/esp/templates/registration/login_by_bday.html
@@ -93,7 +93,7 @@ function preparePage() {
 <p>Please go through a few steps to log in to your account. Follow the steps whether or not you already have an account in our system.</p>
 
 <div id="login_form">
-<form id="login_form_form" action="{{ action }}" method="post">{% csrf_token %}
+<form id="login_form_form" action="{{ action }}" method="post">
 <table cellpadding="2" align="center">
 <thead>
 <tr>

--- a/esp/templates/registration/login_by_bday_pickname.html
+++ b/esp/templates/registration/login_by_bday_pickname.html
@@ -24,7 +24,7 @@ After logging in below, you will return to <tt>{{ next }}</tt>.<br />
 
 
 <div id="login_form">
-<form action="{{ action }}" method="post">{% csrf_token %}
+<form action="{{ action }}" method="post">
 {% if preset_username %}
 <input type="hidden" name="username" value="{{ preset_username }}">
 {% endif %}

--- a/esp/templates/registration/login_byschool.html
+++ b/esp/templates/registration/login_byschool.html
@@ -84,7 +84,7 @@ function preparePage() {
 
 
 <div id="login_form">
-<form id="login_form_form" action="{{ action }}" method="post">{% csrf_token %}
+<form id="login_form_form" action="{{ action }}" method="post">
 <table cellpadding="2" align="center">
 <thead>
 <tr>

--- a/esp/templates/registration/login_byschool_pickname.html
+++ b/esp/templates/registration/login_byschool_pickname.html
@@ -24,7 +24,7 @@ After logging in below, you will return to <tt>{{ next }}</tt>.<br />
 
 
 <div id="login_form">
-<form action="{{ action }}" method="post">{% csrf_token %}
+<form action="{{ action }}" method="post">
 {% if preset_username %}
 <input type="hidden" name="username" value="{{ preset_username }}">
 {% endif %}

--- a/esp/templates/registration/newuser.html
+++ b/esp/templates/registration/newuser.html
@@ -25,13 +25,13 @@ click "Create account" again below.)
 <ul>
   {% for u in accounts %}
   <li>Username: "{{ u.username }}" (
-  <form method="post" action="/myesp/login">{% csrf_token %}
+  <form method="post" action="/myesp/login">
     <input type="hidden" name="username" value="{{ u.username }}" />
     <input type="hidden" name="password" value="" />
     <input type="hidden" name="next" value="/myesp/profile/" />
     <input type="submit" value="Try logging in" />
   </form>
-  <form action="/myesp/passwdrecover/" method="post">{% csrf_token %}
+  <form action="/myesp/passwdrecover/" method="post">
     <input type="hidden" name="email" value="{{ u.email }}" />
     <input type="hidden" name="username" value="{{ u.username }}" />
     <input type="submit" value="I forgot my password!" />
@@ -57,7 +57,7 @@ for programs, sign up for classes, among other things.
 
 
 <div id="program_form">
-<form action="{{ request.path }}" method="post" name="newuser_form">{% csrf_token %}
+<form action="{{ request.path }}" method="post" name="newuser_form">
 <table>
 <thead>
 <tr>

--- a/esp/templates/shortterm/school_response/form.html
+++ b/esp/templates/shortterm/school_response/form.html
@@ -11,7 +11,7 @@
 {% block content %}
 
 <p>
-<form action="" method="post" enctype="multipart/form-data">{% csrf_token %}
+<form action="" method="post" enctype="multipart/form-data">
 <table>
 {{ form }}
 <tr><th></th><td><input type="submit" value="Submit" /></td></tr>

--- a/esp/templates/shortterm/volunteer_signup/form.html
+++ b/esp/templates/shortterm/volunteer_signup/form.html
@@ -17,7 +17,7 @@
 
 <p>
 <div id="volunteer_form">
-<form action="" method="post" enctype="multipart/form-data">{% csrf_token %}
+<form action="" method="post" enctype="multipart/form-data">
 <table align="center">
 <thead>
 <tr>

--- a/esp/templates/survey/survey.html
+++ b/esp/templates/survey/survey.html
@@ -68,7 +68,7 @@
 <h1>Survey for {{ program.niceName }} </h1>
 
 <div id="program_form">
-<form method="post" action="{{ request.path }}">{% csrf_token %}
+<form method="post" action="{{ request.path }}">
 
 {% for question in questions %}{{ question.render|uselist:classes }}{% endfor %}
 

--- a/esp/templates/survey/top_classes.html
+++ b/esp/templates/survey/top_classes.html
@@ -83,7 +83,7 @@
 
 <div id="filterform">
 <h2>Filter results</h2>
-<form action="" method="get">{% csrf_token %}
+<form action="" method="get">
     <div><input type="text" size="3" name="rating_cut" id="rating_cut" value="{{ rating_cut }}" /><label for="rating_cut"> Minimum rating</label></div>
     <div><input type="text" size="3" name="num_cut" id="num_cut" value="{{ num_cut }}" /><label for="num_cut"> Minimum number of ratings</label></div>
     <div><input type="submit" value="Filter" /></div>
@@ -92,7 +92,7 @@
 
 <div id="catsform">
 <h2>Show categories</h2>
-<form action="#" method="get">{% csrf_token %}
+<form action="#" method="get">
     {% for cat in categories %}
         <div><input type="checkbox" name="cat_{{ cat.symbol }}" id="cat_{{ cat.symbol }}" checked="checked" onchange="togglecat(&quot;{{ cat.symbol }}&quot;, this.checked)" /><label for="cat_{{ cat.symbol }}">{{ cat }}</label></div>
     {% endfor %}

--- a/esp/templates/users/create_list.html
+++ b/esp/templates/users/create_list.html
@@ -110,7 +110,7 @@ function checkForNobody() {
 Please generate a list of users from the options below.
 
 
-<form action="{{request.path}}?{{ request.GET.urlencode }}" onsubmit="return checkForNobody();" method="post" name="comm">{% csrf_token %}
+<form action="{{request.path}}?{{ request.GET.urlencode }}" onsubmit="return checkForNobody();" method="post" name="comm">
 <p>
 <em>(If you feel there's a list omitted from this list or this interface is too hard to use, please email <tt>{{ DEFAULT_EMAIL_ADDRESSES.support }}</tt> with questions!)</em>
 <br />

--- a/esp/templates/users/emailrecover.html
+++ b/esp/templates/users/emailrecover.html
@@ -22,7 +22,7 @@ password you would like to use.
 
 <br />
 
-<form action="{{request.path}}" name="recoverpwform" method="post">{% csrf_token %}
+<form action="{{request.path}}" name="recoverpwform" method="post">
 <input type="hidden" name="code" value="{{code}}" />
 <table width='65%' cellpadding='2' align='center' border='0'>
 <tr>

--- a/esp/templates/users/login_initial.html
+++ b/esp/templates/users/login_initial.html
@@ -17,7 +17,7 @@
 </p>
 <hr/>
 
-<form action='login.html' method="post">{% csrf_token %}
+<form action='login.html' method="post">
 <input type='hidden' name='op' value='register'>
 <table width='65%' cellpadding='2' align='center' border='0'>
 

--- a/esp/templates/users/make_admin.html
+++ b/esp/templates/users/make_admin.html
@@ -17,7 +17,7 @@
 
 
 <form action="{{ request.path }}" method="post">
-{% csrf_token %}
+
 <div id="program_form">
     Please select the account to make an admin:
     <table width="550">

--- a/esp/templates/users/merge_accounts.html
+++ b/esp/templates/users/merge_accounts.html
@@ -17,7 +17,7 @@
 
 
 <form action="{{ request.path }}" method="post">
-{% csrf_token %}
+
 <div id="program_form">
   Please select two accounts to merge:
   <table width="550">

--- a/esp/templates/users/newuser.html
+++ b/esp/templates/users/newuser.html
@@ -28,7 +28,7 @@
 {% if form.has_errors %}
 <p class="error">Hey - There was a problem with your registration.  Please try again, errors displayed below.</p>
 {% endif %}
-<form action='/myesp/finish/' method="post">{% csrf_token %}
+<form action='/myesp/finish/' method="post">
 <input type='hidden' name='op' value='register'>
 <table width='65%' cellpadding='2' align='center' border='0'>
 

--- a/esp/templates/users/passwd.html
+++ b/esp/templates/users/passwd.html
@@ -22,7 +22,7 @@ Your password has been successfully changed. Please try not to forget it!
 
 <br />
 
-<form action="{{request.path}}" name="changepwform" method="post">{% csrf_token %}
+<form action="{{request.path}}" name="changepwform" method="post">
 <input type='hidden' name='op' value='register'>
 <table width='65%' cellpadding='2' align='center' border='0'>
 <tr>

--- a/esp/templates/users/profile.html
+++ b/esp/templates/users/profile.html
@@ -42,7 +42,7 @@ label.groupheader { font-size: 1.2em; font-weight: bold; }
 {% endif %}
 
 <div id="program_form">
-<form action="{{request.path}}" method="post">{% csrf_token %}
+<form action="{{request.path}}" method="post">
 <input type="hidden" name="profile_page" value="true" />
 <input type="hidden" name="current_role" value="{{ profiletype }}" />
 <table cellpadding="3" align="center" border="0" width="500">

--- a/esp/templates/users/recovery_email.html
+++ b/esp/templates/users/recovery_email.html
@@ -20,7 +20,7 @@
   Just enter in the username you started to reset your password with, and enter in the password you want to have.
 </p>
 
-<form action="{{ request.path }}" method="post" name="passreset_form_complete">{% csrf_token %}
+<form action="{{ request.path }}" method="post" name="passreset_form_complete">
 <table>
 <thead>
 <tr>

--- a/esp/templates/users/recovery_request.html
+++ b/esp/templates/users/recovery_request.html
@@ -21,7 +21,7 @@ to reset your password. You will need to have access to the email address
 you entered when you signed up.
 </p>
 
-<form action="{{ request.path }}" method="post" name="passreset_form">{% csrf_token %}
+<form action="{{ request.path }}" method="post" name="passreset_form">
 <table>
 <thead>
 <tr>

--- a/esp/templates/users/select_mailman_list.html
+++ b/esp/templates/users/select_mailman_list.html
@@ -28,7 +28,7 @@
 <!-- Future Webmins, in case you're wondering why not to use the Advanced Comm Panel to send e-mail:  First, that whole codepath has lots of issues that can cause it to produce a slightly different set of users than you're expecting, particularly for more-complex combination queries.  It turns out that relational logic is complicated and subtle...  Second, there's not only no Unsubscribe mechanism for Advanced Comm Panel e-mails; there's no reasonable way of making one. -->
 
 
-<form action="{{request.path}}" method="post" name="comm">{% csrf_token %}
+<form action="{{request.path}}" method="post" name="comm">
 
 <p>Click on a list to select it.  Ctrl-click to select multiple lists; your e-mail will be sent once to each user whose e-mail address is on any of the lists.</p>
 

--- a/esp/templates/users/studentprofile.html
+++ b/esp/templates/users/studentprofile.html
@@ -17,7 +17,7 @@
 <h2 style="color:red">Please make sure to fill in all the required fields.  Thanks! </h2>
 {% endif %}
 
-<form action='/learn/{{one}}/{{two}}/profile/' method="post">{% csrf_token %}
+<form action='/learn/{{one}}/{{two}}/profile/' method="post">
 <table cellpadding='2' align='center' border='0'>
 <tr>
  <td><label for="id_full_name">Name: *</label></td>

--- a/esp/templates/users/studentreg.html
+++ b/esp/templates/users/studentreg.html
@@ -55,7 +55,7 @@ border = 1
 
 {% include "users/student_schedule.html" %}
 
-<form action="/learn/{{one}}/{{two}}/finishedStudent" method="post">{% csrf_token %}
+<form action="/learn/{{one}}/{{two}}/finishedStudent" method="post">
 <p style="text-align: center">
 <input type="submit" value="Save!" {% if not status.classes_done or not status.profile_done %}disabled{% endif %}/><br />
 {% if not status.classes_done or not status.profile_done %}<em>(Please complete the above steps first!)</em>{% endif %}

--- a/esp/templates/users/teacherbioedit.html
+++ b/esp/templates/users/teacherbioedit.html
@@ -35,7 +35,7 @@ Please complete the form below to update your biography.  We'd appreciate a pict
 {% endif %}
 
 <div id="program_form">
-<form enctype="multipart/form-data" action="{{request.path}}" method="post">{% csrf_token %}
+<form enctype="multipart/form-data" action="{{request.path}}" method="post">
 <table cellpadding="2" align="center" border="0">
 
 <tr><th colspan="2">Your Teacher Biography</th></tr>

--- a/esp/templates/users/userchecklist.html
+++ b/esp/templates/users/userchecklist.html
@@ -22,7 +22,7 @@
 Please check off the users you'd like to be included in your list:
 </p>
 
-<form action="{{ request.path }}" method="post" name="checklist">{% csrf_token %}
+<form action="{{ request.path }}" method="post" name="checklist">
 
 <table>
 {% for user in users %}

--- a/esp/templates/users/usersearch.html
+++ b/esp/templates/users/usersearch.html
@@ -28,7 +28,7 @@ Please search for a user: <br />
 {% endif %}
 
 <div id="program_form">
-<form action="{{ request.path }}" method="get">{% csrf_token %}
+<form action="{{ request.path }}" method="get">
 <table cellpadding="0" cellspacing="0" width="450" align="center">
 
 <tr><th align="center" colspan="2">User Search Options</th></tr>

--- a/esp/templates/users/userview.html
+++ b/esp/templates/users/userview.html
@@ -47,7 +47,7 @@
 <tr><td class="key">Graduation Year</td><td>{{ profile.student_info.graduation_year }} ({{ user.getGrade }}th Grade)</td></tr>
 <tr><td colspan="2">Is this student's grade incorrect?<br />
 Change grade to: 
-<form action="/manage/userview/" method="get" name="change_grade">{% csrf_token %}
+<form action="/manage/userview/" method="get" name="change_grade">
 {{ change_grade_form.graduation_year }}<br />
 <input type="hidden" name="username" value="{{ user.username }}" />
 <input type="submit" value="Change grade" />


### PR DESCRIPTION
The csrf_token tags do not work anymore with the AutoRequestContext changed to just Context. They give the following warning: `/usr/local/lib/python2.7/dist-packages/Django-1.3.1-py2.7.egg/django/template/defaulttags.py:101: UserWarning: A {% csrf_token %} was used in a template, but the context did not provide the value.  This is usually caused by not using RequestContext.
  warnings.warn("A {% csrf_token %} was used in a template, but the context did not provide the value.  This is usually caused by not using RequestContext.")`. My current csrf system does not actually require csrf_token tags at all (as long as csrf_init.js is included in the page, which it should be for all relevant pages). As such I took out all the csrf_token tags. As far as I can tell, this has broken nothing.

I made this a pull request because it's a significant change, and I want someone to sanity check this before pulling it in.
