### PR TITLE
Improve update_deps.sh script

### DIFF
--- a/esp/update_deps.sh
+++ b/esp/update_deps.sh
@@ -37,15 +37,17 @@ then
     sudo apt-get install -y $(<"$BASEDIR/esp/packages_prod.txt")
 fi
 
-if [[ ! -z "$VIRTUAL_ENV" ]]
+# Ensure that the virtualenv exists and is activated.
+if [[ -z "$VIRTUAL_ENV" ]]
 then
-    pip install -r "$BASEDIR/esp/requirements.txt"
-else
     VIRTUALENV_DIR=${VIRTUALENV_DIR:-$BASEDIR/env}
     if [[ ! -f "$VIRTUALENV_DIR/bin/activate" ]]
     then
         $BASEDIR/esp/make_virtualenv.sh $VIRTUALENV_DIR
     fi
     source "$VIRTUALENV_DIR/bin/activate"
-    pip install -r "$BASEDIR/esp/requirements.txt"
 fi
+
+# Upgrade/install pip, setuptools, wheel, and application dependencies.
+pip install -U pip setuptools wheel
+pip install -U -r "$BASEDIR/esp/requirements.txt"


### PR DESCRIPTION
Request to backport PR #1756 (currently open for review, please do primary review there) into stable release 6.

Eliminate an instance of code duplication. The same ``pip install`` command was being run in both branches of an `if`-statement.

Make sure that `pip`, `setuptools`, and `wheel` get upgraded, since they may periodically receive security patches and other enhancements.

Make sure that application dependencies get upgraded. Though we pin the versions of our immediate dependencies, we don't freeze the versions of their dependencies, which may be partially constrained or completely unconstrained. Make sure these dependencies (e.g. `requests`) get upgraded, since they may periodically receive security patches and other enhancements.

On Python <2.7.9, `urllib3` (via the up-to-date version of `pip`) will now issue the warning `InsecurePlatformWarning` [1]. This is fine and will not prevent `pip` from working, but signals the potential for future limitations we could run into. Hopefully this can serve as a motivation for looking into upgrading Python to 2.7.9+.

[1] https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning