### PR TITLE
Some improvements to ResourceType handling

### DIFF
--- a/esp/esp/program/controllers/classreg.py
+++ b/esp/esp/program/controllers/classreg.py
@@ -249,7 +249,6 @@ class ClassCreationController(object):
         
         # Make some of the fields in new_data nicer for viewing.
         mail_ctxt['category'] = ClassCategories.objects.get(id=new_data['category_id']).category
-        #mail_ctxt['global_resources'] = ResourceType.objects.filter(id__in=new_data['global_resources'])
         mail_ctxt['global_resources'] = cls.get_sections()[0].getResourceRequests()
 
         # Optimal and allowable class size ranges.

--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -784,6 +784,7 @@ class Program(models.Model, CustomFormsLinkModel):
         else:
             return None
 
+    @cache_function
     def getResourceTypes(self, include_classroom=False, include_global=None):
         #   Show all resources pertaining to the program that aren't these two hidden ones.
         from esp.resources.models import ResourceType
@@ -801,7 +802,9 @@ class Program(models.Model, CustomFormsLinkModel):
         else:
             Q_filters = Q(program=self)
         
-        return ResourceType.objects.filter(Q_filters).exclude(id__in=[t.id for t in exclude_types])
+        return ResourceType.objects.filter(Q_filters).exclude(id__in=[t.id for t in exclude_types]).order_by('priority_default')
+    getResourceTypes.depend_on_model(lambda: ResourceType)
+    getResourceTypes.depend_on_model(lambda: Tag)
 
     def getResources(self):
         from esp.resources.models import Resource
@@ -1925,6 +1928,7 @@ def install():
     print "Installing esp.program initial data..."
     install_class()
 
-# The following are only so that we can refer to them in caching Program.getModules.
+# The following are only so that we can refer to them in caching
 from esp.program.modules.base import ProgramModuleObj
 from esp.program.modules.module_ext import ClassRegModuleInfo, StudentClassRegModuleInfo
+from esp.resources.models import ResourceType

--- a/esp/esp/program/modules/forms/teacherreg.py
+++ b/esp/esp/program/modules/forms/teacherreg.py
@@ -90,15 +90,9 @@ class TeacherClassRegForm(FormWithRequiredCss):
         help_text="Which best describes how hard your class will be for your students?")
     allow_lateness = forms.ChoiceField( label='Punctuality', choices=lateness_choices, widget=forms.RadioSelect() )
     
-    has_own_space  = forms.ChoiceField( label='Location', choices=location_choices, widget=forms.RadioSelect(), required=False )
     requested_room = forms.CharField(   label='Room Request', required=False,
                                         help_text='If you have a specific room or type of room in mind, name a room at %s that would be ideal for you.' % settings.INSTITUTION_NAME )
 
-    global_resources = forms.MultipleChoiceField( label='Equipment and Classroom Options',
-                                                  choices=[], widget=forms.CheckboxSelectMultiple(), required=False,
-                                                  help_text="Check all that apply. We can usually supply these common resources at your request. But if your class is truly uncommon, ESP may also have access to unusual rooms and supplies. These can be entered in the next section, 'Special Requests.'" )
-    resources        = forms.MultipleChoiceField( label='Other Resources',
-                                                  choices=[], widget=forms.CheckboxSelectMultiple(), required=False )
     requested_special_resources = forms.CharField( label='Special Requests', widget=forms.Textarea(), required=False,
                                                    help_text="Write in any specific resources you need, like a piano, empty room, or kitchen. We cannot guarantee you any of the special resources you request, but we will contact you if we are unable to get you the resources you need. Please include any necessary explanations in the 'Message for Directors' box! " )
 
@@ -174,17 +168,7 @@ class TeacherClassRegForm(FormWithRequiredCss):
             del self.fields['optimal_class_size_range']
             del self.fields['allowable_class_size_ranges']
             
-        # global_resources: crmi.getResourceTypes(is_global=True)
-        self.fields['global_resources'].choices = crmi.getResourceTypes(is_global=True)
-        # resources: crmi.getResourceTypes(is_global=False)
-        resource_choices = crmi.getResourceTypes(is_global=False)
-        
         # decide whether to display certain fields
-        # resources
-        if len(resource_choices) > 0:
-            self.fields['resources'].choices = resource_choices
-        else:
-            self.fields['resources'].widget = forms.HiddenInput()
         
         # prereqs
         if not crmi.set_prereqs:
