### PR TITLE
Include React from Cloudflare instead of FB so we can get HTTPS

### DIFF
--- a/esp/templates/elements/html
+++ b/esp/templates/elements/html
@@ -44,8 +44,8 @@
     <script type="text/javascript" src="/media/scripts/common.js"></script>
     {% endblock jquery %}
 
-    <script type="text/javascript" src="//fb.me/react-0.11.2.js"></script>
-    <script type="text/javascript" src="//fb.me/JSXTransformer-0.11.2.js"></script>
+    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/react/0.11.2/react.js"></script>
+    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/react/0.11.2/JSXTransformer.js"></script>
 
     {% block js1 %}
     <script type="text/javascript" src="/media/scripts/content/user_data.js"></script>


### PR DESCRIPTION
Facebook's URL was redirecting to HTTP, giving mixed content errors.  Probably
we should just serve it ourselves, but this is simpler.  (Or maybe we should
serve everything from Cloudflare CDN!)  Fixes #1568.