### PR TITLE
Convert an isinstance() back to a type()

### DIFF
--- a/esp/esp/db/views.py
+++ b/esp/esp/db/views.py
@@ -47,7 +47,7 @@ def ajax_autocomplete(request):
     else:
         query_set = autocomplete_wrapper(getattr(Model, ajax_func), data, request.user.is_staff)
 
-    if isinstance(query_set, QuerySet):
+    if type(query_set) is QuerySet:
         raise NotImplementedError
     else:
         output = list(query_set[:limit])


### PR DESCRIPTION
This reverts one line of 673e5dd.  Previously it was checking if the type() of
something was QuerySet (and erroring if so).  The change caused it to error on
_any_ instance of QuerySet, including for example a ValuesListQuerySet.  This broke some (or all?) ajax autocompletes.

It may be worth a more careful look over #1411 to make sure no other similar issues were introduced.
