### PR TITLE
Add migration to remove leading spaces from QSDs

### DIFF
--- a/esp/esp/qsd/migrations/0005_remove_leading_space.py
+++ b/esp/esp/qsd/migrations/0005_remove_leading_space.py
@@ -8,9 +8,10 @@ class Migration(DataMigration):
 
     def forwards(self, orm):
         """ Remove leading space from QSD content. """
-        for q in orm.QuasiStaticData.objects.filter(content__startswith=' '):
-            q.content = q.content.lstrip()
-            q.save()
+        for q in orm.QuasiStaticData.objects.all():
+            if q.content != q.content.lstrip():
+                q.content = q.content.lstrip()
+                q.save()
 
     def backwards(self, orm):
         pass


### PR DESCRIPTION
Before 6f7d69e11136f0b769e47a9c468477d2c58c4cf1, using the inline QSD
editor would add extraneous leading spaces to the content. This is a
bug that has since been fixed, but the leading spaces are still
there. With the new version of Markdown, these leading spaces are
misinterpreted as denoting code blocks, which is undesirable.

Add a migration that, assuming that any leading space is
unintentional, removes it.
