### PR TITLE
Change some Stripe configs to prevent errors

### DIFF
--- a/esp/templates/program/modules/creditcardmodule_stripe/cardpay.html
+++ b/esp/templates/program/modules/creditcardmodule_stripe/cardpay.html
@@ -108,6 +108,8 @@ Check here to support <a href="http://www.learningu.org/about" target="_blank">L
     data-key="{{ module.settings.publishable_key }}"
     data-name="{{ institution }} Splash Payment"
     data-description="Registration for {{ program.niceName }}"
+    data-zip-code="true"
+    data-allow-remember-me="false"
   >
   </script>
 


### PR DESCRIPTION
Request to backport PR #1748 (already merged into main) into stable release 6.


Add extra pre-charge validation by enabling ``data-zip-code``. And prevent browser state from causing problems by disabling ``data-allow-remember-me``.

Documentation of these configurations is at [1].

For more context, see the thread on websupport@learningu.org with the subject

  [ ESP CC ] Credit card error on yale.learningu.org: 3246

This change has been used successfully for multiple Yale programs.

[1] <https://stripe.com/docs/checkout#integration-simple-options>