@@ -210,7 +194,7 @@ class TeacherClassRegForm(FormWithRequiredCss):
             hide_field( self.fields['requested_room'] )
             
         #   Hide resource fields since separate forms are now being used. - Michael P
-        resource_fields = ['has_own_space', 'global_resources', 'resources', 'requested_special_resources']
+        resource_fields = ['requested_special_resources']
         for field in resource_fields:
             self.fields[field].widget = forms.HiddenInput()
         
@@ -325,8 +309,7 @@ class TeacherOpenClassRegForm(TeacherClassRegForm):
                   ('prereqs', ''), ('session_count', 1), ('grade_min', module.get_program().grade_min), ('grade_max', module.get_program().grade_max), 
                   ('class_size_max', 200), ('class_size_optimal', ''), ('optimal_class_size_range', ''), 
                   ('allowable_class_size_ranges', ''), ('hardness_rating', '**'), ('allow_lateness', True), 
-                  ('has_own_space', False), ('requested_room', ''), ('global_resources', ''),
-                  ('resources', '')]
+                  ('requested_room', '')]
         for field, default in fields:
             if field in self.fields:
                 self.fields[field].required = False

--- a/esp/esp/program/modules/forms/teacherreg.py
+++ b/esp/esp/program/modules/forms/teacherreg.py
@@ -194,9 +194,8 @@ class TeacherClassRegForm(FormWithRequiredCss):
             hide_field( self.fields['requested_room'] )
             
         #   Hide resource fields since separate forms are now being used. - Michael P
-        resource_fields = ['requested_special_resources']
-        for field in resource_fields:
-            self.fields[field].widget = forms.HiddenInput()
+        #   Most have now been removed, but this one gets un-hidden by open classes.
+        self.fields['requested_special_resources'].widget = forms.HiddenInput()
         
         #   Add program-custom form components (for inlining additional questions without
         #   introducing a separate program module)

--- a/esp/esp/program/modules/handlers/resourcemodule.py
+++ b/esp/esp/program/modules/handlers/resourcemodule.py
@@ -371,7 +371,7 @@ class ResourceModule(ProgramModuleObj):
         if 'timeslot_form' not in context:
             context['timeslot_form'] = TimeslotForm()
         
-        context['resource_types'] = self.program.getResourceTypes().exclude(priority_default=0).order_by('priority_default')
+        context['resource_types'] = self.program.getResourceTypes().exclude(priority_default=0)
         for c in context['resource_types']:
             if c.program is None:
                 c.is_global = True

--- a/esp/esp/program/modules/handlers/resourcemodule.py
+++ b/esp/esp/program/modules/handlers/resourcemodule.py
@@ -371,7 +371,7 @@ class ResourceModule(ProgramModuleObj):
         if 'timeslot_form' not in context:
             context['timeslot_form'] = TimeslotForm()
         
-        context['resource_types'] = self.program.getResourceTypes().exclude(priority_default=0)
+        context['resource_types'] = self.program.getResourceTypes()
         for c in context['resource_types']:
             if c.program is None:
                 c.is_global = True

--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -783,25 +783,26 @@ class TeacherClassRegModule(ProgramModuleObj):
         else:
             errors = {}
             
-            resource_types = set([])
-            default_restypes = Tag.getProgramTag('default_restypes', program=self.program, )
-            if default_restypes:
-                resource_type_labels = json.loads(default_restypes)
-                resource_types = resource_types.union(set([ResourceType.get_or_create(x, self.program) for x in resource_type_labels]))
-
             if static_resource_requests:
                 # With static resource requests, we need to display a form
                 # each available type --- there's no way to add the types
                 # that we didn't start out with
                 # Thus, if default_restype isn't set, we display everything
                 # potentially relevant
-                q_program = Q(program=self.program)
                 if Tag.getTag('allow_global_restypes'):
-                    q_program = q_program | Q(program__isnull=True)
-                resource_types = resource_types.union(set(ResourceType.objects.filter(q_program).order_by('-priority_default')))
+                    resource_types = prog.getResourceTypes(include_classroom=True,
+                                                           include_global=True)
+                else:
+                    resource_types = prog.getResourceTypes(include_classroom=True)
             else:
                 # If we're not using static resource requests, then just
                 # hardcode some sane defaults
