### PR TITLE
Update the MathJax JavaScript include link.

### DIFF
--- a/esp/templates/elements/html
+++ b/esp/templates/elements/html
@@ -36,7 +36,7 @@
     <script type="text/javascript" src="/media/scripts/content/user_classes.js"></script>
     <script type="text/javascript" src="/media/scripts/csrf_init.js"></script>
     
-    <script type="text/javascript" src="https://d3eoax9i5htok0.cloudfront.net/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+    <script type="text/javascript" src="https://c328740.ssl.cf1.rackcdn.com/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
     <script type="text/x-mathjax-config">
     MathJax.Hub.Config({
         messageStyle: "none",


### PR DESCRIPTION
Just changed URL in template. See #679
