### PR TITLE
Updates lottery to use Django 1.4 bulk_create

### DIFF
--- a/esp/esp/program/controllers/lottery.py
+++ b/esp/esp/program/controllers/lottery.py
@@ -174,7 +174,7 @@ class LotteryAssignmentController(object):
         
         #   Populate student grades; grade will be assumed to be 0 if not entered on profile
         self.student_grades = numpy.zeros((self.num_students,))
-        gradyear_pairs = numpy.array(RegistrationProfile.objects.filter(user__id__in=list(self.student_ids), most_recent_profile=True).values_list('user__id', 'student_info__graduation_year'), dtype=numpy.uint32)
+        gradyear_pairs = numpy.array(RegistrationProfile.objects.filter(user__id__in=list(self.student_ids), most_recent_profile=True, student_info__graduation_year__isnull=False).values_list('user__id', 'student_info__graduation_year'), dtype=numpy.uint32)
         self.student_grades[self.student_indices[gradyear_pairs[:, 0]]] = 12 + ESPUser.current_schoolyear() - gradyear_pairs[:, 1]
         
         #   Find section capacities (TODO: convert to single query)


### PR DESCRIPTION
This code change should produce significant speed boosts in the lottery
assignment controller.

Is untested, but should work correctly, as the given bulk_create
statement is syntactically equivalent to the original code (assuming I
wrote it correctly).

Resolves Github Issue #563.
