### PR TITLE
React-ify scheduling check output tables

### DIFF
--- a/esp/esp/program/modules/handlers/schedulingcheckmodule.py
+++ b/esp/esp/program/modules/handlers/schedulingcheckmodule.py
@@ -47,68 +47,6 @@ class RawSCFormatter:
     def format_list(self, l, options={}, help_text=""):
         return l
 
-class HTMLSCFormatter: # This might be dead, but idk maybe someone still wants it
-    #requires: d, a two level dictionary where the the first set of
-    #   keys are the headings expected on the side of the table, and
-    #   the second set are the headings expected on the top of the table
-    def format_table(self, d, options={}, help_text=""):
-        if isinstance(d, list):
-            return self._format_list_table(d, options['headings'], help_text=help_text)
-        else:
-            return self._format_dict_table(d, options['headings'], help_text=help_text)
-
-    def format_list(self, l, help_text=""):
-        output = self._table_start(help_text)
-        for row in l:
-            output += self._table_row([row])
-        output += "</table>"
-        return output
-
-    def _table_start(self, help_text=""):
-        output = ''
-        if help_text:
-             output += '<div class="help-text">%s</div>' % help_text
-        output += '<table cellpadding=10>'
-        return output
-
-    def _table_headings(self, headings):
-        #column headings
-        next_row = ""
-        for h in headings:
-            next_row = next_row + "<th><div style=\"cursor: pointer;\">" + str(h) + "</div></th>"
-        next_row = next_row + "</tr></thread>"
-        return next_row
-
-    def _table_row(self, row):
-        next_row = ""
-        for r in row:
-            #displaying lists is sometimes borked.  This makes it not borked
-            if isinstance(r, list):
-                r = [str(i) for i in r]
-            next_row += "<td>" + str(r) + "</td>"
-        next_row += "</tr>"
-        return next_row
-        
-    def _format_list_table(self, d, headings, help_text=""):
-        output = self._table_start(help_text)
-        output = output + self._table_headings(headings)
-        for row in d:
-            ordered_row = [row[h] for h in headings]
-            output = output + self._table_row(ordered_row) 
-        output = output + "</table>"
-        return output
-
-    def _format_dict_table(self, d, headings, help_text=""):
-        headings = [""] + headings[:]
-        output = self._table_start(help_text)
-        output = output + self._table_headings(headings)
-
-        for key, row in sorted(d.iteritems()):
-            ordered_row = [row[h] for h in headings if h]
-            output = output + self._table_row([key] + ordered_row)
-        output += "</table>"
-        return output
-
 # Builds JSON output for an object with attributes help_text, headings, and body.
 class JSONFormatter:
     #requires: d, a two level dictionary where the the first set of

--- a/esp/esp/program/modules/handlers/schedulingcheckmodule.py
+++ b/esp/esp/program/modules/handlers/schedulingcheckmodule.py
@@ -64,18 +64,8 @@ class JSONFormatter:
         output["headings"] = [] # no headings
         
         # might be redundant, but it makes sure things aren't in a weird format
-        body = []        
-        for row in l:
-            body.append(self._table_row([row]))
-        output["body"] = body
+        output["body"] = [self._table_row([row]) for row in l]
         return json.dumps(output)
-
-    def _table_headings(self, headings): # in case headings are a dict
-        #column headings
-        next_row = []
-        for h in headings:
-            next_row.append(str(h))
-        return next_row
 
     def _table_row(self, row):
         next_row = []
@@ -89,25 +79,16 @@ class JSONFormatter:
     def _format_list_table(self, d, headings, help_text=""): #needs verify
         output = {}
         output["help_text"] = help_text
-        output["headings"] = self._table_headings(headings)
-        body = []
-        for row in d:
-            ordered_row = [row[h] for h in headings]
-            body.append(self._table_row(ordered_row)) # maybe?
-        output["body"] = body
+        output["headings"] = map(str, headings)
+        output["body"] = [self._table_row([row[h] for h in headings]) for row in d]
         return output
 
     def _format_dict_table(self, d, headings, help_text=""): #needs verify
         headings = [""] + headings[:]
         output = {}
         output["help_text"] = help_text        
