### PR TITLE
Fix SCRMI admin panel slowness

### DIFF
--- a/esp/esp/program/modules/module_ext.py
+++ b/esp/esp/program/modules/module_ext.py
@@ -58,7 +58,7 @@ REG_VERB_BASE = 'V/Flags/Registration'
 class StudentClassRegModuleInfo(models.Model):
     """ Define what happens when students add classes to their schedule at registration. """
 
-    module               = models.ForeignKey(ProgramModuleObj)
+    module               = models.ForeignKey(ProgramModuleObj, editable=False)
     
     #   Set to true to prevent students from registering from full classes.
     enforce_max          = models.BooleanField(default=True, help_text='Check this box to prevent students from signing up for full classes.')


### PR DESCRIPTION
The SCRMI detail view in the admin panel was very slow to load. This
was because it was rendering a dropdown containing all the program
modules in the database, which issues a separate query for each
program module's `__str__` method.

Fix this by making SCRMI.module non-editable, so that the dropdown
isn't rendered, since we aren't going to be editing that from the
admin panel anyway.
