### PR TITLE
Add distinct for biography to prevent duplicate classes.

### DIFF
--- a/esp/esp/web/views/bio.py
+++ b/esp/esp/web/views/bio.py
@@ -166,7 +166,7 @@ def bio_user(request, founduser):
     # Also, sort by the order of the corresponding program's DataTree node.
     # This should roughly order by program date; at the least, it will
     # cluster listed classes by program.
-    recent_classes = founduser.getTaughtClassesAll().filter(status__gte=10).exclude(meeting_times__end__gte=now).exclude(sections__meeting_times__end__gte=datetime.now()).filter(sections__resourceassignment__resource__res_type__name="Classroom").order_by('-anchor__parent__parent__id')
+    recent_classes = founduser.getTaughtClassesAll().filter(status__gte=10).exclude(meeting_times__end__gte=now).exclude(sections__meeting_times__end__gte=datetime.now()).filter(sections__resourceassignment__resource__res_type__name="Classroom").distinct().order_by('-anchor__parent__parent__id')
 
     # Ignore archived classes where we still have a log of the original class
     # Archives lose information; so, display the original form if we still have it


### PR DESCRIPTION
This happened when teachers taught for multiple sections or hours, in the teacher biography page.

See issue #738.
