### PR TITLE
Fixes virtualenv activation

### DIFF
--- a/esp.wsgi
+++ b/esp.wsgi
@@ -12,7 +12,16 @@ sys.path.insert(0, os.path.join(BASEDIR, 'esp'))
 
 # activate virtualenv
 activate_this = os.path.join(BASEDIR, 'env/bin/activate_this.py')
-execfile(activate_this, dict(__file__=activate_this))
+try:
+    execfile(activate_this, dict(__file__=activate_this))
+except IOError, e:
+    # Check if a virtualenv has been installed and activated from elsewhere.
+    # If this has happened, then the VIRTUAL_ENV environment variable should be
+    # defined, and we can ignore the IOError.
+    # If the variable isn't defined, then we really should be using our own
+    # virtualenv, so we re-raise the error.
+    if os.environ.get('VIRTUAL_ENV') is None:
+        raise e
 
 import django.core.handlers.wsgi
 django_application = django.core.handlers.wsgi.WSGIHandler()

--- a/esp/dbmail_cron.py
+++ b/esp/dbmail_cron.py
@@ -13,7 +13,16 @@ sys.path.insert(0, project)
 # activate virtualenv
 root = os.path.dirname(project)
 activate_this = os.path.join(root, 'env', 'bin', 'activate_this.py')
-execfile(activate_this, dict(__file__=activate_this))
+try:
+    execfile(activate_this, dict(__file__=activate_this))
+except IOError, e:
+    # Check if a virtualenv has been installed and activated from elsewhere.
+    # If this has happened, then the VIRTUAL_ENV environment variable should be
+    # defined, and we can ignore the IOError.
+    # If the variable isn't defined, then we really should be using our own
+    # virtualenv, so we re-raise the error.
+    if os.environ.get('VIRTUAL_ENV') is None:
+        raise e
 
 from esp import cache_loader
 from esp.dbmail.cronmail import process_messages, send_email_requests

--- a/esp/manage.py
+++ b/esp/manage.py
@@ -1,13 +1,23 @@
 #!/usr/bin/env python
+import os
+import sys
 
 # activate virtualenv
-import os.path
 project = os.path.dirname(os.path.realpath(__file__))
 root = os.path.dirname(project)
 activate_this = os.path.join(root, 'env', 'bin', 'activate_this.py')
-execfile(activate_this, dict(__file__=activate_this))
-
-import os, sys
+try:
+    execfile(activate_this, dict(__file__=activate_this))
+except IOError, e:
+    # Check if a virtualenv has been installed and activated from elsewhere.
+    # This happens when using the Travis testing environment, which uses its
+    # own virtualenv install.
+    # If this has happened, then the VIRTUAL_ENV environment variable should be
+    # defined, and we can ignore the IOError.
+    # If the variable isn't defined, then we really should be using our own
+    # virtualenv, so we re-raise the error.
+    if os.environ.get('VIRTUAL_ENV') is None:
+        raise e
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "esp.settings")

--- a/esp/useful_scripts/script_setup.py
+++ b/esp/useful_scripts/script_setup.py
@@ -9,7 +9,16 @@ sys.path.append(project)
 # activate virtualenv
 envroot = os.path.dirname(project)
 activate_this = os.path.join(envroot, 'env', 'bin', 'activate_this.py')
-execfile(activate_this, dict(__file__=activate_this))
+try:
+    execfile(activate_this, dict(__file__=activate_this))
+except IOError, e:
+    # Check if a virtualenv has been installed and activated from elsewhere.
+    # If this has happened, then the VIRTUAL_ENV environment variable should be
+    # defined, and we can ignore the IOError.
+    # If the variable isn't defined, then we really should be using our own
+    # virtualenv, so we re-raise the error.
+    if os.environ.get('VIRTUAL_ENV') is None:
+        raise e
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "esp.settings")
 


### PR DESCRIPTION
/esp/dbmail_cron.py was not activating virtualenv, so recently it was
failing to run because could not import new dependencies that weren't
installed globally on the system (specifically, it couldn't import
markdown, which is imported by one of the modules that is imported by
the cache loader). Fixes this error by activating virtualenv in
dbmail_cron.

While doing this, I noticed that we were doing the activation wrong, in
two ways:
- The try/except block was originally designed to make it optional to
  use virtualenv. However, we are always going to be using virtualenv.
  So instead of helping us, the try/except class was masking our own
  bugs. This commit removes the try/except blocks.
- esp.wsgi was not using os.path.realpath(**file**), so it wasn't
  activating the correct file. We didn't notice this because of the
  try/except block, and probably because it doesn't matter for esp.wsgi.
  Fixes this bug.
