### PR TITLE
Rewriting the check availability page

### DIFF
--- a/esp/esp/program/modules/handlers/availabilitymodule.py
+++ b/esp/esp/program/modules/handlers/availabilitymodule.py
@@ -247,8 +247,11 @@ class AvailabilityModule(ProgramModuleObj):
         # Also keep track of what class it is
         teaching_sections = teacher.getTaughtSections(self.program)
         teaching_times = {}
+        unscheduled_classes = []
         for s in teaching_sections:
             sec_times = s.get_meeting_times()
+            if len(sec_times) == 0:
+                unscheduled_classes.append((s.parent_class.id, s.emailcode(), s.parent_class.title, s.prettyDuration()))
             for t in sec_times:
                 rooms = ""
                 for r in s.prettyrooms():
@@ -277,7 +280,7 @@ class AvailabilityModule(ProgramModuleObj):
                 else:
                     available.append((t.start, t.end, False, False, None, None, None, None))
 
-        context = {'available': available, 'teacher_name': teacher.first_name + ' ' + teacher.last_name, 'teaching_times': teaching_times, 'edit_path': '/manage/%s/%s/edit_availability?user=%s' % (one, two, teacher.username) }
+        context = {'available': available, 'unscheduled': unscheduled_classes, 'teacher_name': teacher.first_name + ' ' + teacher.last_name, 'teaching_times': teaching_times, 'edit_path': '/manage/%s/%s/edit_availability?user=%s' % (one, two, teacher.username) }
         return render_to_response(self.baseDir()+'check_availability.html', request, context)
 
     @aux_call

--- a/esp/templates/program/modules/availabilitymodule/check_availability.html
+++ b/esp/templates/program/modules/availabilitymodule/check_availability.html
@@ -16,6 +16,12 @@
 {% for t in available %}
 <dt><font color={% if t.2 and t.3 %}"black"{% elif t.2 and not t.3 %}"blue"{% elif t.3 and not t.2 %}"orange"{% else %}"silver"{% endif %}>{{ t.0 }} to {{ t.1 }}{% if t.3 %} </dt><dd><a href="/manage/{{ program.getUrlBase }}/manageclass/{{ t.4 }}">{{ t.5 }}: {{ t.6 }} ({{ t.7 }})</a></dd>{% else %}</dt>{% endif %}</font>
 {% endfor %}
+<br><br>
+<dl>
+<dt>Unscheduled classes</dt>
+{% for s in unscheduled %}
+<dd><a href="/manage/{{ program.getUrlBase }}/manageclass/{{ s.0 }}">{{ s.1 }}: {{ s.2 }} ({{ s.3 }})</a></dd>
+{% endfor %}
 </dl>
 <br /><br />
 


### PR DESCRIPTION
New version of the check availability page:
All timeslots are shown, in order, whether or not the teacher is available
Four colors: gray for unavailable, blue for available, black for teaching, orange for teaching but not available (colors chosen for accessibility reasons, this was the best thing I could come up with after green/red)
Shows names and rooms of classes under the timeslots and links to the manage page for the class
Shows list of teacher's unscheduled classes at the bottom, with duration
