### PR TITLE
Manage class now only works if class is in same program.

### DIFF
--- a/esp/esp/program/modules/base.py
+++ b/esp/esp/program/modules/base.py
@@ -276,7 +276,7 @@ class ProgramModuleObj(models.Model):
         except:
             return (False, True)
         
-        classes = ClassSubject.objects.filter(id = clsid)
+        classes = ClassSubject.objects.filter(id = clsid, parent_program = self.program)
             
         if len(classes) == 1:
             if not get_current_request().user.canEdit(classes[0]):


### PR DESCRIPTION
So you can't load a class from a previous or future program within the context of a certain program. Also, there seems to be a problem with cannotfindclass.html template not existing, but this is a separate issue.

This is a fix for issue #360.
