### PR TITLE
Allows for $0 options in extracosts.

### DIFF
--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -2034,6 +2034,7 @@ class Record(models.Model):
         ("teacheracknowledgement","Did teacher acknowledgement"),
         ("lunch_selected","Selected a lunch block"),
         ("extra_form_done","Filled out Custom Form"),
+        ("extra_costs_done","Filled out Student Extra Costs Form"),
         ("waitlist","Waitlisted for a program"),
         ("interview","Teacher-interviewed for a program"),
         ("teacher_training","Attended teacher-training for a program"),

--- a/esp/templates/program/modules/studentextracosts/extracosts.html
+++ b/esp/templates/program/modules/studentextracosts/extracosts.html
@@ -47,7 +47,25 @@ td>ul { list-style-type: none; padding: 0px }
 </tr>
 {% for f in forms %}
 <tr style="border-bottom: 1px dashed grey;">
-    <td width="120px">{{ f.form.cost }} {% if f.LineItem.negative_amount %}<i>${{ f.LineItem.negative_amount|floatformat:2 }}</i>{% endif %}</td>
+    <td width="120px">
+        {{ f.form.cost }}
+        {% if f.LineItem.negative_amount %}
+            <i>${{ f.LineItem.negative_amount|floatformat:2 }}</i>
+            {% endif %}
+
+        {# If num_options, radio buttons will be used for the field. In order to  #}
+        {# be able to remove a selected item, we need a button. The Javascript    #}
+        {# code for the button is at the bottom.                                  #}
+
+        {% if f.LineItem.num_options %}
+            <button type="button"
+                    class="remove-item"
+                    name="{{ f.form.prefix }}-cost"
+                    onclick="remove_item(this);">
+                Remove this item
+            </button>
+        {% endif %}
+    </td>
 {% if select_qty %}    <td>{{ f.form.count }}</td>{% endif %}
     <td>{% if f.form.errors %}<font color="red">{{ f.form.errors }}</font>  {% endif %}
 {% if not f.LineItem.negative_amount and f.LineItem.description %} {{ f.LineItem.description }}
@@ -64,5 +82,15 @@ td>ul { list-style-type: none; padding: 0px }
 </center>
 </form>
 </div>
+
+<script type="text/javascript">
+    /*
+     * A click handler that unchecks all inputs with the same name as the
+     * button.
+     **/
+    function remove_item(button) {
+        $j("input[name="+button.name+"]").prop("checked", false);
+    }
+</script>
 
 {% endblock %}


### PR DESCRIPTION
Makes the Student Extra Costs module work with line item types that have
$0 options.

Adds a extra_costs_done Record to keep track of when a student has
completed the module.

Also adds a reset button for each group of radio buttons on the form.

Resolves Github Issue #1118.
(cherry picked from commit b231260f73e42d6dccac98b03980e5c715b0db23)
