### PR TITLE
Fix to /manage///editclass/#### for walk-ins

### DIFF
--- a/esp/esp/program/modules/handlers/adminclass.py
+++ b/esp/esp/program/modules/handlers/adminclass.py
@@ -621,7 +621,7 @@ class AdminClass(ProgramModuleObj):
             return render_to_response(self.baseDir()+'cannoteditclass.html', request, {})
         cls = classes[0]
 
-        if cls.category.category == self.program.open_class_category.category:
+        if cls.category == self.program.open_class_category:
             action = 'editopenclass'
         else:
             action = 'edit'

--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -595,7 +595,7 @@ class TeacherClassRegModule(ProgramModuleObj, module_ext.ClassRegModuleInfo):
             return render_to_response(self.baseDir()+'cannoteditclass.html', request, {})
         cls = classes[0]
 
-        if cls.category.category == self.program.open_class_category.category:
+        if cls.category == self.program.open_class_category:
             action = 'editopenclass'
         else:
             action = 'edit'
@@ -627,7 +627,7 @@ class TeacherClassRegModule(ProgramModuleObj, module_ext.ClassRegModuleInfo):
         cls = classes[0]
 
         # Select the correct action
-        if cls.category.category == self.program.open_class_category.category:
+        if cls.category == self.program.open_class_category:
             action = 'editopenclass'
         else:
             action = 'edit'


### PR DESCRIPTION
It was not using the appropriate editopenclass, so it would not work for walk-in classes if you were using that URL style.
