### PR TITLE
Fixes /cache/view_all/.

### DIFF
--- a/esp/esp/cache/views.py
+++ b/esp/esp/cache/views.py
@@ -41,7 +41,9 @@ from django.http import HttpResponse
 
 @admin_required
 def view_all(request):
-    return render_to_response('cache/view_all.html', request, {'caches': sorted(all_caches.values(), key=lambda c: c.name)})
+    caches = sorted(all_caches.values(), key=lambda c: c.name)
+    cache_data = [{'pretty_name': cache.pretty_name, 'hit_count': cache.hit_count, 'miss_count': cache.miss_count} for cache in caches]
+    return render_to_response('cache/view_all.html', request, {'caches': cache_data})
 
 def varnish_purge(request):
     # Authenticate


### PR DESCRIPTION
Django templates were trying to call some things that shouldn't be
called, and it was breaking the page.
