### PR TITLE
Add program name to the subject line of messages to Mailman lists

### DIFF
--- a/esp/esp/dbmail/receivers/classlist.py
+++ b/esp/esp/dbmail/receivers/classlist.py
@@ -78,6 +78,7 @@ class ClassList(BaseHandler):
                     settings.DEFAULT_EMAIL_ADDRESSES['mailman_moderator'],
                     cls.parent_program.director_email,
                 ],
+                'subject_prefix': "[%s]" % (cls.parent_program.niceName(),),
             })
             send_mail("[ESP] Activated class mailing list: %s@%s" % (list_name, Site.objects.get_current().domain),
                       render_to_string("mailman/new_list_intro_teachers.txt", 
@@ -88,6 +89,7 @@ class ClassList(BaseHandler):
             apply_list_settings(list_name, {'default_member_moderation': False})
             apply_list_settings(list_name, {'generic_nonmember_action': 0})
             apply_list_settings(list_name, {'acceptable_aliases': "%s.*-(students|class)-.*@%s" % (cls.emailcode(), Site.objects.get_current().domain)})
+            apply_list_settings(list_name, {'subject_prefix': "[%s]" % (cls.parent_program.niceName(),)})
 
         add_list_member(list_name, cls.parent_program.director_email)
         add_list_members(list_name, cls.get_teachers())

--- a/esp/esp/dbmail/receivers/sectionlist.py
+++ b/esp/esp/dbmail/receivers/sectionlist.py
@@ -76,6 +76,7 @@ class SectionList(BaseHandler):
                     settings.DEFAULT_EMAIL_ADDRESSES['mailman_moderator'],
                     cls.parent_program.director_email,
                 ],
+                'subject_prefix': "[%s]" % (cls.parent_program.niceName(),),
             })
             if DEBUG: print "Settings applied..."
             send_mail("[ESP] Activated class mailing list: %s@%s" % (list_name, Site.objects.get_current().domain),
@@ -87,6 +88,7 @@ class SectionList(BaseHandler):
             apply_list_settings(list_name, {'default_member_moderation': False})
             apply_list_settings(list_name, {'generic_nonmember_action': 0})
             apply_list_settings(list_name, {'acceptable_aliases': "%s.*-(students|class)-.*@%s" % (cls.emailcode(), Site.objects.get_current().domain)})
+            apply_list_settings(list_name, {'subject_prefix': "[%s]" % (cls.parent_program.niceName(),)})
 
         if DEBUG: print "Settings applied still..."
         add_list_member(list_name, cls.parent_program.director_email)


### PR DESCRIPTION
This won't work for already-existing lists at the time this is merged, because it applies the setting at list creation.