### PR TITLE
Add created_at field to dbmail models

### DIFF
--- a/esp/esp/dbmail/migrations/0008_auto__add_field_messagerequest_created_at__add_field_textofemail_creat.py
+++ b/esp/esp/dbmail/migrations/0008_auto__add_field_messagerequest_created_at__add_field_textofemail_creat.py
@@ -1,0 +1,152 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+_TWO_WEEKS = datetime.timedelta(weeks=2)
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        """Add the created_at field to MessageRequest and TextOfEmail.
+
+        For the already existing objects, set the value to be equal to two
+        weeks ago. Since cronmail will now ignore requests that are over a week
+        old, this is a way of expiring old, unsent messages, so that the recent
+        improvements to dbmail do not cause out-of-date emails to be sent.
+        """
+        now = datetime.datetime.now()
+        two_weeks_ago = now - _TWO_WEEKS
+
+        # Adding field 'MessageRequest.created_at'
+        db.add_column('dbmail_messagerequest', 'created_at',
+                      self.gf('django.db.models.fields.DateTimeField')(default=two_weeks_ago, auto_now_add=False, null=False, blank=False),
+                      keep_default=False)
+
+        # Adding field 'TextOfEmail.created_at'
+        db.add_column('dbmail_textofemail', 'created_at',
+                      self.gf('django.db.models.fields.DateTimeField')(default=two_weeks_ago, auto_now_add=False, null=False, blank=False),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'MessageRequest.created_at'
+        db.delete_column('dbmail_messagerequest', 'created_at')
+
+        # Deleting field 'TextOfEmail.created_at'
+        db.delete_column('dbmail_textofemail', 'created_at')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'dbmail.emaillist': {
+            'Meta': {'ordering': "('seq',)", 'object_name': 'EmailList'},
+            'admin_hold': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'cc_all': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'from_email': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True', 'blank': 'True'}),
+            'handler': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'regex': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'seq': ('django.db.models.fields.PositiveIntegerField', [], {'blank': 'True'}),
+            'subject_prefix': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True', 'blank': 'True'})
+        },
+        'dbmail.emailrequest': {
+            'Meta': {'object_name': 'EmailRequest'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'msgreq': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['dbmail.MessageRequest']"}),
+            'target': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"}),
+            'textofemail': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['dbmail.TextOfEmail']", 'null': 'True', 'blank': 'True'})
+        },
+        'dbmail.messagerequest': {
+            'Meta': {'object_name': 'MessageRequest'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'auto_now_add': 'False', 'null': 'False', 'blank': 'False'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"}),
+            'email_all': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'msgtext': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'priority_level': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'processed': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'processed_by': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'db_index': 'True'}),
+            'recipients': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['users.PersistentQueryFilter']"}),
+            'sender': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'sendto_fn_name': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '128'}),
+            'special_headers': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'subject': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'dbmail.messagevars': {
+            'Meta': {'object_name': 'MessageVars'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'messagerequest': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['dbmail.MessageRequest']"}),
+            'pickled_provider': ('django.db.models.fields.TextField', [], {}),
+            'provider_name': ('django.db.models.fields.CharField', [], {'max_length': '128'})
+        },
+        'dbmail.plainredirect': {
+            'Meta': {'ordering': "('original',)", 'object_name': 'PlainRedirect'},
+            'destination': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'original': ('django.db.models.fields.CharField', [], {'max_length': '512'})
+        },
+        'dbmail.textofemail': {
+            'Meta': {'object_name': 'TextOfEmail'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'False', 'null': 'False', 'blank': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'locked': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'msgtext': ('django.db.models.fields.TextField', [], {}),
+            'send_from': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            'send_to': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            'sent': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'sent_by': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'db_index': 'True'}),
+            'subject': ('django.db.models.fields.TextField', [], {}),
+            'tries': ('django.db.models.fields.IntegerField', [], {'default': '0'})
+        },
+        'users.persistentqueryfilter': {
+            'Meta': {'object_name': 'PersistentQueryFilter'},
+            'create_ts': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'item_model': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'q_filter': ('django.db.models.fields.TextField', [], {}),
+            'sha1_hash': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'useful_name': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['dbmail']

--- a/esp/esp/dbmail/models.py
+++ b/esp/esp/dbmail/models.py
@@ -32,6 +32,7 @@ Learning Unlimited, Inc.
   Phone: 617-379-0178
   Email: web-team@learningu.org
 """
+import re
 import sys
 
 from django.db import models, transaction
@@ -114,7 +115,16 @@ class ActionHandler(object):
             return getattr(obj, key)
         
         return obj.get_msg_vars(self._user, key)
-    
+
+
+_MESSAGE_CREATED_AT_HELP_TEXT = """
+    The time this object was created at. Useful for informational
+    purposes, and also as a safety mechanism for preventing un-sent
+    (because of previous bugs and failures), out-of-date messages from
+    being sent.
+"""
+_MESSAGE_CREATED_AT_HELP_TEXT = re.sub(r'\s+', ' ', _MESSAGE_CREATED_AT_HELP_TEXT.strip())
+
 
 class MessageRequest(models.Model):
     """ An initial request to broadcast an e-mail message """
@@ -159,6 +169,14 @@ class MessageRequest(models.Model):
                     "should receive the message.")
     sender = models.TextField(blank=True, null=True) # E-mail sender; should be a valid SMTP sender string 
     creator = AjaxForeignKey(ESPUser) # the person who sent this message
+
+    # Use `default` instead of `auto_now_add`, so that the migration creating
+    # this field can set times in the past.
+    created_at = models.DateTimeField(
+        default=datetime.now, null=False, blank=False, editable=False,
+        auto_now_add=False, help_text=_MESSAGE_CREATED_AT_HELP_TEXT,
+    )
+
     processed = models.BooleanField(default=False, db_index=True) # Have we made EmailRequest objects from this MessageRequest yet?
     processed_by = models.DateTimeField(null=True, default=None, db_index=True) # When should this be processed by?
     priority_level = models.IntegerField(null=True, blank=True) # Priority of a message; may be used in the future to make a message non-digested, or to prevent a low-priority message from being sent
@@ -317,6 +335,7 @@ class MessageRequest(models.Model):
                     'send_from': send_from,
                     'subject': subject,
                     'msgtext': msgtext,
+                    'created_at': self.created_at,
                     'defaults': {'sent': None},
                 }
 
@@ -355,6 +374,15 @@ class TextOfEmail(models.Model):
     send_from = models.CharField(max_length=1024) # Valid email address
     subject = models.TextField() # E-mail subject; plain text
     msgtext = models.TextField() # Message body; plain text
+
+    # Don't use `default` or `auto_now_add`. When a
+    # :class:`TextOfEmail` is created from a :class:`MessageRequest`, the
+    # `created_at` value should be copied over at creation time.
+    created_at = models.DateTimeField(
+        null=False, blank=False, editable=False, auto_now_add=False,
+        help_text=_MESSAGE_CREATED_AT_HELP_TEXT,
+    )
+
     sent = models.DateTimeField(blank=True, null=True)
     sent_by = models.DateTimeField(null=True, default=None, db_index=True) # When it should be sent by.
     tries = models.IntegerField(default=0) # Number of times we attempted to send this message and failed


### PR DESCRIPTION
Add `created_at` field to `MessageRequest` and `TextOfEmail`.

With the knowledge of how old each request is, cronmail can now filter out un-sent, out-of-date messages.

In a perfect world, this would be unnecessary. But with each release, we improve our dbmail error handling, and can sometimes accidentally pick up and send very old, previously un-sent messages. This commit adds a safe-guard against that.

It is also nice to be able to see when a message was created.

Tested successfully on Yale's site. Without this, 6156 old `TextOfEmails` would get sent. With it, none of them do. But new comm panel emails still get sent successfully.