### PR TITLE
Small tweaks to virtualenv script

### DIFF
--- a/esp/packages.txt
+++ b/esp/packages.txt
@@ -5,7 +5,7 @@ imagemagick
 dvipng
 python
 python-setuptools
-python-virtualenv
+python-pip
 postgresql-9.1
 libevent-dev
 python-dev

--- a/esp/requirements.txt
+++ b/esp/requirements.txt
@@ -2,7 +2,6 @@ Django==1.4.5
 PIL==1.1.7
 South==0.8.1
 argparse==1.2.1
-distribute==0.6.24
 django-extensions==1.1.1
 django-form-utils==0.3.1
 django-reversion==1.6.6
@@ -27,4 +26,3 @@ twill==0.9
 wsgiref==0.1.2
 xlwt==0.7.5
 django-debug-toolbar==0.9.4
-

--- a/esp/useful_scripts/server_setup/dev_server_setup.sh
+++ b/esp/useful_scripts/server_setup/dev_server_setup.sh
@@ -342,6 +342,7 @@ then
     done
 
     #    Install python libraries
+    sudo pip install virtualenv>=1.10
     virtualenv $BASEDIR/env
     source $BASEDIR/env/bin/activate
     pip install -r $BASEDIR/esp/requirements.txt

--- a/esp/useful_scripts/server_setup/make_virtualenv.sh
+++ b/esp/useful_scripts/server_setup/make_virtualenv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 while [[ ! -n $BASEDIR ]]; do
     echo -n "Enter the root directory path of this site install (it should include a .git file) --> "
@@ -7,6 +7,9 @@ done
 FULLPATH=`mkdir -p $BASEDIR; cd $BASEDIR; pwd`
 BASEDIR=`echo "$FULLPATH" | sed -e "s/\/*$//"`
 
+sudo apt-get install $(< $BASEDIR/esp/packages.txt)
+
+sudo pip install virtualenv>=1.10
 virtualenv $BASEDIR/env
 source $BASEDIR/env/bin/activate
 pip install -r $BASEDIR/esp/requirements.txt


### PR DESCRIPTION
A few changes to fix things I encountered while trying to migrate my dev server to virtualenv:
- Remove dependency on distribute because it interacts badly with virtualenv (and doesn't make sense to install inside virtualenv anyway) and is deprecated
- Install virtualenv via pip rather than apt to get a more recent version
- Make the virtualenv script update apt packages
- set -e
