### PR TITLE
Depend on latest django-reversion for proxy caching fix

### DIFF
--- a/esp/requirements.txt
+++ b/esp/requirements.txt
@@ -5,7 +5,8 @@ argparse==1.2.1
 distribute==0.6.24
 django-extensions==1.1.1
 django-form-utils==0.3.1
-django-reversion==1.6.6
+# django-reversion==1.7.1
+git+https://github.com/etianen/django-reversion.git@99a2871fefe0cfd29799ca54149846562e9b4209
 django-selenium==0.9.6
 flup==1.0.2
 icalendar==3.5


### PR DESCRIPTION
See discussion here: https://github.com/learning-unlimited/ESP-Website/pull/709#issuecomment-25444573

This bumps our reversion dependency to the version on github which fixes Vary: Cookie so that QSD pages can be proxy cached again.
