### PR TITLE
AJAX Scheduling: Fix grid scrolling.

### DIFF
--- a/esp/public/media/default_styles/scheduling.css
+++ b/esp/public/media/default_styles/scheduling.css
@@ -80,14 +80,13 @@ background: #eee;
       }
 
 .matrix-body {
-display: block;
-overflow-y: scroll;
+display: block; overflow: hidden;
 position: absolute; top: 50px; left: 0px; right: 0px; bottom: 0px;
 border-top: 2px solid #000;
 }
 .matrix-row-header-box {
 display: block;
-position: absolute; left: 0; width: 123px; top: 0;
+position: absolute; left: 0; width: 123px; top: 0; bottom: 0;
 border-right: 2px solid #000; background: #eee;
 }
       .matrix-row-header-box td {
@@ -96,7 +95,7 @@ border-right: 2px solid #000; background: #eee;
       }
 
 .matrix-cell-body {
-display: block;
+display: block; overflow: auto;
 position: absolute; left: 125px; right: 0; top: 0; bottom: 0;
 }
 

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Matrix.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Matrix.js
@@ -74,8 +74,8 @@ ESP.declare('ESP.Scheduling.Widgets.Matrix', Class.create({
         
         // set up scrolling
         cell_body.scroll(function(evt){
-            row_header.css('top','-'+cell_body.attr('scrollTop')+'px');
-            col_header.children('tbody').css('left','-'+cell_body.attr('scrollLeft')+'px');
+            row_header.css('top','-'+cell_body.scrollTop()+'px');
+            col_header.children('tbody').css('left','-'+cell_body.scrollLeft()+'px');
         });
         
         var BlockStatus = ESP.Scheduling.Resources.BlockStatus;


### PR DESCRIPTION
In jQuery 1.6, .attr() [1] got split [2] into .attr() and .prop()---the
former reserved for element attributes as set in the HTML, and the
latter for things like scrollLeft and scrollTop.

Conveniently, jQuery provides .scrollLeft() [3] and .scrollTop() [4] as
methods of DOM elements. So now we use those.

This also reverts commit 0e7e82c58f2622a0975c571229c43d96b718bb74
("Tweak Ajax scheduling stylesheet for scrolling lock").

[1] http://api.jquery.com/attr/
[2] http://blog.jquery.com/2011/05/03/jquery-16-released/
[3] http://api.jquery.com/scrollLeft/
[4] http://api.jquery.com/scrollTop/
