### PR TITLE
Replaces cls.teachers with cls.teachers.all

### DIFF
--- a/esp/templates/program/modules/programprintables/classes_list.html
+++ b/esp/templates/program/modules/programprintables/classes_list.html
@@ -57,7 +57,7 @@ table.sortable thead {
  <td>{{ cls.title }}</td>
  <td>{{ cls.class_info|truncatewords_html:10 }}
  <td>{{ cls.getTeacherNamesLast|join:"; " }}</td>
- <td>{% for teacher in cls.teachers %}{{ teacher.getLastProfile.contact_user.phone_cell }}{% if not forloop.last %}, {% endif %}{% endfor %}</td>
+ <td>{% for teacher in cls.teachers.all %}{{ teacher.getLastProfile.contact_user.phone_cell }}{% if not forloop.last %}, {% endif %}{% endfor %}</td>
  <td width="170">{% for sec in cls.sections.all %}Section {{ sec.index }}: {% if not sec.prettyrooms|length_is:0 %}{{ sec.prettyrooms|join:", "}}{% else %} Unassigned{% endif %}<br />{% endfor %}</td>
  <td width="260">{% for sec in cls.sections.all %}Section {{ sec.index }}: {% if not sec.prettyrooms|length_is:0 %}{{ sec.friendly_times|join:", "}}{% else %} Unassigned{% endif %}<br />{% endfor %}</td>
  <td>{% if cls.allow_lateness %} Y {% else %} N {% endif %}</td>


### PR DESCRIPTION
There might be more bugs like this, but I can't do this just with grep,
because in some cases cls is a ClassSubject and cls.teachers needs to be
replaced by cls.teachers.all, and in other cases cls is a dictionary and
cls.teachers is an iterable of the teachers for that class. We should
either test all of the other printables that uses cls.teachers, or
manually look at the code for all of those view functions to determine
which other templates need fixing.
