### PR TITLE
Import ESPError in jsondatamodule

### DIFF
--- a/esp/esp/program/modules/handlers/jsondatamodule.py
+++ b/esp/esp/program/modules/handlers/jsondatamodule.py
@@ -1,4 +1,3 @@
-
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"
@@ -45,6 +44,7 @@ from esp.resources.models import Resource, ResourceAssignment, ResourceRequest, 
 from esp.datatree.models import *
 from esp.dbmail.models import MessageRequest
 from esp.tagdict.models import Tag
+from esp.middleware import ESPError
 
 from esp.utils.decorators import cached_module_view, json_response
 from esp.utils.no_autocookie import disable_csrf_cookie_update


### PR DESCRIPTION
As missing imports go, this one was relatively harmless... we should fix it anyway.

(recreated because I accidentally merged it earlier which closed the PR automatically)
