### PR TITLE
Program module install improvements

### DIFF
--- a/esp/esp/program/modules/handlers/onsiteclasslist.py
+++ b/esp/esp/program/modules/handlers/onsiteclasslist.py
@@ -61,17 +61,12 @@ def hsl_to_rgb(hue, saturation, lightness=0.5):
 class OnSiteClassList(ProgramModuleObj):
     @classmethod
     def module_properties(cls):
-        return [ {
-            "admin_title": "Show All Classes at Onsite Registration",
-            "link_title": "List of All Classes",
-            "module_type": "onsite",
-            "seq": 31,
-            }, {
+        return {
             "admin_title": "Show Open Classes at Onsite Registration",
             "link_title": "List of Open Classes",
             "module_type": "onsite",
             "seq": 32,
-            } ]
+            }
 
     @cache_function
     def section_data(sec):

--- a/esp/esp/program/modules/models.py
+++ b/esp/esp/program/modules/models.py
@@ -36,18 +36,6 @@ Learning Unlimited, Inc.
 from esp.program.modules.handlers import *
 from django.db.models import Q
 
-#from django.contrib import admin
-#from django.db import models 
-#from esp.program.models import Program
-#
-#class DBReceipt(models.Model):
-#    """ Per-program Receipt templates """
-#    program = models.OneToOneField(Program)
-#    receipt = models.TextField()
-#
-#admin_site.register(DBReceipt)
-
-
 def updateModules(update_data, overwriteExisting=False, deleteExtra=False, model=None):
     """
     Given a list of key:value dictionaries containing fields from the
@@ -89,7 +77,7 @@ def updateModules(update_data, overwriteExisting=False, deleteExtra=False, model
         for (datum, (mod, created)) in mods:
             ids.append(mod.id)
 
-        #ProgramModule.objects.exclude(id__in=ids).delete()
+        ProgramModule.objects.exclude(id__in=ids).delete()
 
     for (datum, (mod, created)) in mods:
         #   If the module exists but the provided data adds fields that 
@@ -114,6 +102,6 @@ def install(model=None):
     for module in modules:
         table_data += module.module_properties_autopopulated()
 
-    updateModules(table_data, model=model)
+    updateModules(table_data, overwriteExisting=True, deleteExtra=True, model=model)
     
 from esp.program.modules.module_ext import *

--- a/esp/esp/program/modules/models.py
+++ b/esp/esp/program/modules/models.py
@@ -102,6 +102,6 @@ def install(model=None):
     for module in modules:
         table_data += module.module_properties_autopopulated()
 
-    updateModules(table_data, overwriteExisting=True, deleteExtra=True, model=model)
+    updateModules(table_data, deleteExtra=True, model=model)
     
 from esp.program.modules.module_ext import *


### PR DESCRIPTION
Running install() now updates module_properties for program modules that have changed, and deletes modules that don't exist anymore. Also, the code was assuming that (handler, type) pairs are unique. I fixed the one case where this wasn't true, since there was no reason for there to be two modules there.

I tested this by running it on my dev server and checking that only the modules that should be deleted were deleted, nothing bad happened to a program that had one of them enabled, and I was able to change the link_title of a module.