### PR TITLE
Change location of Credit Card redirect

### DIFF
--- a/esp/esp/program/views.py
+++ b/esp/esp/program/views.py
@@ -590,7 +590,7 @@ def submit_transaction(request):
         tl = 'learn'
         one, two = iac.program.url.split('/')
 
-        return HttpResponseRedirect("http://%s/%s/%s/%s/confirmreg" % (request.META['HTTP_HOST'], tl, one, two))
+        return HttpResponseRedirect("http://%s/%s/%s/%s/studentreg" % (request.META['HTTP_HOST'], tl, one, two))
 
     return render_to_response( 'accounting_docs/credit_rejected.html', request, {} )
 


### PR DESCRIPTION
During Splash, I made our site redirect people to the main student registration checklist page instead of the registration receipt (confirm) page after a successful credit card payment because we weren't using the confirm page. I'm not sure what other chapters' use cases are, but is this something we want on `main`?
