### PR TITLE
Fix Javascript problem where csrf_token function is overwritten.

### DIFF
--- a/esp/public/media/scripts/csrf_check.js
+++ b/esp/public/media/scripts/csrf_check.js
@@ -58,7 +58,7 @@ var check_csrf_cookie = function(form)
     }
 
     //Check it
-    csrf_token = $j(form.csrfmiddlewaretoken).val();
+    var csrf_token = $j(form.csrfmiddlewaretoken).val();
     //  console.log(csrf_token);
     csrf_cookie = $j.cookie("csrftoken");
     if (csrf_cookie == null)


### PR DESCRIPTION
csrf_check.js overwrites csrf_token function from csrf_init.js with a variable. Probably this variable should be local, so this changes it to that. This seems to fix #580.
