### PR TITLE
Fix display of small input items in customforms

### DIFF
--- a/esp/public/media/default_styles/customforms-form.css
+++ b/esp/public/media/default_styles/customforms-form.css
@@ -142,7 +142,15 @@ table.address_field tr{
 form.form-stacked label {
 	display: inline;
 	margin-left: 5px;
-}	
+}
+
+form.form-stacked label input[type=checkbox],
+form.form-stacked label input[type=radio] {
+    /* even in form-stacked, checkboxes and radio buttons should be
+       displayed on the same line as the input */
+    display: inline-block;
+    margin-bottom: 5px;
+}
 
 form.form_stacked fieldset{
     margin-left: 5px;


### PR DESCRIPTION
Checkboxes and radio buttons now appear on the same line as the label, instead of on a separate line.

**Before**

![before](https://cloud.githubusercontent.com/assets/2303306/9778936/a5fe8940-5744-11e5-977c-bf1c163d738e.png)

**After**

![after](https://cloud.githubusercontent.com/assets/2303306/9778939/ac69fe36-5744-11e5-8bdb-2bb72a14859b.png)
