### PR TITLE
Handle non-ascii characters in Mailman list members

### DIFF
--- a/esp/esp/mailman/__init__.py
+++ b/esp/esp/mailman/__init__.py
@@ -161,7 +161,7 @@ def remove_list_member(list, member):
     if isinstance(member, unicode):
         member = member.encode('iso-8859-1', 'replace')
 
-    return Popen([MM_PATH + "remove_members", "--file=-", list], stdin=PIPE, stdout=PIPE, stderr=PIPE).communicate(str(member))
+    return Popen([MM_PATH + "remove_members", "--file=-", list], stdin=PIPE, stdout=PIPE, stderr=PIPE).communicate(member)
 
 @enable_with_setting(settings.USE_MAILMAN)
 def list_contents(lst):


### PR DESCRIPTION
Fix #872.

We use `ascii, replace` rather than, say, `utf-8`, because it looks like Mailman might not reliably accept utf-8, and it's not a big deal if we lose some characters in names anyway.
