### PR TITLE
Allow configuration of additional Javascript code (or other HTML) in page footers

### DIFF
--- a/esp/esp/django_settings.py
+++ b/esp/esp/django_settings.py
@@ -311,6 +311,10 @@ CONTACTFORM_EMAIL_ADDRESSES = {}
 #   It can be overridden by setting CDN_ADDRESS in local_settings.py.
 CDN_ADDRESS = 'https://dfwb7shzx5j05.cloudfront.net'
 
+# allow configuration of additional Javascript to be placed on website
+# configuration should include <script></script> tags
+ADDITIONAL_TEMPLATE_SCRIPTS = ''
+
 DEBUG_TOOLBAR = True # set to False in local_settings to globally disable the debug toolbar
 
 DEBUG_TOOLBAR_PATCH_SETTINGS = False

--- a/esp/templates/elements/html
+++ b/esp/templates/elements/html
@@ -110,6 +110,8 @@
     <script type="text/javascript" src="{{ settings.CDN_ADDRESS }}/bootstrap/docs/assets/js/application.js"></script>
     
     <script src="/media/scripts/nav.js" type="text/javascript"></script>
+
+    {% autoescape off %}{{ settings.ADDITIONAL_TEMPLATE_SCRIPTS }}{% endautoescape %}
     {% endblock %}
   </body>
 </html>


### PR DESCRIPTION
The main purpose of this would probably be to add tracking code for analytics.

See Issue #1196 
