### PR TITLE
Display PDFs and media inline

### DIFF
--- a/esp/esp/qsdmedia/views.py
+++ b/esp/esp/qsdmedia/views.py
@@ -38,6 +38,7 @@ from esp.datatree.models import *
 from django.core.exceptions import MultipleObjectsReturned
 from django.conf import settings
 import os.path
+import fnmatch
 
 
 def qsdmedia2(request, url, ignored_part=None):
@@ -63,6 +64,17 @@ def qsdmedia2(request, url, ignored_part=None):
     file_name = media_rec.get_uploaded_filename()
     f = open(file_name, 'rb')
     response = HttpResponse(f.read(), content_type=media_rec.mime_type)
-    response['Content-Disposition'] = 'attachment; filename="' + media_rec.file_name + '"'
+
+    inline_dispositions = ['application/pdf', 'image/*', 'audio/*', 'video/*']
+    # these MIME types are served with Content-Disposition: inline (show in browser)
+    # all others are served with Content-Disposition: attachment (download)
+    disposition = 'attachment'
+    for disp in inline_dispositions:
+        if fnmatch.fnmatch(media_rec.mime_type, disp):
+            disposition = 'inline'
+            break
+    response['Content-Disposition'] = disposition + '; filename="' + media_rec.file_name + '"'
+
+    response['X-Content-Type-Options'] = 'nosniff'  # prevent browsers from second-guessing our MIME type
     return response
 


### PR DESCRIPTION
This change causes user uploads of PDFs, images, video and audio to be served with `Content-Disposition: inline` rather than `Content-Disposition: attachment`, making browsers display them inline rather than trigger a download. An `X-Content-Type-Options: nosniff` header is included to reduce the risk of MIME type hacking.

Bundled in to this pull request is a typo fix related to filename collision handling. I've tested that both this and the above work as advertised.
