### PR TITLE
Update the MathJax JavaScript include link

### DIFF
--- a/esp/templates/elements/html
+++ b/esp/templates/elements/html
@@ -58,7 +58,7 @@
     <script type="text/javascript" src="/media/scripts/content/user_classes.js"></script>
     <script type="text/javascript" src="/media/scripts/csrf_init.js"></script>
     
-    <script type="text/javascript" src="https://c328740.ssl.cf1.rackcdn.com/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+    <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
     <script type="text/x-mathjax-config">
       MathJax.Hub.Config({
       messageStyle: "none",


### PR DESCRIPTION
Use the official MathJax CDN (cdn.mathjax.org) link, as documented at [1].

According to dig, this is a CloudFlare CDN.

This change is necessary because the old link is no longer available, and returns a 404 response.

Fixes #1736.

[1] <http://docs.mathjax.org/en/latest/start.html#using-the-mathjax-content-delivery-network-cdn>