### PR TITLE
Increases LaTeX PNG resolution.

### DIFF
--- a/esp/esp/web/util/latex.py
+++ b/esp/esp/web/util/latex.py
@@ -147,7 +147,7 @@ def gen_latex(texcode, type='pdf', landscape=False):
         mime = 'image/png'
         subprocess.check_call(['latex'] + latex_options + ['%s.tex' % file_base], cwd=TEX_TEMP)
         subprocess.check_call(['dvips'] + dvips_options + ['%s.dvi' % file_base], cwd=TEX_TEMP)
-        subprocess.check_call(['convert', '-density', '96', '%s.ps' % file_base, '%s.png' % file_base], cwd=TEX_TEMP)
+        subprocess.check_call(['convert', '-density', '192', '%s.ps' % file_base, '%s.png' % file_base], cwd=TEX_TEMP)
         if remove_files:
             os.remove('%s.dvi' % file_base)
             os.remove('%s.ps' % file_base)


### PR DESCRIPTION
This is used by the schedule printing script.  96 DPI is pretty blurry;
I found empirically that 192 was not too much slower and looked a lot
better.

(Copied from local commit 7a56c41 on esp.mit.edu, made during Splash.)
