### PR TITLE
Users fixes

### DIFF
--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -2285,7 +2285,9 @@ class Permission(ExpirableModel):
             ("Teacher/Classes/All", "Classes/All"),
             ("Teacher/Classes/View", "Classes/View"),
             ("Teacher/Classes/Edit", "Classes/Edit"),
-            ("Teacher/Classes/Create", "Classes/Create"),
+            ("Teacher/Classes/Create", "Create classes of all types"),
+            ("Teacher/Classes/Create/Class", "Create standard classes"),
+            ("Teacher/Classes/Create/OpenClass", "Create open classes"),
             ("Teacher/Classes/SelectStudents", "Classes/SelectStudents"),
             ("Teacher/Quiz", "Teacher quiz"),
             ("Teacher/MainPage", "Registration mainpage"),
@@ -2308,6 +2310,8 @@ class Permission(ExpirableModel):
                           if x.startswith("Teacher")],
         "Teacher/Classes/All": [x for x in PERMISSION_CHOICES_FLAT
                                   if x.startswith("Teacher/Classes")],
+        "Teacher/Classes/Create": [x for x in PERMISSION_CHOICES_FLAT
+                                     if x.startswith("Teacher/Classes/Create")],
     }
     #i'm not really sure if implications is a good idea
     #use sparingly

--- a/esp/esp/users/tests.py
+++ b/esp/esp/users/tests.py
@@ -701,3 +701,28 @@ class PermissionTestCase(TestCase):
         perm = 'Onsite'
         self.create_role_perm(perm)
         self.assertTrue(self.user_has_perm_for_program(perm, program_is_none_implies_all=True))
+
+    def testTeacherClassesCreateImpliesTeacherClassesCreateClass(self):
+        """Test that Teacher/Classes/Create implies Teacher/Classes/Create/Class.
+
+        Ensure that old Teacher/Classes/Create Permissions, which were
+        intended to give permission to create standard classes, are forward
+        compatible and still grant this permission, which is now
+        Teacher/Classes/Create/Class.
+        """
+        old_name = 'Teacher/Classes/Create'
+        new_name = 'Teacher/Classes/Create/Class'
+
+        self.create_user_perm_for_program(old_name)
+        self.assertTrue(self.user_has_perm_for_program(new_name))
+
+    def testOtherTeacherClassesCreateImplications(self):
+        """Test the other Teacher/Classes/Create implications.
+
+        - Ensure that Teacher/Classes/Create implies
+          Teacher/Classes/Create/OpenClass.
+        """
+        name = 'Teacher/Classes/Create'
+        implications = ['Teacher/Classes/Create/OpenClass']
+        self.create_user_perm_for_program(name)
+        self.assertTrue(all(map(self.user_has_perm_for_program, implications)))

--- a/esp/templates/program/modules/teacherclassregmodule/classedit.html
+++ b/esp/templates/program/modules/teacherclassregmodule/classedit.html
@@ -37,7 +37,7 @@
         <p align="center"><div class="info">If you would like to teach multiple sections of the same class, <b>do not submit this form multiple times.</b>  Instead, select the desired number of sections next to "Number of Sections" (the second field from the top).</div></p>
     {% end_inline_program_qsd_block %}
 
-    {% if open_class_registration and addoredit == 'Add' %}
+    {% if otherclass.reg_open and addoredit == 'Add' %}
     <p style="font-weight:bold;">This page is for registering a {{ classtype }} <span style="text-decoration:underline;">only</span>. If you are trying to register a {{ otherclass.type }}, <a href="{% url esp.web.views.main.program tl one two otherclass.link %}">click here</a>.</p>
     {% endif %}
 {% endif %}

--- a/esp/templates/program/modules/teacherclassregmodule/listclasses.html
+++ b/esp/templates/program/modules/teacherclassregmodule/listclasses.html
@@ -67,6 +67,7 @@ If you have any questions regarding the program, <br /> please email the
    {% if can_create %}
    <tr>
    <td colspan="7" class="clsleft bordertop2"><b>Registration form:</b>
+     {% if can_create_class %}
      <a href="/teach/{{ one }}/{{ two }}/makeaclass" title="Teach for ESP!">
        Add a new class for {{ program.niceName }}!
      </a>
@@ -76,7 +77,8 @@ If you have any questions regarding the program, <br /> please email the
        Teach a class from a previous program for {{ program.niceName }}!
      </a>
      {% endif %}
-     {% if crmi.open_class_registration %}<br />
+     {% endif %}
+     {% if can_create_open_class %}<br />
      <a href="/teach/{{ one }}/{{ two }}/makeopenclass" title="Teach a {{ open_class_category}}!">
        Add a new {{ open_class_category }} for {{ program.niceName }}!
      </a> {% endif %}


### PR DESCRIPTION
- Fixes issue #1295.
- Adds PermissionTestCase.
- Resolves Github issue #1156:
  
  Adds a new teacherreg deadline to control open class (a.k.a. walk-in
  activity) registration separately from normal class registration.
  
  Sometimes directors want to leave open class registration open longer
  than normal class registration. This was previously impossible, because
  they used the same deadline.
  
  This commit adds two new deadlines, Teacher/Classes/Create/Class and
  Teacher/Classes/Create/OpenClass. The latter is for open classes only,
  and the former is for normal classes (and associated functionalities,
  such as class copying). The original deadline, Teacher/Classes/Create,
  continues to exist, and implies both of the new deadlines. In this way,
  the code is backwards-compatible with old settings, and no data
  migration is necessary. And when directors want both types of
  registration open at the same time, they can make use of this
  implication so they only have to set one permission. The program
  creation form should also continue to use this permission.
