### PR TITLE
Fixes walk-ins bug in lottery

### DIFF
--- a/esp/esp/program/modules/handlers/lotterystudentregmodule.py
+++ b/esp/esp/program/modules/handlers/lotterystudentregmodule.py
@@ -96,11 +96,19 @@ class LotteryStudentRegModule(ProgramModuleObj):
         it gets all of its content from AJAX callbacks.
         """
         from django.conf import settings
-        from esp.program.models.class_ import open_class_category
+        from esp.program.models.class_ import open_class_category as open_class_category_function
+        from django.utils import simplejson
+        from django.utils.safestring import mark_safe
 
         crmi = prog.getModuleExtension('ClassRegModuleInfo')
 
-        context = {'prog': prog, 'support': settings.DEFAULT_EMAIL_ADDRESSES['support'], 'open_class_registration': {False: 0, True: 1}[crmi.open_class_registration], 'open_class_category': open_class_category()}
+        open_class_category = open_class_category_function()
+        # Convert the open_class_category ClassCategory object into a dictionary, only including the attributes the lottery needs or might need
+        open_class_category = dict( [ (k, getattr( open_class_category, k )) for k in ['id','symbol','category'] ] )
+        # Convert this into a JSON string, and mark it safe so that the Django template system doesn't try escaping it
+        open_class_category = mark_safe(simplejson.dumps(open_class_category))
+
+        context = {'prog': prog, 'support': settings.DEFAULT_EMAIL_ADDRESSES['support'], 'open_class_registration': {False: 0, True: 1}[crmi.open_class_registration], 'open_class_category': open_class_category}
 
         ProgInfo = prog.getModuleExtension('StudentClassRegModuleInfo')
 

--- a/esp/public/media/scripts/lottery_student_reg/student_reg.js
+++ b/esp/public/media/scripts/lottery_student_reg/student_reg.js
@@ -92,7 +92,7 @@ compare_timeslot_starts = function(a, b){
 get_walkin_header_html = function()
 {
     if (open_class_registration) {
-        return "<h3>"+open_class_category+"</h3>\
+        return "<h3>Walk-in Seminars</h3>\
         <div id='%TIMESLOT_WALKIN_DIV%' style='margin:1em 1em 1em 1em'></div>";
     }
     return "";
@@ -166,7 +166,7 @@ add_classes_to_timeslot = function(timeslot, sections){
 
 	// check grade in range or admin
 	if((user_grade >= section['grade_min'] && user_grade <= section['grade_max']) || esp_user['cur_admin'] == 1){
-            if(!open_class_registration || section['category'] != open_class_category){
+            if(!open_class_registration || section['category'] != open_class_category["symbol"]){
                 if (section['status'] > 0)
                 {
                     has_classes = true;
@@ -183,7 +183,7 @@ add_classes_to_timeslot = function(timeslot, sections){
 
 	//check grade in range or admin
 	if(section['status'] > 0 && user_grade >= section['grade_min'] && user_grade <= section['grade_max'] || esp_user['cur_admin'] == 1){
-            if(open_class_registration && section['category'] == open_class_category){
+            if(open_class_registration && section['category'] == open_class_category["symbol"]){
                 has_walkins = true;
                 walkins_list.push(section);
             }

--- a/esp/templates/program/modules/lotterystudentregmodule/student_reg.html
+++ b/esp/templates/program/modules/lotterystudentregmodule/student_reg.html
@@ -17,7 +17,9 @@
 <script type="text/javascript">    var program_base_url = "/json/"+base_url+"/";
 var support = "{{ support }}";
 var open_class_registration = {{ open_class_registration }};
-var open_class_category = "{{ open_class_category }}";
+var open_class_category = {{ open_class_category }};
+var timeslots;
+var sections;
 </script>
 <script type="text/javascript" src="/media/scripts/lottery_student_reg/student_reg.js"></script>
 <script type="text/javascript" src="/media/scripts/lottery_student_reg/preferences.js"></script>


### PR DESCRIPTION
The lottery uses a ClassCategory's symbol attribute for certain logic,
including figuring out whether a class is a walk-in seminar or not.
However, the open_class_category's name (its category attribute) was
being passed to the template instead.

Fixes this by passing open_class_category to the template as a JSON
string, and referring to its symbol attribute when necessary.

In the future, it might be strictly better to do ClassCategory logic
based on id, rather than symbol, since it is possible for two
ClassCategory objects to have the same symbol (though we haven't run
into problems yet because we usually avoid this).

Used for Stanford Splash Spring 2013 lottery student registration.
