### PR TITLE
Updated django-reversion version in dev setup script

### DIFF
--- a/esp/useful_scripts/server_setup/dev_server_setup.sh
+++ b/esp/useful_scripts/server_setup/dev_server_setup.sh
@@ -362,7 +362,7 @@ then
 	python -m easy_install simplejson
 	python -m easy_install twill
 	python -m easy_install django-form-utils
-	python -m easy_install django-reversion
+	python -m easy_install django-reversion==1.6
 	python -m easy_install selenium
 	python -m easy_install django-selenium==0.3
 	python -m easy_install django-selenium-test-runner


### PR DESCRIPTION
Current/default version of django-reversion is 1.7 which isn't compatible
with django 1.4.  This change specifies django-reversion version 1.6.