+                resource_types = set([])
+                default_restypes = Tag.getProgramTag('default_restypes', program=self.program, )
+                if default_restypes:
+                    resource_type_labels = json.loads(default_restypes)
+                    resource_types = resource_types.union(set([ResourceType.get_or_create(x, self.program) for x in resource_type_labels]))
+
                 resource_type_labels = ['Classroom', 'A/V']
                 resource_types = resource_types.union(set([ResourceType.get_or_create(x, self.program) for x in resource_type_labels]))
 

--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -794,8 +794,8 @@ class TeacherClassRegModule(ProgramModuleObj):
                                                            include_global=True)
                 else:
                     resource_types = prog.getResourceTypes(include_classroom=True)
-                    resource_types = list(resource_types)
-                    resource_types.reverse()
+                resource_types = list(resource_types)
+                resource_types.reverse()
             else:
                 # If we're not using static resource requests, then just
                 # hardcode some sane defaults

--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -794,6 +794,8 @@ class TeacherClassRegModule(ProgramModuleObj):
                                                            include_global=True)
                 else:
                     resource_types = prog.getResourceTypes(include_classroom=True)
+                    resource_types = list(resource_types)
+                    resource_types.reverse()
             else:
                 # If we're not using static resource requests, then just
                 # hardcode some sane defaults
@@ -805,10 +807,9 @@ class TeacherClassRegModule(ProgramModuleObj):
 
                 resource_type_labels = ['Classroom', 'A/V']
                 resource_types = resource_types.union(set([ResourceType.get_or_create(x, self.program) for x in resource_type_labels]))
-
-            # Now that we're done putting together multiple resource type sources, listify!
-            resource_types = list(resource_types)
-            resource_types.sort(key=lambda x: -x.priority_default)
+                # Now that we're done putting together multiple resource type sources, listify!
+                resource_types = list(resource_types)
+                resource_types.sort(key=lambda x: -x.priority_default)
 
             if newclass is not None:
                 current_data = newclass.__dict__

--- a/esp/esp/program/modules/module_ext.py
+++ b/esp/esp/program/modules/module_ext.py
@@ -274,20 +274,6 @@ class ClassRegModuleInfo(models.Model):
     def getResources(self):
         resources = self.get_program().getResources()
         return [(str(x.id), x.name) for x in resources]
-   
-    def getResourceTypes(self, is_global=None):
-        #   Get a list of all resource types, excluding the fundamental ones.
-        base_types = self.get_program().getResourceTypes().filter(priority_default__gt=0)
-        
-        if is_global is True:
-            res_types = base_types.filter(program__isnull=True)
-        elif is_global is False:
-            res_types = base_types.filter(program__isnull=False)
-        else:
-            res_types = base_types
-            
-        return [(str(x.id), x.name) for x in res_types]
-
     
     def __unicode__(self):
         return 'Class Reg Ext. for %s' % str(self.module)

--- a/esp/templates/program/modules/teacherclassregmodule/classreg_email
+++ b/esp/templates/program/modules/teacherclassregmodule/classreg_email
@@ -33,8 +33,6 @@ Optimal class size: {{ class_size_optimal }}
 {% if optimal_class_size_range %}Optimal class size range: {{ optimal_class_size_range }}{% endif %}
 {% if allowable_class_size_ranges %}Allowable class size ranges: {% for cls_size in allowable_class_size_ranges %}{{ cls_size.range_min }}-{{ cls_size.range_max }}, {% endfor %}{% endif %}
 
-Have own space? {{ has_own_space }}
-
 Room request: {{ requested_room }}
 
 Equipment/resource requests:{% for res in global_resources %}
@@ -47,11 +45,7 @@ Planned purchases:
 {{ purchase_requests }}
 
 Comments to Director:
-{% ifequal has_own_space "True" %}*** Notice ***
-The teacher has specified that they will provide their own space for this class.  Please contact them for the size and resources the space provides (if they have not specified below) and create the appropriate resources for scheduling.
-**************
-
-{% endifequal %}{{ message_for_directors }}
+{{ message_for_directors }}
 
 ---------------------------------
 {% if admin %}If you have reviewed all of this information and would like to approve the class, click here: 


### PR DESCRIPTION
My main goal here was to make teacherreg stop get_or_creating default resource types, since the program creation form already handles those and I think it's more reasonable to be able to delete one without having to set a different default resource types tag for the specific program. I also made some improvements to things that confused me while I was working on it; see the commit messages.

Note: This can potentially cause the resource types form in teacherreg to get reordered from how they were before. If you liked the order before and don't like it after merging this, you can mess with priority_default to fix it. Don't use 0, though, it's a special case somewhere in the code and I haven't bothered to figure out why.