### PR TITLE
Fix getTaughtTime to exclude rejected sections of accepted classes

### DIFF
--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -471,7 +471,8 @@ class ESPUser(User, AnonymousUser):
             rounded_hours = lambda x: float( x )
         for s in user_sections:
             #   don't count cancelled or rejected classes -- Ted
-            if (include_scheduled or (s.start_time() is None)) and (s.parent_class.status >= 0):
+            #   or rejected sections -- lua
+            if (include_scheduled or (s.start_time() is None)) and (s.status >= 0 and s.parent_class.status >= 0):
                 total_time = total_time + timedelta(hours=rounded_hours(s.duration))
         return total_time
 


### PR DESCRIPTION
This was making it impossible for a user who somehow registered more hours of class than there were in the program, then had some sections cancelled, to view their classes (due to the availability module).
