### PR TITLE
Fix bug in displaying comm panel user filters

### DIFF
--- a/esp/public/media/scripts/commpanel.js
+++ b/esp/public/media/scripts/commpanel.js
@@ -65,13 +65,13 @@ function submit_prev_selection()
 function prepare_accordion(accordion_id, rb_selected)
 {
     //  Show school/grade options for students, graduation year options for teachers
-    if (rb_selected == "students")
+    if (rb_selected.toLowerCase().substr(0, 7) == "student")
     {
         $j("#" + accordion_id).children(".ui-accordion-header").eq(7).show();
         $j("#" + accordion_id).children(".ui-accordion-header").eq(8).show();
         $j("#" + accordion_id).children(".ui-accordion-header").eq(9).hide();
     }
-    else if (rb_selected == "teachers")
+    else if (rb_selected.toLowerCase().substr(0, 7) == "teacher")
     {
         $j("#" + accordion_id).children(".ui-accordion-header").eq(7).hide();
         $j("#" + accordion_id).children(".ui-accordion-header").eq(8).hide();


### PR DESCRIPTION
The "grade", "school" and "grad year" options had disappeared from
the user list selector.  The problem was a hard coded check for
user type which compared against "students" and "teachers", whereas
the user types present on the form are actually "Student" and
"Teacher".  With this change, a somewhat more tolerant comparison
is used to decide which filter options to show.

Addresses issue #642.
