### PR TITLE
fixed issue of customizing the themes without editing main.py

### DIFF
--- a/esp/esp/web/templatetags/main.py
+++ b/esp/esp/web/templatetags/main.py
@@ -66,8 +66,8 @@ theme = {
 def get_colors(json_str):
     try:
         json_arr=json.loads(json_str)
-        for i in theme.keys():
-            theme[i]=str(json_arr.get(i,False))
+        for i in json_arr.keys():
+            theme[i]=str(json_arr[i])
     except:
         pass
     


### PR DESCRIPTION
 providing a `{{'{"":"color1","Splash":"color2","Spark":"color3"}'|get_colors}}` in the template override file would  let you edit the template colors within the template override .

The Module simplejson has been used . Do notify me if there are any compatibility issues
