### PR TITLE
Ressurect old schedule printing script

### DIFF
--- a/esp/esp/program/modules/handlers/programprintables.py
+++ b/esp/esp/program/modules/handlers/programprintables.py
@@ -972,10 +972,10 @@ Volunteer schedule for %s:
         elif 'img_format' in request.GET:
             file_type = request.GET['img_format']
         else:
-            file_type = 'pdf'
-
-        if onsite and file_type == 'pdf':
-            file_type = 'png'
+            if onsite:
+                file_type = 'png'
+            else:
+                file_type = 'pdf'
 
         from django.conf import settings
         context['PROJECT_ROOT'] = settings.PROJECT_ROOT.rstrip('/') + '/'

--- a/esp/useful_scripts/poll_schedules.sh
+++ b/esp/useful_scripts/poll_schedules.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+PROGRAM="Spark"
+INSTANCE="2015"
+
+echo "What printer do you want to print to? (lpr printer name)"
+read PRINTERNAME
+
+echo "Where are you? (ESP website printer name)"
+read LOCATION
+
+echo "Please enter the onsite username and password for the ESP website:"
+echo -n "Username: "
+read USERNAME
+
+echo -n "Password: "
+read -s PASSWORD
+echo
+
+CURL_COOKIE_STORE="curl_cookies.txt"
+
+echo "Logging in..."
+curl -c "${CURL_COOKIE_STORE}" "https://esp.mit.edu/admin/" >/dev/null 2>&1
+curl -b "${CURL_COOKIE_STORE}" -c "${CURL_COOKIE_STORE}" -d "username=${USERNAME}&password=${PASSWORD}&this_is_the_login_form=1" "https://esp.mit.edu/admin/" >/dev/null 2>&1
+echo "Logged in!"
+
+while (true); do
+  TMPFILE="`mktemp`"
+  curl -b "${CURL_COOKIE_STORE}" "https://esp.mit.edu/onsite/${PROGRAM}/${INSTANCE}/printschedules/${LOCATION}?gen_img&img_format=pdf" -o "${TMPFILE}" 2>/dev/null
+
+  if [ -n "`cat "${TMPFILE}"`" ]; then
+    lpr -P "${PRINTERNAME}" < "${TMPFILE}"
+    echo -n "Printed! "
+    date
+    rm "${TMPFILE}"
+  else
+    echo -n "."
+    rm "${TMPFILE}"
+    sleep 2s 
+  fi  
+done
+
+


### PR DESCRIPTION
At some point the old `poll_schedules.sh` script got deleted in favor of the new interface.  While the new one is better, occasionally it's useful to be able to print headlessly, which the new interface doesn't do by construction.  This adds the old script back, with some slight modifications, along with a change to the schedule-printer module to make it work.  Fixes #1630.