### PR TITLE
Fix an __import__ that was causing a cache dumping problem.

### DIFF
--- a/esp/esp/db/views.py
+++ b/esp/esp/db/views.py
@@ -40,7 +40,7 @@ def ajax_autocomplete(request):
         return response
 
     # import the model
-    Model = getattr(__import__(model_module,(),(),['']),model_name)
+    Model = getattr(__import__(model_module,(),(),[str(model_name)]),model_name)
 
     if hasattr(Model.objects, ajax_func):
         query_set = autocomplete_wrapper(getattr(Model.objects, ajax_func), data, request.user.is_staff)


### PR DESCRIPTION
The cache registry no longer guards against models being imported
multiple times, so certain uses of `__import__` will cause things to be
sad. We should move away from `__import__` in general (use importlib, or
get_model, or something more sane instead), but this fixes the
instance that was problematic.

(cherry picked from commit 666053f539c5b3ebae49b192f855b459aeb17e22)
