### PR TITLE
Fixes some settings imports

### DIFF
--- a/esp/esp/dbmail/migrations/0002_defaultlists.py
+++ b/esp/esp/dbmail/migrations/0002_defaultlists.py
@@ -5,7 +5,7 @@ from south.v2 import SchemaMigration
 from django.db import models
 
 from esp.dbmail.models import EmailList
-from esp import settings
+from django.conf import settings
 
 class Migration(SchemaMigration):
 

--- a/esp/esp/dbmail/receivers/classlist.py
+++ b/esp/esp/dbmail/receivers/classlist.py
@@ -45,6 +45,8 @@ class ClassList(BaseHandler):
 
 
     def process_mailman(self, user, class_id, user_type):
+        if not (settings.USE_MAILMAN and 'mailman_moderator' in settings.DEFAULT_EMAIL_ADDRESSES.keys()):
+            return
         try:
             cls = ClassSubject.objects.get(id = class_id)
             sections = cls.sections.all()

--- a/esp/esp/dbmail/receivers/sectionlist.py
+++ b/esp/esp/dbmail/receivers/sectionlist.py
@@ -44,6 +44,8 @@ class SectionList(BaseHandler):
             self.send = True
 
     def process_mailman(self, user, class_id, section_num, user_type):
+        if not (settings.USE_MAILMAN and 'mailman_moderator' in settings.DEFAULT_EMAIL_ADDRESSES.keys()):
+            return
         try:
             cls = ClassSubject.objects.get(id=int(class_id))
             section = filter(lambda s: s.index() == int(section_num), cls.sections.all())[0]

--- a/esp/esp/gen_media/inlinelatex.py
+++ b/esp/esp/gen_media/inlinelatex.py
@@ -52,7 +52,8 @@ COMMANDS = {'latex'  : 'latex',
             'dvipng' : 'dvipng'}
 
 try:
-    from esp.settings import NULL_FILE
+    from django.conf import settings
+    NULL_FILE = settings.NULL_FILE
 except:
     NULL_FILE = '/dev/null'
 

--- a/esp/esp/program/modules/handlers/programprintables.py
+++ b/esp/esp/program/modules/handlers/programprintables.py
@@ -47,7 +47,7 @@ from esp.accounting_core.models import LineItem, LineItemType, Transaction
 from esp.tagdict.models import Tag
 from esp.cal.models import Event
 from esp.middleware import ESPError
-from esp import settings
+from django.conf import settings
 from django.template.loader import select_template
 from django.utils.encoding import smart_str
 

--- a/esp/esp/program/modules/module_ext.py
+++ b/esp/esp/program/modules/module_ext.py
@@ -36,7 +36,7 @@ from django.db import models
 from esp.datatree.models import *
 from esp.program.modules.base import ProgramModuleObj
 from esp.db.fields import AjaxForeignKey
-from esp import settings
+from django.conf import settings
 from esp.users.models import ESPUser
 from esp.program.models import Program, RegistrationType
 

--- a/esp/esp/program/views.py
+++ b/esp/esp/program/views.py
@@ -555,7 +555,7 @@ def newprogram(request):
             
             manage_url = '/manage/' + new_prog.url() + '/resources'
 
-            if 'mailman_moderator' in settings.DEFAULT_EMAIL_ADDRESSES.keys():
+            if settings.USE_MAILMAN and 'mailman_moderator' in settings.DEFAULT_EMAIL_ADDRESSES.keys():
                 # While we're at it, create the program's mailing list
                 mailing_list_name = "%s_%s" % (new_prog.anchor.parent.name, new_prog.anchor.name)
                 teachers_list_name = "%s-%s" % (mailing_list_name, "teachers")

--- a/esp/esp/users/views/registration.py
+++ b/esp/esp/users/views/registration.py
@@ -15,7 +15,7 @@ from django.core.urlresolvers import reverse
 import hashlib
 import random
 import urllib
-from esp import settings
+from django.conf import settings
 from django.utils.datastructures import MultiValueDictKeyError
 
 __all__ = ['join_emaillist','user_registration_phase1', 'user_registration_phase2','resend_activation_view']

--- a/esp/esp/utils/custom_cache.py
+++ b/esp/esp/utils/custom_cache.py
@@ -33,7 +33,7 @@ Learning Unlimited, Inc.
   Email: web-team@lists.learningu.org
 """
 
-from esp import settings
+from django.conf import settings
 import random
 
 class custom_cache:

--- a/esp/esp/utils/deferred_notifier.py
+++ b/esp/esp/utils/deferred_notifier.py
@@ -1,4 +1,4 @@
-from esp import settings
+from django.conf import settings
 
 if getattr(settings, "WARN_ON_LAZY_QUERIES", False):
 

--- a/esp/esp/utils/memcached_multihost.py
+++ b/esp/esp/utils/memcached_multihost.py
@@ -40,7 +40,7 @@ other servers need to regenerate their corresponding cached content).
 
 from django.core.cache.backends.base import BaseCache
 from django.core.cache.backends.memcached import PyLibMCCache as MemcacheCacheClass
-from esp import settings
+from django.conf import settings
 
 class CacheClass(BaseCache):
     def __init__(self, server, params):

--- a/esp/esp/utils/memcached_multikey.py
+++ b/esp/esp/utils/memcached_multikey.py
@@ -7,7 +7,7 @@ try:
     from django.core.cache.backends.memcached import PyLibMCCache as PylibmcCacheClass
 except ImportError:
     from django.core.cache.backends.memcached import CacheClass as PylibmcCacheClass
-from esp import settings
+from django.conf import settings
 from esp.utils.try_multi import try_multi
 from esp.utils import ascii
 import hashlib

--- a/esp/esp/utils/tests.py
+++ b/esp/esp/utils/tests.py
@@ -22,7 +22,7 @@ except:
     print "Couldn't import MultihostCacheClass.  Not running tests against it."
 from utils.defaultclass import defaultclass
 from esp import utils
-from esp import settings
+from django.conf import settings
 from esp.utils.models import TemplateOverride
 
 from django.test import TestCase as DjangoTestCase

--- a/esp/esp/web/views/bio.py
+++ b/esp/esp/web/views/bio.py
@@ -42,7 +42,7 @@ from django.http          import HttpResponseRedirect, Http404
 from django.contrib.auth.decorators import login_required
 from esp.middleware       import ESPError
 from datetime             import datetime
-from esp                  import settings
+from django.conf import settings
 
 @login_required
 def bio_edit(request, tl='', last='', first='', usernum=0, progid = None, external = False, username=''):


### PR DESCRIPTION
See Github Issue #241 for details.

Correctly uses settings.USE_MAILMAN (see commit message for 9a828a63).

Please make sure I haven't broken anything. I don't know if there were reasons why these imports were still using the incorrect method.
