### PR TITLE
Fix new flag form on class search page

### DIFF
--- a/esp/esp/program/modules/handlers/classsearchmodule.py
+++ b/esp/esp/program/modules/handlers/classsearchmodule.py
@@ -112,6 +112,7 @@ class ClassSearchModule(ProgramModuleObj):
                 'queryset': queryset,
                 'english': english,
                 'program': self.program,
+                'flag_types': self.program.flag_types.all(),
             }
             return render_to_response(self.baseDir()+'search_results.html',
                                       request, context)


### PR DESCRIPTION
At some point the list of flag types was no longer getting passed through to
the context, so the list of options on the new flag form was empty.  Fixes #1729.