### PR TITLE
Add support for matching NavBarCategory to request path

### DIFF
--- a/esp/esp/web/util/main.py
+++ b/esp/esp/web/util/main.py
@@ -88,7 +88,7 @@ def render_to_response(template, request, context, prog=None, auto_per_program_t
         category = None
         if context.has_key('nav_category'):
             category = context['nav_category']
-        context['navbar_list'] = makeNavBar(section, category)
+        context['navbar_list'] = makeNavBar(section, category, path=request.path[1:])
 
     if not use_request_context:
         context['request'] = request

--- a/esp/esp/web/views/navBar.py
+++ b/esp/esp/web/views/navBar.py
@@ -32,32 +32,21 @@ Learning Unlimited, Inc.
   Phone: 617-379-0178
   Email: web-team@lists.learningu.org
 """
-from esp.web.models import NavBarEntry, NavBarCategory
-from esp.users.models import AnonymousUser, ESPUser
-from django.http import HttpResponseRedirect, Http404, HttpResponse
-from esp.dblog.models import error
-from esp.middleware.esperrormiddleware import ESPError
 
-from esp.program.models import Program
+from django.http import HttpResponseRedirect, Http404, HttpResponse
 from django.core.exceptions import PermissionDenied
 from django.contrib.auth.decorators import login_required
 from django.db.models.query import Q
 
-def nav_category(section=''):
-    """ A function to guess the appropriate navigation category when one
-        is not provided in the context. """
-        
-    #   See if there's a category with the provided section name.
-    categories = NavBarCategory.objects.filter(name=section)
-    if categories.count() > 0:
-        return categories[0]
-    
-    #   If all else fails, make something up.
-    return NavBarCategory.default()
+from esp.web.models import NavBarEntry, NavBarCategory
+from esp.users.models import AnonymousUser, ESPUser
+from esp.dblog.models import error
+from esp.program.models import Program
+from esp.middleware.esperrormiddleware import ESPError
 
-def makeNavBar(section='', category=None):
+def makeNavBar(section=None, category=None, path=None):
     if not category:
-        category = nav_category(section)
+        category = NavBarCategory.from_request(section, path)
 
     navbars = list(category.get_navbars().order_by('sort_rank'))
     navbar_context = [{'entry': x} for x in navbars]


### PR DESCRIPTION
Earlier migrations for NavBarCategory copied the DataTree anchor
URI into the new path field, which is helpful for keeping track of
what the anchor originally was, but not so helpful for controlling
when that NavBarCategory should appear.

This change takes the functionality of the esp.web.views.nav_category
function and moves it to NavBarCategory.from_request(), which is now
cached.  The from_request() function takes a request path and a
section.  It first tries to match the path against the path of a
NavBarCategory.  If that fails, it falls back to the earlier
algorithm of matching the section (teach, learn, manage, etc.)
against the NavBarCategory names.

This means that the nav bars for program registration and
management pages can now be controlled.
