### PR TITLE
Fix JS error on homepage when morphed

### DIFF
--- a/esp/public/media/scripts/content/user_classes.js
+++ b/esp/public/media/scripts/content/user_classes.js
@@ -4,7 +4,7 @@ function update_user_classes() {
   }
   if (esp_user.cur_retTitle) {
     $j(".unmorph").removeClass("unmorph_hidden");
-    document.getElementById("unmorph_text").innerHTML = "Click above to return to your administrator account - " + esp_user.cur_retTitle;
+    $j("#unmorph_text").html("Click above to return to your administrator account - " + esp_user.cur_retTitle);
   }
   if (esp_user.cur_qsd_bits == "1") {
     $j(".qsd_bits").removeClass("qsd_bits_hidden");


### PR DESCRIPTION
On the homepage, there's no unmorph_text element, so document.getElementById("unmorph_text") returns null.

Change this to a $j("unmorph_text") because the surrounding lines use jQuery anyway and it works.
