### PR TITLE
Fix scheduling checks

### DIFF
--- a/esp/esp/program/modules/handlers/schedulingcheckmodule.py
+++ b/esp/esp/program/modules/handlers/schedulingcheckmodule.py
@@ -184,13 +184,15 @@ class SchedulingCheckRunner:
           if self.listed_sections:
                return self.all_sections
           else:
-               self.all_sections = self.p.sections()
+               qs = self.p.sections()
                #filter out walkins
-               self.all_sections = filter(lambda x: not x.category == self.p.open_class_category, self.all_sections)
+               qs = qs.exclude(parent_class__category__id=self.p.open_class_category.id)
                #filter out non-approved classes
-               self.all_sections = filter(lambda x: len(x.classrooms()) > 0, self.all_sections)
+               qs = qs.exclude(status__lte=0)
+               qs = qs.exclude(resourceassignment__isnull=True)
                #filter out lunch
-               self.all_sections = filter(lambda x: not x.category.category == u'Lunch', self.all_sections)
+               qs = qs.exclude(parent_class__category__category=u'Lunch')
+               self.all_sections = list(qs)
                self.listed_sections = True
                return self.all_sections
 


### PR DESCRIPTION
I didn't find many errors so this is a fairly small pull request.  The scheduling checks view is quite slow but the main reasons for the slowness (e.g. ClassSection.unsatisfied_requests()) are hard to work around.  I did eliminate about 20% of the queries with some changes to the fetching of class sections, but it can still take a couple of minutes to run everything.

Interesting fact: I can only load the scheduling checks for Splash 2012 with the debug toolbar disabled.  With it enabled, my 32-bit Python interpreter runs out of memory.
