### PR TITLE
Extra slash after the host URL in Application Questions page

### DIFF
--- a/esp/templates/program/modules/teacherreviewapps/questions.html
+++ b/esp/templates/program/modules/teacherreviewapps/questions.html
@@ -19,7 +19,7 @@
 The directors would like you to specify up to {{ clrmi.num_teacher_questions }} question[s] per subject for your students to answer on their applications to {{ prog.niceName }}.  You will read the students' responses to these questions when scoring their applications.  Please enter the questions below and click "Submit Questions" when finished.
 </p>
 <p><b>
-<a href="http://{{ request.META.HTTP_HOST }}/{{prog.get_teach_url}}teacherreg">If you do not want to fill out application questions, click here to return to the main teacher reg page.</a></b>
+<a href="{{prog.get_teach_url}}teacherreg">If you do not want to fill out application questions, click here to return to the main teacher reg page.</a></b>
 </p>
 
 <div id="program_form">


### PR DESCRIPTION
For teach/Splash/2012/app_questions, the link, which redirects teachers if they do not wish to fill in application questions, is hardcoded with the full URL path. This causes an additional slash after the host URL. This fix will use relative path instead.
