### PR TITLE
Fix issue with $MODE_PROD in server setup script

### DIFF
--- a/esp/useful_scripts/server_setup/dev_server_setup.sh
+++ b/esp/useful_scripts/server_setup/dev_server_setup.sh
@@ -135,7 +135,7 @@ then
     then
         MODE_PROD=true
     else
-        MODE_PROD=false
+        MODE_PROD=
     fi
 fi
 if [[ $MODE_PROD ]]
@@ -143,7 +143,7 @@ then
 	echo "MODE_PROD=true" >> $BASEDIR/.espsettings
 	echo "Installing production site"
 else
-	echo "MODE_PROD=false" >> $BASEDIR/.espsettings
+	echo "MODE_PROD=" >> $BASEDIR/.espsettings
 	echo "Installing development site"
 fi
 


### PR DESCRIPTION
In shell, `[[ false ]]` returns 0 (i.e. evaluates to true). In
particular, `[[ $MODE_PROD ]]` always return true.

Instead of this, use an empty string for `$MODE_PROD` to indicate
non-prod mode.
