### PR TITLE
Remove catalog sort by _num_students for performance reasons

### DIFF
--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -213,16 +213,12 @@ class ClassManager(Manager):
         #   Retrieve the content type for finding class documents (generic relation)
         content_type_id = ContentType.objects.get_for_model(ClassSubject).id
         
-        select = SortedDict([( '_num_students', 'SELECT COUNT(DISTINCT "program_studentregistration"."user_id") FROM "program_studentregistration", "program_classsection" WHERE ("program_studentregistration"."relationship_id" = %s AND "program_studentregistration"."section_id" = "program_classsection"."id" AND "program_classsection"."parent_class_id" = "program_class"."id" AND ("program_studentregistration"."start_date" IS NULL OR "program_studentregistration"."start_date" <= %s) AND ("program_studentregistration"."end_date" IS NULL OR "program_studentregistration"."end_date" >= %s))'),
-                             ('teacher_ids', 'SELECT list(DISTINCT espuser_id) FROM program_class_teachers Where program_class_teachers.classsubject_id=program_class.id'),
+        select = SortedDict([('teacher_ids', 'SELECT list(DISTINCT espuser_id) FROM program_class_teachers Where program_class_teachers.classsubject_id=program_class.id'),
                              ('media_count', 'SELECT COUNT(*) FROM "qsdmedia_media" WHERE ("qsdmedia_media"."owner_id" = "program_class"."id") AND ("qsdmedia_media"."owner_type_id" = %s)'),
                              ('_index_qsd', 'SELECT list("qsd_quasistaticdata"."id") FROM "qsd_quasistaticdata" WHERE ("qsd_quasistaticdata"."name" = \'learn:index\' AND "qsd_quasistaticdata"."url" LIKE %s AND "qsd_quasistaticdata"."url" SIMILAR TO %s || "program_class"."id" || %s)'),
                              ('_studentapps_count', 'SELECT COUNT(*) FROM "program_studentappquestion" WHERE ("program_studentappquestion"."subject_id" = "program_class"."id")')])
                              
-        select_params = [ enrolled_type.id,
-                          now,
-                          now,
-                          content_type_id,
+        select_params = [ content_type_id,
                           '%/Classes/%',
                           '%[A-Z]',
                           '/%',
@@ -234,7 +230,7 @@ class ClassManager(Manager):
         if order_args_override:
             order_args = order_args_override
         else:
-            order_args = ['category__symbol', 'category__category', 'sections__meeting_times__start', '_num_students', 'id']
+            order_args = ['category__symbol', 'category__category', 'sections__meeting_times__start', 'id']
             #   First check if there is an ordering specified for the program.
             program_sort_fields = Tag.getProgramTag('catalog_sort_fields', program)
             if program_sort_fields:

--- a/esp/esp/program/modules/handlers/programprintables.py
+++ b/esp/esp/program/modules/handlers/programprintables.py
@@ -252,9 +252,6 @@ class ProgramPrintables(ProgramModuleObj):
             sort_order = Tag.getProgramTag('catalog_sort_fields', prog, default='category').split(',')
 
         #   Perform sorting based on specified order rules
-        #   NOTE: Other catalogs can filter by _num_students but this one can't.
-        if '_num_students' in sort_order:
-            sort_order.remove('_num_students')
         #   Replace incorrect 'timeblock' sort field with sorting by meeting times start field.
         for i in xrange(len(sort_order)):
             if sort_order[i] == 'timeblock':


### PR DESCRIPTION
This is removing a feature that's still in use, but I think it's a good tradeoff. The catalog query is an abomination, it gets run all the time during FCFS student reg, and removing _num_students from it helps a lot: down from 2000-3300ms to 1100-1300ms on a really big program on my dev server. Having this sorting seems relatively unimportant compared to having FCFS be less slow. If we do remove it, we'd have to edit the tags on the bc and chicago sites (which appear to just be copies of what the default sort order was before #1576 was fixed).

Thoughts?