### PR TITLE
Fix issue #602 -- confusing browser cache behavior

### DIFF
--- a/esp/esp/qsd/views.py
+++ b/esp/esp/qsd/views.py
@@ -264,7 +264,7 @@ def qsd(request, branch, name, section, action):
             'qsd'          : True,
             'missing_files': m.BrokenLinks(),
             'target_url'   : base_url.split("/")[-1] + ".edit.html",
-            'return_to_view': base_url.split("/")[-1] + ".html?v=" + str(qsd_rec.id) }, # pass a "unique" query parameter to bypass browser cache
+            'return_to_view': base_url.split("/")[-1] + ".html#refresh" },
                                   use_request_context=False)
 
     

--- a/esp/templates/qsd/qsd.html
+++ b/esp/templates/qsd/qsd.html
@@ -9,6 +9,15 @@
 
 {% block subsection %}{% autoescape off %}{{ title|subsection }}{% endautoescape %}{% endblock %}
 
+{% block xtrajs %}
+<script type="text/javascript">
+  if (window.location.hash == '#refresh') {
+    window.location.hash = '';
+    window.location.reload(true);
+  }
+</script>
+{% endblock %}
+
 {% block content %}
 
 {% load render_qsd %}


### PR DESCRIPTION
#602

Make the "Back to Page View" link from the QSD edit page trigger a
`window.location.reload(true)` on the QSD page, which forces a reload
from the server. This should properly fix the problem of successive
QSD edits clobbering each other due to browser caching.
