### PR TITLE
Added duration, grade range to the Status on the program dashboard.

### DIFF
--- a/esp/esp/program/modules/handlers/jsondatamodule.py
+++ b/esp/esp/program/modules/handlers/jsondatamodule.py
@@ -328,6 +328,8 @@ _name': t.last_name, 'availability': avail_for_user[t.id], 'sections': [x.id for
             'prereqs': cls.prereqs, 
             'sections': [x.id for x in cls.sections.all()],
             'class_size_max': cls.class_size_max,
+            'duration': cls.prettyDuration(),
+            'grade_range': str(cls.grade_min) + "th to " + str(cls.grade_max) + "th grades" ,
         }
 
         return {return_key: [return_dict]}

--- a/esp/public/media/scripts/program/modules/adminclass.js
+++ b/esp/public/media/scripts/program/modules/adminclass.js
@@ -85,6 +85,8 @@ function fill_class_popup(clsid, classes_data) {
     .append("<p><b>Status:</b> " + status_string + "</p>")
     .append("<p><b>Sections:</b> " + class_info.sections.length + "</p>")
     .append("<p><b>Max Size:</b> " + class_info.class_size_max + "</p>")
+    .append("<p><b>Duration:</b> " + class_info.duration + "</p>")
+    .append("<p><b>Grade Range:</b> " + class_info.grade_range + "</p>")
     .append("<p><b>Category:</b> " + class_info.category + "</p>")
     //.append("<p>Difficulty: " + class_info.difficulty + "</p>")
     .append("<p><b>Prereqs:</b> " + class_info.prereqs + "</p>")


### PR DESCRIPTION
"(no ticket) On program dashboard, one can click "status" to read a class's description and approve it quickly. It would be great if this displayed some other information—grade range, class length, class size, number of sections."

Class size, number of sections already seem to exist on the status page.
