### PR TITLE
Fix admin panel filtering for Resource

### DIFF
--- a/esp/esp/resources/admin.py
+++ b/esp/esp/resources/admin.py
@@ -55,11 +55,11 @@ class ResourceRequestAdmin(admin.ModelAdmin):
 
 class ResourceAdmin(admin.ModelAdmin):
     def program(obj):
-        return obj.res_type.program.name
+        return obj.event.program.name
     list_display = ('name', 'res_type', 'num_students', 'event', 'res_group', program)
-    list_filter = ('res_type__program',)
+    list_filter = ('event__program',)
     search_fields = ('name', 'res_type__name', 'res_type__description',
-            'res_type__attributes_pickled', 'res_type__program__name',
+            'res_type__attributes_pickled', 'event__program__name',
             'num_students', 'event__name', 'event__short_description',
             '=res_group__id')
 


### PR DESCRIPTION
Filtering Resources by program would miss some resources, because it
got the program by checking res_type__program. Some ResourceTypes are global,
so this doesn't catch everything. This commit switches to checking
event__program. ResourceRequest has a similar problem, but can't be
reliably fixed in the same way because of target and target_subj, and that one
wasn't causing a problem in MIT ESP's setup so I left it as is.