### PR TITLE
Bump Reversion to latest Git version

### DIFF
--- a/esp/requirements.txt
+++ b/esp/requirements.txt
@@ -5,7 +5,7 @@ argparse==1.2.1
 django-extensions==1.1.1
 django-form-utils==0.3.1
 # django-reversion==1.7.1
-git+https://github.com/etianen/django-reversion.git@99a2871fefe0cfd29799ca54149846562e9b4209
+git+https://github.com/etianen/django-reversion.git@a5a9c59582329af1b8dc8218f72b3e0021a44aed
 django-selenium==0.9.6
 flup==1.0.2
 icalendar==3.5


### PR DESCRIPTION
This pulls in an upstream fix to a bug that was causing all of our exceptions to throw RevisionManagementErrors: https://github.com/etianen/django-reversion/commit/a5a9c59
