### PR TITLE
Cache ESPUser.isAdministrator

### DIFF
--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -773,6 +773,7 @@ class ESPUser(User, AnonymousUser):
         send_mail(subject, msgtext, from_email, to_email)
 
 
+    @cache_function
     def isAdministrator(self, program=None):
         """Determine if the user is an admin for the program.
 
@@ -793,6 +794,9 @@ class ESPUser(User, AnonymousUser):
                         quser & qprogram & Permission.is_valid_qobject(),
                         permission_type="Administer",
         ).exists()
+    isAdministrator.depend_on_row('users.ESPUser', lambda user: {'self': user})
+    isAdministrator.depend_on_m2m('users.ESPUser', 'groups', lambda user, group: {'self': user})
+    isAdministrator.depend_on_m2m('users.Permission', lambda perm: {'self': perm.user})
     isAdmin = isAdministrator
 
     @cache_function

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -798,10 +798,12 @@ class ESPUser(User, AnonymousUser):
     isAdministrator.get_or_create_token(('program',))
     isAdministrator.depend_on_row('users.ESPUser', lambda user: {'self': user})
     isAdministrator.depend_on_m2m('users.ESPUser', 'groups', lambda user, group: {'self': user})
-    # if the permission has null role, expire all caches, otherwise expire only
-    # the one for the relevant user.
+    # if the permission has null user and non-null group, expire all caches,
+    # otherwise expire only the one for the relevant user.
     isAdministrator.depend_on_row('users.Permission', lambda perm:
-                                  {'self': perm.user} if perm.role is None
+                                  {'self': perm.user}
+                                  if perm.user is not None
+                                  or perm.role is None
                                   else {'self': wildcard})
     isAdmin = isAdministrator
 


### PR DESCRIPTION
It gets called a lot, such as in every `@meets_deadline` call, so even though it's not too expensive a call, it's still worth caching IMO, since it doesn't change very often.  Will hopefully fix #1614.

It won't properly open/expire permissions at a time, but I don't think we do that for admin bits much if ever, so I'm not worried.