### PR TITLE
Fix whitespace being added when editing QSD inline

### DIFF
--- a/esp/templates/inclusion/qsd/render_qsd.html
+++ b/esp/templates/inclusion/qsd/render_qsd.html
@@ -7,9 +7,7 @@
 <div class="qsd_bits qsd_bits_hidden">
 	<div class="qsd_header qsd_bits qsd_bits_hidden" onclick="qsd_inline_edit({{ qsdrec.id }});">This is quasi-static content.  Click here to edit the text; click outside the box to save changes.</div>
 	<div class="qsd_edit_hidden qsd_bits qsd_bits_hidden" id="inline_edit_{{ qsdrec.id }}">
-		<textarea rows="8" cols="80" id="qsd_content_{{ qsdrec.id }}" onblur="qsd_inline_upload({{ qsdrec.id }});" name="qsd_content" class="qsd_editor qsd_fullsize qsd_bits qsd_bits_hidden">
-		    {% autoescape off %}{{ qsdrec.content }}{% endautoescape %}
-		</textarea>
+		<textarea rows="8" cols="80" id="qsd_content_{{ qsdrec.id }}" onblur="qsd_inline_upload({{ qsdrec.id }});" name="qsd_content" class="qsd_editor qsd_fullsize qsd_bits qsd_bits_hidden">{% autoescape off %}{{ qsdrec.content }}{% endautoescape %}</textarea>
 	</div>
 </div>
 

--- a/esp/templates/inclusion/qsd/render_qsd_inline.html
+++ b/esp/templates/inclusion/qsd/render_qsd_inline.html
@@ -8,9 +8,7 @@
     <div class="qsd_bits qsd_bits_hidden">
         <div class="qsd_header qsd_bits qsd_bits_hidden" onclick="qsd_inline_edit({{ qsdrec.id }});">This is quasi-static content.  Click here to edit the text; click outside the box to save changes.</div>
         <div class="qsd_edit_hidden qsd_bits qsd_bits_hidden" id="inline_edit_{{ qsdrec.id }}">
-		    <textarea rows="8" cols="80" id="qsd_content_{{ qsdrec.id }}" onblur="qsd_inline_upload({{ qsdrec.id }});" name="qsd_content" class="qsd_editor qsd_bits qsd_bits_hidden">
-		        {% autoescape off %}{{ qsdrec.content }}{% endautoescape %}
-		    </textarea>
+		    <textarea rows="8" cols="80" id="qsd_content_{{ qsdrec.id }}" onblur="qsd_inline_upload({{ qsdrec.id }});" name="qsd_content" class="qsd_editor qsd_bits qsd_bits_hidden">{% autoescape off %}{{ qsdrec.content }}{% endautoescape %}</textarea>
         </div>
     </div>
     <div class="qsd_view_visible prettify" id="inline_qsd_{{ qsdrec.id }}">


### PR DESCRIPTION
The template for the inline QSD editor had a bunch of whitespace inside the `<textarea>` tag before and after the actual QSD content, which ended up being rendered verbatim and then saved into the database (only to be inserted yet again by the template the next time).

I removed the whitespace in the template and it appears to fix the issue.
