### PR TITLE
Added a link to morph into this user on the userview page

### DIFF
--- a/esp/esp/users/urls.py
+++ b/esp/esp/users/urls.py
@@ -26,6 +26,7 @@ urlpatterns = patterns('esp.users.views',
                        (r'^emailpref/?$', 'emailpref'),
                        (r'^emailpref/(success)?/?$', 'emailpref'),
                        (r'^makeadmin/?$', 'make_admin'),
+                       (r'^morph/?$', 'morph_into_user'),
                        )
 
 urlpatterns += patterns('esp.web.views.main',

--- a/esp/esp/users/views/__init__.py
+++ b/esp/esp/users/views/__init__.py
@@ -5,6 +5,8 @@ from esp.users.views.emailpref import *
 from esp.users.views.make_admin import *
 from esp.users.models import ESPUser
 
+from esp.program.modules.base import needs_admin
+
 from django.http import HttpResponseRedirect, HttpResponse
 from django.template import RequestContext
 from esp.web.util.main import render_to_response
@@ -165,3 +167,13 @@ def disable_account(request):
     context = {'user': curUser}
         
     return render_to_response('users/disable_account.html', request, request.get_node('Q/Web/myesp'), context)
+
+def morph_into_user(request):
+    morph_user = ESPUser.objects.get(id=request.GET[u'morph_user'])
+    request.user.switch_to_user(request,
+                                morph_user,
+                                '/manage/userview?username=' + morph_user.username,
+                                'User Search for '+morph_user.name(),
+                                False)
+
+    return HttpResponseRedirect('/')

--- a/esp/templates/users/userview.html
+++ b/esp/templates/users/userview.html
@@ -86,6 +86,8 @@ Change grade to:
 
 </div>
 
+<a href="/myesp/morph?morph_user={{profile.user.id}}">Morph into this user</a>
+
 <p><emph>Last Updated on {{ profile.last_ts|date }}</emph></p>
 
 <table>


### PR DESCRIPTION
Testing done:
I tested that this works for morphing into both students and teachers, but that you do get an error if you try to morph into an admin.  The link shows up in a reasonable place at the top of the user profile.  The unmorph button also works.

This pull request is the product of an ESP website hackathon, where MIT ESP bought me one veggie burger to eat while I did this.
