### PR TITLE
Don't require login for volunteer signup

### DIFF
--- a/esp/esp/program/modules/base.py
+++ b/esp/esp/program/modules/base.py
@@ -206,7 +206,7 @@ class ProgramModuleObj(models.Model):
         #   If a "core" module has been found:
         #   Put the user through a sequence of all required modules in the same category.
         #   Only do so if we've not blocked this behavior, though
-        if tl != "manage" and tl != "json" and isinstance(moduleobj, CoreModule):
+        if tl not in ["manage", "json", "volunteer"] and isinstance(moduleobj, CoreModule):
             scrmi = prog.getModuleExtension('StudentClassRegModuleInfo')
             if scrmi.force_show_required_modules:
                 if not_logged_in(request):


### PR DESCRIPTION
Add the volunteer module to the list of modules that don't trigger
force_show_required_modules, since that requires login.
