### PR TITLE
Allow volunteer registrations to be removed.

### DIFF
--- a/esp/esp/program/modules/handlers/volunteersignup.py
+++ b/esp/esp/program/modules/handlers/volunteersignup.py
@@ -57,10 +57,13 @@ class VolunteerSignup(ProgramModuleObj, CoreModule):
             form = VolunteerOfferForm(request.POST, program=prog)
             if form.is_valid():
                 offers = form.save()
-                context['complete'] = True
-                context['complete_name'] = offers[0].name
-                context['complete_email'] = offers[0].email
-                context['complete_phone'] = offers[0].phone
+                if len(offers) > 0:
+                    context['complete'] = True
+                    context['complete_name'] = offers[0].name
+                    context['complete_email'] = offers[0].email
+                    context['complete_phone'] = offers[0].phone
+                else:
+                    context['cancelled'] = True
                 form = VolunteerOfferForm(program=prog)
         else:
             form = VolunteerOfferForm(program=prog)

--- a/esp/templates/program/modules/volunteersignup/signup.html
+++ b/esp/templates/program/modules/volunteersignup/signup.html
@@ -7,6 +7,43 @@
     <link rel="stylesheet" href="/media/styles/forms.css" type="text/css" />
 {% endblock %}    
 
+{% block xtrajs %}
+<script type="text/javascript">
+function confirm_cancellation() {
+    $j("input[name=clear_requests]").val("True");
+    $j("#confirm_cancellation_dialog").dialog("close");
+    $j("#volunteer_shift_form").submit();
+}
+
+function decline_cancellation() {
+    $j("#confirm_cancellation_dialog").dialog("close");
+}
+
+$j(document).ready(function () {
+    $j("#confirm_cancellation_dialog").dialog({
+        autoOpen: false,
+        buttons: [ { text: "Confirm", click: confirm_cancellation }, {text: "Cancel", click: decline_cancellation} ]
+    });
+    $j("#volunteer_form_submit").click(function (event) {   
+        //  Check if the user has previous requests and is asking to clear all of them
+        var checkboxes_checked = $j("input[name=requests]:checked");
+        if (($j("input[name=has_previous_requests]").val() == "True") &&
+            (checkboxes_checked.size() == 0)) {
+            //  If so, prevent the form from being submitted - we want a confirmation
+            event.preventDefault();
+            
+            //  Show the confirmation dialog
+            $j("#confirm_cancellation_dialog").dialog("open");
+        }
+        else {
+            //  They are not cancelling all shifts; submit the form normally
+            $j("#volunteer_shift_form").submit();
+        }
+    });
+});
+</script>
+{% endblock %}
+
 {% block content %}
 
 {% load render_qsd %}
@@ -21,9 +58,17 @@ Thank you, {{ complete_name }}, for volunteering! You will receive reminder emai
 {% load render_qsd %}
 {% render_inline_program_qsd program "volunteer_complete" %}
 {% endif %}
+{% if cancelled %}
+<h3>Volunteer Shifts Cancelled</h3>
+<p>
+The directors have been notified that you are no longer able to volunteer at {{ program.name }}.
+</p>
+{% load render_qsd %}
+{% render_inline_program_qsd program "volunteer_cancelled" %}
+{% endif %}
 
 <div id="program_form">
-<form method="POST" action="{{ request.path }}">
+<form method="POST" id="volunteer_shift_form" action="{{ request.path }}">
 <center>
 <table width="500">
 <tr>
@@ -39,10 +84,11 @@ Thank you, {{ complete_name }}, for volunteering! You will receive reminder emai
 {% endif %}
     {{ form }}
 <tr>   
-    <td colspan="2" align="center"><input type="submit" value="Submit" /></td>
+    <td colspan="2" align="center"><input id="volunteer_form_submit" type="submit" value="Submit" /></td>
 </tr>
 </table>
 </center>
 </form>
 </div>
+<div id="confirm_cancellation_dialog" title="Confirm Cancellation">You have unchecked all volunteer shifts.  If you must cancel your volunteer commitments, please click "Confirm" to notify the directors.  Otherwise, click "Cancel".</div>
 {% endblock %}


### PR DESCRIPTION
Addresses #1230.  A hidden form field has been added to mark whether the
user has volunteer shifts.  If they do, then they will be shown a
Javascript confirmation box when they try to submit a form without any
shifts.  If they confirm that they do indeed want to remove all of their
shifts, it will now allow them to do so.

For everyone else, submitting an empty form still raises a validation
error.  (All of the fields are now non-required but there is more logic in
the clean() method to compensate.)
