### PR TITLE
Adds app_label to models/ directories

### DIFF
--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -1450,6 +1450,9 @@ class BooleanToken(models.Model):
     text = models.TextField(help_text='Boolean value, or text needed to compute it', default='', blank=True)
     seq = models.IntegerField(help_text='Location of this token on the expression stack (larger numbers are higher)', default=0)
 
+    class Meta:
+        app_label = 'program'
+
     def get_expr(self):
         return self.exp.subclass_instance()
     #   Renamed to expr to avoid conflicting with Django SQL evaluator "expression"
@@ -1510,6 +1513,10 @@ class BooleanExpression(models.Model):
         Arbitrary arguments can be supplied to the evaluate function in order
         to help subclassed tokens do their thing.
     """
+
+    class Meta:
+        app_label = 'program'
+
     label = models.CharField(max_length=80, help_text='Description of the expression')
 
     def __unicode__(self):
@@ -1618,6 +1625,9 @@ class ScheduleConstraint(models.Model):
     requirement = models.ForeignKey(BooleanExpression, related_name='requirement_constraint')
     #   This is a function of one argument, schedule_map, which returns an updated schedule_map.
     on_failure = models.TextField()
+
+    class Meta:
+        app_label = 'program'
     
     def __unicode__(self):
         return '%s: "%s" requires "%s"' % (self.program.niceName(), unicode(self.condition), unicode(self.requirement))
@@ -1663,10 +1673,16 @@ class ScheduleTestTimeblock(BooleanToken):
     """
     timeblock = models.ForeignKey(Event, help_text='The timeblock that this schedule test pertains to')
 
+    class Meta:
+        app_label = 'program'
+
 class ScheduleTestOccupied(ScheduleTestTimeblock):
     """ Boolean value testing: Does the schedule contain at least one
         section at the specified time?
     """
+    class Meta:
+        app_label = 'program'
+
     def boolean_value(self, *args, **kwargs):
         timeblock_id = self.timeblock.id
         user_schedule = kwargs['map']
@@ -1688,12 +1704,19 @@ class ScheduleTestCategory(ScheduleTestTimeblock):
                 if sec.category == self.category:
                     return True
         return False
+
+    class Meta:
+        app_label = 'program'
             
 class ScheduleTestSectionList(ScheduleTestTimeblock):
     """ Boolean value testing: Does the schedule contain one of the specified
         sections at the specified time?
     """
     section_ids = models.TextField(help_text='A comma separated list of ClassSection IDs that can be selected for this timeblock')
+
+    class Meta:
+        app_label = 'program'
+    
     def boolean_value(self, *args, **kwargs):
         timeblock_id = self.timeblock.id
         user_schedule = kwargs['map']
@@ -1726,6 +1749,9 @@ class VolunteerRequest(models.Model):
     program = models.ForeignKey(Program)
     timeslot = models.ForeignKey('cal.Event')
     num_volunteers = models.PositiveIntegerField()
+
+    class Meta:
+        app_label = 'program'
     
     def num_offers(self):
         return self.volunteeroffer_set.count()
@@ -1752,6 +1778,9 @@ class VolunteerOffer(models.Model):
     shirt_type = models.CharField(max_length=20, blank=True, choices=shirt_types, null=True)
     
     comments = models.TextField(blank=True, null=True)
+
+    class Meta:
+        app_label = 'program'
     
     def __unicode__(self):
         return u'%s (%s, %s) for %s' % (self.name, self.email, self.phone, self.request)
@@ -1787,6 +1816,7 @@ class RegistrationType(models.Model):
     
     class Meta:
         unique_together = (("name", "category"),)
+        app_label = 'program'
     
     @cache_function
     def get_cached(name, category):
@@ -1826,6 +1856,9 @@ class StudentRegistration(ExpirableModel):
     section = AjaxForeignKey('ClassSection')
     user = AjaxForeignKey(ESPUser)
     relationship = models.ForeignKey(RegistrationType)
+
+    class Meta:
+        app_label = 'program'
     
     def __unicode__(self):
         return u'%s %s in %s' % (self.user, self.relationship, self.section)
@@ -1836,6 +1869,9 @@ class StudentSubjectInterest(ExpirableModel):
     """
     subject = AjaxForeignKey('ClassSubject')
     user = AjaxForeignKey(ESPUser)
+
+    class Meta:
+        app_label = 'program'
 
     def __unicode__(self):
         return u'%s interest in %s' % (self.user, self.subject)

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -112,6 +112,7 @@ class UserAvailability(models.Model):
     priority = models.DecimalField(max_digits=3, decimal_places=2, default='1.0')
 
     class Meta:
+        app_label = 'users'
         db_table = 'users_useravailability'
 
     def __unicode__(self):
@@ -1906,6 +1907,9 @@ class Record(models.Model):
 
     time = models.DateTimeField(blank=True, default = datetime.now)
 
+    class Meta:
+        app_label = 'users'
+
     @classmethod
     def user_completed(cls, user, event, program=None):
         if program is None:
@@ -2000,6 +2004,9 @@ class Permission(ExpirableModel):
     #their classes
     #it may, however, be the case that this model is not general enough,
     #in which case program may need to be replaced by a generic foreignkey
+
+    class Meta:
+        app_label = 'users'
 
     @classmethod
     def user_has_perm(self, user, name, program=None, when=None):


### PR DESCRIPTION
I think this was the cause of our heisenbug where the table names were
occasionally wrong, causing database errors.  I have no idea why that was not happening consistently, but this seems like it would cause it.  This adds a class Meta with an app_label per https://docs.djangoproject.com/en/1.4/ref/models/options/#app-label since we have a models directory instead of a models.py.  (This will no longer be necessary (although I think will not hurt) in django 1.7.)
