### PR TITLE
Remove non-static resource requests

### DIFF
--- a/esp/esp/program/controllers/classreg.py
+++ b/esp/esp/program/controllers/classreg.py
@@ -82,10 +82,8 @@ class ClassCreationController(object):
     def get_forms(self, reg_data, form_class=TeacherClassRegForm):
         reg_form = form_class(self.crmi, reg_data)
 
-        static_resource_requests = Tag.getProgramTag('static_resource_requests', self.program, )
-
         try:
-            resource_formset = ResourceRequestFormSet(reg_data, prefix='request', static_resource_requests=static_resource_requests, )
+            resource_formset = ResourceRequestFormSet(reg_data, prefix='request')
         except ValidationError:
             resource_formset = None
 

--- a/esp/esp/resources/forms.py
+++ b/esp/esp/resources/forms.py
@@ -53,8 +53,6 @@ class ResourceRequestForm(forms.Form):
         if 'resource_type' in kwargs:
             self.resource_type = kwargs['resource_type']
             del kwargs['resource_type']
-        self.static_resource_requests = kwargs['static_resource_requests']
-        del kwargs['static_resource_requests']
 
         super(ResourceRequestForm, self).__init__(data, **kwargs)
     
@@ -66,18 +64,13 @@ class ResourceRequestForm(forms.Form):
             
         if hasattr(self, 'resource_type'):
             self.fields['desired_value'].label = self.resource_type.name
-            if self.static_resource_requests:
-                #   If this is the only form to be displayed, show all options as checkboxes and let the user pick
-                #   any number (or none) with this form
-                if self.resource_type.only_one:
-                    pass
-                else:
-                    self.fields['desired_value'] = forms.MultipleChoiceField(choices=(), widget=forms.CheckboxSelectMultiple, required=False)
-                    self.fields['desired_value'].label = self.resource_type.name
+            #   If this is the only form to be displayed, show all options as checkboxes and let the user pick
+            #   any number (or none) with this form
+            if self.resource_type.only_one:
+                pass
             else:
-                #   Use radio buttons for 4 or fewer choices; select boxes above that to save space
-                if len(self.resource_type.choices) > 4:
-                    self.fields['desired_value'].widget = forms.Select()
+                self.fields['desired_value'] = forms.MultipleChoiceField(choices=(), widget=forms.CheckboxSelectMultiple, required=False)
+                self.fields['desired_value'].label = self.resource_type.name
             #   Don't provide a blank default value
             #   self.fields['desired_value'].choices = zip(tuple(' ') + self.resource_type.choices, tuple(' ') + self.resource_type.choices)    
             self.fields['desired_value'].choices = zip(self.resource_type.choices, self.resource_type.choices)
@@ -91,11 +84,6 @@ class ResourceRequestFormSet(formset_factory(ResourceRequestForm, extra=0)):
         if 'resource_type' in kwargs:
             self.resource_type = kwargs['resource_type']
             del kwargs['resource_type']
-        if 'static_resource_requests' in kwargs:
-            self.static_resource_requests = kwargs['static_resource_requests']
-            del kwargs['static_resource_requests']
-        else:
-            raise TypeError, "static_resource_requests is required for ResourceRequestFormSet"
         super(ResourceRequestFormSet, self).__init__(*args, **kwargs)
     
     def initial_form_count(self):
@@ -129,7 +117,6 @@ class ResourceRequestFormSet(formset_factory(ResourceRequestForm, extra=0)):
             #   Select out appropriate list item for the form being constructed.
             if isinstance(self.resource_type, list):
                 default_args['resource_type'] = self.resource_type[i]
-        default_args['static_resource_requests'] = self.static_resource_requests
             
         defaults.update(default_args)
         form = self.form(**defaults)

--- a/esp/templates/program/modules/teacherclassregmodule/classedit.html
+++ b/esp/templates/program/modules/teacherclassregmodule/classedit.html
@@ -78,26 +78,6 @@
         <td colspan="2">Please specify your classroom needs by building a list of requests.  You may submit more than one request per category (for example, you would need separate A/V requests for both DVD player and speakers).  If you are providing your own space for this class, please remove all requests.</td>
     </tr>
     -->
-{% if not static_resource_requests %}
-    <tr>
-        <td width="30%">
-            <b>Click to add requests:</b>
-            <noscript>(Note: Please enable Javascript.)</noscript>
-        </td>
-        <td>
-            {% for rt in resource_types %}<a id="add_request_{{ rt.id }}" href="/teach/{{ program.getUrlBase }}/makeaclass">{{ rt.name }}</a>{% if not forloop.last %} | {% endif %}{% endfor %}{% if allow_restype_creation %} | <a id="add_restype" href="/teach/{{ program.getUrlBase }}/makeaclass">Other</a>{% endif %}
-        </td>
-    </tr>
-<script type="text/javascript">
-<!--
-    register_fragment({id: "request_forms_html", url: ""});
-    register_fragment({id: "restype_forms_html", url: ""});
-    {% for rt in resource_types %}
-    register_link({id: "add_request_{{ rt.id }}", url: "/teach/{{ program.getUrlBase }}/ajax_requests", content: {action: "add", restype: "{{ rt.id }}"}, post_form: "clsform"});{% endfor %}
-    register_link({id: "add_restype", url: "/teach/{{ program.getUrlBase }}/ajax_restypes", content: {action: "add"}, post_form: "clsform"});
--->
-</script>
-{% endif %}
 {% include "program/modules/teacherclassregmodule/requests_form_fragment.html" %}
 {% with restype_formset as formset %}
 {% include "program/modules/teacherclassregmodule/restype_form_fragment.html" %}

--- a/esp/templates/program/modules/teacherclassregmodule/requests_form_fragment.html
+++ b/esp/templates/program/modules/teacherclassregmodule/requests_form_fragment.html
@@ -13,9 +13,6 @@
             {% endif %}
             {% if field.errors %}{{ field.errors }}<br />{% endif %}
             {{ field }} 
-            {% if not static_resource_requests %}
-            <a id="remove_request_{{ forloop.parentloop.counter0 }}" href="/teach/{{ program.getUrlBase }}/makeaclass">Remove</a>
-            {% endif %}
         </td>
     </tr>
     {% endfor %}


### PR DESCRIPTION
This was an alternate system that was added (edit: maybe it was the original system and the other one was added?), but most chapters that use resources don't use it, and I think the ones that do don't actually care, they're just using it because it's the default.  In addition, the non-static system appears broken.  I'd like to remove it, because it will be easier to do the resources schema changes if we don't have to maintain two systems.  As far as I can tell, this doesn't need any migration, since it's stored in the same models, it will just display things differently.