### PR TITLE
Fixes various bugs with user types code

### DIFF
--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -300,16 +300,15 @@ class Program(models.Model, CustomFormsLinkModel):
     USER_TYPE_LIST_NUM_FUNCS    = ['num_'+user_type for user_type in USER_TYPE_LIST_FUNCS]  # the names of the num methods, e.g. num_students(), num_teachers()
     USER_TYPE_LIST_DESC_FUNCS   = [user_type.lower()+'Desc' for user_type in USER_TYPES_WITH_LIST_FUNCS]    # the names of the description methods, e.g. studentDesc(), teacherDesc()
 
-    def __init__(self, *args, **kwargs):
-        super(Program, self).__init__(*args, **kwargs)
-        self.setup_user_filters()
-
-    def setup_user_filters(self):
-        # Setup for the ProgramModule user filters
-        if not hasattr(Program, Program.USER_TYPE_LIST_FUNCS[0]):
-            for i, user_type in enumerate(Program.USER_TYPE_LIST_FUNCS):
-                setattr(Program, user_type, Program.get_users_from_module(user_type))
-                setattr(Program, Program.USER_TYPE_LIST_NUM_FUNCS[i], Program.counts_from_query_dict(getattr(Program, user_type)))
+    @classmethod
+    def setup_user_filters(cls):
+        """
+        Setup for the ProgramModule user filters
+        """
+        if not hasattr(cls, cls.USER_TYPE_LIST_FUNCS[0]):
+            for i, user_type in enumerate(cls.USER_TYPE_LIST_FUNCS):
+                setattr(cls, user_type, cls.get_users_from_module(user_type))
+                setattr(cls, cls.USER_TYPE_LIST_NUM_FUNCS[i], cls.counts_from_query_dict(getattr(cls, user_type)))
 
     @cache_function
     def isUsingStudentApps(self):
@@ -1080,6 +1079,8 @@ class Program(models.Model, CustomFormsLinkModel):
             return self._splashinfo_objects
         self._splashinfo_objects = dict(SplashInfo.objects.filter(program=self, siblingdiscount=True).distinct().values_list('student', 'siblingdiscount'))
         return self._splashinfo_objects
+
+Program.setup_user_filters()
 
 
 class SplashInfo(models.Model):


### PR DESCRIPTION
Partially resolves Github issue #646. Changes
Program.setup_user_filters() to be a classmethod, and calls it at class
definition time. This should eliminate any caching bugs that would cause
Program.students(), etc. to be undefined after retrieving a Program
directly from the cache.

Defines the classmethod ESPUser.create_membership_methods(), and calls
it from ESPUser.**init**() rather than having the code directly included
in **init**(). Unfortunately, this method cannot be called at class
definition time in order to resolve #646; see the commit message for
commit 2874259dbcc3 for the reason why. But now that this method exists,
it can be called at cache retrieval time if necessary, though this
commit does not do that.

Adds optional parameter use_tag to ESPUser.getAllUserTypes() and
ESPUser.getTypes(). It defaults to True, but when it is False, the
user_types Tag is ignored and the default user types are always
returned.

Extends ESPUser.create_membership_methods() to make sure that all of the
default user types have membership methods defined, because some (such
as isStudent()) are used in the code even if that user type isn't
included in the Tag override. It starts by defining all the membership
methods for the default types as returning False, and then overwrites
them as necessary. This fixes a bug in the splashcon.learningu.org
website, where no pages could be loaded because ESPAuthMiddleware always
calls ESPUser.getGrade(), which always calls ESPUser.isStudent(); but
splashcon.learningu.org did not have the Student user type defined in
its user_types Tag.
