### PR TITLE
Adds useful script to run a query against each chapter site

### DIFF
--- a/esp/useful_scripts/run_queries.sh
+++ b/esp/useful_scripts/run_queries.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Run a query against each chapter site on the LU server.
+# usage e.g. $0 "print Program.objects.count()"
+#            $0 "$(cat script.py)"
+
+set -e
+
+this_dir=${0%/*}
+base_dir=/lu/sites
+
+cd $base_dir || exit 1
+sites=$(ls -d */ | tr -d '/')
+echo "$@"
+for i in $sites ; do
+  if [ -f $i/esp/manage.py ] ; then
+    echo -n "$i: "
+    python $this_dir/single_query.py "$base_dir/$i" "$@"
+  fi
+done

--- a/esp/useful_scripts/single_query.py
+++ b/esp/useful_scripts/single_query.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python2
+
+# Run a query against a site in a given directory.
+# usage e.g. $0 /lu/sites/smith "print Program.objects.count()"
+#            $0 /lu/sites/smith "$(cat script.py)"
+# Intended primarily to be used by run_queries.sh.
+
+import sys
+sys.path.insert(0, sys.argv[1]+'/esp/useful_scripts')
+
+try:
+    from script_setup import *
+except:
+    print "ERROR: no script_setup.py"
+    sys.exit(1)
+
+try:
+    exec sys.argv[2]
+except:
+    print "ERROR: code failed to run"
+    raise


### PR DESCRIPTION
I was tired of having questions like "how many chapters have X object in their database" (for example in discussion on #1656) and having no easy way to answer them.  This script is janky but should hopefully work; maybe some day we will have an actual build system that can do this reasonably.  Note that while the script lives in the codebase of one site, it is designed to run on all sites, I just don't have a better place to keep it.