### PR TITLE
Mailman fixes

### DIFF
--- a/esp/esp/dbmail/receivers/classlist.py
+++ b/esp/esp/dbmail/receivers/classlist.py
@@ -69,8 +69,8 @@ class ClassList(BaseHandler):
             send_mail("[ESP] Activated class mailing list: %s@%s" % (list_name, Site.objects.get_current().domain),
                       render_to_string("mailman/new_list_intro_teachers.txt", 
                                        { 'classname': str(cls),
-                                         'mod_password': set_list_moderator_password(list_name) }), 
-                      "esp@mit.edu", ["%s-teachers@%s" % (cls.emailcode(), Site.objects.get_current().domain), ])
+                                         'mod_password': set_list_moderator_password(list_name) }),
+                      settings.DEFAULT_EMAIL_ADDRESSES['default'], ["%s-teachers@%s" % (cls.emailcode(), Site.objects.get_current().domain), ])
         else:
             apply_list_settings(list_name, {'default_member_moderation': False})
             apply_list_settings(list_name, {'generic_nonmember_action': 0})

--- a/esp/esp/dbmail/receivers/sectionlist.py
+++ b/esp/esp/dbmail/receivers/sectionlist.py
@@ -83,6 +83,6 @@ class SectionList(BaseHandler):
             add_list_member(list_name, settings.DEFAULT_EMAIL_ADDRESSES['archive'])
         if DEBUG: print "Members added"
 
-        self.recipients = ["%s@esp.mit.edu" % list_name]
+        self.recipients = ["%s@%s" % (list_name, Site.objects.get_current().domain)]
         self.send = True
 


### PR DESCRIPTION
A number of minor fixes to the mailman setup.  Includes fixes to #649 and #650, along with some other minor things to bring the section and class mailing lists in line with each other.
