### PR TITLE
Add total number of lunch classes to dashboard. fixes: #295

### DIFF
--- a/esp/templates/program/modules/adminvitals/vitals.html
+++ b/esp/templates/program/modules/adminvitals/vitals.html
@@ -40,6 +40,14 @@
   <td>{{ vitals.classsections.count }}</td>
 </tr>
 <tr>
+  <th class="smaller">Total # of Lunch Classes</th>
+{% for cat in categories %}
+{% if cat.category == "Lunch" %}
+  <td>{{ cat.num_subjects }}</td>
+{% endif %}
+{% endfor %}
+</tr>
+<tr>
   <th class="smaller">Total # of Classes <span style="color: #00C;">Unreviewed</span></th>
   <td>{{ vitals.classunreviewed.count }}</td>
 </tr>


### PR DESCRIPTION
In the dashboard, lunch classes shown separately now.
