### PR TITLE
Fixes bug where archived classes show up in wrong teacher bios

### DIFF
--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -248,8 +248,7 @@ class ArchiveClass(models.Model):
     def getForUser(user):
         """ Get a list of archive classes for a specific user. """
         from django.db.models.query import Q
-        Q_ClassTeacher = Q(teacher__icontains = (user.first_name + ' ' + user.last_name)) |\
-               Q(teacher_ids__icontains = ('|%s|' % user.id))
+        Q_ClassTeacher = Q(teacher_ids__icontains = ('|%s|' % user.id))
         Q_ClassStudent = Q(student_ids__icontains = ('|%s|' % user.id))
         #   We want to only show archive classes for teachers.  At least for now.
         Q_Class = Q_ClassTeacher #  | Q_ClassStudent


### PR DESCRIPTION
This fixes issue #1072, in which teacher bios show the archived classes of teachers with identical names but different accounts. When generating the list of archived classes taught by someone, the code now only takes classes taught by someone with the same user ID and no longer searches based on first/last name. 
