### PR TITLE
Change "Nothing selected" to "No classes" in studentreg

### DIFF
--- a/esp/public/media/scripts/lottery_student_reg/hssp_timeslot.js
+++ b/esp/public/media/scripts/lottery_student_reg/hssp_timeslot.js
@@ -209,7 +209,7 @@ var Timeslot = function(data){
 		}
 	    }
 	    if (has_priority_class == false){
-		interested_div.append("<font color='red'>Nothing selected.</font><br/>");
+		interested_div.append("<font color='red'>No classes.</font><br/>");
 	    }
 	}    
     }

--- a/esp/public/media/scripts/program/modules/studentregphase2/timeslot.js
+++ b/esp/public/media/scripts/program/modules/studentregphase2/timeslot.js
@@ -209,7 +209,7 @@ var Timeslot = function(data){
 		}
 	    }
 	    if (has_priority_class == false){
-		interested_div.append("<font color='red'>Nothing selected.</font><br/>");
+		interested_div.append("<font color='red'>No classes.</font><br/>");
 	    }
 	}    
     }

--- a/esp/templates/program/modules/studentregtwophase/studentregtwophase.html
+++ b/esp/templates/program/modules/studentregtwophase/studentregtwophase.html
@@ -83,7 +83,7 @@ recommend you mark a class for every priority slot to ensure a full schedule.
             {% endfor %}
             </i>
             {% if priority_list|length_is:0 %}
-                Nothing Selected
+                No classes
             {% endif %}
         </td>
 

--- a/esp/templates/program/receipts/default.html
+++ b/esp/templates/program/receipts/default.html
@@ -51,7 +51,7 @@ User Information: <br />
             {% if not forloop.last %}<br />{% endif %}
         {% endfor %}
         {% if timeslot.1|length_is:0 %}
-            Nothing Selected
+            No classes
         {% endif %}
         </td> 
     </tr>

--- a/esp/templates/users/student_schedule.html
+++ b/esp/templates/users/student_schedule.html
@@ -125,7 +125,7 @@ you arrive.
             {% if not forloop.last %}<br />{% endif %}
         {% endfor %}
         {% if timeslot.1|length_is:0 %}
-            Nothing Selected
+            No classes
         {% endif %}
         </td>
         

--- a/esp/templates/users/student_schedule_inline.html
+++ b/esp/templates/users/student_schedule_inline.html
@@ -56,7 +56,7 @@
             {% if not forloop.last %}<br />{% endif %}
         {% endfor %}
         {% if timeslot.1|length_is:0 %}
-            Nothing Selected
+            No classes
         {% endif %}
         </td>
         


### PR DESCRIPTION
"Nothing selected" is confusing if the user has previously selected lottery
preferences, but didn't get anything -- users empirically think their
preferences were lost.  "No classes" should be accurate for lottery
registration and FCFS registration both with and without a lottery.  Alternate
wording suggestions welcome, but it would be really nice to fix this.

Fixes #1123 
