### PR TITLE
Fix autocomplete field bug

### DIFF
--- a/esp/esp/db/forms.py
+++ b/esp/esp/db/forms.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import User
 from django.utils.safestring import mark_safe
 import re
 
-get_id_re = re.compile('.*\D(\d+)\D')
+get_id_re = re.compile('.*\((\d+)\)$')
 
 class AjaxForeignKeyFieldBase:
 


### PR DESCRIPTION
Improves a regex that is used in the clean() method of
AjaxForeignKeyNewformField.

There are three possible states for the data in such a field
after a form submission:
- The field contains raw text.
- An autocomplete option was correctly selected, and the value
  is an integer id.
- An autocomplete option was incorrectly selected, and the value
  is something that looks like "Foo Bar (17)", where the number
  is the object's integer id.

The clean() method attempts to catch and correct the last case
with a regex. But that regex captured things that it shouldn't
have, such as (encountered on the Stanford site)
"k12 online school".

The improved regex only matches the field when the number is in
parentheses, at the very end of the string.