### PR TITLE
Fixes the dashboard manage class listing

### DIFF
--- a/esp/templates/program/modules/adminclass/listclasses.html
+++ b/esp/templates/program/modules/adminclass/listclasses.html
@@ -294,7 +294,7 @@ and <tt>M100-class@{{ EMAIL_HOST }}</tt> will email everyone in the class.
 <tbody>
   {% for cls in classes %}
   <tr id="{{cls.id}}-row">
-   {% render_class_teacher_list_row cls %}
+   {% render_class_manage_row cls %}
    </tr>
    {% endfor %}
 </tbody>


### PR DESCRIPTION
Fix for the dashboard manage class rows. Currently they're using the teacher_list rows instead, which is not the correct behavior. This should probably get merged in ASAP, so that it can be correct when chapters do testing.
