### PR TITLE
Fixes order of @meets_deadline and @needs_teacher on various views.

### DIFF
--- a/esp/esp/program/modules/handlers/availabilitymodule.py
+++ b/esp/esp/program/modules/handlers/availabilitymodule.py
@@ -123,8 +123,8 @@ class AvailabilityModule(ProgramModuleObj):
         return [(str(t.id), t.short_description) for t in times]
 
     @main_call
-    @meets_deadline('/Availability')
     @needs_teacher
+    @meets_deadline('/Availability')
     def availability(self, request, tl, one, two, module, extra, prog):
         #   Renders the teacher availability page and handles submissions of said page.
         

--- a/esp/esp/program/modules/handlers/creditcardmodule_cybersource.py
+++ b/esp/esp/program/modules/handlers/creditcardmodule_cybersource.py
@@ -72,14 +72,14 @@ class CreditCardModule_Cybersource(ProgramModuleObj):
         return {'creditcard': """Students who have filled out the credit card form."""}
 
     @main_call
-    @meets_deadline('/Payment')
     @usercheck_usetl
+    @meets_deadline('/Payment')
     def startpay_cybersource(self, request, tl, one, two, module, extra, prog):
         return render_to_response(self.baseDir() + 'cardstart.html', request, {})
 
     @aux_call
-    @meets_deadline('/Payment')
     @usercheck_usetl
+    @meets_deadline('/Payment')
     def paynow_cybersource(self, request, tl, one, two, module, extra, prog):
 
         # Force users to pay for non-optional stuffs

--- a/esp/esp/program/modules/handlers/creditcardmodule_firstdata.py
+++ b/esp/esp/program/modules/handlers/creditcardmodule_firstdata.py
@@ -135,8 +135,8 @@ class CreditCardModule_FirstData(ProgramModuleObj, module_ext.CreditCardSettings
         return render_to_response(self.baseDir() + 'failure.html', request, context)
 
     @main_call
-    @meets_deadline('/Payment')
     @usercheck_usetl
+    @meets_deadline('/Payment')
     def payonline(self, request, tl, one, two, module, extra, prog):
 
         user = ESPUser(request.user)

--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -578,8 +578,8 @@ class TeacherClassRegModule(ProgramModuleObj, module_ext.ClassRegModuleInfo):
         return HttpResponse(json.dumps({'restype_forms_html': formset_str, 'script': formset_script}))
         
     @aux_call
-    @meets_deadline("/Classes/Edit")
     @needs_teacher
+    @meets_deadline("/Classes/Edit")
     def editclass(self, request, tl, one, two, module, extra, prog):
         try:
             int(extra)
@@ -602,14 +602,14 @@ class TeacherClassRegModule(ProgramModuleObj, module_ext.ClassRegModuleInfo):
         return self.makeaclass_logic(request, tl, one, two, module, extra, prog, cls, action)
 
     @main_call
-    @meets_deadline('/Classes/Create')
     @needs_teacher
+    @meets_deadline('/Classes/Create')
     def makeaclass(self, request, tl, one, two, module, extra, prog, newclass = None):
         return self.makeaclass_logic(request, tl, one, two, module, extra, prog, newclass = None)
 
     @aux_call
-    @meets_deadline('/Classes/Create')
     @needs_teacher
+    @meets_deadline('/Classes/Create')
     def copyaclass(self, request, tl, one, two, module, extra, prog):
         if request.method == 'POST':
             return self.makeaclass_logic(request, tl, one, two, module, extra, prog)
@@ -634,8 +634,8 @@ class TeacherClassRegModule(ProgramModuleObj, module_ext.ClassRegModuleInfo):
         return self.makeaclass_logic(request, tl, one, two, module, extra, prog, cls, action, populateonly = True)
 
     @aux_call
-    @meets_deadline('/Classes/Create')
     @needs_teacher
+    @meets_deadline('/Classes/Create')
     def copyclasses(self, request, tl, one, two, module, extra, prog):
         context = {}
         context['all_class_list'] = request.user.getTaughtClasses()
@@ -644,8 +644,8 @@ class TeacherClassRegModule(ProgramModuleObj, module_ext.ClassRegModuleInfo):
         return render_to_response(self.baseDir()+'listcopyclasses.html', request, context)
 
     @aux_call
-    @meets_deadline('/Classes/Create')
     @needs_teacher
+    @meets_deadline('/Classes/Create')
     def makeopenclass(self, request, tl, one, two, module, extra, prog, newclass = None):
         return self.makeaclass_logic(request, tl, one, two, module, extra, prog, newclass = None, action = 'createopenclass')
 

--- a/esp/esp/program/modules/handlers/teacherregcore.py
+++ b/esp/esp/program/modules/handlers/teacherregcore.py
@@ -48,8 +48,8 @@ class TeacherRegCore(ProgramModuleObj, CoreModule):
             }
 
     @main_call
-    @meets_deadline("/MainPage")
     @needs_teacher
+    @meets_deadline("/MainPage")
     def teacherreg(self, request, tl, one, two, module, extra, prog):
         """ Display a teacher reg page """
         context = {}

--- a/esp/esp/program/modules/handlers/teacherreviewapps.py
+++ b/esp/esp/program/modules/handlers/teacherreviewapps.py
@@ -59,8 +59,8 @@ class TeacherReviewApps(ProgramModuleObj):
             }
     
     @aux_call
-    @meets_deadline("/AppReview")
     @needs_teacher
+    @meets_deadline("/AppReview")
     @never_cache
     def review_students(self, request, tl, one, two, module, extra, prog):
         try:
@@ -125,8 +125,8 @@ class TeacherReviewApps(ProgramModuleObj):
                                    'students':students})
 
     @aux_call
-    @meets_deadline()
     @needs_teacher
+    @meets_deadline()
     def app_questions(self, request, tl, one, two, module, extra, prog):
         """ Edit the subject-specific questions that students will respond to on
         their applications. """
@@ -178,8 +178,8 @@ class TeacherReviewApps(ProgramModuleObj):
         return render_to_response(self.baseDir()+'questions.html', request, context)
 
     @aux_call
-    @meets_deadline("/AppReview")
     @needs_teacher
+    @meets_deadline("/AppReview")
     def review_student(self, request, tl, one, two, module, extra, prog):
         scrmi = prog.getModuleExtension('StudentClassRegModuleInfo')
         reg_nodes = scrmi.reg_verbs()


### PR DESCRIPTION
This will cause a teacher who accidentally makes a student account to get a @needs_teacher error (which is helpful) instead of a deadline error (which isn't) if they go to teacher registration, for example.  This was generally not necessary before the schema changes, since the deadline was open for all users, but with the new Permissions system it will generally only be open for the correct Role.
