### PR TITLE
UI for flushing individual caches

### DIFF
--- a/esp/esp/cache/urls.py
+++ b/esp/esp/cache/urls.py
@@ -2,4 +2,5 @@ from django.conf.urls.defaults import *
 
 urlpatterns = patterns('',
                         (r'^view_all/?$', 'esp.cache.views.view_all'),
+                        (r'^flush/([0-9]+)/?$', 'esp.cache.views.flush')
                         )

--- a/esp/esp/cache/views.py
+++ b/esp/esp/cache/views.py
@@ -39,6 +39,6 @@ from esp.web.util.main import render_to_response
 
 @admin_required
 def view_all(request):
-    caches = sorted(all_caches.values(), key=lambda c: c.name)
+    caches = sorted(all_caches, key=lambda c: c.name)
     cache_data = [{'pretty_name': cache.pretty_name, 'hit_count': cache.hit_count, 'miss_count': cache.miss_count} for cache in caches]
     return render_to_response('cache/view_all.html', request, {'caches': cache_data})

--- a/esp/esp/cache/views.py
+++ b/esp/esp/cache/views.py
@@ -36,9 +36,17 @@ Learning Unlimited, Inc.
 from esp.cache.registry import all_caches
 from esp.users.models import admin_required
 from esp.web.util.main import render_to_response
+from django.shortcuts import redirect
+from django.core.urlresolvers import reverse
 
 @admin_required
 def view_all(request):
     caches = sorted(all_caches, key=lambda c: c.name)
     cache_data = [{'pretty_name': cache.pretty_name, 'hit_count': cache.hit_count, 'miss_count': cache.miss_count} for cache in caches]
     return render_to_response('cache/view_all.html', request, {'caches': cache_data})
+
+@admin_required
+def flush(request, cache_id):
+    cache = sorted(all_caches, key=lambda c: c.name)[int(cache_id)]
+    cache.delete_all()
+    return redirect(reverse(view_all))

--- a/esp/templates/cache/view_all.html
+++ b/esp/templates/cache/view_all.html
@@ -18,12 +18,12 @@
 <table class="sortable">
 <thead>
 <tr>
-<th>Cache</th><th>Hits</th><th>Misses</th>
+<th>Cache</th><th>Hits</th><th>Misses</th><th></th>
 </tr>
 </thead>
 <tbody>
 {% for cache in caches %}
-<tr><td>{{ cache.pretty_name }}</td> <td>{{ cache.hit_count }}</td> <td>{{ cache.miss_count }}</td></tr>
+<tr><td>{{ cache.pretty_name }}</td> <td>{{ cache.hit_count }}</td> <td>{{ cache.miss_count }}</td> <td>[<a href="/cache/flush/{{ forloop.counter0 }}">Flush</a>]</td></tr>
 {% endfor %}
 </tbody>
 </table>

--- a/esp/templates/cache/view_all.html
+++ b/esp/templates/cache/view_all.html
@@ -15,10 +15,10 @@
 {% block content %}
 
 <div id="program_form">
-<table class="sortable">
+<table class="sortable" style="table-layout: fixed; width: 100%; word-wrap: break-word;">
 <thead>
 <tr>
-<th>Cache</th><th>Hits</th><th>Misses</th><th></th>
+<th style="width: 70%;">Cache</th><th>Hits</th><th>Misses</th><th></th>
 </tr>
 </thead>
 <tbody>


### PR DESCRIPTION
Fix the /cache/view_all view, which displays a list of all cached functions, and add the ability to flush individual cached functions.