### PR TITLE
Add *_admin_thumbnail files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ esp/esp/database_settings.py.mit
 env
 useful_logs
 theme_compiled.css
+*_admin_thumbnail.gif
+*_admin_thumbnail.jpg
+*_admin_thumbnail.png


### PR DESCRIPTION
The media file thing adds thumbnails with filenames
`<name>_admin_thumbnail.<ext>`.  These shouldn't be in git.
