### PR TITLE
Add support for nice filenames in QSD Media.

### DIFF
--- a/esp/esp/qsdmedia/views.py
+++ b/esp/esp/qsdmedia/views.py
@@ -46,7 +46,12 @@ def qsdmedia2(request, url):
     try:
         media_rec = Media.objects.get(hashed_name=url)
     except Media.DoesNotExist:
-        raise Http404
+        try:
+            media_rec = Media.objects.get(file_name=url)
+        except Media.DoesNotExist:
+            raise Http404
+        except MultipleObjectsreturned:
+            media_rec = Media.objects.filter(file_name=url).latest('id')
     except MultipleObjectsReturned: # If there exist multiple Media entries, we want the first one
         media_rec = Media.objects.filter(hashed_name=url).latest('id')
 

--- a/esp/esp/urls.py
+++ b/esp/esp/urls.py
@@ -160,7 +160,7 @@ urlpatterns += patterns('',
     (r'^dataviews/', include('esp.dataviews.urls')) )
     
 urlpatterns += patterns('esp.qsdmedia.views', 
-    (r'^download\/([-A-Za-z0-9_ ]+)/?$', 'qsdmedia2') )
+    (r'^download\/([^/]+)/?$', 'qsdmedia2') )
 
 urlpatterns += patterns('', 
     (r'^accounting/', include('esp.accounting.urls')) )


### PR DESCRIPTION
This allows access via the filename instead of the hashed filename.

If a file is uploaded with the same filename again, this will overwrite the first one. But hashed names currently get overwritten as well, so this isn't a problem. Class files have class codes added so they won't conflict. In the future hashed names should just be a random string instead of a hash possibly.
