### PR TITLE
Remove "shorthand" hack allowing "esp." to be omitted in imports

### DIFF
--- a/esp/esp/cache_loader/__init__.py
+++ b/esp/esp/cache_loader/__init__.py
@@ -23,14 +23,6 @@ cf_cache._populate()
 for app_name in settings.INSTALLED_APPS:
     if app_name != 'esp.cache_loader':
         __import__(app_name, {}, {}, ['models'])
-    # HACK: Duplicate esp.foo in sys.modules as foo.
-    # This lets console users type "import program.models"
-    # As shorthand for "import esp.program.models".
-    # In the code you should of course still write out the "esp."
-    if app_name.startswith('esp.'):
-        for key, value in sys.modules.items():
-           if key.startswith(app_name):
-               sys.modules[key[4:]] = value
 
 #   Make sure template override cache is registered
 from esp.utils.template import Loader

--- a/esp/esp/customforms/views.py
+++ b/esp/esp/customforms/views.py
@@ -4,7 +4,7 @@ from django.http import Http404,HttpResponseRedirect
 from django.template import RequestContext
 from django.db import connection
 from django.utils import simplejson as json
-from customforms.models import *
+from esp.customforms.models import *
 from esp.program.models import Program
 from esp.customforms.DynamicModel import DynamicModelHandler as DMH
 from esp.customforms.DynamicForm import FormHandler

--- a/esp/esp/dataviews/forms/__init__.py
+++ b/esp/esp/dataviews/forms/__init__.py
@@ -1,8 +1,8 @@
 from django.forms import *
 from django.contrib.formtools.wizard import FormWizard
 from django.template.context import RequestContext
-from dataviews import useful_models as all_usefull_models
-from dataviews import * 
+from esp.dataviews import useful_models as all_usefull_models
+from esp.dataviews import *
 from django.forms.util import flatatt, ErrorDict, ErrorList
 from django.forms.forms import pretty_name
 from django.core.urlresolvers import get_callable, get_mod_func

--- a/esp/esp/dataviews/urls.py
+++ b/esp/esp/dataviews/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls.defaults import *
-from dataviews.views import wizard_view, mode_view, doc_view, path_view
-from dataviews import useful_models
+from esp.dataviews.views import wizard_view, mode_view, doc_view, path_view
+from esp.dataviews import useful_models
 
 useful_models_text = r'|'.join([useful_model.__name__ for useful_model in useful_models])
 

--- a/esp/esp/dataviews/views.py
+++ b/esp/esp/dataviews/views.py
@@ -1,7 +1,7 @@
 # Create your views here.
 from esp.web.util.main import render_to_response
-from dataviews import * 
-from dataviews.forms import ModeForm, DataViewsWizard
+from esp.dataviews import *
+from esp.dataviews.forms import ModeForm, DataViewsWizard
 from django.db.models.related import RelatedObject
 from django.db.models.fields.related import RelatedField, ForeignKey, ManyToManyField
 

--- a/esp/esp/django_settings.py
+++ b/esp/esp/django_settings.py
@@ -366,7 +366,7 @@ SHELL_PLUS_POST_IMPORTS = (
         )
 
 #   Exclude apps from testing
-TEST_RUNNER = 'utils.testing.ExcludeTestSuiteRunner'
+TEST_RUNNER = 'esp.utils.testing.ExcludeTestSuiteRunner'
 TEST_EXCLUDE = ('django', 'grappelli', 'reversion')
 
 #   Twilio configuration - should be completed in local_settings.py

--- a/esp/esp/users/views/registration.py
+++ b/esp/esp/users/views/registration.py
@@ -142,7 +142,7 @@ When there are already accounts with this email address (depending on some tags)
 
         #form is valid, and not caring about multiple accounts
         email = urllib.quote(form.cleaned_data['email'])
-        return HttpResponseRedirect(reverse('users.views.user_registration_phase2')+'?email='+email)
+        return HttpResponseRedirect(reverse('esp.users.views.user_registration_phase2')+'?email='+email)
     else: #form is not valid
         return render_to_response('registration/newuser_phase1.html',
                                   request,
@@ -180,12 +180,12 @@ def user_registration_phase2(request):
         return user_registration_validate(request)
 
     if not Tag.getBooleanTag("ask_about_duplicate_accounts",default=False):
-        return HttpResponseRedirect(reverse("users.views.user_registration_phase1"))
+        return HttpResponseRedirect(reverse("esp.users.views.user_registration_phase1"))
 
     try:
         email = urllib.unquote(request.GET['email'])
     except MultiValueDictKeyError:
-        return HttpResponseRedirect(reverse("users.views.user_registration_phase1"))
+        return HttpResponseRedirect(reverse("esp.users.views.user_registration_phase1"))
     form = UserRegForm(initial={'email':email,'confirm_email':email})
     return render_to_response('registration/newuser.html',
                               request, {'form':form, 'email':email})

--- a/esp/esp/utils/tests.py
+++ b/esp/esp/utils/tests.py
@@ -16,11 +16,11 @@ except:
 import os
 import sys
 try:
-    from utils.memcached_multihost import CacheClass as MultihostCacheClass
+    from esp.utils.memcached_multihost import CacheClass as MultihostCacheClass
 except:
     MultihostCacheClass = False
     print "Couldn't import MultihostCacheClass.  Not running tests against it."
-from utils.defaultclass import defaultclass
+from esp.utils.defaultclass import defaultclass
 from esp import utils
 from django.conf import settings
 from esp.utils.models import TemplateOverride


### PR DESCRIPTION
This shorthand isn't used much anyway, it adds bloat, and we now have
shell_utils which is a much better place to put shell conveniences
like this.
