### PR TITLE
Removes GZip Middleware for security reasons

### DIFF
--- a/esp/esp/django_settings.py
+++ b/esp/esp/django_settings.py
@@ -173,7 +173,6 @@ MIDDLEWARE_GLOBAL = [
     (1000, 'esp.middleware.espauthmiddleware.ESPAuthMiddleware'),
     (1050, 'django.middleware.csrf.CsrfViewMiddleware'),
     (1100, 'django.middleware.doc.XViewMiddleware'),
-    (1200, 'django.middleware.gzip.GZipMiddleware'),
     (1250, 'esp.middleware.espdebugtoolbarmiddleware.ESPDebugToolbarMiddleware'),
     (1300, 'esp.middleware.PrettyErrorEmailMiddleware'),
     (1400, 'esp.middleware.StripWhitespaceMiddleware'),


### PR DESCRIPTION
See
<docs.djangoproject.com/en/dev/ref/middleware/#django.middleware.gzip.GZipMiddleware>

This is currently commented out on all sites. Might as well actually remove it.
