### PR TITLE
Fixes bug with onsite classchange grid

### DIFF
--- a/esp/public/media/scripts/onsite/ajax_status.js
+++ b/esp/public/media/scripts/onsite/ajax_status.js
@@ -261,6 +261,7 @@ function update_checkboxes()
 
 function handle_schedule_response(new_data, text_status, jqxhr)
 {
+    data.students[new_data.user].grade = new_data.user_grade
     //  Save the new schedule
     state.student_schedule = new_data.sections;
     state.student_schedule.sort();
@@ -789,7 +790,7 @@ function populate_students()
         new_student.id = data.students_list[i][0];
         new_student.last_name = data.students_list[i][1];
         new_student.first_name = data.students_list[i][2];
-        new_student.grade = data.students_list[i][3];
+        new_student.grade = 0;
         new_student.sections = [];
         new_student.checked_in = null;
         data.students[new_student.id] = new_student;


### PR DESCRIPTION
The print_schedule() function was overriding the global 'data' variable,
which has all of the class and timeblock data, making it impossible to
do anything after printing a student's schedule.

Also speeds up loading of the onsite grid by avoiding the unnecessary precomputation of all student grades.

Resolves (partially?) #75.
