### PR TITLE
Removes hack to hide evening timeblocks from middle schoolers

### DIFF
--- a/esp/esp/program/modules/handlers/studentclassregmodule.py
+++ b/esp/esp/program/modules/handlers/studentclassregmodule.py
@@ -222,9 +222,6 @@ class StudentClassRegModule(ProgramModuleObj):
             
         is_onsite = user.isOnsite(self.program)
         scrmi = self.program.getModuleExtension('StudentClassRegModuleInfo')
-        # Hack, to hide the Saturday night timeslots from grades 7-8
-        if not is_onsite and not user.getGrade() > 8:
-            timeslots = [x for x in timeslots if x.start.hour < 19]
         
         #   Filter out volunteer timeslots
         timeslots = [x for x in timeslots if x.event_type.description != 'Volunteer']


### PR DESCRIPTION
MIT isn't doing the high school only evening blocks anymore (because all of Splash is high school only), and someday some other program, maybe ours, was going to get very confused by this. Spark 2014 just missed it by an hour.
