### PR TITLE
Remove meta author tag from fruitsalad theme

### DIFF
--- a/esp/esp/themes/theme_data/fruitsalad/templates/bubblesfront.html
+++ b/esp/esp/themes/theme_data/fruitsalad/templates/bubblesfront.html
@@ -11,7 +11,6 @@
 {% endif %}
 {% endif %}
 {% endcomment %}
-<meta name="author" content="Tony Valderrama, Vincent Lee, and others" />
 <link rel="stylesheet" type="text/css" href="/media/styles/theme_compiled.css" media="all" />
 <link rel="shortcut icon" href="/media/images/favicon.ico" />
 {% endblock %}

--- a/esp/esp/themes/theme_data/fruitsalad/templates/main.html
+++ b/esp/esp/themes/theme_data/fruitsalad/templates/main.html
@@ -7,7 +7,6 @@
 {% block stylesheets %}
 {{ block.super }}
 <link rel="shortcut icon" href="/media/images/favicon.ico" />
-<meta name="author" content="Tony Valderrama, Vincent Lee, and others" />
 <!--[if lte IE 6]>
 <style type="text/css">
 * {


### PR DESCRIPTION
At the request of Tony Valderrama.  It shows up in search engines and stuff as
the author, but in fact they just wrote the theme.  Since determining the
actual "author" of a page could be hard, let's just remove it entirely.