### PR TITLE
Stop settings.CACHES warnings from bring printed at startup

### DIFF
--- a/esp/esp/settings.py
+++ b/esp/esp/settings.py
@@ -79,8 +79,14 @@ for (key,value) in CONTACTFORM_EMAIL_CHOICES:
     if (key in ('esp','general','esp-web','relations')) and not (key in CONTACTFORM_EMAIL_ADDRESSES):
         CONTACTFORM_EMAIL_ADDRESSES[key] = DEFAULT_EMAIL_ADDRESSES[{'esp':'default','general':'default','esp-web':'support','relations':'default'}[key]]
 
-#CACHE_BACKEND = "esp.utils.memcached_multikey://174.129.184.116:11211/?timeout=%d" % DEFAULT_CACHE_TIMEOUT
-CACHE_BACKEND = "esp.utils.memcached_multikey://127.0.0.1:11211/?timeout=%d" % DEFAULT_CACHE_TIMEOUT
+
+CACHES = {
+    'default': {
+        'BACKEND': 'esp.utils.memcached_multikey.CacheClass',
+        'LOCATION': '127.0.0.1:11211',
+        'TIMEOUT': DEFAULT_CACHE_TIMEOUT,
+    }
+}
 
 MIDDLEWARE_CLASSES = tuple([pair[1] for pair in sorted(MIDDLEWARE_GLOBAL + MIDDLEWARE_LOCAL)])
 


### PR DESCRIPTION
Anyone on serverlog@learningu.org has probably noticed that we get an e-mail every time the dbmail cron job is run, rather than every time it sends e-mail.  This results in a lot of e-mails.  This fix should stop that - someone should sanity check that it doesn't break anything before we pull it to all of our live sites.

Includes commit: Switch to new format for settings.CACHES
This should prevent warnings from being displayed whenever the code is
imported.
(cherry picked from commit 5829d326fca496914c73c093f765482d3578acd6)
