### PR TITLE
Display user data in custom form responses

### DIFF
--- a/esp/esp/customforms/DynamicForm.py
+++ b/esp/esp/customforms/DynamicForm.py
@@ -650,10 +650,7 @@ class FormHandler:
             elif generic_fields[ftype]['typeMap'] is not DummyField:
                 response_data['questions'].append([qname, field['label'], ftype])
 
-        users = ESPUser.objects.filter(id__in=map(lambda response: response['user_id'], responses)).distinct()
-        users_dict = {}
-        for user in users:
-            users_dict[user.id] = user
+        users = ESPUser.objects.in_bulk(map(lambda response: response['user_id'], responses))
 
         # Now let's set up the responses
         for response in responses:
@@ -661,7 +658,7 @@ class FormHandler:
             
             # Add in user if form is not anonymous
             if not form.anonymous:
-                user = users_dict[response['user_id']]
+                user = users[response['user_id']]
                 response['user_id'] = unicode(response['user_id'])
                 response['user_display'] = user.name()
                 response['user_email'] = user.email

--- a/esp/esp/customforms/tests.py
+++ b/esp/esp/customforms/tests.py
@@ -200,8 +200,8 @@ class CustomFormsTest(TestCase):
         for field_spec in indiv_response:
             self.assertEqual(self.map_form_value(responses_corrected[key]), indiv_response[key])
         self.assertTrue('questions' in response_data)
-        self.assertEqual(len(response_data['questions']), len(responses_initial) + 1)   #   provided fields plus user_id
+        self.assertEqual(len(response_data['questions']), len(responses_initial) + 4)   #   provided fields plus user_id, user_display, user_email, username
         for entry in response_data['questions']:
-            if entry[0] == 'user_id':
+            if entry[0] in ['user_id', 'user_display', 'user_email', 'username']:
                 continue
             self.assertTrue(entry[0] in responses_corrected)


### PR DESCRIPTION
Show usernames, names, and email addresses in custom form responses. Previously only the user id was visible, which didn't make for a good UI.

Fixes #547.