### PR TITLE
Remove django.extensions.tests from INSTALLED_APPS

### DIFF
--- a/esp/esp/django_settings.py
+++ b/esp/esp/django_settings.py
@@ -363,7 +363,7 @@ SHELL_PLUS_POST_IMPORTS = (
 
 #   Exclude apps from testing
 TEST_RUNNER = 'esp.utils.testing.ExcludeTestSuiteRunner'
-TEST_EXCLUDE = ('django', 'grappelli', 'reversion')
+TEST_EXCLUDE = ('django', 'grappelli', 'reversion', 'django_extensions')
 
 #   Twilio configuration - should be completed in local_settings.py
 TWILIO_ACCOUNT_SID = None


### PR DESCRIPTION
Resolves #887.

This is currently being tested on mit-prod and the site seems to be up and running fine.
