### PR TITLE
Remove `isinstance(user, AnonymousUser)` checks

### DIFF
--- a/esp/esp/cache/marinade.py
+++ b/esp/esp/cache/marinade.py
@@ -69,7 +69,10 @@ def marinade_dish(arg):
     if isinstance(arg, list):
         return '[%s]' % ','.join([marinade_dish(item) for item in arg])
     if isinstance(arg, Model):
-        if not isinstance(arg, AnonymousUser) and arg.id is None:
+        # ESPUsers are also instances of AnonymousUser, but might not be
+        # anonymous.
+        if arg.id is None and (not isinstance(arg, AnonymousUser) or
+                               not arg.is_anonymous()):
             import random
             # TODO: Make this log something
             print "PASSING UNSAVED MODEL!!! ERROR!!! CACHING CODE SHOULD NOT BE ENABLED!!!"

--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -40,7 +40,7 @@ import random
 import simplejson as json
 
 from django.conf import settings
-from django.contrib.auth.models import User, AnonymousUser
+from django.contrib.auth.models import User
 from django.contrib.contenttypes import generic
 from django.contrib.localflavor.us.models import PhoneNumberField
 from django.core import urlresolvers
@@ -1303,7 +1303,7 @@ class RegistrationProfile(models.Model):
     @cache_function
     def getLastForProgram(user, program):
         """ Returns the newest RegistrationProfile attached to this user and this program (or any ancestor of this program). """
-        if isinstance(user, AnonymousUser):
+        if user.is_anonymous():
             regProfList = RegistrationProfile.objects.none()
         else:
             regProfList = RegistrationProfile.objects.filter(user__exact=user,program__exact=program).select_related().order_by('-last_ts','-id')[:1]

--- a/esp/esp/program/modules/handlers/volunteersignup.py
+++ b/esp/esp/program/modules/handlers/volunteersignup.py
@@ -36,7 +36,7 @@ Learning Unlimited, Inc.
 from esp.program.modules.base import ProgramModuleObj, CoreModule, main_call, aux_call
 from esp.web.util        import render_to_response
 from esp.program.modules.forms.volunteer import VolunteerOfferForm
-from esp.users.models import ESPUser, AnonymousUser
+from esp.users.models import ESPUser
 from django.db.models.query import Q
 
 class VolunteerSignup(ProgramModuleObj, CoreModule):

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -89,15 +89,6 @@ DEFAULT_USER_TYPES = [
     ['Volunteer', {'label': 'On-site Volunteer', 'profile_form': 'VolunteerProfileForm'}]
 ]
 
-def user_get_key(user):
-    """ Returns the key of the user, regardless of anything about the user object. """
-    if user is None or isinstance(user, AnonymousUser) or \
-        (not isinstance(user, User)) or \
-         user.id is None:
-        return 'None'
-    else:
-        return str(user.id)
-
 def admin_required(func):
     @functools.wraps(func)
     def wrapped(request, *args, **kwargs):

--- a/esp/esp/web/util/main.py
+++ b/esp/esp/web/util/main.py
@@ -38,7 +38,6 @@ from django.template import Context, Template, loader, RequestContext
 from django.conf import settings
 from django import http
 from django.http import HttpResponse, HttpResponseRedirect
-from django.contrib.auth.models import AnonymousUser
 from esp.program.models import Program
 from esp.qsd.models import ESPQuotations
 from esp.middleware import ESPError


### PR DESCRIPTION
Turns out `ESPUser` inherits from `AnonymousUser`, so that doesn't do what one
might think.  I generally replaced it with `user.is_anonymous()` which does work
correctly on ESPUsers.  I didn't remove it from `ESPAuthMiddleware` because I
don't understand that well enough to know if I will break something massively.
Also removed an unused function rather than fixing it, and some unused imports
of `AnonymousUser`.
