### PR TITLE
Removes update_deps from manage.py update command

### DIFF
--- a/esp/esp/utils/management/commands/update.py
+++ b/esp/esp/utils/management/commands/update.py
@@ -39,7 +39,6 @@ from django.core.management.base import NoArgsCommand
 class Command(NoArgsCommand):
     """Update the site.
 
-    - Update site dependencies.
     - Sync the database tables.
     - Perform database migrations.
     - Install initial data.
@@ -55,7 +54,6 @@ class Command(NoArgsCommand):
         }
         default_options.update(options)
         options = default_options
-        call_command('update_deps', **options)
         call_command('syncdb', **options)
         call_command('migrate', **options)
         call_command('install', **options)


### PR DESCRIPTION
First reason: changes to deps will often break manage.py until
you've run update_deps.sh, and I want this command to be honest
about what it can and can't do. Second reason: we're likely to
have a lot of people using the new vagrant-based dev setup
in the near future, and update_deps has weird behavior on vagrant
but everything else in this command works.
