### PR TITLE
Adds missing </div> in render_qsd_inline.html

### DIFF
--- a/esp/templates/inclusion/qsd/render_qsd_inline.html
+++ b/esp/templates/inclusion/qsd/render_qsd_inline.html
@@ -27,6 +27,7 @@
 		<div class="qsd_header qsd_bits hidden" onclick="qsd_inline_edit('{{ url }}');">This is a placeholder for quasi-static content that has not yet been added.  Click here to edit the text; click outside the box to save changes.</div>
 		<div class="hidden qsd_bits hidden" id="inline_edit_{{ url }}">
 			<textarea rows="8" cols="80" id="qsd_content_{{ url }}" onblur="qsd_inline_create('{{ url }}');" name="qsd_content" class="qsd_editor qsd_halfsize qsd_bits hidden"></textarea>
+		</div>
 		<div class="qsd_view_visible prettify" id="inline_qsd_{{ url }}"></div>
     </div>
 {% endif %}


### PR DESCRIPTION
In render_qsd_inline.html, there was a missing </div> in the case where
no qsd object exists yet. This was causing rendering issues. When logged
out, the contents of the catalog would be swallowed by the .hidden class
of the textarea's enclosing div.

Should resolve Github Issue #888.
