### PR TITLE
Changes error500() to use RequestContext

### DIFF
--- a/esp/esp/web/util/main.py
+++ b/esp/esp/web/util/main.py
@@ -111,8 +111,17 @@ def error404(request, template_name='404.html'):
 
 def error500(request, template_name='500.html'):
     context = {}
+    context['settings'] = settings # needed by elements/html
     context['DEFAULT_EMAIL_ADDRESSES'] = settings.DEFAULT_EMAIL_ADDRESSES
     context['EMAIL_HOST'] = settings.EMAIL_HOST
     context['request'] = request
     t = loader.get_template(template_name) # You need to create a 500.html template.
-    return http.HttpResponseServerError(t.render(Context(context)))
+
+    # If possible, we want to render this page with a RequestContext so that
+    # the context processors are run. If this fails for some reason, we still
+    # want to display the original 500 error page, so fall back to using a
+    # normal Context.
+    try:
+        return http.HttpResponseServerError(t.render(RequestContext(context)))
+    except Exception:
+        return http.HttpResponseServerError(t.render(Context(context)))


### PR DESCRIPTION
Resolves part of Github Issue #946.

This should be safe, but I don't know if there was a reason that `Context` was originally used. @pricem ?
