### PR TITLE
Restore Entry objects in announcement list.

### DIFF
--- a/esp/esp/miniblog/views/__init__.py
+++ b/esp/esp/miniblog/views/__init__.py
@@ -71,16 +71,16 @@ def get_visible_announcements(user, limit, tl):
 	if tl:
 	    result = result.filter(section=tl)
 
-    if limit:
-        overflowed = ((len(result) - limit) > 0)
-        total = len(result)
-        result = result[:limit]
-    else:
-        overflowed = False
-        total = len(result)
+        if limit:
+            overflowed = ((len(result) - limit) > 0)
+            total = len(result)
+            result = result[:limit]
+        else:
+            overflowed = False
+            total = len(result)
 
-    results += result
-    grand_total += total
+        results += result
+        grand_total += total
 
     return {'announcementList': results,
               'overflowed':       overflowed,


### PR DESCRIPTION
An indentation change in 9988b0b15227068260b1ce6bfc112e7102afe8d4
caused only the last model scanned (AnnouncementLink, namely) to
make it into the results.