-        output["headings"] = self._table_headings(headings)
-        
-        body = []
-        for key, row in sorted(d.iteritems()):
-            ordered_row = [row[h] for h in headings if h]
-            body.append(self._table_row([key] + ordered_row)) #maybe
-        output["body"] = body
+        output["headings"] = map(str, headings)
+        output["body"] = [self._table_row([key] + [row[h] for h in headings if h]) for key, row in sorted(d.iteritems())]
         return output
         
 class SchedulingCheckRunner:

--- a/esp/esp/program/modules/handlers/schedulingcheckmodule.py
+++ b/esp/esp/program/modules/handlers/schedulingcheckmodule.py
@@ -67,13 +67,17 @@ class JSONFormatter:
         output["body"] = [self._table_row([row]) for row in l]
         return json.dumps(output)
 
+
     def _table_row(self, row):
         next_row = []
         for r in row:
             #displaying lists is sometimes borked.  This makes it not borked
             if isinstance(r, list):
                 r = [str(i) for i in r]
-            next_row.append(str(r))
+            if isinstance(r, int):
+                next_row.append(r)
+            else:
+                next_row.append(str(r))
         return next_row
         
     def _format_list_table(self, d, headings, help_text=""): #needs verify

--- a/esp/public/media/default_styles/scheduling_checks.css
+++ b/esp/public/media/default_styles/scheduling_checks.css
@@ -1,3 +1,7 @@
+table { border-spacing: 0; }
+td { padding: 10px; cursor: pointer; }
+th { cursor: pointer; }
+
 .scheduling-check {
      border: 1px solid black;
      padding: 10px;
@@ -14,6 +18,11 @@
      font-size: 14px;
 }
 
