### PR TITLE
Added sorting by category name as well as category symbol.

### DIFF
--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -235,7 +235,7 @@ class ClassManager(Manager):
         if order_args_override:
             order_args = order_args_override
         else:
-            order_args = ['category__symbol', 'sections__meeting_times__start', '_num_students', 'id']
+            order_args = ['category__symbol', 'category__category', 'sections__meeting_times__start', '_num_students', 'id']
             #   First check if there is an ordering specified for the program.
             program_sort_fields = Tag.getProgramTag('catalog_sort_fields', program)
             if program_sort_fields:


### PR DESCRIPTION
Addresses #1576 at least in the default case. In particular, if the tag catalog_sort_fields is defined (which it is for MIT) this won't actually have any visible effects but whatever. 

I also haven't actually tested this change directly since I don't see an obvious way to do so. However, based on changing the catalog_sort_fields tag, this should fix the issue assuming it doesn't break anything.

