### PR TITLE
Fixed list of open classes to use sec.capacity for section capacities

### DIFF
--- a/esp/templates/inclusion/program/class_row_fragment.html
+++ b/esp/templates/inclusion/program/class_row_fragment.html
@@ -13,7 +13,7 @@
             {{ class.grade_min }}&ndash;{{ class.grade_max }}
         </td>
         <td>
-            {{ sec.num_students }} / {{ class.class_size_max }}
+            {{ sec.num_students }} / {{ sec.capacity }}
         </td>
         <td>
             {% for room in sec.initial_rooms %}


### PR DESCRIPTION
Addresses #1470 as far as I saw there was a discrepancy. In particular, it looks like this was a problem any time a class was assigned to a room which had a max capacity less than the teacher's given max capacity for the class. The classchange_grid looks fine to me though.
