### PR TITLE
Refresh QSD pages after editing

### DIFF
--- a/esp/public/media/scripts/qsd.js
+++ b/esp/public/media/scripts/qsd.js
@@ -39,6 +39,7 @@ function qsd_send_command(qsd_url, edit_id, postdata)
             if (data)
             {
                 qsd_inline_update(qsd_url, edit_id, data);
+                window.location.reload(true); // bust the cache
             }
         }
         else


### PR DESCRIPTION
Make the inline ajax-based QSD editor trigger a page reload after
editing, so as to clear the cached version of the page for the person
who just edited it. This fixes #276.
