### PR TITLE
Fix studentreg big board when there are no student regs

### DIFF
--- a/esp/esp/program/modules/handlers/bigboardmodule.py
+++ b/esp/esp/program/modules/handlers/bigboardmodule.py
@@ -63,16 +63,21 @@ class BigBoardModule(ProgramModuleObj):
         ]
         # Drop the first and last 10 times, because those are usually
         # special snowflakes or admins and really aren't worth getting excited
-        # about.  Then round start down and end up to the nearest day.
-        start = min([times[10:-10][0] for desc, times in timess])
-        start = start.replace(hour=0, minute=0, second=0, microsecond=0)
-        end = max([times[10:-10][-1] for desc, times in timess])
-        end = end.replace(hour=0, minute=0, second=0, microsecond=0)
-        end += datetime.timedelta(1)
-        end = min(end, datetime.datetime.now())
-        graph_data = [{"description": desc,
-                       "data": BigBoardModule.chunk_times(times, start, end)}
-                      for desc, times in timess]
+        # about.  Then round start down and end up to the nearest day.  If
+        # there aren't many registrations, don't bother with the graph.
+        if any(len(times) < 25 for desc, times in timess):
+            graph_data = []
+            start = None
+        else:
+            start = min([times[10:-10][0] for desc, times in timess])
+            start = start.replace(hour=0, minute=0, second=0, microsecond=0)
+            end = max([times[10:-10][-1] for desc, times in timess])
+            end = end.replace(hour=0, minute=0, second=0, microsecond=0)
+            end += datetime.timedelta(1)
+            end = min(end, datetime.datetime.now())
+            graph_data = [{"description": desc,
+                           "data": BigBoardModule.chunk_times(times, start, end)}
+                          for desc, times in timess]
 
         context = {
             "numbers": numbers,

--- a/esp/templates/program/modules/bigboardmodule/bigboard.html
+++ b/esp/templates/program/modules/bigboardmodule/bigboard.html
@@ -20,58 +20,60 @@
 
 {% block body %}
 
-<div class="bigboard-graph">
-  <div id="highcharts-placeholder"></div>
-  <script type="text/javascript">
-    $j(function () {
-      $j('#highcharts-placeholder').highcharts({
-        credits: {
-            enabled: false
-        },
-        legend: {
-          align: "right",
-          floating: true,
-          layout: "vertical",
-          verticalAlign: "middle",
-        },
-        plotOptions: {
-          line: {
-            marker: {enabled: false},
+{% if graph_data %}
+  <div class="bigboard-graph">
+    <div id="highcharts-placeholder"></div>
+    <script type="text/javascript">
+      $j(function () {
+        $j('#highcharts-placeholder').highcharts({
+          credits: {
+              enabled: false
           },
-        },
-        title: {
-          text: null,
-        },
-        tooltip: {
-          shared: true,
-        },
-        xAxis: {
-          type: 'datetime',
-          minRange: 24 * 60 * 60 * 1000, // one day
-        },
-        yAxis: {
-          title: {text: null},
-          min: 0,
-          maxPadding: 0.01,
-          endOnTick: false,
-        },
-        series: [
-          {% for series in graph_data %}
-            {
-              type: 'line',
-              name: '{{series.description}}',
-              pointInterval: 60 * 60 * 1000, // one hour
-              pointStart: Date.UTC(
-                  {{first_hour.year}}, {{first_hour.month}} - 1,
-                  {{first_hour.day}}, {{first_hour.hour}}),
-              data: {{series.data}},
+          legend: {
+            align: "right",
+            floating: true,
+            layout: "vertical",
+            verticalAlign: "middle",
+          },
+          plotOptions: {
+            line: {
+              marker: {enabled: false},
             },
-          {% endfor %}
-        ],
+          },
+          title: {
+            text: null,
+          },
+          tooltip: {
+            shared: true,
+          },
+          xAxis: {
+            type: 'datetime',
+            minRange: 24 * 60 * 60 * 1000, // one day
+          },
+          yAxis: {
+            title: {text: null},
+            min: 0,
+            maxPadding: 0.01,
+            endOnTick: false,
+          },
+          series: [
+            {% for series in graph_data %}
+              {
+                type: 'line',
+                name: '{{series.description}}',
+                pointInterval: 60 * 60 * 1000, // one hour
+                pointStart: Date.UTC(
+                    {{first_hour.year}}, {{first_hour.month}} - 1,
+                    {{first_hour.day}}, {{first_hour.hour}}),
+                data: {{series.data}},
+              },
+            {% endfor %}
+          ],
+        });
       });
-    });
-  </script>
-</div>
+    </script>
+  </div>
+{% endif %}
 
 <div class="bigboard-numbers">
   {% for description, number in numbers %}


### PR DESCRIPTION
Previously it would error, because of the way it draws the graph.  Now it will
just omit the graph.  Fixes #1560.