### PR TITLE
Fix Travis failure related to pip install command.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
 install: 
   - sudo apt-get install -y $(cat esp/packages_base.txt | grep -v ^memcached | grep -v ^postgres) -qq
   - esp/packages_base_manual_install.sh
-  - (pip install -r esp/requirements.txt --use-mirrors || tail pip.log 1>&2 2>/dev/null) | tee pip.log | grep '^Downloading/unpacking'
+  - pip install -r esp/requirements.txt --use-mirrors -q --log pip.log || (tail pip.log && exit 1)
 before_script:
   - cp esp/esp/local_settings.py.travis esp/esp/local_settings.py
   - ln -s `pwd`/esp/public/media/default_images esp/public/media/images


### PR DESCRIPTION
The output format of pip changed, causing grep to fail and Travis to
treat that as a build error. Modify it to not do the grep thing at
all, since the only reason we had it in the first place was to output
some progress information so that Travis wouldn't think we stalled,
and that doesn't seem to be happening anymore.