### PR TITLE
Make useful_scripts run standalone with proper imports, path

### DIFF
--- a/esp/useful_scripts/finaid_approve.py
+++ b/esp/useful_scripts/finaid_approve.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python2
 #
 # Approve Financial Aid Requests
 # 
@@ -5,8 +6,8 @@
 # and prints the email address of these users to the screen. Make sure to configure
 # PROGRAM_ID and PROGRAM_COST (in dollars) below.
 #
-# This script should be run from the manage.py shell
-#
+
+from script_setup import *
 
 from esp.program.models import FinancialAidRequest
 from datetime import datetime

--- a/esp/useful_scripts/finaid_autoapproved.py
+++ b/esp/useful_scripts/finaid_autoapproved.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python2
 #
 # Display Auto-Approved Financial Aid Requests
 # 
@@ -8,6 +9,8 @@
 #
 # This script should be run from the manage.py shell
 #
+
+from script_setup import *
 
 from esp.program.models import FinancialAidRequest
 from datetime import datetime

--- a/esp/useful_scripts/script_setup.py
+++ b/esp/useful_scripts/script_setup.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+import os, sys
+
+project = os.path.dirname(os.path.realpath(__file__))
+root = os.path.dirname(project)
+sys.path.append(root)
+
+try:
+    # activate virtualenv
+    envroot = os.path.dirname(root)
+    activate_this = os.path.join(envroot, 'env', 'bin', 'activate_this.py')
+    execfile(activate_this, dict(__file__=activate_this))
+except IOError:
+    print "virtualenv loading failed"
+    pass
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "esp.settings")
+
+from django.db.models.loading import get_models
+from django.conf import settings as S
+
+# http://sontek.net/blog/detail/tips-and-tricks-for-the-python-interpreter
+for m in get_models():
+    globals()[m.__name__] = m
+


### PR DESCRIPTION
This change enables scripts to run standalone and get all of their imports automagically as if they were run from `manage.py shell_plus`. Including `from setup_script import *` at the top of a standalone script allows us to write the rest of the script as if each line were typed at the shell, which is really useful.

I also magic-ified `finaid_approve.py` this way.
