### PR TITLE
Fixes an issue where fab doesn't work for some setups

### DIFF
--- a/esp/fabfile.py
+++ b/esp/fabfile.py
@@ -59,7 +59,6 @@ def remote_pipe(local_command, remote_command, buf_size=1024*1024):
 
 def use_vagrant():
     vagrant_key_file = local('cd ../vagrant && vagrant ssh-config | grep IdentityFile', capture=True).split(' ', 1)[1].strip("\"")
-    print vagrant_key_file
     host_str = '127.0.0.1:2222'
     config_dict = {
         'user': REMOTE_USER,


### PR DESCRIPTION
This is an issue I ran into during setup a while ago. 

Using fab load_db_dump or open_db or whatever doesn't work if the file insecure_private_key (which use_vagrant() searches for in fabfile.py) was installed in a location with a space in the directory path. In particular (at least on Windows), local('cd ../vagrant && vagrant ssh-config | grep IdentityFile', capture=True) returns something of the form:

IdentityFile path/to/insecure_private_key

so splitting and taking the index-1 element makes sense, but if the path contains a space, it'll return something like

IdentityFile "path/to/the file/insecure_private_key"

so I split exactly once, take the index-1 element, and strip the quotes. 

I haven't tested this on another machine, but it should work the same as before if the problem I'm addressing is irrelevant to you.
