### PR TITLE
Add hosed teachers scheduling check

### DIFF
--- a/esp/esp/program/modules/handlers/schedulingcheckmodule.py
+++ b/esp/esp/program/modules/handlers/schedulingcheckmodule.py
@@ -574,7 +574,7 @@ class SchedulingCheckRunner:
              class_hours = teacher.getTaughtTime(program=self.p, round_to=1).seconds/3600
              delta = availability - class_hours
              # Arbitrary formula, seems to do a good job of catching the cases I care about
-             if delta == 0 or class_hours/float(delta) >= 2:
+             if delta <= 0 or class_hours/float(delta) >= 2:
                  hosed.append({'Teacher': teacher.username,
                                'Class hours': class_hours,
                                'Available hours': availability,

--- a/esp/esp/program/modules/handlers/schedulingcheckmodule.py
+++ b/esp/esp/program/modules/handlers/schedulingcheckmodule.py
@@ -574,7 +574,7 @@ class SchedulingCheckRunner:
              class_hours = teacher.getTaughtTime(program=self.p, round_to=1).seconds/3600
              delta = availability - class_hours
              # Arbitrary formula, seems to do a good job of catching the cases I care about
-             if delta <= 0 or class_hours/float(delta) >= 2:
+             if class_hours/float(availability) <= 2/float(3):
                  hosed.append({'Teacher': teacher.username,
                                'Class hours': class_hours,
                                'Available hours': availability,

--- a/esp/esp/program/modules/handlers/schedulingcheckmodule.py
+++ b/esp/esp/program/modules/handlers/schedulingcheckmodule.py
@@ -574,7 +574,7 @@ class SchedulingCheckRunner:
              class_hours = teacher.getTaughtTime(program=self.p, round_to=1).seconds/3600
              delta = availability - class_hours
              # Arbitrary formula, seems to do a good job of catching the cases I care about
-             if class_hours/float(availability) <= 2/float(3):
+             if class_hours/float(availability) >= 2/float(3):
                  hosed.append({'Teacher': teacher.username,
                                'Class hours': class_hours,
                                'Available hours': availability,


### PR DESCRIPTION
It's a weird scheduling check because it's intended for use before scheduling, not during/after. But I think it's useful and works well in this format. Fixes #1790.