### PR TITLE
Remove thousands of queries from the studentreg mainpage

### DIFF
--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -1161,10 +1161,11 @@ class ClassSection(models.Model):
 
     def getRegVerbs(self, user, allowed_verbs=False):
         """ Get the list of reg-types that a student has on this class. """
+        qs = self.getRegistrations(user).select_related('relationship')
         if not allowed_verbs:
-            return [v.relationship for v in self.getRegistrations(user).distinct()]
+            return [v.relationship for v in qs.distinct()]
         else:
-            return [v.relationship for v in self.getRegistrations(user).filter(relationship__name__in=allowed_verbs).distinct()]
+            return [v.relationship for v in qs.filter(relationship__name__in=allowed_verbs).distinct()]
 
     def unpreregister_student(self, user, prereg_verb = None):
         #   New behavior: prereg_verb should be a string matching the name of

--- a/esp/esp/program/modules/handlers/studentclassregmodule.py
+++ b/esp/esp/program/modules/handlers/studentclassregmodule.py
@@ -259,7 +259,6 @@ class StudentClassRegModule(ProgramModuleObj):
                 else:
                     timeslot_dict[mt.id] = [section_dict]
                     
-        user_priority = user.getRegistrationPriorities(self.program, [t.id for t in timeslots])
         for i in range(len(timeslots)):
             timeslot = timeslots[i]
             daybreak = False
@@ -270,9 +269,12 @@ class StudentClassRegModule(ProgramModuleObj):
 
             if timeslot.id in timeslot_dict:
                 cls_list = timeslot_dict[timeslot.id]
-                schedule.append((timeslot, cls_list, blockCount + 1, user_priority[i]))
+                doesnt_have_enrollment = not any(sec['section'].is_enrolled
+                                                 for sec in cls_list)
+                schedule.append((timeslot, cls_list, blockCount + 1,
+                                 doesnt_have_enrollment))
             else:                
-                schedule.append((timeslot, [], blockCount + 1, user_priority[i]))
+                schedule.append((timeslot, [], blockCount + 1, False))
 
             prevTimeSlot = timeslot
                 

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -712,19 +712,6 @@ class ESPUser(User, AnonymousUser):
             priority += 1
 
         return priority
-        
-    #   We often request the registration priority for all timeslots individually
-    #   because our schedules display enrollment status on a per-timeslot (rather
-    #   than per-class) basis.  This function is intended to speed that up.
-    def getRegistrationPriorities(self, prog, timeslot_ids):
-        num_slots = len(timeslot_ids)
-        events = list(Event.objects.filter(id__in=timeslot_ids).order_by('id'))
-        result = [0 for i in range(num_slots)]
-        id_order = range(num_slots)
-        id_order.sort(key=lambda i: timeslot_ids[i])
-        for i in range(num_slots):
-            result[id_order[i]] = self.getRegistrationPriority(prog, [events[i]])
-        return result
 
     def isEnrolledInClass(self, clsObj, request=None):
         return clsObj.students().filter(id=self.id).exists()


### PR DESCRIPTION
@emannes noticed that the studentreg mainpage was doing as many as thousands of
queries to get data it didn't need.  Now it doesn't.

In particular, it would compute, in a very inefficient way, the highest
priority level a user has in that timeblock (with zero being enrolled), and
then use that only to check whether the user had an enrolled class in that
timeblock.  The view using the data in fact already had that information, so
the entire mess was unnecessary.

The issue was that the function ESPUser.getRegistrationPriority was getting
called for each timeblock, and it does a query for each section for which the
user has a StudentRegistration.  That function is still inefficient, but the
other callers only call it once, so that should be less of an issue.

We may want to consider cherry-picking this to other sites in FCFS reg, since it cut off like 3s from studentreg load time for users with a reasonably large number of preferences for me.  I did test that it works with the old lottery, but only briefly.
