### PR TITLE
Remove unnecessary datetime.now() statements

### DIFF
--- a/esp/esp/program/controllers/lottery.py
+++ b/esp/esp/program/controllers/lottery.py
@@ -158,8 +158,6 @@ class LotteryAssignmentController(object):
         for i in range(len(lunch_by_day)):
             self.lunch_timeslots[i, :len(lunch_by_day[i])] = numpy.array(lunch_by_day[i])
 
-        now = datetime.now()
-        
         #   Populate interest matrix
         interest_regs = StudentRegistration.valid_objects().filter(section__parent_class__parent_program=self.program, relationship__name='Interested').values_list('user__id', 'section__id').distinct()
         ira = numpy.array(interest_regs, dtype=numpy.uint32)

--- a/esp/esp/program/modules/handlers/studentclassregmodule.py
+++ b/esp/esp/program/modules/handlers/studentclassregmodule.py
@@ -146,8 +146,6 @@ class StudentClassRegModule(ProgramModuleObj, module_ext.StudentClassRegModuleIn
     def students(self, QObject = False):
         from django.db.models import Q
 
-        now = datetime.now()
-
         Enrolled = Q(studentregistration__relationship__name='Enrolled')
         Par = Q(studentregistration__section__parent_class__parent_program=self.program)
         Unexpired = nest_Q(StudentRegistration.is_valid_qobject(), 'studentregistration')
@@ -641,7 +639,6 @@ class StudentClassRegModule(ProgramModuleObj, module_ext.StudentClassRegModuleIn
     @needs_student
     @vary_on_cookie
     def catalog_registered_classes_json(self, request, tl, one, two, module, extra, prog, timeslot=None):
-        now = datetime.now()
         reg_bits = StudentRegistration.valid_objects().filter(user=request.user, section__parent_class__parent_program=prog).select_related()
 
         reg_bits_data = [

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -557,8 +557,6 @@ class ESPUser(User, AnonymousUser):
         here's a slightly more general function for finding who belongs where. """
         from esp.program.models import ClassSection, RegistrationType
         
-        now = datetime.now()
-        
         if verbs:
             rts = RegistrationType.objects.filter(name__in=verbs)
         else:

--- a/esp/esp/utils/classchange.py
+++ b/esp/esp/utils/classchange.py
@@ -16,7 +16,6 @@ from esp.utils.query_utils import nest_Q
 
 p = None # program
 timeslots = None
-NOW = datetime.now()
 priorityLimit = 1
 SR_PROG = None
 SR_REQ = None
@@ -55,7 +54,7 @@ def get_student_schedule(student):
 
 def main(): 
     
-    global NOW, priorityLimit, SR_PROG, SR_REQ, SR_WAIT, SR_EN, PROG, REQ, WAIT, EN, p, students, sections, timeslots, timeslot, all_students
+    global priorityLimit, SR_PROG, SR_REQ, SR_WAIT, SR_EN, PROG, REQ, WAIT, EN, p, students, sections, timeslots, timeslot, all_students
     global en, req, loc, en_new, cap, score, req_num, wait, changed, unchanged, student
     
     save_enrollments = False


### PR DESCRIPTION
(Follow-up to #741 -- does some cleanup and fixes another instance of the datetime.now()-related bug that didn't show up in the tests.)

StudentRegistration now uses ExpirableModel.valid_objects() and
.is_valid_qobject(), which call datetime.now() internally. This commit
cleans up the datetime.now() calls that are no longer being used.

We need to keep the datetime.now() in ClassSection.clearStudents(),
and pass 'now' to valid_objects(), because 'now' is used later in the
same function and it's important that both values of now need to be
the same.
