### PR TITLE
Removes legacy redirects to home

### DIFF
--- a/esp/esp/urls.py
+++ b/esp/esp/urls.py
@@ -77,9 +77,6 @@ urlpatterns += patterns('',
 # generic stuff
 urlpatterns += patterns('esp.web.views.main',
                         (r'^error_reporter', 'error_reporter'),
-                        (r'^web$', 'home'), # index
-                        (r'^esp_web', 'home'), # index
-                        (r'.php$', 'home'), # index
                         (r'^$', 'home'), # index
                         (r'^set_csrf_token', 'set_csrf_token'), # tiny view used to set csrf token
                         )


### PR DESCRIPTION
These shouldn't be needed anymore. It's been many years since the old
website was used, no one should have links to these pages anymore.
