### PR TITLE
Fix incorrect link to class docs in catalog

### DIFF
--- a/esp/templates/inclusion/program/class_catalog_core.html
+++ b/esp/templates/inclusion/program/class_catalog_core.html
@@ -95,7 +95,7 @@
        <b>Materials for this class include:</b>
         <span class="doclist">
         {% for doc in class.docs_summary %}
-        <a href="{{ doc.target_url }}">{{ doc.friendly_name }}</a>{% if not forloop.last %},{% endif %}
+        <a href="/download/{{ doc.hashed_name }}/{{ doc.file_name }}">{{ doc.friendly_name }}</a>{% if not forloop.last %},{% endif %}
         {% endfor %}
         {% if class.media_count > class.docs_summary|length %}
         <b><a href="{{ class.parent_program.get_learn_url }}class_docs/{{ class.id }}">(view all {{ class.media_count }})</a></b>


### PR DESCRIPTION
target_url was removed in #856, and all the other class docs interfaces use the code I've changed it to here.