### PR TITLE
Fixes QSD saving rendered versions of HTML special characters

### DIFF
--- a/esp/templates/inclusion/qsd/render_qsd.html
+++ b/esp/templates/inclusion/qsd/render_qsd.html
@@ -3,7 +3,7 @@
 <div class="qsd_bits hidden">
 	<div class="qsd_header qsd_bits hidden" onclick="qsd_inline_edit('{{ qsdrec.url }}', '{{ qsdrec.edit_id }}');">This is quasi-static content.  Click here to edit the text; click outside the box to save changes.</div>
 	<div class="hidden qsd_bits hidden" id="inline_edit_{{ qsdrec.edit_id }}">
-		<textarea rows="8" cols="80" id="qsd_content_{{ qsdrec.edit_id }}" onblur="qsd_inline_upload('{{ qsdrec.url }}', '{{ qsdrec.edit_id }}');" name="qsd_content" class="qsd_editor qsd_fullsize qsd_bits hidden">{% autoescape off %}{{ qsdrec.content }}{% endautoescape %}</textarea>
+		<textarea rows="8" cols="80" id="qsd_content_{{ qsdrec.edit_id }}" onblur="qsd_inline_upload('{{ qsdrec.url }}', '{{ qsdrec.edit_id }}');" name="qsd_content" class="qsd_editor qsd_fullsize qsd_bits hidden">{% autoescape on %}{{ qsdrec.content }}{% endautoescape %}</textarea>
 	</div>
 </div>
 

--- a/esp/templates/inclusion/qsd/render_qsd_inline.html
+++ b/esp/templates/inclusion/qsd/render_qsd_inline.html
@@ -11,7 +11,7 @@
     <div class="hidden" id="inline_edit_{{ qsdrec.edit_id }}">
         <textarea rows="8" cols="80" id="qsd_content_{{ qsdrec.edit_id }}"
                   onblur="qsd_inline_upload('{{ qsdrec.url }}', '{{ qsdrec.edit_id }}');" name="qsd_content"
-                  class="qsd_editor qsd_bits hidden {% if not qsdrec.id %}qsd_halfsize{% endif %}">{% autoescape off %}{{ qsdrec.content }}{% endautoescape %}
+                  class="qsd_editor qsd_bits hidden {% if not qsdrec.id %}qsd_halfsize{% endif %}">{% autoescape on %}{{ qsdrec.content }}{% endautoescape %}
         </textarea>
     </div>
 </div>


### PR DESCRIPTION
Previously, the direct QSD editing textarea used the non-escaped
version of the content to put as the starting point for the textarea,
which resulted in special characters being saved as their rendered
form on the second save of a QSD page. This change makes those
contents escaped. The static edit page was already doing this
properly.

See #974 for more details.
