### PR TITLE
Change old-style user list selection from main_call to aux_call

### DIFF
--- a/esp/esp/program/modules/handlers/listgenmodule.py
+++ b/esp/esp/program/modules/handlers/listgenmodule.py
@@ -347,7 +347,7 @@ class ListGenModule(ProgramModuleObj):
         context.update(usc.prepare_context(prog, target_path='/manage/%s/selectList' % prog.url))
         return render_to_response(self.baseDir()+'search.html', request, context)
 
-    @main_call
+    @aux_call
     @needs_admin
     def selectList_old(self, request, tl, one, two, module, extra, prog):
         """ Allow use of the "old style" user selector if that is desired for


### PR DESCRIPTION
New style and old style were both main_call, and that was confusing
the manage page and causing it to only link to the old style.
