### PR TITLE
Make 'survey' and 'surveys' aliases of each other

### DIFF
--- a/esp/esp/program/modules/handlers/surveymanagement.py
+++ b/esp/esp/program/modules/handlers/surveymanagement.py
@@ -99,6 +99,8 @@ class SurveyManagement(ProgramModuleObj):
         elif extra == 'top_classes':
             return top_classes(request, tl, one, two)
 
+    survey = surveys
+
     class Meta:
         proxy = True
 

--- a/esp/esp/program/modules/handlers/surveymodule.py
+++ b/esp/esp/program/modules/handlers/surveymodule.py
@@ -116,6 +116,8 @@ class SurveyModule(ProgramModuleObj):
         elif extra == 'review_single':
             return survey_review_single(request, tl, one, two)
 
+    surveys = survey
+
     class Meta:
         proxy = True
 


### PR DESCRIPTION
Because I got annoyed that the manage and teach/learn URLs are different.