### PR TITLE
Make QSD .edit.html pages raise 403 instead of ESPError

### DIFF
--- a/esp/esp/qsd/views.py
+++ b/esp/esp/qsd/views.py
@@ -44,7 +44,7 @@ from os.path import basename, dirname
 from datetime import datetime
 from django.core.cache import cache
 from django.template.defaultfilters import urlencode
-from esp.middleware import ESPError, Http403
+from esp.middleware import Http403
 from esp.utils.no_autocookie import disable_csrf_cookie_update
 from django.utils.cache import add_never_cache_headers, patch_cache_control, patch_vary_headers
 from django.views.decorators.vary import vary_on_cookie
@@ -179,7 +179,7 @@ def qsd(request, url):
 
         # Enforce authorizations (FIXME: SHOW A REAL ERROR!)
         if not have_edit:
-            raise ESPError("You don't have permission to edit this page.", log=False)
+            raise Http403, "You don't have permission to edit this page."
 
         # Render an edit form
         return render_to_response('qsd/qsd_edit.html', request, {

--- a/esp/esp/qsd/views.py
+++ b/esp/esp/qsd/views.py
@@ -208,10 +208,10 @@ def ajax_qsd(request):
     post_dict = request.POST.copy()
 
     if ( request.user.id is None ):
-        return HttpResponse(content='Oops! Your session expired!\nPlease open another window, log in, and try again.\nYour changes will not be lost if you keep this page open.', status=500)
+        return HttpResponse(content='Oops! Your session expired!\nPlease open another window, log in, and try again.\nYour changes will not be lost if you keep this page open.', status=401)
     if post_dict['cmd'] == "update":
         if not Permission.user_can_edit_qsd(request.user, post_dict['url']):
-            return HttpResponse(content='Sorry, you do not have permission to edit this page.', status=500)
+            return HttpResponse(content='Sorry, you do not have permission to edit this page.', status=403)
 
         qsd, created = QuasiStaticData.objects.get_or_create(url=post_dict['url'], defaults={'author': request.user})
 


### PR DESCRIPTION
Addresses #1765. Make this case consistent with the other permission
checks in this file, which raise 403.