### PR TITLE
mainview bugfix for stable jan12

### DIFF
--- a/esp/esp/program/modules/base.py
+++ b/esp/esp/program/modules/base.py
@@ -161,7 +161,7 @@ class ProgramModuleObj(models.Model):
         modules = self.program.getModules(get_current_request().user, tl)
         for module in modules:
             if isinstance(module, CoreModule):
-                 return '/'+tl+'/'+self.program.getUrlBase()+'/'+module.main_view
+                 return '/'+tl+'/'+self.program.getUrlBase()+'/'+module.get_main_view(tl)
 
     def goToCore(self, tl):
         return HttpResponseRedirect(self.getCoreURL(tl))


### PR DESCRIPTION
Fixes required module bugs caused by combination of 2+ main_calls and ProgramModule.main_view.

Commit b2d21277f8 fixes a bug that was causing the wrong module to be loaded when one of two ProgramModuleObjs for the same ProgramModule was made required. I believe that this bugfix should be merged into the stable code.

Commit 22529b0f17 isn't a bugfix, but makes a change that could prevent bugs in the future. Also, please note the following from that commit message: 

> I'm not entirely sure that this change is necessary, since we shouldn't
> ever have a CoreModule that has two distinct main_calls. However, it
> shouldn't hurt to make this change. Unless we rely on the caching that
> module.main_view provides.

If it is deemed that this change is bad, or not worth merging into the stable code, I can revert it.
