### PR TITLE
Suppress "sequence of required modules" behavior for json data module

### DIFF
--- a/esp/esp/program/modules/base.py
+++ b/esp/esp/program/modules/base.py
@@ -213,13 +213,13 @@ class ProgramModuleObj(models.Model):
     @staticmethod
     def findModule(request, tl, one, two, call_txt, extra, prog):
         moduleobj = ProgramModuleObj.findModuleObject(tl, call_txt, prog)
-        scrmi = prog.getModuleExtension('StudentClassRegModuleInfo')
 
         #   If a "core" module has been found:
         #   Put the user through a sequence of all required modules in the same category.
         #   Only do so if we've not blocked this behavior, though
-        if scrmi.force_show_required_modules:
-            if tl != "manage" and isinstance(moduleobj, CoreModule):
+        if tl != "manage" and tl != "json" and isinstance(moduleobj, CoreModule):
+            scrmi = prog.getModuleExtension('StudentClassRegModuleInfo')
+            if scrmi.force_show_required_modules:
                 if not_logged_in(request):
                     return HttpResponseRedirect('%s?%s=%s' % (LOGIN_URL, REDIRECT_FIELD_NAME, quote(request.get_full_path())))
                 other_modules = moduleobj.findCategoryModules(False)


### PR DESCRIPTION
Currently the JSON views require login, because the JSON data module is considered a core module and so the website tries to put the user through the series of required modules of type "json".

This behavior is undesirable, both because we might want unlogged users to be able to access JSON views, and because it breaks proxy caching(?). This PR disables it.
