### PR TITLE
Extend base styles in customform view_results page

### DIFF
--- a/esp/templates/customforms/view_results.html
+++ b/esp/templates/customforms/view_results.html
@@ -5,7 +5,7 @@
 {% block fulltitle %}Form responses{% endblock %}
 
 {% block stylesheets %}
-    {#{{ block.super }}#}
+    {{ block.super }}
 		<link rel="stylesheet" type="text/css" href="/media/default_styles/customforms-style.css">
 		<link rel="stylesheet" type="text/css" href="/media/styles/jquery-ui/ui.jqgrid.css" />
 {% endblock %}


### PR DESCRIPTION
Fixes display issue introduced by 23c5079a139672aa9c863d0301a6ba528009eed4, where jquery-ui.css stopped being loaded on the page.