### PR TITLE
Added statement descriptor to Stripe Module

### DIFF
--- a/esp/esp/program/modules/handlers/creditcardmodule_stripe.py
+++ b/esp/esp/program/modules/handlers/creditcardmodule_stripe.py
@@ -262,6 +262,7 @@ class CreditCardModule_Stripe(ProgramModuleObj):
                         currency="usd",
                         card=request.POST['stripeToken'],
                         description="Payment for %s %s - %s" % (group_name, prog.niceName(), request.user.name()),
+                        statement_descriptor=group_name[0:22], #stripe limits statement descriptors to 22 characters
                         metadata={
                             'ponumber': request.POST['ponumber'],
                         },


### PR DESCRIPTION
Added statement descriptor to be the group's name's first 22 characters. Perhaps a more elegant way might be to have the descriptor be a setting in local_settings.py, and to use the group_name if none is given there.

Fixes #1725.