### PR TITLE
Add back the template admin/base_site.html 

### DIFF
--- a/esp/templates/admin/base_site.html
+++ b/esp/templates/admin/base_site.html
@@ -1,7 +1,7 @@
-{% comment "DO NOT DELETE; this customizes the admin panel." %}{% endcomment %}
-
 {% extends "admin/base.html" %}
 {% load i18n %}
+
+{% comment "DO NOT DELETE THIS FILE; this customizes the admin panel." %}{% endcomment %}
 
 {% block extrahead %}{{ block.super }}
 <script type="text/javascript" src="/media/scripts/jquery.js"> </script>

--- a/esp/templates/admin/base_site.html
+++ b/esp/templates/admin/base_site.html
@@ -1,3 +1,5 @@
+{% comment "DO NOT DELETE; this customizes the admin panel." %}{% endcomment %}
+
 {% extends "admin/base.html" %}
 {% load i18n %}
 

--- a/esp/templates/admin/base_site.html
+++ b/esp/templates/admin/base_site.html
@@ -1,0 +1,38 @@
+{% extends "admin/base.html" %}
+{% load i18n %}
+
+{% block extrahead %}{{ block.super }}
+<script type="text/javascript" src="/media/scripts/jquery.js"> </script>
+<script type="text/javascript" src="/media/scripts/jquery.cookie.js"> </script>
+<script type="text/javascript" src="/media/scripts/common.js"> </script>
+<script type="text/javascript">
+    $j(document).ready(function () {
+        $j("div.raw_id_admin").hide();
+    });
+</script>
+<script type="text/javascript" src="/media/scripts/content/user_data.js"></script>
+<script type="text/javascript" src="/media/scripts/content/user_classes.js"></script>
+<script type="text/javascript" src="/media/scripts/csrf_init.js"></script>
+<link rel="stylesheet" type="text/css" href="/media/styles/jquery-ui/jquery-ui.css" />
+<script type="text/javascript" src="/media/scripts/jquery-ui.js"></script>
+<style type="text/css">
+ul.ui-autocomplete li
+{
+    list-style-type: none;
+}
+</style>
+{% endblock %}
+
+{% block title %}{{ title|escape }} | {% trans 'ESP site admin' %}{% endblock %}
+
+{% block branding %}
+<h1 id="site-name"><a href="/" title="Go to the main page">{% trans 'ESP administration' %}</a></h1>
+{% endblock %}
+
+{% block nav-global %}{% endblock %}
+
+{% block userlinks %}
+{{ block.super }}
+<li><a href="{% url filebrowser:fb_browse %}">{% trans 'FileBrowser' %}</a></li>
+<li><a href="{% url esp.themes.views.landing %}">{% trans 'Theme settings' %}</a></li>
+{% endblock userlinks %}


### PR DESCRIPTION
This template was removed in e9df9f5 (pull request #1479), but it's not actually unused; it's used to
customize the admin site.

Fixes #1566.