### PR TITLE
Work around Ajax scheduler failure for non-integer-hour classes

### DIFF
--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Scheduling.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Scheduling.js
@@ -590,58 +590,59 @@ ESP.Scheduling = function(){
     };
     
     var validate_start_time = function(time, section, str_err) {
-	var length = Math.ceil(section.length_hr);
-	if (!length || length == 0){
-	    return (str_err ? "No length defined!" : false)
-	}
-	    
+        var length = Math.ceil(section.length_hr);
+        if (!length || length == 0)
+        {
+            return (str_err ? "No length defined!" : false)
+        }
+
         //  Check for not scheduling across a contiguous group of lunch periods - check start block only
         var test_time = time;
         var covered_lunch_start = false;
 
-	// Start with the proposed start time and iterate over all time blocks the section will need
-	var time_included = 0;
-	for (var i = 0; i < length; i++)
-	{
-		//  Maintain a count of the time included by the timeslots so far.
-		time_included += test_time.length;
+        // Start with the proposed start time and iterate over all time blocks the section will need
+        var time_included = 0;
+        for (var i = 0; i < length; i++)
+        {
+            //  Maintain a count of the time included by the timeslots so far.
+            time_included += test_time.length;
 
-	    if (test_time.is_lunch && !covered_lunch_start)
-	    {
-			//  Check that this is the first lunch in the group:
-			//  - this is the first time slot, or
-			//  - the previous time slot is not a lunch block
-			if ((ESP.Scheduling.data.times.indexOf(test_time) == 0) || !(ESP.Scheduling.data.times[ESP.Scheduling.data.times.indexOf(test_time) - 1].is_lunch))
-			{
-				covered_lunch_start = true;
-			}
-	    }
-	    
-		//  Check that the section would not run over the end of the program,
-		//  or the end of the contiguous time block (if there is a break).
-		//  (10 min error tolerance)
-		//  This is a temporary workaround for a larger problem; see Github issue #972.
-		//  - Michael P, 1/24/2014
-		if (!test_time.seq)
-		{
-			if (section.length > time_included + 10 * 60 * 1000)
-				return (str_err ? "Section " + section.code + " does not fit within the contiguous time available" : false);
-			else
-				return true;
-		}
+            if (test_time.is_lunch && !covered_lunch_start)
+            {
+                //  Check that this is the first lunch in the group:
+                //  - this is the first time slot, or
+                //  - the previous time slot is not a lunch block
+                if ((ESP.Scheduling.data.times.indexOf(test_time) == 0) || !(ESP.Scheduling.data.times[ESP.Scheduling.data.times.indexOf(test_time) - 1].is_lunch))
+                {
+                    covered_lunch_start = true;
+                }
+            }
 
-		//  But, if our class period overlapped with the beginning of the lunch sequence
-		//  and now also overlaps with the end of the lunch sequence, that's a conflict.
-		else if (covered_lunch_start && !(test_time.seq.is_lunch))
-	    {
-			return (str_err ? "Section " + section.code + " starting at " + time.text + " would conflict with a group of lunch periods" : false);
-	    }
-	    
-	    //  Move on to the next time slot.
-	    test_time = test_time.seq;
-	}
+            //  Check that the section would not run over the end of the program,
+            //  or the end of the contiguous time block (if there is a break).
+            //  (10 min error tolerance)
+            //  This is a temporary workaround for a larger problem; see Github issue #972.
+            //  - Michael P, 1/24/2014
+            if (!test_time.seq)
+            {
+                if (section.length > time_included + 10 * 60 * 1000)
+                    return (str_err ? "Section " + section.code + " does not fit within the contiguous time available" : false);
+                else
+                    return true;
+            }
 
-	return (str_err ? "OK" : true);
+            //  But, if our class period overlapped with the beginning of the lunch sequence
+            //  and now also overlaps with the end of the lunch sequence, that's a conflict.
+            else if (covered_lunch_start && !(test_time.seq.is_lunch))
+            {
+                return (str_err ? "Section " + section.code + " starting at " + time.text + " would conflict with a group of lunch periods" : false);
+            }
+
+        //  Move on to the next time slot.
+        test_time = test_time.seq;
+        }
+
+        return (str_err ? "OK" : true);
     };
     
     var self = {


### PR DESCRIPTION
Yale reported that they were unable to schedule a 1.5 hour class into a
single 1.5 hour time block that was not contiguous with any other time
blocks (#972).  It was not hard to find the reason why since Ruthie put a helpful
comment by the relevant code saying that it wouldn't work in that case.

The Ajax scheduling module makes dangerous assumptions about class and
timeslot lengths (e.g. integer hours, non-overlapping) in other places, so
this is not an attempt to fix the general problem, just an attempt to fix
the immediate problem without breaking anything else.

The check in question was designed to prevent scheduling a class into a
start time that was too late for the class to finish by the end of the
program (or the end of a contiguous set of timeslots).  It has been
modified to count time in milliseconds rather than hours.
