### PR TITLE
Custom form: 404 if form does not exist.

### DIFF
--- a/esp/esp/customforms/views.py
+++ b/esp/esp/customforms/views.py
@@ -260,10 +260,9 @@ def viewForm(request, form_id):
     """
     try:
         form_id = int(form_id)
-    except ValueError:
+        form = Form.objects.get(pk=form_id)
+    except (ValueError, Form.DoesNotExist):
         raise Http404
-        
-    form = Form.objects.get(pk=form_id)
     
     perm, error_text = hasPerm(request.user, form)
     if not perm:


### PR DESCRIPTION
Previously it encountered uncaught exception and had 500 error.
