### PR TITLE
Fix nodejs install

### DIFF
--- a/esp/packages_base_manual_install.sh
+++ b/esp/packages_base_manual_install.sh
@@ -4,7 +4,7 @@
 # that cannot be installed via apt-get.
 
 sudo apt-get install python-software-properties
-sudo add-apt-repository ppa:chris-lea/node.js
+sudo add-apt-repository -y ppa:chris-lea/node.js
 sudo apt-get update
 sudo apt-get install nodejs
 sudo npm install -g less@1.3.1


### PR DESCRIPTION
It looks like the version of less that we use doesn't exist in the mirrors anymore, so the Travis build was failing.

Fix this by switching to a different method of installing less, which is to use ppa and npm.
