### PR TITLE
Adds student shirt type tag

### DIFF
--- a/esp/esp/users/forms/user_profile.py
+++ b/esp/esp/users/forms/user_profile.py
@@ -210,6 +210,8 @@ class StudentInfoForm(FormUnrestrictedOtherUser):
         if not Tag.getTag('show_student_tshirt_size_options'):
             del self.fields['shirt_size']
             del self.fields['shirt_type']
+        elif Tag.getTag('studentinfo_shirt_type_selection') == 'False':
+            del self.fields['shirt_type']
 
         if not Tag.getTag('show_student_vegetarianism_options'):
             del self.fields['food_preference']


### PR DESCRIPTION
Adds a studentinfo_shirt_type_selection tag to toggle presence of just plain/fitted shirt selection (but letting them choose size) in parallel with the corresponding tags for teachers and volunteers.