### PR TITLE
Make the admin list pages more usable

### DIFF
--- a/esp/esp/accounting_core/admin.py
+++ b/esp/esp/accounting_core/admin.py
@@ -42,9 +42,14 @@ class LITAdmin(admin.ModelAdmin):
 admin_site.register(LineItemType, LITAdmin)
 
 class TXNAdmin(admin.ModelAdmin):
-    pass
+    list_display = ['id', 'timestamp', 'text', 'complete', ]
+    list_display_links = list_display
 admin_site.register(Transaction, TXNAdmin)
 
+def transaction_id(lineitem):
+    return lineitem.transaction_id
+transaction_id.admin_order_field = 'transaction__id'
+
 class LIAdmin(admin.ModelAdmin):
-    pass
+    list_display = ['id', transaction_id, 'amount', 'anchor', 'user', 'text', ]
 admin_site.register(LineItem, LIAdmin)

--- a/esp/esp/program/admin.py
+++ b/esp/esp/program/admin.py
@@ -95,7 +95,19 @@ class TeacherBioAdmin(admin.ModelAdmin):
 admin_site.register(TeacherBio, TeacherBioAdmin)
     
 admin_site.register(FinancialAidRequest)
-admin_site.register(SplashInfo)
+
+class Admin_SplashInfo(admin.ModelAdmin):
+    list_display = (
+        'student',
+        'program',
+    )
+    search_fields = [
+        'student__username',
+        'student__last_name',
+        'student__email',
+    ]
+    list_filter = [ 'program', ]
+admin_site.register(SplashInfo, Admin_SplashInfo)
 
 ## Schedule stuff (wish it was schedule_.py)
 
@@ -114,7 +126,13 @@ class BooleanExpressionAdmin(admin.ModelAdmin):
         return len(obj.get_stack())
 admin_site.register(BooleanExpression, BooleanExpressionAdmin)   
 
-admin_site.register(ScheduleConstraint)
+class Admin_ScheduleConstraint(admin.ModelAdmin):
+    list_display = (
+        'program',
+        'condition',
+        'requirement',
+    )
+admin_site.register(ScheduleConstraint, Admin_ScheduleConstraint)
 
 class ScheduleTestOccupiedAdmin(admin.ModelAdmin):
     list_display = ('timeblock', 'expr', 'seq', subclass_instance_type, 'text')
@@ -137,7 +155,9 @@ class ProgramCheckItemAdmin(admin.ModelAdmin):
     list_display = ('id', 'title', 'program')
 admin_site.register(ProgramCheckItem, ProgramCheckItemAdmin)
 
-admin_site.register(RegistrationType)
+class Admin_RegistrationType(admin.ModelAdmin):
+    list_display = ('name', 'category', )
+admin_site.register(RegistrationType, Admin_RegistrationType)
 
 def expire_student_registrations(modeladmin, request, queryset):
     for reg in queryset:
@@ -165,12 +185,43 @@ class SubjectAdmin(admin.ModelAdmin):
     search_fields = ['class_info', 'anchor__friendly_name']
 admin_site.register(ClassSubject, SubjectAdmin)
 
-admin_site.register(ClassCategories)
-admin_site.register(ClassSizeRange)
+class Admin_ClassCategories(admin.ModelAdmin):
+     list_display = ('category', 'symbol', 'seq', )
+admin_site.register(ClassCategories, Admin_ClassCategories)
+
+class Admin_ClassSizeRange(admin.ModelAdmin):
+     list_display = ('program', 'range_min', 'range_max', )
+admin_site.register(ClassSizeRange, Admin_ClassSizeRange)
 
 ## app_.py
 
 admin_site.register(StudentApplication)
-admin_site.register(StudentAppQuestion)
-admin_site.register(StudentAppResponse)
-admin_site.register(StudentAppReview)
+
+class Admin_StudentAppQuestion(admin.ModelAdmin):
+    list_display = (
+        'program',
+        'subject',
+        'question',
+    )
+    list_display_links = ('program', 'subject', )
+    list_filter = ('subject__parent_program', 'program', )
+admin_site.register(StudentAppQuestion, Admin_StudentAppQuestion)
+
+class Admin_StudentAppResponse(admin.ModelAdmin):
+    list_display = (
+        'question',
+        'response',
+        'complete',
+    )
+    list_display_links = list_display
+    list_filter = ('question__subject__parent_program', 'question__program', )
+admin_site.register(StudentAppResponse, Admin_StudentAppResponse)
+
+class Admin_StudentAppReview(admin.ModelAdmin):
+    list_display = (
+        'reviewer',
+        'date',
+        'score',
+        'comments',
+    )
+admin_site.register(StudentAppReview, Admin_StudentAppReview)

--- a/esp/esp/program/modules/admin.py
+++ b/esp/esp/program/modules/admin.py
@@ -39,7 +39,12 @@ from esp.program.modules.module_ext import DBReceipt, StudentClassRegModuleInfo,
 from esp.program.modules.module_ext import RemoteProfile
 from esp.program.modules.base import ProgramModuleObj
 
-admin_site.register(DBReceipt)
+class Admin_DBReceipt(admin.ModelAdmin):
+    list_display = (
+        'action',
+        'program',
+    )
+admin_site.register(DBReceipt, Admin_DBReceipt)
 
 admin_site.register(SATPrepAdminModuleInfo)
 
@@ -53,7 +58,13 @@ class CRMIAdmin(admin.ModelAdmin):
 admin_site.register(ClassRegModuleInfo, CRMIAdmin)
 
 class ProgramModelObjAdmin(admin.ModelAdmin):
-    list_display = ('program', 'module')
+    list_display = (
+        'program',
+        'module',
+        'seq',
+        'required',
+        'required_label',
+    )
     list_filter = ('program', 'module')
     search_fields = ('program__anchor__friendly_name', 'program__anchor__parent__friendly_name', 'module__admin_title', 'module__link_title')
 admin_site.register(ProgramModuleObj, ProgramModelObjAdmin)


### PR DESCRIPTION
Mostly by aggressively using list_display to display more data
more readably on the listing pages, but also make some other minor
tweaks to the listing pages.

(Ironically, one of the few things I _didn't_ touch was issue #76...)
