### PR TITLE
Fixes bug with password reset

### DIFF
--- a/esp/esp/users/views/password_reset.py
+++ b/esp/esp/users/views/password_reset.py
@@ -41,7 +41,7 @@ def initial_passwd_request(request, success=None):
             for user in users:
                 user.recoverPassword()
 
-            return HttpResponseRedirect(os.path.join(request.path, 'success/'))
+            return HttpResponseRedirect('/%s/success/' % request.path.strip('/'))
 
 
     else:


### PR DESCRIPTION
The passwdrecover url doesn't have to end in a slash, but the code was
assuming the slash was always there. This commit changes it so that a
slash is added if it is missing.
