### PR TITLE
Fixes PIL dependency

### DIFF
--- a/esp/packages.txt
+++ b/esp/packages.txt
@@ -18,3 +18,4 @@ memcached
 libmemcached-dev
 libpq-dev
 libcurl4-openssl-dev
+libjpeg-dev

--- a/esp/requirements.txt
+++ b/esp/requirements.txt
@@ -1,5 +1,5 @@
 Django==1.4.8
-PIL==1.1.7
+pillow==2.2.1
 South==0.8.1
 argparse==1.2.1
 django-extensions==1.1.1


### PR DESCRIPTION
Teachers without biography photos were generating 500 errors on their
biography pages. This was happening with the assignment
teacherbio.picture = 'images/not-available.jpg'.
PIL was throwing the exception "decoder jpeg not available".

libjpeg-dev is a dependency for PIL jpeg decoder support. See
http://stackoverflow.com/questions/8915296/decoder-jpeg-not-available-pil.
This is now added as a dependency.

The bug remained after making this change. Further investigation revealed that
PIL does not easily support virtualenv. It looks for the jpeg decoder files in
a fixed directory; see
http://stackoverflow.com/questions/11692111/getting-django-to-recognize-pil-jpeg-support
and http://stackoverflow.com/a/13053041.

PIL has not been updated since 2009, and it is unlikely that virtualenv
support will be added. However, the Pillow package, a fork of PIL, does
support virtualenv, and is under active development. See
http://stackoverflow.com/a/7611630 and https://pypi.python.org/pypi/Pillow/2.2.1.

This commit changes the dependency on PIL to a dependency on Pillow. After
uninstalling PIL and installing Pillow, the bug is fixed. However, manage.py
validate will complain about the lack of PIL.

If PIL is already installed in the virtualenv, the following commands must be
run to uninstall PIL:
$ source env/bin/activate
$ pip uninstall PIL
