### PR TITLE
Possibly fix bug involving the schedule_assignments JSON.

### DIFF
--- a/esp/esp/program/modules/handlers/jsondatamodule.py
+++ b/esp/esp/program/modules/handlers/jsondatamodule.py
@@ -136,7 +136,7 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
     @needs_admin
     @cached_module_view
     def schedule_assignments(prog):
-        data = ClassSection.objects.filter(status__gte=0, parent_class__status__gte=0, parent_class__parent_program=prog).select_related('resourceassignment__resource__name', 'resourceassignment__resource__event').extra({'timeslots': 'SELECT string_agg(to_char(resources_resource.event_id, \'999\'), \',\') FROM resources_resource, resources_resourceassignment WHERE resources_resource.id = resources_resourceassignment.resource_id AND resources_resourceassignment.target_id = program_classsection.id'}).values('id', 'resourceassignment__resource__name', 'timeslots').distinct()
+        data = ClassSection.objects.filter(status__gte=0, parent_class__status__gte=0, parent_class__parent_program=prog).select_related('resourceassignment__resource__name', 'resourceassignment__resource__event', 'resourceassignment__resource__id').extra({'timeslots': 'SELECT string_agg(to_char(resources_resource.event_id, \'999\'), \',\') FROM resources_resource WHERE resources_resource.id = resources_resourceassignment.resource_id'}).values('id', 'resourceassignment__resource__name', 'timeslots').distinct()
         #   Convert comma-separated timeslot IDs to lists
         for i in range(len(data)):
             if data[i]['timeslots']:


### PR DESCRIPTION
The bug was causing timeslots in jsondatamodule->schedule_assignments to be incorrect (single class scheduled to same event ID across multiple rooms). This may have caused AJAX scheduler to crash in certain cases where a class is scheduled into multiple rooms at different times.

I don't really know what I did but the output looks like it be more correct now. The AJAX scheduler no longer shows the class in the incorrect timeblock/room combination; it doesn't show the class in one of the correct timeblock/room combinations though, but in the later one it works.
