### PR TITLE
Fixes bug in profile form

### DIFF
--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -995,7 +995,7 @@ class StudentInfo(models.Model):
             
         studentInfo.school          = new_data['school'] if not studentInfo.k12school else studentInfo.k12school.name
         studentInfo.dob             = new_data['dob']
-        studentInfo.gender          = new_data['gender']
+        studentInfo.gender          = new_data.get('gender', None)
         
         studentInfo.heard_about      = new_data.get('heard_about', '')
 


### PR DESCRIPTION
The profile form as an optional gender field, which is Tag-disabled by
default. However, the code was using the dictionary bracket accessor to
get the gender data, which fails when the key is not present (which is
the default). Fixes this by changing the access to use get() with a
default of None.
