### PR TITLE
Adds werkzeug to requirements

### DIFF
--- a/esp/requirements.txt
+++ b/esp/requirements.txt
@@ -30,4 +30,4 @@ xlwt==0.7.5
 django-debug-toolbar==0.9.4
 django-grappelli==2.4.8
 django-filebrowser==3.5.2
-
+werkzeug


### PR DESCRIPTION
Needed for runserver_plus

I don't know if we need to require a certain version. Leaving the
version blank worked for me.
