### PR TITLE
Long overdue update to AUTHORS

### DIFF
--- a/esp/AUTHORS
+++ b/esp/AUTHORS
@@ -13,7 +13,7 @@ Work on this project has been hosted by the following organizations:
     Learning Unlimited, Inc.
       527 Franklin St, Cambridge, MA 02139
       Phone: 617-379-0178
-      Email: web-team@lists.learningu.org
+      Email: web-team@learningu.org
 
 Names of the contributors, in approximate order of appearance:
     Jason Alonso                
@@ -37,7 +37,34 @@ Names of the contributors, in approximate order of appearance:
     Ruth Byers          
     Theodore Hwa
     Jordan Moldow
+    Max Burstein
+    Jaydeep Khandelwal
+    Evan Kroske
     Vishal Dugar
+    Gurtej Kanwar
+    Sweet Tea Dorminy
+    Gary Wang
+    Taylor Sutton
+    Vikrant Varma
+    Abhiram Ampabathina
+    Sebin Thomas
+    Anthony Lu
+    Omer Faruk Uzun
+    Karthik Abinav
+    Alan Yeo Jie Wei
+    Benjamin Tidor
+    Benjamin Kraft
+    Favyen Bastani
+    Nicole Glabinski
+    Megan Belzner
+    Shulin Ye
+    Sam Thompson
+    Miriam Gershenson
+    James Hobin
+    Miles Calabresi
+    Joel Legris
+    Eric Mannes
+    Asya Bergal
 
 
 


### PR DESCRIPTION
Adds authors who have contributed to the main branch in the past 3-4
years. The command to get the list of authors, in order of first
contribution, is:
git log --format='%aN' | tac | cat -n | sort -k 2 | uniq -f 1 | sort -n | cut -f 2-
Then I did some manual filtering of already present authors and invalid
names.

Feel free to change the format of your own name if you wish.
