### PR TITLE
Fixes MiniblogNode.render()

### DIFF
--- a/esp/esp/miniblog/templatetags/preview.py
+++ b/esp/esp/miniblog/templatetags/preview.py
@@ -30,12 +30,7 @@ class MiniblogNode(template.Node):
         try:
             user_obj = template.resolve_variable(self.user, context)
         except template.VariableDoesNotExist:
-            if self.user == "AnonymousUser":
-                user_obj = AnonymousUser()
-            else:
-                raise template.VariableDoesNotExist, "Argument to miniblog_for_user, %s, did not exist" % self.user
-        if not isinstance(user_obj, (User, AnonymousUser)):
-            raise template.TemplateSyntaxError("Requires a user object, recieved '%s'" % user_obj)
+            user_obj = None
 
         context[self.var_name] = get_visible_announcements(user_obj, self.limit, self.tl)
         return ''


### PR DESCRIPTION
I found this as a local, uncommitted change on Chicago's server.
Without it, I could not run a dev server with a Chicago database dump
without running into errors. I don't have a good understanding of what
this does though, so someone should verify that this change is correct.
