### PR TITLE
Fix #776: QuerySet.prefetch_related broken

### DIFF
--- a/esp/esp/cache_loader/__init__.py
+++ b/esp/esp/cache_loader/__init__.py
@@ -102,14 +102,18 @@ def new_create_many_related_manager(*args, **kwargs):
 related.create_many_related_manager = new_create_many_related_manager
 
 old_get = related.ManyRelatedObjectsDescriptor.__get__
-def new__get__(self, *args, **kwargs):
-    manager = old_get(self, *args, **kwargs)
+def new__get__(self, instance, instance_type=None):
+    if instance is None:
+        return self
+    manager = old_get(self, instance, instance_type)
     manager.field_name = self.related.get_accessor_name()
     manager.rev_field_name = self.related.field.name
     return manager
 related.ManyRelatedObjectsDescriptor.__get__ = new__get__
 old_rev_get = related.ReverseManyRelatedObjectsDescriptor.__get__
 def new__rev_get__(self, instance, instance_type=None):
+    if instance is None:
+        return self
     manager = old_rev_get(self, instance, instance_type)
     manager.field_name = self.field.name
 


### PR DESCRIPTION
Fixes a bug in cache_loader where trying to access a many-to-many
field descriptor of a model class (e.g. ClassSection.meeting_times)
threw an error, which confuses prefetch_related. This was happening
because the cache_loader overrides the `__get__` methods on these
descriptors to provide extra attributes, but the overriden methods
assumed you were trying to access the field from the instance to get a
ManyRelatedManager (e.g. sec.meeting_times for a particular sec),
rather than trying to access the field descriptor from the class itself.
