### PR TITLE
Fix error in grade change request __unicode__

### DIFF
--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -2601,7 +2601,7 @@ class GradeChangeRequest(TimeStampedModel):
 
 
     def __unicode__(self):
-        return  "%s requests a grade change to %s" % (self.requesting_student, self.claimed_grade) + (" (Approved)" if self.approved else None)
+        return  "%s requests a grade change to %s" % (self.requesting_student, self.claimed_grade) + (" (Approved)" if self.approved else "")
         
 # We can't import these earlier because of circular stuff...
 from esp.users.models.userbits import UserBit, UserBitImplication


### PR DESCRIPTION
This was breaking the admin panel for GradeChangeRequests. Already in mit-prod.