### PR TITLE
Add generic thanks page for when a mainpage is closed

### DIFF
--- a/esp/esp/program/modules/handlers/teachereventsmodule.py
+++ b/esp/esp/program/modules/handlers/teachereventsmodule.py
@@ -148,7 +148,7 @@ class TeacherEventsModule(ProgramModuleObj):
                 # Register for training
                 if data['training']:
                     ua, created = UserAvailability.objects.get_or_create( user=request.user, event=data['training'], role=self.availability_role())
-                return self.goToCore(tl)
+                return self.goToCore(tl, check_deadline=True)
         else:
             data = {}
             entries = self.entriesByTeacher(request.user)

--- a/esp/esp/urls.py
+++ b/esp/esp/urls.py
@@ -125,6 +125,8 @@ urlpatterns += patterns('esp.web.views.main',
     (r'^contact/contact/(?P<section>[^/]+)/?$', 'contact'),
 #    (r'^contact/submit\.html$', 'contact_submit'),
 
+    # Generic "thank you for submitting" page
+    (r'^thanks/$', 'thanks'),
 
     # Program stuff
     (r'^(onsite|manage|teach|learn|volunteer)/([-A-Za-z0-9_ ]+)/([-A-Za-z0-9_ ]+)/classchangerequest/?$', 'classchangerequest'),

--- a/esp/esp/web/views/main.py
+++ b/esp/esp/web/views/main.py
@@ -513,3 +513,7 @@ def set_csrf_token(request):
     from django.middleware.csrf import get_token
     get_token(request)
     return HttpResponse('') # Return the minimum possible 
+
+def thanks(request):
+    """Return a generic "thank you for submitting the form" page."""
+    return render_to_response('thanks.html', request, {})

--- a/esp/templates/thanks.html
+++ b/esp/templates/thanks.html
@@ -1,0 +1,18 @@
+{% extends "main.html" %}
+{% load render_qsd %}
+
+{% block title %}
+Thanks!
+{% endblock %}
+
+{% block content %}
+
+<h2>Thanks!</h2>
+
+{% inline_qsd_block "thanks" %}
+<p>
+Your form submission has been saved.  You can return to the <a href="javascript:history.back()">previous page</a>.
+</p>
+{% end_inline_qsd_block %}
+
+{% endblock %}


### PR DESCRIPTION
Sometimes it is useful to have a program module deadline open even if the
corresponding /MainPage deadline is closed.  However, many program modules
redirect to the main page on completion, which causes the user to get confused
if that page is in fact a deadline error.  Now modules can optionally have the
redirect be changed to a generic thanks page if the core module is closed.  I
added this to the teacher events module, which is the one MIT wanted it for.

This is a bit hacky, so suggestions of better ways to do it are welcome.  Or we may just not want it in main.