### PR TITLE
Fixing program module documentation

### DIFF
--- a/docs/admin/program_modules.rst
+++ b/docs/admin/program_modules.rst
@@ -455,7 +455,7 @@ Custom forms and Formstack may be used to augment or replace these features.
 Admin Module for showing basic vitals (AdminVitals)
 ---------------------------------------------------
 
-This module is deprecated and will be removed in a future release.
+This module shows statistics about your program on the dashboard.
 
 AJAX Scheduling Module (AJAXSchedulingModule)
 ---------------------------------------------


### PR DESCRIPTION
It currently claims that Admin Vitals is deprecated. Actually, it's a pretty important part of the dashboard.