+.reset-button {
+     margin-left: auto;
+     float: right;
+}
+
 .refresh-button {
      margin-left: auto;
      float: right;
@@ -21,4 +30,16 @@
 
 .placeholder {
      text-align: center;
+}
+
+.rowGreyed {
+color: lightgray;
+}
+
+.headerSelected {
+  color: blue;
+}
+
+.sortReversed {
+  color: red;
 }

--- a/esp/public/media/scripts/program/modules/scheduling_checks.jsx
+++ b/esp/public/media/scripts/program/modules/scheduling_checks.jsx
@@ -39,7 +39,7 @@ var SchedulingCheck = React.createClass({
       timestamp: "never",
       tableState: {
         greyed: {},
-        sort: false,
+        sort: -1,
         reverse: false
       }
     };
@@ -47,6 +47,18 @@ var SchedulingCheck = React.createClass({
   
   updateTableState: function (state) {
     this.state.tableState = state;
+  },
+  
+  resetTable: function () {
+    this.setState({
+      tableState: {
+        greyed: {},
+        sort: -1,
+        reverse: false
+      },
+      open: false
+      });
+    
   },
 
   handleClick: function () {
@@ -125,6 +137,7 @@ var SchedulingCheck = React.createClass({
       <div className="scheduling-check-title">
         <span onClick={this.handleClick}>{this.props.title}</span>
         <RefreshButton onClick={this.loadData} />
+        <ResetButton onClick={this.resetTable} />
       </div>
       <div className="scheduling-check-body">
         {body}
@@ -148,6 +161,20 @@ var RefreshButton = React.createClass({
   },
 });
 
+/**
+ * Calls its onClick prop to reset table greying/sorting
+ */
+var ResetButton = React.createClass({
+  propTypes: {
+    onClick: React.PropTypes.func.isRequired,
+  },
+
+  render: function () {
+    return <button onClick={this.props.onClick} className="reset-button">
+      Reset
+    </button>;
+  },
+});
 
 // Modified from react-json-table example code.
 var SelectTable = React.createClass({
@@ -174,9 +201,7 @@ var SelectTable = React.createClass({
     // clone the rows
     items = this.props.rows.slice();
     
-    items = _.sortBy(items, function( item ){
-         return item[ me.state.sort ];
-      });
+    items = _.sortBy(items, me.state.sort);
     
     if (this.state.reverse) items.reverse();
     

--- a/esp/public/media/scripts/program/modules/scheduling_checks.jsx
+++ b/esp/public/media/scripts/program/modules/scheduling_checks.jsx
@@ -16,6 +16,15 @@ var SchedulingCheckList = React.createClass({
  *
  * This might or might not be loaded yet; clicking the heading will load the
  * data from the server and expand it.
+ * 
+ * There is supposedly a functionality in which clicking on a table row will cause it
+ * to be greyed out, however whether this actually happens depends on your
+ * scheduling_checks.css (clicking could possibly do nothing, or possibly
+ * do other things).
+ *
+ * Likewise, clicking on a table header will sort by that column. You can also
+ * add formatting in scheduling_checks.css so that the selected header will
+ * look different, e.g. be colored differently.
  */
 var SchedulingCheck = React.createClass({
   propTypes: {
@@ -28,6 +37,10 @@ var SchedulingCheck = React.createClass({
       open: false,
       failed: false,
       timestamp: "never",
+      tableState: {
+        greyed: {},
+        sort: -1          
+      }
     };
   },
 
@@ -86,7 +99,7 @@ var SchedulingCheck = React.createClass({
         var settings = {
           header: false
         };
-        table = <SelectTable rows = {data.body} settings = {settings} />;
+      table = <SelectTable rows = {data.body} settings = {settings} saveState = {this.state.tableState} />;
       } else {
         var columns = [];
         for (i = 0; i < data.headings.length; i++) {
@@ -96,7 +109,10 @@ var SchedulingCheck = React.createClass({
             columns[i] = {key: String(i), label: " "};
           }
         }
-        table = <SelectTable rows = {data.body} columns = {columns} />;
+        var settings = {
+          header: true
+        };
+        table = <SelectTable rows = {data.body} columns = {columns} settings = {settings} saveState = {this.state.tableState} />;
       }
       body = <div>
         <div className="placeholder">
@@ -135,19 +151,11 @@ var RefreshButton = React.createClass({
 
 
 // Modified from react-json-table example code.
+// Required props: rows, saveState (with sort and greyed attributes), settings (with header attribute)
 var SelectTable = React.createClass({
   getInitialState: function(){
     // We will store the sorted column and whether each row is greyed out
-    var temp = new Array();
-    for (i = 0; i < this.props.rows.length; i++) {
-        temp[this.props.rows[i]] = false;
-    }
-    if (this.props.settings == undefined) {
-        this.props.settings = {
-          header: true
-        };
-    }
-    return {sort: -1, greyed : temp};
+    return {sort: this.props.saveState.sort, greyed : this.props.saveState.greyed};
   },  
   render: function(){
     var me = this,
@@ -198,11 +206,13 @@ var SelectTable = React.createClass({
   },
     
   onClickHeader: function( e, column ){
+    this.props.saveState.sort = column;
     this.setState( {sort: column} );
   },
   
   onClickRow: function( e, item ){
     this.state.greyed[item] = !this.state.greyed[item];
+    this.props.saveState.greyed[item] = this.state.greyed[item];
     this.setState(); // so that it actually updates
   }
 });

--- a/esp/public/media/scripts/program/modules/scheduling_checks.jsx
+++ b/esp/public/media/scripts/program/modules/scheduling_checks.jsx
@@ -80,11 +80,48 @@ var SchedulingCheck = React.createClass({
     } else if (!this.state.data) {
       body = <div className="placeholder">loading...</div>;
     } else {
+      var data = JSON.parse(this.state.data); // Might not work on old browsers
+      var table;
+      if (data.headings.length == 0) {
+        var settings = {
+          header: false
+        };
+        /*var settings = {
+          cellClass: function( current, key, item){
+              return current + ' cell_' + key + item.age;
+          },
+          classPrefix: 'mytable',
+          header: true,
+          headerClass: function( current, key ){
+            if( key == 'color')
+              return current + ' imblue';
+            return current;
+          },
+          keyField: 'name',
+          noRowsMessage: 'Where are my rows?',
+          rowClass: function( current, item ){
+            return current + ' row_' + item.name;
+          }
+        };*/
+        table = <JsonTable rows = {data.body} settings = {settings} />;
+        // table = <JsonTable rows = {data.body} />;
+      } else {
+        var columns = [];
+        for (i = 0; i < data.headings.length; i++) {
+          if (!!data.headings[i]) {
+            columns[i] = {key: String(i), label: data.headings[i]};
+          } else {
+            columns[i] = {key: String(i), label: " "};
+          }
+        }
+        table = <JsonTable rows = {data.body} columns = {columns} />;
+        //table = <JsonTable rows = {data.body} />;
+      }
       body = <div>
         <div className="placeholder">
           (loaded {this.state.timestamp}, click title to close)
         </div>
-        <div className="data" dangerouslySetInnerHTML={{__html: this.state.data}} />
+        {table}
       </div>;
     }
 

--- a/esp/public/media/scripts/program/modules/scheduling_checks.jsx
+++ b/esp/public/media/scripts/program/modules/scheduling_checks.jsx
@@ -103,7 +103,7 @@ var SchedulingCheck = React.createClass({
             return current + ' row_' + item.name;
           }
         };*/
-        table = <JsonTable rows = {data.body} settings = {settings} />;
+        table = <SelectTable rows = {data.body} settings = {settings} />;
         // table = <JsonTable rows = {data.body} />;
       } else {
         var columns = [];
@@ -114,7 +114,7 @@ var SchedulingCheck = React.createClass({
             columns[i] = {key: String(i), label: " "};
           }
         }
-        table = <JsonTable rows = {data.body} columns = {columns} />;
+        table = <SelectTable rows = {data.body} columns = {columns} />;
         //table = <JsonTable rows = {data.body} />;
       }
       body = <div>
@@ -150,4 +150,79 @@ var RefreshButton = React.createClass({
       ↻
     </button>;
   },
+});
+
+
+// Modified from react-json-table example code.
+var SelectTable = React.createClass({
+  getInitialState: function(){
+    // We will store the sorted column and whether each row is greyed out
+    var temp = new Array();
+    for (i = 0; i < this.props.rows.length; i++) {
+        temp[this.props.rows[i]] = false;
+    }
+    if (this.props.settings == undefined) {
+        this.props.settings = {
+          header: true
+        };
+    }
+    return {sort: -1, greyed : temp};
+    //return {sort: false};
+  },  
+  render: function(){
+    var me = this,
+        // clone the rows
+        items = this.props.rows.slice()
+    ;
+    // Sort the table
+    if( this.state.sort ){
+      items.sort( function( a, b ){
+         return a[ me.state.sort ] > b[ me.state.sort ] ? 1 : -1;
+      });
+    }
+      
+    if (this.props.columns == undefined) {
+      return <JsonTable 
+        rows={items} 
+        settings={ this.getSettings() } 
+        onClickHeader={ this.onClickHeader }
+        onClickRow={ this.onClickRow }
+      />;
+    } else {
+      return <JsonTable 
+        rows={items} 
+        columns={this.props.columns}
+        settings={ this.getSettings() } 
+        onClickHeader={ this.onClickHeader }
+        onClickRow={ this.onClickRow }
+      />;
+    }
+  },
+  
+  getSettings: function(){
+      var me = this;
+      // We will add some classes to the selected rows and cells
+      return {
+        headerClass: function( current, key ){
+            if( me.state.sort == key )
+              return current + ' headerSelected';
+            return current;
+        },
+        rowClass: function( current, item ){
+          if( me.state.greyed[item] )
+            return current + ' rowGreyed';
+          return current;
+        },
+        header: this.props.settings.header
+      };
+  },
+    
+  onClickHeader: function( e, column ){
+    this.setState( {sort: column} );
+  },
+  
+  onClickRow: function( e, item ){
+    this.state.greyed[item] = !this.state.greyed[item];
+    this.setState(); // so that it actually updates
+  }
 });

--- a/esp/public/media/scripts/program/modules/scheduling_checks.jsx
+++ b/esp/public/media/scripts/program/modules/scheduling_checks.jsx
@@ -86,25 +86,7 @@ var SchedulingCheck = React.createClass({
         var settings = {
           header: false
         };
-        /*var settings = {
-          cellClass: function( current, key, item){
-              return current + ' cell_' + key + item.age;
-          },
-          classPrefix: 'mytable',
-          header: true,
-          headerClass: function( current, key ){
-            if( key == 'color')
-              return current + ' imblue';
-            return current;
-          },
-          keyField: 'name',
-          noRowsMessage: 'Where are my rows?',
-          rowClass: function( current, item ){
-            return current + ' row_' + item.name;
-          }
-        };*/
         table = <SelectTable rows = {data.body} settings = {settings} />;
-        // table = <JsonTable rows = {data.body} />;
       } else {
         var columns = [];
         for (i = 0; i < data.headings.length; i++) {
@@ -115,7 +97,6 @@ var SchedulingCheck = React.createClass({
           }
         }
         table = <SelectTable rows = {data.body} columns = {columns} />;
-        //table = <JsonTable rows = {data.body} />;
       }
       body = <div>
         <div className="placeholder">
@@ -167,7 +148,6 @@ var SelectTable = React.createClass({
         };
     }
     return {sort: -1, greyed : temp};
-    //return {sort: false};
   },  
   render: function(){
     var me = this,

--- a/esp/public/media/scripts/program/modules/scheduling_checks.jsx
+++ b/esp/public/media/scripts/program/modules/scheduling_checks.jsx
@@ -42,7 +42,6 @@ var SchedulingCheck = React.createClass({
         sort: -1,
         reverse: false
       },
-      tableKey: 0 // so React knows to rerender the table
     };
   },
   
@@ -51,12 +50,10 @@ var SchedulingCheck = React.createClass({
       this.setState( {
         tableState: React.addons.update(this.state.tableState, 
           { reverse: {$set: !this.state.tableState.reverse} } ),
-        tableKey: this.state.tableKey + 1
         } );   
     } else {
       this.setState( {
         tableState: React.addons.update(this.state.tableState, { sort: {$set: column}, reverse: {$set: false} }),
-        tableKey: this.state.tableKey + 1        
         } );
     }
   },
@@ -66,7 +63,6 @@ var SchedulingCheck = React.createClass({
     newkey[item] = !this.state.tableState.greyed[item];
     this.setState( {
       tableState: React.addons.update(this.state.tableState, { greyed: {$merge: newkey} } ),
-      tableKey: this.state.tableKey + 1
       } );
   },
   
@@ -77,7 +73,6 @@ var SchedulingCheck = React.createClass({
         sort: -1,
         reverse: false
       },
-      tableKey: this.state.tableKey + 1
       });
     
   },
@@ -137,7 +132,7 @@ var SchedulingCheck = React.createClass({
         table = <SelectTable rows = {data.body} header = {false} 
                   saveState = {this.state.tableState} 
                   clickHeader = {this.sortColumn} clickRow = {this.greyRow} 
-                  key = {this.state.tableKey} />;
+                  />;
       } else {
         var columns = [];
         for (i = 0; i < data.headings.length; i++) {
@@ -150,7 +145,7 @@ var SchedulingCheck = React.createClass({
         table = <SelectTable rows = {data.body} columns = {columns} 
                   header = {true} saveState = {this.state.tableState} 
                   clickHeader = {this.sortColumn} clickRow = {this.greyRow} 
-                  key = {this.state.tableKey} />;
+                  />;
       }
       body = <div>
         <div className="placeholder">

--- a/esp/public/media/scripts/program/modules/scheduling_checks.jsx
+++ b/esp/public/media/scripts/program/modules/scheduling_checks.jsx
@@ -220,15 +220,15 @@ var SelectTable = React.createClass({
   },
     
   getInitialState: function(){
-    return {sort: this.props.saveState.sort, greyed: this.props.saveState.greyed, reverse: this.props.saveState.reverse};
+    return {};
   },  
   render: function(){
     // clone the rows
     items = this.props.rows.slice();
     
-    items = _.sortBy(items, this.state.sort);
+    items = _.sortBy(items, this.props.saveState.sort);
     
-    if (this.state.reverse) items.reverse();
+    if (this.props.saveState.reverse) items.reverse();
     
     return <JsonTable 
       rows={items} 
@@ -244,8 +244,8 @@ var SelectTable = React.createClass({
       // We will add some classes to the selected rows and cells
       return {
         headerClass: function( current, key ){
-            if( me.state.sort == key ) {
-              if ( me.state.reverse) {
+            if( me.props.saveState.sort == key ) {
+              if ( me.props.saveState.reverse) {
                 return current + ' headerSelected sortReversed';
               } else {
                 return current + ' headerSelected';
@@ -255,7 +255,7 @@ var SelectTable = React.createClass({
             }
         },
         rowClass: function( current, item ){
-          if( me.state.greyed[item] ) {
+          if( me.props.saveState.greyed[item] ) {
             return current + ' rowGreyed';
           } else {
             return current;

--- a/esp/public/media/scripts/program/modules/scheduling_checks.jsx
+++ b/esp/public/media/scripts/program/modules/scheduling_checks.jsx
@@ -43,6 +43,14 @@ var SchedulingCheck = React.createClass({
       }
     };
   },
+  
+  updateTableState: function (state) {
+    /*this.state.tableState = {
+      greyed: state.greyed,
+      sort: state.sort
+    };*/
+    this.state.tableState = state;
+  },
 
   handleClick: function () {
     if (this.state.open) {
@@ -96,7 +104,7 @@ var SchedulingCheck = React.createClass({
       var data = JSON.parse(this.state.data); // Might not work on old browsers
       var table;
       if (data.headings.length == 0) {
-        table = <SelectTable rows = {data.body} header = {false} saveState = {this.state.tableState} />;
+        table = <SelectTable rows = {data.body} header = {false} saveState = {this.state.tableState} updateTableState = {this.updateTableState} />;
       } else {
         var columns = [];
         for (i = 0; i < data.headings.length; i++) {
@@ -106,7 +114,7 @@ var SchedulingCheck = React.createClass({
             columns[i] = {key: String(i), label: " "};
           }
         }
-        table = <SelectTable rows = {data.body} columns = {columns} header = {true} saveState = {this.state.tableState} />;
+        table = <SelectTable rows = {data.body} columns = {columns} header = {true} saveState = {this.state.tableState} updateTableState = {this.updateTableState} />;
       }
       body = <div>
         <div className="placeholder">
@@ -149,19 +157,21 @@ var SelectTable = React.createClass({
   
   propTypes: {
     rows: React.PropTypes.array.isRequired,
-    savestate: React.PropTypes.shape({
+    saveState: React.PropTypes.shape({
       greyed: React.PropTypes.object.isRequired,
       sort: React.PropTypes.any.isRequired
     }).isRequired,
     header: React.PropTypes.bool.isRequired,
-    columns: React.PropTypes.object
+    columns: React.PropTypes.array,
+    updateTableState: React.PropTypes.func.isRequired
   },
     
   getInitialState: function(){
     // We will store the sorted column and whether each row is greyed out
-    return {sort: this.props.saveState.sort, greyed: this.props.saveState.greyed};
+    return {sort: this.props.saveState.sort, greyed: this.props.saveState.greyed };
   },  
   render: function(){
+    this.props.updateTableState(this.state);
     var me = this,
         // clone the rows
         items = this.props.rows.slice()
@@ -204,13 +214,13 @@ var SelectTable = React.createClass({
   },
     
   onClickHeader: function( e, column ){
-    this.props.saveState.sort = column;
     this.setState( {sort: column} );
   },
   
-  onClickRow: function( e, item ){
-    this.state.greyed[item] = !this.state.greyed[item];
-    this.props.saveState.greyed[item] = this.state.greyed[item];
-    this.setState(); // so that it actually updates
+  onClickRow: function( e, item ){ 
+    // kind of kludgy but I can't figure out how to do this more nicely
+    newgreyed = jQuery.extend({}, this.state.greyed);
+    newgreyed[item] = !newgreyed[item]; 
+    this.setState( {greyed: newgreyed} );
   }
 });

--- a/esp/templates/elements/html
+++ b/esp/templates/elements/html
@@ -46,6 +46,7 @@
 
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/react/0.13.3/react.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/react/0.13.3/JSXTransformer.js"></script>
+    <script type="text/javascript" src="https://rawgit.com/arqex/react-json-table/master/build/react-json-table.min.js"></script>
     <script type="text/javascript" src="/media/scripts/lodash.compat.min.js"></script>
 
     {% block js1 %}

--- a/esp/templates/elements/html
+++ b/esp/templates/elements/html
@@ -46,7 +46,6 @@
 
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/react/0.13.3/react.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/react/0.13.3/JSXTransformer.js"></script>
-    <script type="text/javascript" src="https://rawgit.com/arqex/react-json-table/master/build/react-json-table.min.js"></script>
     <script type="text/javascript" src="/media/scripts/lodash.compat.min.js"></script>
 
     {% block js1 %}

--- a/esp/templates/elements/html
+++ b/esp/templates/elements/html
@@ -44,7 +44,7 @@
     <script type="text/javascript" src="/media/scripts/common.js"></script>
     {% endblock jquery %}
 
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/react/0.13.3/react.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/react/0.13.3/react-with-addons.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/react/0.13.3/JSXTransformer.js"></script>
     <script type="text/javascript" src="/media/scripts/lodash.compat.min.js"></script>
 

--- a/esp/templates/program/modules/schedulingcheckmodule/output.html
+++ b/esp/templates/program/modules/schedulingcheckmodule/output.html
@@ -14,7 +14,9 @@ function updateDocs(docs) {
 }
 //-->
 </script>
+<script type="text/javascript" src="https://rawgit.com/arqex/react-json-table/6518983b5ecc0a314e50a4b7f26985c04069babd/build/react-json-table.min.js"></script>
 <script type="text/jsx" src="/media/scripts/program/modules/scheduling_checks.jsx"></script>
+
 {% endblock %}
 
 {% block stylesheets %}


### PR DESCRIPTION
Addresses #1687.

Some notes (some of which are mentioned in in-code comments):
I didn't touch HTMLSCFormatter. It looks to me like there isn't actually any code which uses it (except for scheduling checks obviously except those now use JSONFormatter), but idk if it'll be useful in the future.
JSONFormatter possibly contains redundant code, but maybe the code is useful for making sure things are formatted properly-- I didn't check preconditions/postconditions carefully enough to tell.
I'm using JSON.parse() which apparently isn't supported in old browsers, idk if we care about that for a management page.
Changes in public/media/styles/scheduling_checks.css are needed, but that's in .gitignore; stuff I added is below. (My devserver originally didn't even have this file, so I don't know what other people's  scheduling_checks.css files look like or if this conflicts.)
Scheduling check tables now enable sorting (upon header click) and greying-out of a row (upon row click, *provided that you make the appropriate change in scheduling_checks.css*. I didn't add any buttons to this effect, though (in my css I did do cursor:pointer-- although it's for the whole table so this is kind of silly), and the sorting can be kinda sketchy.
Sorting and greying does not persist across closing and reopening the scheduling check, let alone refreshing.

Additions to scheduling_checks.css:
table { border-spacing: 0; }
td { padding: 10px; cursor: pointer; }
th { cursor: pointer; }
.rowGreyed {
color: grey;
}
.headerSelected {
  color: blue;
}

People probably have opinions on the changes made, so feel free to comment. Although I note that if you want slightly different behavior upon clicking a row, if it's doable in css, you can probably just do it in css on your end.