### PR TITLE
Allow QSD.name to be blank

### DIFF
--- a/esp/esp/qsd/models.py
+++ b/esp/esp/qsd/models.py
@@ -1,4 +1,3 @@
-
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"
@@ -74,7 +73,7 @@ class QuasiStaticData(models.Model):
     objects = QSDManager(8, 'QuasiStaticData')
 
     url = models.CharField(max_length=256, help_text="Full url, without the trailing .html")
-    name = models.SlugField()
+    name = models.SlugField(blank=True)
     title = models.CharField(max_length=256)
     content = models.TextField()
     


### PR DESCRIPTION
After schema simplification, QSD doesn't use the name field anymore, and most (all?) QSD objects have a blank value for it. This is fine, except that the admin panel complains whenever you try to save a QSD object with a blank name. Thus, make the field blank-able.
