### PR TITLE
Fixes XSS vulnerability in rapid approval system

### DIFF
--- a/esp/public/media/scripts/program/modules/adminclass.js
+++ b/esp/public/media/scripts/program/modules/adminclass.js
@@ -52,7 +52,6 @@ function getStatusDetails(statusCode) {
 }
 
 function make_attrib_para(field, content) {
-    console.log(content);
     return $j("<p></p>")
         .append("<b>"+field+":</b>")
         .append($j("<div/>").text(content));


### PR DESCRIPTION
Previously it was possible to pull an XSS attack on a reviewing admin by adding HTML tags to the description.
