### PR TITLE
Add coteachers to program mailing lists when they are added to a class (#24)

### DIFF
--- a/esp/esp/program/modules/handlers/adminclass.py
+++ b/esp/esp/program/modules/handlers/adminclass.py
@@ -562,10 +562,11 @@ class AdminClass(ProgramModuleObj):
                     cls.removeAdmin(teacher)
 
                 # add bits for all new (and old) coteachers
+                ccc = ClassCreationController(self.program)
                 for teacher in coteachers:
-                    cls.makeTeacher(teacher)
-                    cls.makeAdmin(teacher)                    
-                ClassCreationController(self.program).send_class_mail_to_directors(cls)
+                    ccc.associate_teacher_with_class(cls, teacher)
+                cls.update_cache()
+                ccc.send_class_mail_to_directors(cls)
                 return self.goToCore(tl)
 
 

--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -480,13 +480,11 @@ class TeacherClassRegModule(ProgramModuleObj, module_ext.ClassRegModuleInfo):
                     cls.removeAdmin(teacher)
 
                 # add bits for all new coteachers
+                ccc = ClassCreationController(self.program)
                 for teacher in to_be_added:
-                    self.program.teacherSubscribe(teacher)
-                    cls.makeTeacher(teacher)
-                    cls.subscribe(teacher)
-                    cls.makeAdmin(teacher, self.teacher_class_noedit)                    
+                    ccc.associate_teacher_with_class(cls, teacher)
                 cls.update_cache()
-                ClassCreationController(self.program).send_class_mail_to_directors(cls)
+                ccc.send_class_mail_to_directors(cls)
                 return self.goToCore(tl)
 
 


### PR DESCRIPTION
Currently, coteachers are not added to program mailing lists from either AdminClass.coteachers() or TeacherClassRegModule.coteachers().  This replaces the code for adding coteachers with ClassCreationController.associate_teacher_with_class(), which adds the teacher to the program mailing list (in addition to the appropriate UserBits).

(#24)
