### PR TITLE
Several fixes to RegistrationType handling in Two-Phase Student Reg

### DIFF
--- a/esp/esp/program/modules/handlers/studentregtwophase.py
+++ b/esp/esp/program/modules/handlers/studentregtwophase.py
@@ -90,12 +90,12 @@ class StudentRegTwoPhase(ProgramModuleObj):
         # mappings for each timeslot.
         priority_regs = StudentRegistration.valid_objects().filter(
             user=request.user, relationship__name__startswith='Priority')
-        priority_regs = priority_regs.values(
-            'relationship__displayName', 'section', 'section__parent_class__title')
+        priority_regs = priority_regs.select_related(
+            'relationship', 'section', 'section__parent_class')
         for student_reg in priority_regs:
-            rel = student_reg['relationship__displayName']
-            title = student_reg['section__parent_class__title']
-            sec = ClassSection.objects.get(pk=student_reg['section'])
+            rel = student_reg.relationship
+            title = student_reg.section.parent_class.title
+            sec = student_reg.section
             times = sec.meeting_times.all().order_by('start')
             if times.count() == 0:
                 continue
@@ -293,10 +293,11 @@ class StudentRegTwoPhase(ProgramModuleObj):
         context['timeslot'] = timeslot
         context['num_priorities'] = prog.priorityLimit()
         context['priorities'] = []
-        for i in range(1, prog.priorityLimit()+1):
-            priority_name = 'Priority/' + str(i)
-            priority = RegistrationType.objects.get(name=priority_name)
-            context['priorities'].append((i, priority.displayName))
+        for rel_index in range(1, prog.priorityLimit()+1):
+            rel_name = 'Priority/%s' % rel_index
+            rel, created = RegistrationType.objects.get_or_create(
+                name=rel_name, category='student')
+            context['priorities'].append((rel_index, rel))
 
         catalog_context = self.catalog_context(
             request, tl, one, two,module, extra, prog)
@@ -319,8 +320,7 @@ class StudentRegTwoPhase(ProgramModuleObj):
         priorities = data[timeslot_id]
         for rel_index, cls_id in priorities.items():
             rel_name = 'Priority/%s' % rel_index
-            rel, created = RegistrationType.objects.get_or_create(
-                name=rel_name)
+            rel = RegistrationType.objects.get(name=rel_name, category='student')
 
             # Pull up any registrations that exist (including expired ones)
             srs = StudentRegistration.objects.annotate(

--- a/esp/public/media/scripts/catalog-new.js
+++ b/esp/public/media/scripts/catalog-new.js
@@ -487,7 +487,7 @@ var CatalogViewModel = function () {
         }
         if (dirty_priorities) {
             var priorities = {};
-            $j('#catalog-sticky .pri-select').each(function() {
+            $j('#catalog-sticky select.pri-select').each(function() {
                 priorities[$j(this).data('pri')] = $j(this).val();
             });
             var response = {};


### PR DESCRIPTION
1. Use `reg_type.__unicode__()` rather than `reg_type.displayName`
   directly (in case `.displayName` is not set, we should default to `.name`,
   which `.__unicode__()` already does).
2. Use `RegistrationType.get_or_create` in /rank_classes view, so that
   the page doesn't crash if one of the expected RegistrationTypes
   doesn't exist yet. (Also make the variable naming more consistent.)
3. Don't use `get_or_create` in /save_priorities view. Previously this
   was a minor security hole that allowed students to e.g. register for a
   class with a RegistrationType of Priority/{arbitrary injected string}
   by submitting tampered post data.
4. Fix a jQuery selector so that the page doesn't try to submit empty
   registrations with Priority/undefined.
