### PR TITLE
Removes deadline reached message for lottery registration.

### DIFF
--- a/esp/esp/program/modules/handlers/studentclassregmodule.py
+++ b/esp/esp/program/modules/handlers/studentclassregmodule.py
@@ -196,7 +196,8 @@ class StudentClassRegModule(ProgramModuleObj, module_ext.StudentClassRegModuleIn
         if extension is not None:
             return super(StudentClassRegModule, self).deadline_met(extension)
         else:
-            return super(StudentClassRegModule, self).deadline_met('/Classes/OneClass')
+            return super(StudentClassRegModule, self).deadline_met('/Classes/OneClass') or \
+                   super(StudentClassRegModule, self).deadline_met('/Classes/Lottery')
 
     def prepare(self, context={}):
         from esp.program.controllers.studentclassregmodule import RegistrationTypeController as RTC


### PR DESCRIPTION
See #429: box "Student registration is no longer open" would show
up for lottery registration despite it being open.

Added extra check for deadline bit /Classes/Lottery in deadline_met function.
