### PR TITLE
Remove specification of postgres version in packages_base.txt

### DIFF
--- a/esp/packages_base.txt
+++ b/esp/packages_base.txt
@@ -6,7 +6,7 @@ dvipng
 python
 python-setuptools
 python-pip
-postgresql-9.1
+postgresql
 libevent-dev
 python-dev
 zlib1g-dev


### PR DESCRIPTION
The dev server setup script wasn't working on my Ubuntu 14.04 laptop because of this. Is there some reason why not specifying the version is a bad idea?
