### PR TITLE
ESPUserManager improvements

### DIFF
--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -40,7 +40,7 @@ import simplejson as json
 from django import forms, dispatch
 from django.conf import settings
 from django.contrib.auth import logout, login, REDIRECT_FIELD_NAME
-from django.contrib.auth.models import User, AnonymousUser, Group
+from django.contrib.auth.models import User, AnonymousUser, Group, UserManager
 from django.contrib.localflavor.us.forms import USStateSelect
 from django.contrib.localflavor.us.models import USStateField, PhoneNumberField
 from django.contrib.sites.models import Site
@@ -126,7 +126,7 @@ class UserAvailability(models.Model):
         return super(UserAvailability, self).save(*args, **kwargs)
 
 
-class ESPUserManager(Manager):
+class ESPUserManager(UserManager):
     pass
 
 def get_studentreg_model():

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -127,7 +127,82 @@ class UserAvailability(models.Model):
 
 
 class ESPUserManager(UserManager):
-    pass
+    def create_users_for_program(self, program, username_format, password_format, groups, number=1):
+        """Create a set of generic users for a program.
+
+        Example use case: create one-time accounts for a HS's outreach students.
+
+        :param program:
+            Create a :class:`RegistrationProfile` for the user, with this as
+            the value of the `program` field.
+        :type program:
+            :class:`Program` or None
+        :param username_format:
+            A format string for the usernames. Must contain exactly one '{}'
+            substring. Generate usernames by formatting the string with the
+            current index of iteration.
+        :type username_format:
+            `unicode`
+        :param password_format:
+            A format string for the password. Generate passwords by formatting
+            the string with the current index of iteration. May contain no '{}'
+            substrings, to reuse the same password for each user.
+        :type password_format:
+            `unicode`
+        :param groups:
+            A list of groups, specified by object or name, to add each new user
+            to. Can also pass a single group or group name.
+        :type groups:
+            (`list` of (:class:`Group` or `unicode`)) or (:class:`Group` or `unicode`)
+        :param number:
+            A positive number of new users to create.
+        :type number:
+            `int`
+        :return:
+            A list of data dictionaries, one for each created user. Each
+            dictionary contains 'username', 'password', 'user', and 'profile'
+            keys.
+        :rtype:
+            `list` of `dict`
+        """
+        from esp.program.models import RegistrationProfile
+        if not isinstance(groups, (list, tuple)):
+            groups = [groups]
+        def get_group(group):
+            if isinstance(group, Group):
+                return group
+            elif isinstance(group, basestring):
+                return Group.objects.get(name=group)
+            else:
+                raise AssertionError('{} is not a Group or Group name'.format(unicode(group)))
+        groups = map(get_group, groups)
+        ret = []
+        for i in xrange(number):
+            username = username_format.format(i)
+            password = password_format.format(i)
+            user = self.create_user(username=username, password=password)
+            user.groups.add(*groups)
+            profile = RegistrationProfile.objects.create(user=user, program=program)
+
+            # Set the `last_ts` field of the profile to be a long time ago. If
+            # the `last_ts` field is too recent, the user won't be prompted to
+            # edit their profile when they log in and register for the program,
+            # and they'll forever have a blank, useless profile.
+            #
+            # NOTE(jmoldow): But we can't set `last_ts` with `create()` or
+            # `save()`, because the custom `RegistrationProfile.save()` always
+            # sets that field using `datetime.now()`. So we must use
+            # `update()`.
+            RegistrationProfile.objects.filter(id=profile.id).update(last_ts=(datetime.now() - timedelta(days=20)))
+
+            profile = RegistrationProfile.objects.get(id=profile.id)
+            ret.append({
+                'username': username,
+                'password': password,
+                'user': user,
+                'profile': profile,
+            })
+        return ret
 
 def get_studentreg_model():
     from esp.program.models import StudentRegistration


### PR DESCRIPTION
Make ``ESPUserManager`` derive from Django's ``UserManager``, so that it gets utility methods such as ``create_user()``. Also add a new utility method, ``create_users_for_program()``.