### PR TITLE
AJAX scheduler: don't allow scheduling over non-contiguous timeslot

### DIFF
--- a/esp/esp/program/modules/migrations/0031_auto__add_ajaxsectiondetail__add_field_ajaxchangelogentry_isScheduling.py
+++ b/esp/esp/program/modules/migrations/0031_auto__add_ajaxsectiondetail__add_field_ajaxchangelogentry_isScheduling.py
@@ -1,0 +1,247 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'AJAXSectionDetail'
+        db.create_table('modules_ajaxsectiondetail', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('program', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['program.Program'])),
+            ('cls_id', self.gf('django.db.models.fields.IntegerField')()),
+            ('comment', self.gf('django.db.models.fields.CharField')(max_length=256)),
+            ('locked', self.gf('django.db.models.fields.BooleanField')(default=False)),
+        ))
+        db.send_create_signal('modules', ['AJAXSectionDetail'])
+
+        # Adding field 'AJAXChangeLogEntry.isScheduling'
+        db.add_column('modules_ajaxchangelogentry', 'isScheduling',
+                      self.gf('django.db.models.fields.BooleanField')(default=True),
+                      keep_default=False)
+
+        # Adding field 'AJAXChangeLogEntry.comment'
+        db.add_column('modules_ajaxchangelogentry', 'comment',
+                      self.gf('django.db.models.fields.CharField')(max_length=256, null=True),
+                      keep_default=False)
+
+        # Adding field 'AJAXChangeLogEntry.locked'
+        db.add_column('modules_ajaxchangelogentry', 'locked',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting model 'AJAXSectionDetail'
+        db.delete_table('modules_ajaxsectiondetail')
+
+        # Deleting field 'AJAXChangeLogEntry.isScheduling'
+        db.delete_column('modules_ajaxchangelogentry', 'isScheduling')
+
+        # Deleting field 'AJAXChangeLogEntry.comment'
+        db.delete_column('modules_ajaxchangelogentry', 'comment')
+
+        # Deleting field 'AJAXChangeLogEntry.locked'
+        db.delete_column('modules_ajaxchangelogentry', 'locked')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'modules.ajaxchangelog': {
+            'Meta': {'object_name': 'AJAXChangeLog'},
+            'entries': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['modules.AJAXChangeLogEntry']", 'symmetrical': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'program': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['program.Program']"})
+        },
+        'modules.ajaxchangelogentry': {
+            'Meta': {'object_name': 'AJAXChangeLogEntry'},
+            'cls_id': ('django.db.models.fields.IntegerField', [], {}),
+            'comment': ('django.db.models.fields.CharField', [], {'max_length': '256', 'null': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'index': ('django.db.models.fields.IntegerField', [], {}),
+            'isScheduling': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'locked': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'room_name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'time': ('django.db.models.fields.FloatField', [], {}),
+            'timeslots': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'null': 'True', 'blank': 'True'})
+        },
+        'modules.ajaxsectiondetail': {
+            'Meta': {'object_name': 'AJAXSectionDetail'},
+            'cls_id': ('django.db.models.fields.IntegerField', [], {}),
+            'comment': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'locked': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'program': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['program.Program']"})
+        },
+        'modules.classregmoduleinfo': {
+            'Meta': {'object_name': 'ClassRegModuleInfo'},
+            'allow_coteach': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'allow_lateness': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'allowed_sections': ('django.db.models.fields.CommaSeparatedIntegerField', [], {'max_length': '100', 'blank': 'True'}),
+            'ask_for_room': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'class_max_duration': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'class_max_size': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'class_min_cap': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'class_other_sizes': ('django.db.models.fields.CommaSeparatedIntegerField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'class_size_step': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'color_code': ('django.db.models.fields.CharField', [], {'max_length': '6', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'module': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['modules.ProgramModuleObj']"}),
+            'num_teacher_questions': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1', 'null': 'True', 'blank': 'True'}),
+            'open_class_registration': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'progress_mode': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'session_counts': ('django.db.models.fields.CommaSeparatedIntegerField', [], {'max_length': '100', 'blank': 'True'}),
+            'set_prereqs': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'use_allowable_class_size_ranges': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'use_class_size_max': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'use_class_size_optimal': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'use_optimal_class_size_range': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        'modules.dbreceipt': {
+            'Meta': {'object_name': 'DBReceipt'},
+            'action': ('django.db.models.fields.CharField', [], {'default': "'confirm'", 'max_length': '80'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'program': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['program.Program']"}),
+            'receipt': ('django.db.models.fields.TextField', [], {})
+        },
+        'modules.programmoduleobj': {
+            'Meta': {'object_name': 'ProgramModuleObj'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'module': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['program.ProgramModule']"}),
+            'program': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['program.Program']"}),
+            'required': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'required_label': ('django.db.models.fields.CharField', [], {'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'seq': ('django.db.models.fields.IntegerField', [], {})
+        },
+        'modules.studentclassregmoduleinfo': {
+            'Meta': {'object_name': 'StudentClassRegModuleInfo'},
+            'apply_multiplier_to_room_cap': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'cancel_button_dereg': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'cancel_button_text': ('django.db.models.fields.CharField', [], {'default': "'Cancel Registration'", 'max_length': '80'}),
+            'class_cap_multiplier': ('django.db.models.fields.DecimalField', [], {'default': "'1.00'", 'max_digits': '3', 'decimal_places': '2'}),
+            'class_cap_offset': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'confirm_button_text': ('django.db.models.fields.CharField', [], {'default': "'Confirm'", 'max_length': '80'}),
+            'enforce_max': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'force_show_required_modules': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'module': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['modules.ProgramModuleObj']"}),
+            'priority_limit': ('django.db.models.fields.IntegerField', [], {'default': '3'}),
+            'progress_mode': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'register_from_catalog': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'send_confirmation': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'show_emailcodes': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'signup_verb': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['program.RegistrationType']", 'null': 'True'}),
+            'temporarily_full_text': ('django.db.models.fields.CharField', [], {'default': "'Class temporarily full; please check back later'", 'max_length': '255'}),
+            'use_grade_range_exceptions': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'use_priority': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'view_button_text': ('django.db.models.fields.CharField', [], {'default': "'View Receipt'", 'max_length': '80'}),
+            'visible_enrollments': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'visible_meeting_times': ('django.db.models.fields.BooleanField', [], {'default': 'True'})
+        },
+        'program.classcategories': {
+            'Meta': {'object_name': 'ClassCategories'},
+            'category': ('django.db.models.fields.TextField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'seq': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'symbol': ('django.db.models.fields.CharField', [], {'default': "'?'", 'max_length': '1'})
+        },
+        'program.classflagtype': {
+            'Meta': {'ordering': "['seq']", 'object_name': 'ClassFlagType'},
+            'color': ('django.db.models.fields.CharField', [], {'max_length': '20', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'seq': ('django.db.models.fields.SmallIntegerField', [], {'default': '0'}),
+            'show_in_dashboard': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'show_in_scheduler': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        'program.program': {
+            'Meta': {'object_name': 'Program'},
+            'class_categories': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['program.ClassCategories']", 'symmetrical': 'False'}),
+            'director_cc_email': ('django.db.models.fields.EmailField', [], {'default': "''", 'max_length': '75', 'blank': 'True'}),
+            'director_confidential_email': ('django.db.models.fields.EmailField', [], {'default': "''", 'max_length': '75', 'blank': 'True'}),
+            'director_email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'flag_types': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['program.ClassFlagType']", 'symmetrical': 'False', 'blank': 'True'}),
+            'grade_max': ('django.db.models.fields.IntegerField', [], {}),
+            'grade_min': ('django.db.models.fields.IntegerField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'program_allow_waitlist': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'program_modules': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['program.ProgramModule']", 'symmetrical': 'False'}),
+            'program_size_max': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'url': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        'program.programmodule': {
+            'Meta': {'object_name': 'ProgramModule'},
+            'admin_title': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'handler': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'inline_template': ('django.db.models.fields.CharField', [], {'max_length': '32', 'null': 'True', 'blank': 'True'}),
+            'link_title': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True', 'blank': 'True'}),
+            'module_type': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'required': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'seq': ('django.db.models.fields.IntegerField', [], {})
+        },
+        'program.registrationtype': {
+            'Meta': {'unique_together': "(('name', 'category'),)", 'object_name': 'RegistrationType'},
+            'category': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'displayName': ('django.db.models.fields.CharField', [], {'max_length': '32', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '32'})
+        },
+        'qsdmedia.media': {
+            'Meta': {'object_name': 'Media'},
+            'file_extension': ('django.db.models.fields.TextField', [], {'max_length': '16', 'null': 'True', 'blank': 'True'}),
+            'file_name': ('django.db.models.fields.TextField', [], {'max_length': '256', 'null': 'True', 'blank': 'True'}),
+            'format': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'friendly_name': ('django.db.models.fields.TextField', [], {}),
+            'hashed_name': ('django.db.models.fields.TextField', [], {'max_length': '256', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'mime_type': ('django.db.models.fields.CharField', [], {'max_length': '256', 'null': 'True', 'blank': 'True'}),
+            'owner_id': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'owner_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']", 'null': 'True', 'blank': 'True'}),
+            'size': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'target_file': ('django.db.models.fields.files.FileField', [], {'max_length': '100'})
+        }
+    }
+
+    complete_apps = ['modules']

--- a/esp/esp/program/modules/module_ext.py
+++ b/esp/esp/program/modules/module_ext.py
@@ -41,7 +41,7 @@ from esp.program.modules.base import ProgramModuleObj
 from esp.db.fields import AjaxForeignKey
 from django.conf import settings
 from esp.users.models import ESPUser
-from esp.program.models import Program, RegistrationType
+from esp.program.models import Program, RegistrationType, ClassSection
 
 class DBReceipt(models.Model):
     """ Per-program Receipt templates """
@@ -283,13 +283,22 @@ class AJAXChangeLogEntry(models.Model):
     # unique index in change_log of this entry
     index = models.IntegerField()
 
-    # comma-separated list of integer timeslots
+    # whether this is a scheduling entry (or comment entry)
+    isScheduling = models.BooleanField(default=True)
+
+    # scheduling entry: comma-separated list of integer timeslots
     timeslots = models.CharField(max_length=256)
 
-    # name of the room involved in scheduling update
+    # scheduling entry: name of the room involved in scheduling update
     room_name = models.CharField(max_length=256)
 
-    # class ID to update
+    # comment entry: comment text
+    comment = models.CharField(max_length=256, null=True)
+
+    # comment entry: is locked
+    locked = models.BooleanField(default=False)
+
+    # ClassSection ID to update
     cls_id = models.IntegerField()
 
     # user responsible for this entry
@@ -298,10 +307,16 @@ class AJAXChangeLogEntry(models.Model):
     # time we entered this
     time = models.FloatField()
 
-    def update(self, index, timeslots, room_name, cls_id):
-        self.index = index
+    def setScheduling(self, timeslots, room_name, cls_id):
+        self.isScheduling = True
         self.timeslots = ','.join([str(x) for x in timeslots])
         self.room_name = room_name
+        self.cls_id = cls_id
+
+    def setComment(self, comment, lock, cls_id):
+        self.isScheduling = False
+        self.comment = comment
+        self.locked = lock
         self.cls_id = cls_id
 
     def save(self, *args, **kwargs):
@@ -318,6 +333,20 @@ class AJAXChangeLogEntry(models.Model):
             return self.user.username
         else:
             return "unknown"
+
+    def toDict(self):
+        d = {}
+        d['index'] = self.index
+        d['id'] = self.cls_id
+        d['user'] = self.getUserName()
+        d['isScheduling'] = self.isScheduling
+        if self.isScheduling:
+            d['room_name'] = self.room_name
+            d['timeslots'] = self.getTimeslots()
+        else:
+            d['comment'] = self.comment
+            d['locked'] = self.locked
+        return d
 
 class AJAXChangeLog(models.Model):
     # program this change log stores changes for
@@ -338,19 +367,25 @@ class AJAXChangeLog(models.Model):
         self.entries.filter(time__lte=max_time).delete()
         self.save()
 
-    def append(self, timeslots, room_name, cls_id, user=None):
-        next_index = self.get_latest_index() + 1
-
-        entry = AJAXChangeLogEntry()
-        entry.update(next_index, timeslots, room_name, cls_id)
-
+    def append(self, entry, user=None):
+        entry.index = self.get_latest_index() + 1
         if user:
-        	entry.user = user
+            entry.user = user
 
         entry.save()
         self.save()
         self.entries.add(entry)
         self.save()
+
+    def appendScheduling(self, timeslots, room_name, cls_id, user=None):
+        entry = AJAXChangeLogEntry()
+        entry.setScheduling(timeslots, room_name, cls_id)
+        self.append(entry, user)
+
+    def appendComment(self, comment, lock, cls_id, user=None):
+        entry = AJAXChangeLogEntry()
+        entry.setComment(comment, lock, cls_id)
+        self.append(entry, user)
 
     def get_latest_index(self):
         index = self.entries.all().aggregate(models.Max('index'))['index__max']
@@ -373,12 +408,28 @@ class AJAXChangeLog(models.Model):
         entry_list = list()
 
         for entry in new_entries:
-            entry_list.append( {	'index'     : entry.index,
-                                    'room_name' : entry.room_name,
-                                    'id'    : entry.cls_id,
-                                    'timeslots' : entry.getTimeslots(),
-                                    'user'      : entry.getUserName() })
+            entry_list.append(entry.toDict())
 
         return entry_list
+
+# stores scheduling details about an section for the AJAX scheduler
+#  (e.g., scheduling comments, locked from AJAX scheduling, etc.)
+class AJAXSectionDetail(models.Model):
+    program = AjaxForeignKey(Program)
+    cls_id = models.IntegerField()
+    comment = models.CharField(max_length=256)
+    locked = models.BooleanField(default=False)
+
+    def initialize(self, program, cls_id, comment, locked):
+        self.program = program
+        self.cls_id = cls_id
+        self.comment = comment
+        self.locked = locked
+        self.save()
+
+    def update(self, comment, locked):
+        self.comment = comment
+        self.locked = locked
+        self.save()
 
 from esp.application.models import FormstackAppSettings

--- a/esp/public/media/default_styles/scheduling.css
+++ b/esp/public/media/default_styles/scheduling.css
@@ -90,8 +90,8 @@ input.numeric {
 th {
     color: black;
 }
-button#unschedule {
-    font-size: .7em;
+button.sidetoolbar {
+    font-size: .7em !important;
 }
 
 #side-panel-header {

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/ApiClient.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/ApiClient.js
@@ -21,6 +21,31 @@ function ApiClient() {
     }
 
     /**
+     * Set a scheduling comment on a section.
+     *
+     * @param section_id: the section to set comment on
+     * @param comment: comment to set, or blank for no comment
+     * @param locked: true/false whether to lock the section from further scheduling
+     * @param callback(): called on success
+     * @param errorReporter(err): called on error with string error message
+     */
+    this.set_comment = function(section_id, comment, locked, callback, errorReporter) {
+        params = {
+            'cls': section_id,
+            'comment': comment,
+            'csrfmiddlewaretoken': csrf_token(),
+        };
+        if(locked) {
+            params['locked'] = 'yes';
+        }
+        $j.post('ajax_set_comment', params).success(function() {
+            callback();
+        }).error(function() {
+            errorReporter('An error occurred setting comment.');
+        });
+    };
+
+    /**
      * Schedule a section on the server.
      *
      * @param section_id: The ID of the section to schedule

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/ApiClient.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/ApiClient.js
@@ -1,7 +1,7 @@
 function ApiClient() {
     /**
      * Fetch the change log from the server
-     * 
+     *
      * @param last_fetched_index: The previous index we retrieved from the server
      * @param callback: If successful, this function will be called. Takes one param
      *                  ajax_data which is the data that was fetched.
@@ -9,15 +9,15 @@ function ApiClient() {
      *                        Takes one param msg with an error message.
      */
     this.get_change_log = function(last_fetched_index, callback, errorReporter){
-	    $j.getJSON(
-	        'ajax_change_log',
-	        { 'last_fetched_index': last_fetched_index })
-	        .success(function(ajax_data, status) {
-	            callback(ajax_data);
-	        })
-	        .error(function(ajax_data, status) {
-	            errorReporter("An error occurred fetching the changelog.");
-	        });
+        $j.getJSON(
+            'ajax_change_log',
+            { 'last_fetched_index': last_fetched_index })
+            .success(function(ajax_data, status) {
+                callback(ajax_data);
+            })
+            .error(function(ajax_data, status) {
+                errorReporter("An error occurred fetching the changelog.");
+            });
     }
 
     /**
@@ -31,17 +31,17 @@ function ApiClient() {
      *                       Takes one param msg with an error message.
      */
     this.schedule_section = function(section_id, timeslot_ids, room_name, callback, errorReporter){
-	    assignments = timeslot_ids.map(function(id) {
-	        return id + "," + room_name;
-	    }).join("\n");
+        assignments = timeslot_ids.map(function(id) {
+            return id + "," + room_name;
+        }).join("\n");
 
-        var req = { 
-	        action: 'assignreg',
+        var req = {
+            action: 'assignreg',
             csrfmiddlewaretoken: csrf_token(),
             cls: section_id,
             block_room_assignments: assignments
-	    };
-	    return this.send_request(req, callback, errorReporter);
+        };
+        return this.send_request(req, callback, errorReporter);
     };
 
     /**
@@ -53,12 +53,12 @@ function ApiClient() {
      *                       Takes one param msg with an error message.
      */
     this.unschedule_section = function(section_id, callback, errorReporter){
-	    var req = { 
-	        action: 'deletereg',
+        var req = {
+            action: 'deletereg',
             csrfmiddlewaretoken: csrf_token(),
             cls: section_id
-	    };
-	    this.send_request(req, callback, errorReporter);
+        };
+        this.send_request(req, callback, errorReporter);
     };
 
     /**
@@ -72,18 +72,18 @@ function ApiClient() {
     this.send_request = function(req, callback, errorReporter){
         $j.post('ajax_schedule_class', req, "json")
             .success(function(ajax_data, status) {
-	            if (ajax_data.ret){
-		            console.log("success");
-		            callback();
-	            }
-	            else {
-		            console.log("failure");
-		            errorReporter(ajax_data.msg);
-	            }
-	        })
-	        .error(function(ajax_data, status) {
-	            console.log("error");
-	            errorReporter("An error occurred saving the schedule change.");
-	        });
+                if (ajax_data.ret){
+                    console.log("success");
+                    callback();
+                }
+                else {
+                    console.log("failure");
+                    errorReporter(ajax_data.msg);
+                }
+            })
+            .error(function(ajax_data, status) {
+                console.log("error");
+                errorReporter("An error occurred saving the schedule change.");
+            });
     };
 }

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Cell.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Cell.js
@@ -40,26 +40,26 @@ function Cell(el, section, room_name, timeslot_id, matrix) {
      */
     this.init = function(new_section){
         // Add the cell as data to the element
-	    this.el.data("cell", this);
+        this.el.data("cell", this);
 
         // When cells are occupied, show a tooltip
-	    $j(this.el).tooltip({
-	        items: ".occupied-cell",
-	        content: this.tooltip.bind(this),
+        $j(this.el).tooltip({
+            items: ".occupied-cell",
+            content: this.tooltip.bind(this),
             show: {duration: 100},
             hide: {duration: 100},
             track: true,
-	    });
+        });
 
         // If the cell is initialized with a section, add it.
-	    if (new_section != null){
-	        this.addSection(new_section);
-	    }
+        if (new_section != null){
+            this.addSection(new_section);
+        }
         // Otherwise call removeSection to apply the correct styling
-	    else{
-	        this.removeSection();
-	    }
-	    this.el.addClass("matrix-cell");
+        else{
+            this.removeSection();
+        }
+        this.el.addClass("matrix-cell");
     }
 
 
@@ -88,22 +88,22 @@ function Cell(el, section, room_name, timeslot_id, matrix) {
      *       work. It would be nice if this was in Sectinos instead.
      */
     this.tooltip = function(){
-	    var tooltip_parts = [
-	        "<b>" + this.section.emailcode + ": " + this.section.title + "</b>", 
+        var tooltip_parts = [
+            "<b>" + this.section.emailcode + ": " + this.section.title + "</b>",
             "Teachers: " + this.matrix.sections.getTeachersString(this.section),
-	        "Class size max: " + this.section.class_size_max,
-	        "Length: " + Math.ceil(this.section.length),
+            "Class size max: " + this.section.class_size_max,
+            "Length: " + Math.ceil(this.section.length),
             "Grades: " + this.section.grade_min + "-" + this.section.grade_max,
             "Resource Requests:" + this.matrix.sections.getResourceString(this.section),
             "Flags: " + this.section.flags,
-	    ];
+        ];
         if(this.section.comments) {
             tooltip_parts.push("Comments: " + this.section.comments);
         }
         if(this.section.special_requests && this.section.special_requests.length > 0) {
             tooltip_parts.push("Room Requests: " + this.section.special_requests);
         }
-	    return tooltip_parts.join("<br/>");
+        return tooltip_parts.join("<br/>");
     };
 
     /**
@@ -113,18 +113,18 @@ function Cell(el, section, room_name, timeslot_id, matrix) {
      */
     this.addSection = function(section){
         // Add the section data
-	    this.section = section;
-	    this.el.data("section", section);
+        this.section = section;
+        this.el.data("section", section);
 
         // Mark the cell as occupied and selectable
-	    this.el.addClass("occupied-cell");
+        this.el.addClass("occupied-cell");
         this.el.addClass("selectable-cell");
-	    this.el.removeClass("available-cell");
+        this.el.removeClass("available-cell");
 
         // Add the styling for the section
-	    this.el.css("background-color", this.cellColors.color(section));
+        this.el.css("background-color", this.cellColors.color(section));
         this.el.css("color", this.cellColors.textColor(section));
-	    this.el[0].innerHTML = "<a href='#'>" + section.emailcode + "</a>";
+        this.el[0].innerHTML = "<a href='#'>" + section.emailcode + "</a>";
     };
 
     /**
@@ -132,16 +132,16 @@ function Cell(el, section, room_name, timeslot_id, matrix) {
      */
     this.removeSection = function(){
         // Remove the section data
-	    this.section = null;
-	    this.el.removeData("section");
+        this.section = null;
+        this.el.removeData("section");
 
         // Mark the cell as available and unselectable
-	    this.el.addClass("available-cell");
-	    this.el.removeClass("occupied-cell");
+        this.el.addClass("available-cell");
+        this.el.removeClass("occupied-cell");
         this.el.removeClass("selectable-cell");
-        
+
         // Remove the styling for the section
-	    this.el[0].innerHTML = "";
+        this.el[0].innerHTML = "";
         this.el.css("background-color", "");
     };
 
@@ -183,8 +183,8 @@ function DisabledCell(el, room_name, timeslot_id) {
     this.el = el;
     this.disabled = true;
     this.init = function(new_section){
-	    this.el.addClass("matrix-cell");
-	    this.el.addClass("disabled-cell");
+        this.el.addClass("matrix-cell");
+        this.el.addClass("disabled-cell");
     };
 
     this.init();

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Cell.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Cell.js
@@ -88,22 +88,29 @@ function Cell(el, section, room_name, timeslot_id, matrix) {
      *       work. It would be nice if this was in Sectinos instead.
      */
     this.tooltip = function(){
-        var tooltip_parts = [
-            "<b>" + this.section.emailcode + ": " + this.section.title + "</b>",
-            "Teachers: " + this.matrix.sections.getTeachersString(this.section),
-            "Class size max: " + this.section.class_size_max,
-            "Length: " + Math.ceil(this.section.length),
-            "Grades: " + this.section.grade_min + "-" + this.section.grade_max,
-            "Resource Requests:" + this.matrix.sections.getResourceString(this.section),
-            "Flags: " + this.section.flags,
-        ];
+        var tooltip_parts = {};
+        if(this.section.schedulingComment) {
+            tooltip_parts['Scheduling Comment'] = this.section.schedulingComment +
+                (this.section.schedulingLocked ? ' <b><i>(locked)</i></b>' : '');
+        }
+        tooltip_parts['Teachers'] = this.matrix.sections.getTeachersString(this.section);
+        tooltip_parts['Class size max'] = this.section.class_size_max;
+        tooltip_parts['Length'] = Math.ceil(this.section.length);
+        tooltip_parts['Grades'] = this.section.grade_min + "-" + this.section.grade_max;
+        tooltip_parts['Resource Requests'] = this.matrix.sections.getResourceString(this.section);
+        tooltip_parts['Flags'] = this.section.flags;
         if(this.section.comments) {
-            tooltip_parts.push("Comments: " + this.section.comments);
+            tooltip_parts['Comments'] = this.section.comments;
         }
         if(this.section.special_requests && this.section.special_requests.length > 0) {
-            tooltip_parts.push("Room Requests: " + this.section.special_requests);
+            tooltip_parts['Room Requests'] = this.section.special_requests;
         }
-        return tooltip_parts.join("<br/>");
+
+        var tooltipText = "<b>" + this.section.emailcode + ": " + this.section.title + "</b>";
+        for(var header in tooltip_parts) {
+            tooltipText += "<br/><b>" + header + "</b>: " + tooltip_parts[header];
+        }
+        return tooltipText;
     };
 
     /**

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/CellColors.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/CellColors.js
@@ -12,9 +12,9 @@ function CellColors() {
      * @param section: The section to compute the background color of
      */
     this.color = function(section){
- 	    return "#" + 
-            section.emailcode[2] + "0" + 
-            section.emailcode[3] + "0" + 
+        return "#" +
+            section.emailcode[2] + "0" +
+            section.emailcode[3] + "0" +
             section.emailcode [4] + "0";
     };
 
@@ -25,7 +25,7 @@ function CellColors() {
      */
     this.textColor = function(section) {
         var color = helpers_hex_string_to_color(this.color(section));
-        
+
         // The relative luminance is a measure of how bright the color is.
         // Green counts more because human eyes are more sensitive to it.
         relativeLuminance = 0.2126 * color[0] + 0.7152 * color[1] + 0.0722 * color[2];
@@ -36,4 +36,3 @@ function CellColors() {
         }
     };
 }
-

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/ChangelogFetcher.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/ChangelogFetcher.js
@@ -43,10 +43,15 @@ function ChangelogFetcher(matrix, api_client, start_index){
     this.applyChangeLog = function(data){
         $j.each(data.changelog, function(id, change){
             var section = matrix.sections.getById(change.id);
-            if (change.timeslots.length == 0){
-                this.matrix.sections.unscheduleSectionLocal(section);
+            if (change.isScheduling) {
+                if (change.timeslots.length == 0){
+                    this.matrix.sections.unscheduleSectionLocal(section);
+                } else {
+                    this.matrix.sections.scheduleSectionLocal(section, change.room_name, change.timeslots);
+                }
             } else {
-                this.matrix.sections.scheduleSectionLocal(section, change.room_name, change.timeslots);
+                section.schedulingComment = change.comment;
+                section.schedulingLocked = change.locked;
             }
             this.last_applied_index = change.index;
         }.bind(this));

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/ChangelogFetcher.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/ChangelogFetcher.js
@@ -19,20 +19,20 @@ function ChangelogFetcher(matrix, api_client, start_index){
      * @param interval: The time in milliseconds between polling the server
      */
     this.pollForChanges = function(interval){
-	    window.setInterval(this.getChanges.bind(this), interval);
+        window.setInterval(this.getChanges.bind(this), interval);
     };
 
     /**
      * Fetch the changelog from the server
      */
     this.getChanges = function(){
-	    this.api_client.get_change_log(
-	        this.last_applied_index,
-	        this.applyChangeLog.bind(this),
-	        function(msg) {
-		        console.log(msg);
-	        }
-	    );
+        this.api_client.get_change_log(
+            this.last_applied_index,
+            this.applyChangeLog.bind(this),
+            function(msg) {
+                console.log(msg);
+            }
+        );
     };
 
     /**
@@ -41,14 +41,14 @@ function ChangelogFetcher(matrix, api_client, start_index){
      * @param data: the data to apply to the matrix
      */
     this.applyChangeLog = function(data){
-	    $j.each(data.changelog, function(id, change){
-	        var section = matrix.sections.getById(change.id);
-	        if (change.timeslots.length == 0){
-		        this.matrix.sections.unscheduleSectionLocal(section);
-	        } else {
-		        this.matrix.sections.scheduleSectionLocal(section, change.room_name, change.timeslots);
-	        }
-	        this.last_applied_index = change.index;
-	    }.bind(this));
+        $j.each(data.changelog, function(id, change){
+            var section = matrix.sections.getById(change.id);
+            if (change.timeslots.length == 0){
+                this.matrix.sections.unscheduleSectionLocal(section);
+            } else {
+                this.matrix.sections.scheduleSectionLocal(section, change.room_name, change.timeslots);
+            }
+            this.last_applied_index = change.index;
+        }.bind(this));
     };
 };

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Directory.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Directory.js
@@ -1,6 +1,6 @@
 /**
  * This is the directory of classes that has yet to be scheduled
- * 
+ *
  * @param sections
  * @param el
  * @param schedule_assignments
@@ -15,26 +15,26 @@ function Directory(sections, el, schedule_assignments, matrix) {
     /**
      * Render the directory.
      */
-    this.render = function(){        
+    this.render = function(){
         // Remove old classes from the directory
         var oldChildren = this.el.children();
         $j.each(oldChildren, function(c){
-                oldChildren[c].hidden = true;
-                });
+            oldChildren[c].hidden = true;
+        });
 
         setTimeout(function(){
-                $j.each(oldChildren, function(c){
-                    oldChildren[c].remove();
-                    });
-                }.bind(this), 0);
+            $j.each(oldChildren, function(c){
+                oldChildren[c].remove();
+                });
+        }.bind(this), 0);
 
         // Create the directory table
         var table = $j("<table/>");
         $j.each(this.sections.filtered_sections(), function(id, section){
-                var row = new TableRow(section, $j("<tr/>"), this);
-                row.render();
-                row.el.appendTo(table);
-                }.bind(this))
+            var row = new TableRow(section, $j("<tr/>"), this);
+            row.render();
+            row.el.appendTo(table);
+        }.bind(this))
         table.appendTo(this.el);
 
     };
@@ -52,7 +52,7 @@ function Directory(sections, el, schedule_assignments, matrix) {
 
 /**
  * This is one row in the directory containing a section to be scheduled
- * 
+ *
  * @param section: The section represented by that row
  * @param el: The element that will form the row
  * @param directory: The directory that contains the row
@@ -74,10 +74,10 @@ function TableRow(section, el, directory){
      */
     this.render = function(){
         var baseURL = directory.sections.getBaseUrlString();
-        this.el[0].innerHTML = "<td>" + this.section.title + 
-            " <a target='_blank' href='" + baseURL + 
-            "manageclass/" + this.section.parent_class + 
-            "'>Manage</a>" + " <a target='_blank' href='" + baseURL + 
+        this.el[0].innerHTML = "<td>" + this.section.title +
+            " <a target='_blank' href='" + baseURL +
+            "manageclass/" + this.section.parent_class +
+            "'>Manage</a>" + " <a target='_blank' href='" + baseURL +
             "editclass/" + this.section.parent_class + "'>Edit</a></td>";
         this.el.append(this.cell.el);
     };
@@ -96,4 +96,3 @@ function TableRow(section, el, directory){
         this.el.css("display", "table-row");
     };
 }
-

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Helpers.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Helpers.js
@@ -10,14 +10,14 @@ helpers_add_timeslots_order = function(timeslot_object){
 
     // Sort timeslots by start time
     var sorted_timeslot_array = timeslot_array.sort(function(a,b){
-            for (i=0; i<a.start.length; i++) {
+        for (i=0; i<a.start.length; i++) {
             var comp = a.start[i] - b.start[i];
             if (comp != 0) {
-            return comp;
+                return comp;
             }
-            }
-            return 0;
-            });
+        }
+        return 0;
+    });
 
     // Update the order in the original timeslot_object
     for (i=0; i<sorted_timeslot_array.length; i++){
@@ -44,25 +44,25 @@ helpers_hex_string_to_color = function(hex_string) {
 helpersIntersection = function(arrays, isInteger) {
     var frequencies = {};
     $j.each(arrays, function(index, array) {
-            $j.each(array, function(index, elt) {
-                if(frequencies.hasOwnProperty(elt)) {
+        $j.each(array, function(index, elt) {
+            if(frequencies.hasOwnProperty(elt)) {
                 frequencies[elt] += 1;
-                } else {
+            } else {
                 frequencies[elt] = 1;
-                }
-                });
-            });
+            }
+        });
+    });
 
     var intersection = [];
     $j.each(frequencies, function(elt, freq) {
-            if(freq == arrays.length) {
+        if(freq == arrays.length) {
             if(isInteger) {
-            intersection.push(parseInt(elt));
+                intersection.push(parseInt(elt));
             } else {
-            intersection.push(elt);
+                intersection.push(elt);
             }
-            }
-            });
+        }
+    });
 
     return intersection;
 

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Main.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Main.js
@@ -27,22 +27,26 @@ window.onresize = resizeElements;
 // Fetch the data from the server
 var data = {};
 json_get('lunch_timeslots', {}, function(lunch_timeslots) {
-    json_fetch(['sections_admin', 'lunch_timeslots', 'timeslots', 'rooms', 'schedule_assignments', "resource_types"], function(){
-        console.log(data)
-        resizeElements();
+    $j.getJSON('ajax_section_details', function(section_details) {
+        json_fetch(['sections_admin', 'lunch_timeslots', 'timeslots', 'rooms', 'schedule_assignments', "resource_types"], function(){
+            console.log(data)
+            resizeElements();
 
-        $j("div#side-panel").tabs();
-        // Create a new Scheduler which does the rest
-        var s = new Scheduler(
-            data,
-            $j("#directory"),
-            $j("#matrix-div"),
-            $j("#message-div"),
-            $j("#section-info-div"),
-            last_applied_index,
-            5000
-        );
-        s.render();
-    }, data);
+            $j("div#side-panel").tabs();
+            // Create a new Scheduler which does the rest
+            var s = new Scheduler(
+                data,
+                $j("#directory"),
+                $j("#matrix-div"),
+                $j("#message-div"),
+                $j("#section-info-div"),
+                $j("#commentDialog"),
+                last_applied_index,
+                5000
+            );
+            s.render();
+        }, data);
+        data['section_details'] = section_details;
+    });
     data['lunch_timeslots'] = Object.keys(lunch_timeslots['timeslots']);
 }, function() {});

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Main.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Main.js
@@ -14,10 +14,11 @@ $j.getJSON('ajax_schedule_last_changed', function(data, status) {
 var resizeElements = function() {
     var window_height = window.innerHeight - 20;
     var window_width = window.innerWidth - 20;
-    $j("#side-panel-wrapper").height(window_height)
-        .width(window_width/4);
+    var sidePanelTopHeight = 180;
     $j("#matrix-div").height(window_height)
         .width(window_width*3/4);
+    $j("#side-panel-wrapper").width(window_width/4);
+    $j("#side-panel").height(window_height - sidePanelTopHeight);
 };
 
 // Resize window handler

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Main.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Main.js
@@ -5,18 +5,18 @@
 // For the changelog
 var last_applied_index = 0;
 $j.getJSON('ajax_schedule_last_changed', function(data, status) {
-        if (status == "success") {
+    if (status == "success") {
         last_applied_index = data['latest_index'];
-        }
-        });
+    }
+});
 
 // Set the width and height of the matrix and directory
 var resizeElements = function() {
-        var window_height = window.innerHeight - 20;
-        var window_width = window.innerWidth - 20;
-        $j("#side-panel-wrapper").height(window_height)
+    var window_height = window.innerHeight - 20;
+    var window_width = window.innerWidth - 20;
+    $j("#side-panel-wrapper").height(window_height)
         .width(window_width/4);
-        $j("#matrix-div").height(window_height)
+    $j("#matrix-div").height(window_height)
         .width(window_width*3/4);
 };
 
@@ -29,7 +29,7 @@ json_get('lunch_timeslots', {}, function(lunch_timeslots) {
     json_fetch(['sections_admin', 'lunch_timeslots', 'timeslots', 'rooms', 'schedule_assignments', "resource_types"], function(){
         console.log(data)
         resizeElements();
-                
+
         $j("div#side-panel").tabs();
         // Create a new Scheduler which does the rest
         var s = new Scheduler(
@@ -40,8 +40,8 @@ json_get('lunch_timeslots', {}, function(lunch_timeslots) {
             $j("#section-info-div"),
             last_applied_index,
             5000
-            );
+        );
         s.render();
     }, data);
     data['lunch_timeslots'] = Object.keys(lunch_timeslots['timeslots']);
-    }, function() {});
+}, function() {});

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Matrix.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Matrix.js
@@ -1,6 +1,6 @@
 /**
  * The grid of cells that displays the schedule.
- * 
+ *
  * @param timeslots: A Timeslots object corresponding to times available for classes
  * @param rooms: The rooms that are available for scheduling. Keys are ids values are room data.
  * @param sections: A list of all sections for the program
@@ -15,7 +15,7 @@ function Matrix(
         el,
         messagePanel,
         sectionInfoPanel
-        ){ 
+        ){
     this.el = el;
     this.el.id = "matrix-table";
 
@@ -40,18 +40,18 @@ function Matrix(
             // inner object
             var cells = {};
             $j.each(rooms, function(room_name, room){
-                    cells[room_name] = [];
-                    $j.each(this.timeslots.timeslots, function(timeslot_id_string, timeslot){
-                        var timeslot_id = parseInt(timeslot_id_string);
-                        if (room.availability.indexOf(timeslot_id) >= 0){
+                cells[room_name] = [];
+                $j.each(this.timeslots.timeslots, function(timeslot_id_string, timeslot){
+                    var timeslot_id = parseInt(timeslot_id_string);
+                    if (room.availability.indexOf(timeslot_id) >= 0){
                         cells[room_name][timeslot.order] = new Cell($j("<td/>"), null, room_name,
                             timeslot_id, matrix);
-                        } else {
+                    } else {
                         cells[room_name][timeslot.order] = new DisabledCell($j("<td/>"), room_name,
                             timeslot_id)
-                        }
-                        }.bind(this));
-                    }.bind(this));
+                    }
+                }.bind(this));
+            }.bind(this));
             return cells;
         }.bind(this)();
 
@@ -63,8 +63,8 @@ function Matrix(
      * Highlight the timeslots on the grid.
      *
      * @param timeslots: A 2-d array. The first element is an array of
-     *                   timeslots where all teachers are completely available. 
-     *                   The second is an array of timeslots where one or more 
+     *                   timeslots where all teachers are completely available.
+     *                   The second is an array of timeslots where one or more
      *                   teachers are teaching, but would be available otherwise.
      */
     this.highlightTimeslots = function(timeslots, section) {
@@ -77,14 +77,14 @@ function Matrix(
          */
         addClassToTimeslots = function(timeslots, className) {
             $j.each(timeslots, function(j, timeslot) {
-                    this.timeslotHeaders[timeslot].addClass(className);
-                    $j.each(this.rooms, function(k, room) {
-                        var cell = this.getCell(room.id, timeslot);
-                        if(!cell.section && !cell.disabled) {
+                this.timeslotHeaders[timeslot].addClass(className);
+                $j.each(this.rooms, function(k, room) {
+                    var cell = this.getCell(room.id, timeslot);
+                    if(!cell.section && !cell.disabled) {
                         cell.el.addClass(className);
-                        } 
-                        }.bind(this));
-                    }.bind(this));
+                    }
+                }.bind(this));
+            }.bind(this));
         }.bind(this);
         var available_timeslots = timeslots[0];
         var teaching_timeslots = timeslots[1];
@@ -107,8 +107,8 @@ function Matrix(
                         } else {
                             notEnoughSlots = true;
                         }
-                    }                    
-                    if(notEnoughSlots || 
+                    }
+                    if(notEnoughSlots ||
                        !this.validateAssignment(section, room.id, scheduleTimeslots).valid) {
                                 cell.el.removeClass("teacher-available-cell");
                                 cell.el.addClass("teacher-available-not-first-cell");
@@ -122,8 +122,8 @@ function Matrix(
      * Unhighlight the cells that are currently highlighted
      *
      * @param timeslots: A 2-d array. The first element is an array of
-     *                   timeslots where all teachers are completely available. 
-     *                   The second is an array of timeslots where one or more 
+     *                   timeslots where all teachers are completely available.
+     *                   The second is an array of timeslots where one or more
      *                   teachers are teaching, but would be available otherwise.
      */
     this.unhighlightTimeslots = function(timeslots) {
@@ -136,12 +136,12 @@ function Matrix(
          */
         removeClassFromTimeslots = function(timeslots, className) {
             $j.each(timeslots, function(j, timeslot) {
-                    this.timeslotHeaders[timeslot].removeClass(className);
-                    $j.each(this.rooms, function(k, room) {
-                        var cell = this.getCell(room.id, timeslot);
-                        cell.el.removeClass(className);
-                        }.bind(this));
-                    }.bind(this));
+                this.timeslotHeaders[timeslot].removeClass(className);
+                $j.each(this.rooms, function(k, room) {
+                    var cell = this.getCell(room.id, timeslot);
+                    cell.el.removeClass(className);
+                }.bind(this));
+            }.bind(this));
         }.bind(this);
 
         var available_timeslots = timeslots[0];
@@ -152,47 +152,47 @@ function Matrix(
 
 
     /**
-     * Initialize the sections that have already been scheduled. Must be called at the end 
+     * Initialize the sections that have already been scheduled. Must be called at the end
      * after all other initialization happens.
      */
     this.initSections = function() {
         // Associated already scheduled classes with rooms
         $j.each(this.sections.scheduleAssignments, function(class_id, assignmentData){
-                $j.each(assignmentData.timeslots, function(j, timeslot_id){
-                    var cell = this.getCell(assignmentData.room_name, timeslot_id);
-                    if(cell && !cell.disabled) {
+            $j.each(assignmentData.timeslots, function(j, timeslot_id){
+                var cell = this.getCell(assignmentData.room_name, timeslot_id);
+                if(cell && !cell.disabled) {
                     cell.addSection(sections.getById(class_id));
-                    } else {
+                } else {
                     if(!cell) {
-                    var errorMessage = "Error: Could not find cell with room "
-                    + assignmentData.room_name
-                    + " and timeslot with id "
-                    + timeslot_id
-                    + " to schedule section with id "
-                    + class_id;
-                    console.log(errorMessage);
-                    messagePanel.addMessage(errorMessage);
+                        var errorMessage = "Error: Could not find cell with room "
+                            + assignmentData.room_name
+                            + " and timeslot with id "
+                            + timeslot_id
+                            + " to schedule section with id "
+                            + class_id;
+                        console.log(errorMessage);
+                        messagePanel.addMessage(errorMessage);
                     }
                     else {
-                    var errorMessage = "Error: Room "
-                    + assignmentData.room_name
-                    + " appears to be unavailable during timeslot with id "
-                    + timeslot_id
-                    + " but section with id "
-                    + class_id
-                    + " is scheduled there.";
-                    console.log(errorMessage);
-                    messagePanel.addMessage(errorMessage);
+                        var errorMessage = "Error: Room "
+                            + assignmentData.room_name
+                            + " appears to be unavailable during timeslot with id "
+                            + timeslot_id
+                            + " but section with id "
+                            + class_id
+                            + " is scheduled there.";
+                        console.log(errorMessage);
+                        messagePanel.addMessage(errorMessage);
                     }
-                    }
-                }.bind(this));
+                }
+            }.bind(this));
         }.bind(this));
     };
 
 
     /**
      * Gets the cell that represents room_name and timeslot_id.
-     * 
+     *
      * @param room_name: The name of the room corresponding to the cell
      * @param timeslot_id: The ID of the timeslot corresponding to the cell
      */
@@ -295,13 +295,13 @@ function Matrix(
         var header_row = $j("<tr/>").appendTo($j("<thead/>").appendTo(table));
         header_row.append($j("<th/>"));
         $j.each(this.timeslots.timeslots_sorted, function(index, timeslot){
-                var timeslotHeader = $j("<th>" + timeslot.label + "</th>");
-                this.timeslotHeaders[timeslot.id] = timeslotHeader;
-                timeslotHeader.appendTo(header_row);
-                colModal.push({width: 80, align: 'center'});
-                }.bind(this));
+            var timeslotHeader = $j("<th>" + timeslot.label + "</th>");
+            this.timeslotHeaders[timeslot.id] = timeslotHeader;
+            timeslotHeader.appendTo(header_row);
+            colModal.push({width: 80, align: 'center'});
+        }.bind(this));
         //Room headers
-        var rows = {};	//table rows by room name
+        var rows = {}; //table rows by room name
         var room_ids = Object.keys(this.rooms);
         room_ids.sort();
         $j.each(this.rooms, function(id, room){
@@ -310,7 +310,7 @@ function Matrix(
             var row = $j("<tr></tr>");
             room_header.appendTo(row);
             rows[id] = row;
-            }.bind(this));
+        }.bind(this));
         //populate cells
         var cells = this.cells;
         $j.each(room_ids, function(index, room_id){
@@ -322,7 +322,7 @@ function Matrix(
         }.bind(this));
         table.appendTo(this.el);
         table.fxdHdrCol({fixedCols: 1, colModal: colModal, width: "100%", height: "100%"});
-        
+
         // Hack to make tooltips work
         var that = this;
         this.el.tooltip({
@@ -336,7 +336,7 @@ function Matrix(
                     "<b>" + room.text + "</b>",
                     "Capacity: " + room.num_students + " students",
                     "Resources: " + "<ul><li>"+ resource_names.join("</li><li>") + "</li></ul>",
-                    ];
+                ];
                 return tooltipParts.join("</br>");
             },
             items: ".ft_c td",
@@ -346,8 +346,7 @@ function Matrix(
         });
     };
 
-    
+
     this.initSections();
 
 };
-

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/MessagePanel.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/MessagePanel.js
@@ -23,7 +23,10 @@ function MessagePanel(el, initialMessage) {
      */
     this.addMessage = function(msg) {
         this.el.append( "<p>" + msg + "</p>");
-        this.el.scrollTop(this.el[0].scrollHeight);
+        // some browsers need delay before scrollHeight is updated
+        setTimeout(function() {
+            this.el.scrollTop(this.el[0].scrollHeight);
+        }.bind(this), 0);
     };
 
     /**

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/MessagePanel.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/MessagePanel.js
@@ -1,6 +1,6 @@
 /**
  * The panel that shows error and log messages to the user.
- * 
+ *
  * @param el: The element to render into the panel
  * @param initialMessage: The message to go initially on the panel
  */
@@ -18,7 +18,7 @@ function MessagePanel(el, initialMessage) {
 
     /**
      * Append a line to the message div in the form of a <p>.
-     * 
+     *
      * @param msg: The message to add
      */
     this.addMessage = function(msg) {

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Scheduler.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Scheduler.js
@@ -15,6 +15,7 @@ function Scheduler(
     matrixEl,
     messageEl,
     sectionInfoEl,
+    sectionDialogEl,
     last_applied_index,
     update_interval
 ) {
@@ -48,15 +49,18 @@ function Scheduler(
     this.rooms = data.rooms;
 
     this.sections = new Sections(data.sections,
+                                 data.section_details,
                                  data.teachers,
                                  data.schedule_assignments,
                                  new ApiClient());
 
     this.messagePanel = new MessagePanel(messageEl,
                                          "Welcome to the Ajax Scheduler!");
+    this.sectionCommentDialog = new SectionCommentDialog(sectionDialogEl, this.sections);
     this.sectionInfoPanel = new SectionInfoPanel(sectionInfoEl,
                                                  this.sections,
-                                                 this.messagePanel)
+                                                 this.messagePanel,
+                                                 this.sectionCommentDialog)
 
     this.matrix = new Matrix(
         this.timeslots,

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Scheduler.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Scheduler.js
@@ -38,24 +38,24 @@ function Scheduler(
             section.resource_requests = {};
             section.resource_requests[section.id] = [];
         }
-        
+
 
     });
 
     this.lunch_timeslots = data.lunch_timeslots;
     this.timeslots = new Timeslots(data.timeslots, this.lunch_timeslots);
-    
+
     this.rooms = data.rooms;
 
-    this.sections = new Sections(data.sections, 
-                                 data.teachers, 
-                                 data.schedule_assignments, 
+    this.sections = new Sections(data.sections,
+                                 data.teachers,
+                                 data.schedule_assignments,
                                  new ApiClient());
 
-    this.messagePanel = new MessagePanel(messageEl, 
+    this.messagePanel = new MessagePanel(messageEl,
                                          "Welcome to the Ajax Scheduler!");
-    this.sectionInfoPanel = new SectionInfoPanel(sectionInfoEl, 
-                                                 this.sections, 
+    this.sectionInfoPanel = new SectionInfoPanel(sectionInfoEl,
+                                                 this.sections,
                                                  this.messagePanel)
 
     this.matrix = new Matrix(
@@ -67,9 +67,9 @@ function Scheduler(
         this.sectionInfoPanel
     );
 
-    this.directory = new Directory(this.sections, 
-                                   directoryEl, 
-                                   data.schedule_assignments, 
+    this.directory = new Directory(this.sections,
+                                   directoryEl,
+                                   data.schedule_assignments,
                                    this.matrix);
 
     this.changelogFetcher = new ChangelogFetcher(
@@ -107,8 +107,8 @@ function Scheduler(
     $j("body").on("click", "td.matrix-cell > a", function(evt, ui) {
         var cell = $j(evt.currentTarget.parentElement).data("cell");
         this.sections.selectSection(cell.section);
-    }.bind(this)); 
- 
+    }.bind(this));
+
     $j("body").on("mouseleave click", "td.teacher-available-cell", function(evt, ui) {
         this.sections.unscheduleAsGhost();
     }.bind(this));
@@ -116,7 +116,7 @@ function Scheduler(
     $j("body").on("click", "td.teacher-available-cell", function(evt, ui) {
         var cell = $j(evt.currentTarget).data("cell");
         if(this.sections.selectedSection) {
-            this.sections.scheduleSection(this.sections.selectedSection, 
+            this.sections.scheduleSection(this.sections.selectedSection,
                                           cell.room_name, cell.timeslot_id);
         }
     }.bind(this));

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/SectionCommentDialog.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/SectionCommentDialog.js
@@ -1,0 +1,47 @@
+/**
+ * Dialog box to set the comment for class.
+ *
+ * @param el: The element to use for dialog
+ * @param sections: The sections object of the scheduler
+ */
+function SectionCommentDialog(el, sections) {
+    this.el = el;
+    this.dialog = el.dialog({
+        autoOpen: false,
+        height: 300,
+        width: 350,
+        modal: true,
+        buttons: {
+            "Set Comment": function() {
+                this.doSetComment();
+                this.dialog.dialog("close");
+            }.bind(this),
+            Cancel: function() {
+                this.dialog.dialog("close");
+            }.bind(this),
+        },
+        close: function() {
+            this.el.find('form')[0].reset();
+        }.bind(this),
+    });
+    this.sections = sections;
+
+    /**
+     * Show the dialog for the given section.
+     */
+    this.show = function(section) {
+        this.el.data('section', section.id);
+        this.el.find('#commentDialog-comment').val(section.schedulingComment);
+        if(section.schedulingLocked) {
+            this.el.find('#commentDialog-lock').prop("checked", true);
+        }
+        this.dialog.dialog("open");
+    }.bind(this);
+
+    this.doSetComment = function() {
+        var section = this.sections.sections_data[this.el.data('section')];
+        this.sections.setComment(section,
+                                 this.el.find('#commentDialog-comment').val(),
+                                 this.el.find('#commentDialog-lock').prop("checked"));
+    }.bind(this);
+}

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/SectionInfoPanel.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/SectionInfoPanel.js
@@ -1,6 +1,6 @@
 /**
  * The panel to display information about a section.
- * 
+ *
  * @param el: The element to shape into the panel
  * @param sections: The sections object of the scheduler
  * @param togglePanel: The panel to hide when this one is shown. May be null.
@@ -51,15 +51,15 @@ function SectionInfoPanel(el, sections, togglePanel) {
                 this.sections.unscheduleSection(section);
             }.bind(this));
         var baseURL = this.sections.getBaseUrlString();
-	    var links =  $j(
-            "<a target='_blank' href='" + baseURL + "manageclass/" + section.parent_class + 
-                "'>Manage</a>" + 
+        var links =  $j(
+            "<a target='_blank' href='" + baseURL + "manageclass/" + section.parent_class +
+                "'>Manage</a>" +
                 " <a target='_blank' href='" + baseURL + "editclass/" + section.parent_class +
                 "'>Edit</a>");
         toolbar.append(unscheduleButton);
         toolbar.append(links);
         return toolbar;
-        
+
     }.bind(this);
 
     // The content to put on the panel
@@ -69,12 +69,12 @@ function SectionInfoPanel(el, sections, togglePanel) {
         // Make content
         var teachers = this.sections.getTeachersString(section);
         var resources = this.sections.getResourceString(section);
-        
+
         var content_parts = [
             "Title: " + section.title,
             "Teachers: " + teachers,
             "Class size max: " + section.class_size_max,
-	        "Length: " + Math.ceil(section.length),
+            "Length: " + Math.ceil(section.length),
             "Grades: " + section.grade_min + "-" + section.grade_max,
             "Resource Requests: " + resources,
             "Flags: " + section.flags,
@@ -85,7 +85,7 @@ function SectionInfoPanel(el, sections, togglePanel) {
         if(section.special_requests && section.special_requests.length > 0) {
             content_parts.push("Room Requests: " + section.special_requests);
         }
-	
+
 
         contentDiv.append(content_parts.join("</br>"));
 

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/SectionInfoPanel.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/SectionInfoPanel.js
@@ -5,10 +5,11 @@
  * @param sections: The sections object of the scheduler
  * @param togglePanel: The panel to hide when this one is shown. May be null.
  */
-function SectionInfoPanel(el, sections, togglePanel) {
+function SectionInfoPanel(el, sections, togglePanel, sectionCommentDialog) {
     this.el = el;
     this.togglePanel = togglePanel; // The panel that should be hidden when the info panel is shown
     this.sections = sections;
+    this.sectionCommentDialog = sectionCommentDialog;
 
     /**
      * Hide the panel and show togglePanel if it exists.
@@ -44,19 +45,38 @@ function SectionInfoPanel(el, sections, togglePanel) {
     // The buttons available for this section
     var getToolbar = function(section) {
         var toolbar = $j("<div>");
-        var unscheduleButton = $j("<button id='unschedule'>Unschedule Section</button></br>");
-        unscheduleButton
-            .button()
-            .click(function(evt) {
-                this.sections.unscheduleSection(section);
-            }.bind(this));
+        if(this.sections.isScheduled(section)) {
+            var unscheduleButton = $j("<button class='sidetoolbar'>Unschedule Section</button>");
+            unscheduleButton
+                .button()
+                .click(function(evt) {
+                    this.sections.unscheduleSection(section);
+                }.bind(this)
+            );
+
+            var commentText = 'Set Comment';
+            if (section.schedulingLocked) {
+                commentText = 'Edit Comment or Unlock';
+            } else if (section.schedulingComment) {
+                commentText = 'Edit Comment';
+            }
+            var commentButton = $j("<button class='sidetoolbar'>" + commentText + "</button>");
+            commentButton
+                .button()
+                .click(function(evt) {
+                    this.sectionCommentDialog.show(section);
+                }.bind(this)
+            );
+
+            toolbar.append(unscheduleButton);
+            toolbar.append(commentButton);
+        }
         var baseURL = this.sections.getBaseUrlString();
         var links =  $j(
-            "<a target='_blank' href='" + baseURL + "manageclass/" + section.parent_class +
+            "<br/><a target='_blank' href='" + baseURL + "manageclass/" + section.parent_class +
                 "'>Manage</a>" +
                 " <a target='_blank' href='" + baseURL + "editclass/" + section.parent_class +
                 "'>Edit</a>");
-        toolbar.append(unscheduleButton);
         toolbar.append(links);
         return toolbar;
 
@@ -70,24 +90,33 @@ function SectionInfoPanel(el, sections, togglePanel) {
         var teachers = this.sections.getTeachersString(section);
         var resources = this.sections.getResourceString(section);
 
-        var content_parts = [
-            "Title: " + section.title,
-            "Teachers: " + teachers,
-            "Class size max: " + section.class_size_max,
-            "Length: " + Math.ceil(section.length),
-            "Grades: " + section.grade_min + "-" + section.grade_max,
-            "Resource Requests: " + resources,
-            "Flags: " + section.flags,
-        ]
+        var content_parts = {};
+
+        if(section.schedulingComment) {
+            content_parts['Scheduling Comment'] = section.schedulingComment;
+        }
+
+        content_parts['Title'] = section.title;
+        content_parts['Teachers'] = teachers;
+        content_parts['Class size max'] = section.class_size_max;
+        content_parts['Length'] = Math.ceil(section.length);
+        content_parts['Grades'] = section.grade_min + "-" + section.grade_max;
+        content_parts['Resource Requests'] = resources;
+        content_parts['Flags'] = section.flags;
+
         if(section.comments) {
-            content_parts.push("Comments: " + section.comments);
+            content_parts['Comments'] = section.comments;
         }
         if(section.special_requests && section.special_requests.length > 0) {
-            content_parts.push("Room Requests: " + section.special_requests);
+            content_parts['Room Requests'] = section.special_requests;
         }
 
-
-        contentDiv.append(content_parts.join("</br>"));
+        for(var header in content_parts) {
+            var partDiv = $j('<div>');
+            partDiv.append('<b>' + header + ': </b>');
+            partDiv.append(content_parts[header]);
+            contentDiv.append(partDiv);
+        }
 
         return contentDiv;
     }.bind(this);

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
@@ -1,7 +1,7 @@
 /**
  * Stores the section data and provides helper methods for accessing and scheduling
  * sections.
- * 
+ *
  * @params sections_data: The raw section data
  * @params teacher_data: The raw teacher data for populating the sections
  * @params scheduleAssignments: The scheule assignments
@@ -63,7 +63,7 @@ function Sections(sections_data, teacher_data, scheduleAssignments, apiClient) {
             $j("body").trigger("schedule-changed");
         });
     }.bind(this));
-    
+
     // Set up search
     this.searchObject = {active: false, text: "", type: $j("[name='class-search-type']").val()}
     $j("#class-search-text, [name='class-search-type']").on("keyup change", function(evt) {
@@ -82,18 +82,18 @@ function Sections(sections_data, teacher_data, scheduleAssignments, apiClient) {
      */
     this.init = function() {
         $j.each(sections_data, function(section_id, section) {
-                section.teacher_data = []
-                $j.each(section.teachers, function(index, teacher_id) {
-                    section.teacher_data.push(teacher_data[teacher_id]);
-                    });
-                });
+            section.teacher_data = []
+            $j.each(section.teachers, function(index, teacher_id) {
+                section.teacher_data.push(teacher_data[teacher_id]);
+            });
+        });
     };
 
     this.init();
 
     /**
      * Bind a matrix to the sections to allow the scheduling methods to work
-     * 
+     *
      * @param matrix: The matrix to bind
      */
     this.bindMatrix = function(matrix) {
@@ -122,26 +122,26 @@ function Sections(sections_data, teacher_data, scheduleAssignments, apiClient) {
             $j.each(this.filter, function(filterName, filterObject) {
                 if(filterObject.active && !filterObject.valid(section)) {
                     sectionValid = false;
-                } 
+                }
                 if(section.emailcode==="C8682s2"){
                     console.log(sectionValid, filterObject.valid(section));
                 }
                 if(this.searchObject.active) {
-                    
+
                     if(section[this.searchObject.type].toLowerCase().search(this.searchObject.text.toLowerCase())>-1) {
                         sectionValid = true;
-                         
+
                     }
                 }
-                }.bind(this));
-             if (
-                this.scheduleAssignments[section.id] && 
+            }.bind(this));
+            if (
+                this.scheduleAssignments[section.id] &&
                 this.scheduleAssignments[section.id].room_name == null &&
                 sectionValid
                 ){
-                    returned_sections.push(section);
-                }
-            }.bind(this));
+                returned_sections.push(section);
+            }
+           }.bind(this));
         return returned_sections;
     };
 
@@ -149,7 +149,7 @@ function Sections(sections_data, teacher_data, scheduleAssignments, apiClient) {
      * Select the cells associated with this section, put it on the section info
      * panel, and highlight the available cells to place the section.
      *
-     * @param section: The section to select 
+     * @param section: The section to select
      */
     this.selectSection = function(section) {
         if(this.selectedSection) {
@@ -164,9 +164,9 @@ function Sections(sections_data, teacher_data, scheduleAssignments, apiClient) {
         var assignment = this.scheduleAssignments[section.id];
         if(assignment.room_name) {
             $j.each(assignment.timeslots, function(index, timeslot) {
-                    var cell = this.matrix.getCell(assignment.room_name, timeslot);
-                    cell.select();
-                    }.bind(this));
+                var cell = this.matrix.getCell(assignment.room_name, timeslot);
+                cell.select();
+            }.bind(this));
         } else {
             section.directoryCell.select();
         }
@@ -181,7 +181,7 @@ function Sections(sections_data, teacher_data, scheduleAssignments, apiClient) {
     /**
      * Unselect the cells associated with the currently selected section, hide the section info
      * panel, and unhighlight the available cells to place the section.
-     */ 
+     */
     this.unselectSection = function() {
         if(!this.selectedSection) {
             return;
@@ -189,9 +189,9 @@ function Sections(sections_data, teacher_data, scheduleAssignments, apiClient) {
         var assignment = this.scheduleAssignments[this.selectedSection.id];
         if(assignment.room_name) {
             $j.each(assignment.timeslots, function(index, timeslot) {
-                    var cell = this.matrix.getCell(assignment.room_name, timeslot);
-                    cell.unselect();
-                    }.bind(this));
+                var cell = this.matrix.getCell(assignment.room_name, timeslot);
+                cell.unselect();
+            }.bind(this));
         } else {
             this.selectedSection.directoryCell.unselect();
         }
@@ -204,9 +204,9 @@ function Sections(sections_data, teacher_data, scheduleAssignments, apiClient) {
 
     /**
      * Get the timeslots available for scheduling this section.
-     * Returns an array of two lists. 
+     * Returns an array of two lists.
      *
-     * The first has all the timeslots where all teachers are available and 
+     * The first has all the timeslots where all teachers are available and
      * none are teaching.
      *
      * The second has all the timeslots where teachers are available but already teaching
@@ -215,26 +215,26 @@ function Sections(sections_data, teacher_data, scheduleAssignments, apiClient) {
      */
     this.getAvailableTimeslots = function(section) {
         var availabilities = [];
-        var already_teaching = [];        
+        var already_teaching = [];
         $j.each(section.teacher_data, function(index, teacher) {
-                var teacher_availabilities = teacher.availability.slice();
-                teacher_availabilities = teacher_availabilities.filter(function(val) {
-                    return this.matrix.timeslots.get_by_id(val);
-                }.bind(this));
-                $j.each(teacher.sections, function(index, section_id) {
-                    var assignment = this.scheduleAssignments[section_id];
-                    if(assignment && section_id != section.id) {
+            var teacher_availabilities = teacher.availability.slice();
+            teacher_availabilities = teacher_availabilities.filter(function(val) {
+                return this.matrix.timeslots.get_by_id(val);
+            }.bind(this));
+            $j.each(teacher.sections, function(index, section_id) {
+                var assignment = this.scheduleAssignments[section_id];
+                if(assignment && section_id != section.id) {
                     $j.each(assignment.timeslots, function(index, timeslot_id) {
                         var availability_index = teacher_availabilities.indexOf(timeslot_id);
                         if(availability_index >= 0) {
-                        teacher_availabilities.splice(availability_index, 1);
-                        already_teaching.push(timeslot_id);
+                            teacher_availabilities.splice(availability_index, 1);
+                            already_teaching.push(timeslot_id);
                         }
-                        }.bind(this));
-                    }
                     }.bind(this));
-                availabilities.push(teacher_availabilities);
-                }.bind(this));
+                }
+            }.bind(this));
+            availabilities.push(teacher_availabilities);
+        }.bind(this));
         var availableTimeslots = helpersIntersection(availabilities, true);
         return [availableTimeslots, already_teaching];
     };
@@ -247,8 +247,8 @@ function Sections(sections_data, teacher_data, scheduleAssignments, apiClient) {
     this.getTeachersString = function(section) {
         var teacher_list = []
             $j.each(section.teacher_data, function(index, teacher) {
-                    teacher_list.push(teacher.first_name + " " + teacher.last_name);
-                    });
+                teacher_list.push(teacher.first_name + " " + teacher.last_name);
+            });
         var teachers = teacher_list.join(", ");
         return teachers;
     };
@@ -264,7 +264,7 @@ function Sections(sections_data, teacher_data, scheduleAssignments, apiClient) {
 
     /**
      * Schedule a section of a class.
-     * 
+     *
      * @param section: The section to schedule
      * @param room_name: The name of the room to schedule it in
      * @param first_timeslot_id: The ID of the first timeslot to schedule the section in
@@ -282,19 +282,19 @@ function Sections(sections_data, teacher_data, scheduleAssignments, apiClient) {
         // Optimistically schedule the section locally before hearing back from the server
         this.scheduleSectionLocal(section, room_name, schedule_timeslots);
         this.apiClient.schedule_section(
-                section.id,
-                schedule_timeslots,
-                room_name, 
-                function() {},
-                // If there's an error, reschedule the section in its old location
-                function(msg) {
-                this.scheduleSectionLocal(section, 
-                    old_assignment.room_name, 
+            section.id,
+            schedule_timeslots,
+            room_name,
+            function() {},
+            // If there's an error, reschedule the section in its old location
+            function(msg) {
+                this.scheduleSectionLocal(section,
+                    old_assignment.room_name,
                     old_assignment.timeslots);
                 this.matrix.messagePanel.addMessage("Error: " + msg)
                 console.log(msg);
-                }.bind(this)
-                );
+            }.bind(this)
+        );
     }
 
 
@@ -310,9 +310,9 @@ function Sections(sections_data, teacher_data, scheduleAssignments, apiClient) {
 
         // Check to see if we need to make any changes
         if(
-                old_assignment.room_name == room_name &&
-                JSON.stringify(old_assignment.timeslots)==JSON.stringify(schedule_timeslots)
-          ){
+            old_assignment.room_name == room_name &&
+            JSON.stringify(old_assignment.timeslots)==JSON.stringify(schedule_timeslots)
+            ){
             return;
         }
 
@@ -335,9 +335,9 @@ function Sections(sections_data, teacher_data, scheduleAssignments, apiClient) {
 
         // Update the array that keeps track of the assignments
         this.scheduleAssignments[section.id] = {
-room_name: room_name,
-           timeslots: schedule_timeslots,
-           id: section.id
+            room_name: room_name,
+            timeslots: schedule_timeslots,
+            id: section.id
         };
 
         // Trigger the event that tells the directory to update itself.
@@ -346,7 +346,7 @@ room_name: room_name,
 
     /**
      * Make the selected section appear as a "ghost" on the schedule.
-     * 
+     *
      * @param room_name: The room that the class would go in
      * @param first_timeslot_id: The id of the first timeslot the class would go in
      */
@@ -382,16 +382,15 @@ room_name: room_name,
         // Optimistically make local changes to unschedule the class
         this.unscheduleSectionLocal(section);
         this.apiClient.unschedule_section(
-                section.id,
-                function(){ 
-                },
-                // If the server returns an error, put the class back in its original spot
-                function(msg){
+            section.id,
+            function(){},
+            // If the server returns an error, put the class back in its original spot
+            function(msg){
                 this.scheduleSectionLocal(section, old_room_name, old_schedule_timeslots);
                 this.matrix.messagePanel.addMessage("Error: " + msg);
                 console.log(msg);
-                }.bind(this)
-                );
+            }.bind(this)
+        );
     };
 
     /**

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
@@ -123,14 +123,9 @@ function Sections(sections_data, teacher_data, scheduleAssignments, apiClient) {
                 if(filterObject.active && !filterObject.valid(section)) {
                     sectionValid = false;
                 }
-                if(section.emailcode==="C8682s2"){
-                    console.log(sectionValid, filterObject.valid(section));
-                }
                 if(this.searchObject.active) {
-
                     if(section[this.searchObject.type].toLowerCase().search(this.searchObject.text.toLowerCase())>-1) {
                         sectionValid = true;
-
                     }
                 }
             }.bind(this));

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Timeslots.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Timeslots.js
@@ -30,15 +30,11 @@ function Timeslots(timeslots_data, lunch_timeslots){
 
     /**
      * Get a timeslot by its rank in the day based on start time
-     * 
+     *
      * @param order: get the order-th timeslot
      */
     this.get_by_order = function(order){
-        for (id in this.timeslots){
-            if (this.timeslots[id].order == order){
-                return this.timeslots[id];
-            }
-        }	
+        return this.timeslots_sorted[order];
     };
 
     /**

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Timeslots.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Timeslots.js
@@ -8,16 +8,19 @@ function Timeslots(timeslots_data, lunch_timeslots){
     this.timeslots_sorted = helpers_add_timeslots_order(timeslots_data);
     this.timeslots = timeslots_data;
     this.lunch_timeslots = {};
-    $j.each(lunch_timeslots, function(index, lunch_id) {
-        var lunch_slot = this.timeslots[lunch_id];
-        var lunch_slot_day = lunch_slot.end[2];
-        if(this.lunch_timeslots[lunch_slot_day]) {
-            this.lunch_timeslots[lunch_slot_day].push(lunch_slot);
-        } else {
-            this.lunch_timeslots[lunch_slot_day] = [lunch_slot];
-        }
-    }.bind(this));
-    console.log(this.lunch_timeslots);
+
+    if(lunch_timeslots) {
+        $j.each(lunch_timeslots, function(index, lunch_id) {
+            var lunch_slot = this.timeslots[lunch_id];
+            var lunch_slot_day = lunch_slot.end[2];
+            if(this.lunch_timeslots[lunch_slot_day]) {
+                this.lunch_timeslots[lunch_slot_day].push(lunch_slot);
+            } else {
+                this.lunch_timeslots[lunch_slot_day] = [lunch_slot];
+            }
+        }.bind(this));
+        console.log(this.lunch_timeslots);
+    }
 
     /**
      * Get a timeslot by its id

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Timeslots.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Timeslots.js
@@ -1,12 +1,12 @@
 /**
  * Stores timeslot data and provides convenience methods
- * 
+ *
  * @param timeslots_data: The raw timeslot data
  */
 function Timeslots(timeslots_data, lunch_timeslots){
     // TODO: move helper to add timeslot order here
     this.timeslots_sorted = helpers_add_timeslots_order(timeslots_data);
-    this.timeslots = timeslots_data; 
+    this.timeslots = timeslots_data;
     this.lunch_timeslots = {};
     $j.each(lunch_timeslots, function(index, lunch_id) {
         var lunch_slot = this.timeslots[lunch_id];
@@ -16,7 +16,7 @@ function Timeslots(timeslots_data, lunch_timeslots){
         } else {
             this.lunch_timeslots[lunch_slot_day] = [lunch_slot];
         }
-    }.bind(this)); 
+    }.bind(this));
     console.log(this.lunch_timeslots);
 
     /**

--- a/esp/public/media/scripts/ajaxschedulingmodule/spec/ApiClientSpec.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/spec/ApiClientSpec.js
@@ -5,165 +5,165 @@ csrf_token = function(){
 describe("ApiClient", function(){
     var a;
     beforeEach(function(){
-	    a = new ApiClient();
+        a = new ApiClient();
     });
 
     describe("get_change_log", function(){
-	    var request, callback, errorReporter;
+        var request, callback, errorReporter;
 
-	    beforeEach(function(){
-	        jasmine.Ajax.useMock();
-	        callback = jasmine.createSpy('callback');
-	        errorReporter = jasmine.createSpy('errorReporter');
+        beforeEach(function(){
+            jasmine.Ajax.useMock();
+            callback = jasmine.createSpy('callback');
+            errorReporter = jasmine.createSpy('errorReporter');
 
-	        a.get_change_log(0, callback, errorReporter);
-	        request = mostRecentAjaxRequest();
-	    });
+            a.get_change_log(0, callback, errorReporter);
+            request = mostRecentAjaxRequest();
+        });
 
-	    describe("when there is an error", function(){
-	        beforeEach(function(){
-		        request.response({
-		            status: 500,
-		            responseText: 'an error has occurred'
-		        });
-	        });
+        describe("when there is an error", function(){
+            beforeEach(function(){
+                request.response({
+                    status: 500,
+                    responseText: 'an error has occurred'
+                });
+            });
 
-	        it("does not execute the callback", function(){
-		        expect(callback).not.toHaveBeenCalled();
-		        expect(errorReporter).toHaveBeenCalledWith("An error occurred fetching the changelog.");
-	        });
-	    });
+            it("does not execute the callback", function(){
+                expect(callback).not.toHaveBeenCalled();
+                expect(errorReporter).toHaveBeenCalledWith("An error occurred fetching the changelog.");
+            });
+        });
 
-	    describe("when the request comes back with success", function(){
-	        beforeEach(function(){
-		        request.response({
-		            status: 200,
-		            responseText: '{"changelog":[], "other":[]}'
-		        });
-	        });
+        describe("when the request comes back with success", function(){
+            beforeEach(function(){
+                request.response({
+                    status: 200,
+                    responseText: '{"changelog":[], "other":[]}'
+                });
+            });
 
-	        it("executes the callback", function(){
-		        expect(callback).toHaveBeenCalled();
-		        expect(errorReporter).not.toHaveBeenCalled();
-	        });
-	    });
+            it("executes the callback", function(){
+                expect(callback).toHaveBeenCalled();
+                expect(errorReporter).not.toHaveBeenCalled();
+            });
+        });
     });
 
     describe("schedule_section", function(){
-	    it("makes an ajax request", function(){
-	        spyOn(a, "send_request");
-	        var callback_function = function(){};
-	        var errorReporter_function = function(){};
-	        
-	        a.schedule_section(1234, [1], "my-room",
-			                   callback_function,
-			                   errorReporter_function);
+        it("makes an ajax request", function(){
+            spyOn(a, "send_request");
+            var callback_function = function(){};
+            var errorReporter_function = function(){};
 
-	        expect(a.send_request).toHaveBeenCalledWith(
-		        {
-		            action: 'assignreg',
-		            csrfmiddlewaretoken: 'abcd',
-		            cls: 1234,
-		            block_room_assignments: '1,my-room',
-		        }, 
-		        callback_function,
-		        errorReporter_function
-	        );
-	    });
+            a.schedule_section(1234, [1], "my-room",
+                               callback_function,
+                               errorReporter_function);
 
-	    it("can send a request with multiple timeslots", function(){
-	        spyOn(a, "send_request");
-	        var callback_function = function(){};
-	        var errorReporter_function = function(){};
+            expect(a.send_request).toHaveBeenCalledWith(
+                {
+                    action: 'assignreg',
+                    csrfmiddlewaretoken: 'abcd',
+                    cls: 1234,
+                    block_room_assignments: '1,my-room',
+                },
+                callback_function,
+                errorReporter_function
+            );
+        });
 
-	        a.schedule_section(1234, [1,2], "my-room",
-			                   callback_function,
-			                   errorReporter_function);
+        it("can send a request with multiple timeslots", function(){
+            spyOn(a, "send_request");
+            var callback_function = function(){};
+            var errorReporter_function = function(){};
 
-	        expect(a.send_request).toHaveBeenCalledWith(
-		        {
-		            action: 'assignreg',
-		            csrfmiddlewaretoken: 'abcd',
-		            cls: 1234,
-		            block_room_assignments: '1,my-room\n2,my-room',
-		        },
-		        callback_function,
-		        errorReporter_function
-	        );
-	    });
+            a.schedule_section(1234, [1,2], "my-room",
+                               callback_function,
+                               errorReporter_function);
+
+            expect(a.send_request).toHaveBeenCalledWith(
+                {
+                    action: 'assignreg',
+                    csrfmiddlewaretoken: 'abcd',
+                    cls: 1234,
+                    block_room_assignments: '1,my-room\n2,my-room',
+                },
+                callback_function,
+                errorReporter_function
+            );
+        });
     });
 
     describe("unschedule_section", function(){
-	    it("makes an ajax request", function(){
-	        spyOn(a, "send_request");
-	        var callback_function = function(){};
-	        var errorReporter_function = function(){};
+        it("makes an ajax request", function(){
+            spyOn(a, "send_request");
+            var callback_function = function(){};
+            var errorReporter_function = function(){};
 
-	        a.unschedule_section(1234, callback_function, errorReporter_function);
+            a.unschedule_section(1234, callback_function, errorReporter_function);
 
-	        expect(a.send_request).toHaveBeenCalledWith(
-		        {
-		            action: 'deletereg',
-		            csrfmiddlewaretoken: 'abcd',
-		            cls: 1234,
-		        }, 
-		        callback_function,
-		        errorReporter_function
-	        );
-	    });
+            expect(a.send_request).toHaveBeenCalledWith(
+                {
+                    action: 'deletereg',
+                    csrfmiddlewaretoken: 'abcd',
+                    cls: 1234,
+                },
+                callback_function,
+                errorReporter_function
+            );
+        });
     });
 
     describe("send_request", function(){
-	    var request, callback, errorReporter;
+        var request, callback, errorReporter;
 
-	    beforeEach(function(){
-	        jasmine.Ajax.useMock();
-	        callback = jasmine.createSpy('callback');
-	        errorReporter = jasmine.createSpy('errorReporter');
-	        
-	        a.send_request({}, callback, errorReporter);
-	        request = mostRecentAjaxRequest();
-	    });
+        beforeEach(function(){
+            jasmine.Ajax.useMock();
+            callback = jasmine.createSpy('callback');
+            errorReporter = jasmine.createSpy('errorReporter');
 
-	    describe("when there is an error", function(){
-	        beforeEach(function(){
-		        request.response({
-		            status: 500,
-		            responseText: 'an error has occurred'
-		        });
-	        });
-	        it("does not execute the callback", function(){
-		        expect(callback).not.toHaveBeenCalled();
-		        expect(errorReporter).toHaveBeenCalledWith("An error occurred saving the schedule change.");
-	        });
-	    });
+            a.send_request({}, callback, errorReporter);
+            request = mostRecentAjaxRequest();
+        });
 
-	    describe("when the request comes back with failure", function(){
-	        beforeEach(function(){
-		        request.response({
-		            status: 200,
-		            responseText: '{"ret":false,"msg":"The teacher is not available"}'
-		        });
-	        });
-	        it("does not execute the callback", function(){
-		        expect(callback).not.toHaveBeenCalled();
-		        expect(errorReporter).toHaveBeenCalledWith("The teacher is not available");
-	        });
-	    });
+        describe("when there is an error", function(){
+            beforeEach(function(){
+                request.response({
+                    status: 500,
+                    responseText: 'an error has occurred'
+                });
+            });
+            it("does not execute the callback", function(){
+                expect(callback).not.toHaveBeenCalled();
+                expect(errorReporter).toHaveBeenCalledWith("An error occurred saving the schedule change.");
+            });
+        });
 
-	    describe("when the request comes back with success", function(){
-	        beforeEach(function(){
-		        request.response({
-		            status: 200,
-		            responseText: '{"ret":true}'
-		        });
-		        
-	        });
-	        it("executes the callback", function(){
-		        expect(callback).toHaveBeenCalled();
-		        expect(errorReporter).not.toHaveBeenCalled();
-	        });
-	    });
+        describe("when the request comes back with failure", function(){
+            beforeEach(function(){
+                request.response({
+                    status: 200,
+                    responseText: '{"ret":false,"msg":"The teacher is not available"}'
+                });
+            });
+            it("does not execute the callback", function(){
+                expect(callback).not.toHaveBeenCalled();
+                expect(errorReporter).toHaveBeenCalledWith("The teacher is not available");
+            });
+        });
+
+        describe("when the request comes back with success", function(){
+            beforeEach(function(){
+                request.response({
+                    status: 200,
+                    responseText: '{"ret":true}'
+                });
+
+            });
+            it("executes the callback", function(){
+                expect(callback).toHaveBeenCalled();
+                expect(errorReporter).not.toHaveBeenCalled();
+            });
+        });
     });
 
 });

--- a/esp/public/media/scripts/ajaxschedulingmodule/spec/CellColorsSpec.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/spec/CellColorsSpec.js
@@ -18,8 +18,8 @@ describe("CellColors", function(){
             valid_characters = ["0", "1","2","3","4","5","6","7","8","9","A","B","C","D","E","F"];
             characters = color.substr(1);
             for (i in characters){
-	            var c = characters[i];
-	            expect(valid_characters.indexOf(c)).toBeGreaterThan(-1);
+                var c = characters[i];
+                expect(valid_characters.indexOf(c)).toBeGreaterThan(-1);
             };
         });
 

--- a/esp/public/media/scripts/ajaxschedulingmodule/spec/CellSpec.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/spec/CellSpec.js
@@ -101,7 +101,7 @@ describe("Cell", function(){
 
                 it("adds the section to the element", function(){
                     c.addSection(section);
-                    expect(c.el[0].innerText).toEqual(section.emailcode);
+                    expect(c.el[0].innerHTML).toContain(section.emailcode);
                     });
 
                 it("adds styling to the el", function(){
@@ -153,17 +153,19 @@ describe("Cell", function(){
                 expect($j(c.el[0]).css('background-color')).toEqual('rgb(32, 32, 32)');
                 expect(c.el.hasClass("ghost-section")).toBeTrue();
             });
-           
+
         });
 
         describe("removeGhostSection", function() {
+            var originalBackgroundColor;
             beforeEach(function() {
+                originalBackgroundColor = $j(c.el[0]).css('background-color');
                 c.addSection(section);
                 c.addGhostSection(section2);
             });
             it("removes the styling from the cell", function() {
                 c.removeGhostSection();
-                expect(c.el[0].innerHTML).not.toMatch(section2.emailcode);  
+                expect(c.el[0].innerHTML).not.toMatch(section2.emailcode);
                 expect(c.el.hasClass("ghost-section")).toBeFalse();
             });
 
@@ -174,14 +176,14 @@ describe("Cell", function(){
                 expect($j(c.el[0]).css('background-color')).toEqual('rgb(16, 16, 16)');
                 expect($j(c.el[0]).css('color')).toEqual('rgb(255, 255, 255)');
             });
-    
+
             it("returns the cell to its previous styling otherwise", function() {
                 c.removeSection(section);
                 c.removeGhostSection();
                 expect(c.el[0].innerHTML).toEqual("");
-                expect($j(c.el[0]).css('background-color')).toEqual('');
+                expect($j(c.el[0]).css('background-color')).toEqual(originalBackgroundColor);
             });
         });
-        
-        
+
+
 });

--- a/esp/public/media/scripts/ajaxschedulingmodule/spec/CellSpec.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/spec/CellSpec.js
@@ -1,189 +1,189 @@
 describe("Cell", function(){
-        var c, section, section2;
+    var c, section, section2;
 
+    beforeEach(function(){
+        var matrix = generateFakeMatrix();
+        c = new Cell($j("<td/>"), null, "1-115", 1, matrix);
+        section = matrix.sections.getById(1);
+        section.emailcode = 'S1111s1';
+        section2 = matrix.sections.getById(3);
+        section2.emailcode = 'A2222s1';
+    });
+
+    // Initialization Tests
+
+    it("has an element with the matrix cell class", function(){
+        expect(c.el).toBeDefined();
+        expect(c.el.hasClass("matrix-cell")).toBeTrue();
+    });
+
+    it("has a room attached as data on the el", function(){
+        expect(c.room_name).toEqual("1-115");
+    });
+
+    it("has a timeslot", function(){
+        expect(c.timeslot_id).toEqual(1);
+    });
+
+    it("attaches itself to its el", function(){
+        expect($j(c.el).data("cell")).toEqual(c);
+    });
+
+    describe("with a section", function(){
+        it("has a section", function(){
+            spyOn(c, 'addSection');
+            c.init(section);
+            expect(c.addSection).toHaveBeenCalledWith(section);
+        });
+    });
+
+    describe("without a section", function(){
+        it("calls removeSection", function(){
+            spyOn(c, 'removeSection');
+            c.init(null);
+            expect(c.removeSection).toHaveBeenCalled();
+        });
+    });
+
+
+    describe("select", function() {
+        it("adds the class selected-section", function() {
+            c.addSection(section);
+            c.select();
+            expect(c.el.hasClass("selected-section")).toBeTrue();
+
+        });
+    });
+
+    describe("unselect", function() {
+        it("removes the class selected-section", function() {
+            c.addSection(section);
+            c.select();
+            c.unselect();
+            expect(c.el.hasClass("selected-section")).toBeFalse();
+        });
+
+        it("does nothing if class was not already selected", function() {
+            c.addSection(section);
+            c.unselect();
+            expect(c.el.hasClass("selected-section")).toBeFalse();
+        });
+
+    });
+
+    describe("tooltip", function(){
         beforeEach(function(){
-            var matrix = generateFakeMatrix();
-            c = new Cell($j("<td/>"), null, "1-115", 1, matrix);
-            section = matrix.sections.getById(1);
-            section.emailcode = 'S1111s1';
-            section2 = matrix.sections.getById(3);
-            section2.emailcode = 'A2222s1';
+            var s = c.matrix.sections.getById(1);
+            c.addSection(s);
             });
 
-        // Initialization Tests
-
-        it("has an element with the matrix cell class", function(){
-            expect(c.el).toBeDefined();
-            expect(c.el.hasClass("matrix-cell")).toBeTrue();
-            });
-
-        it("has a room attached as data on the el", function(){
-            expect(c.room_name).toEqual("1-115");
-            });
-
-        it("has a timeslot", function(){
-            expect(c.timeslot_id).toEqual(1);
-            });
-
-        it("attaches itself to its el", function(){
-                expect($j(c.el).data("cell")).toEqual(c);
-                });
-
-        describe("with a section", function(){
-                it("has a section", function(){
-                    spyOn(c, 'addSection');
-                    c.init(section);
-                    expect(c.addSection).toHaveBeenCalledWith(section);
-                    });
-                });
-
-        describe("without a section", function(){
-                it("calls removeSection", function(){
-                    spyOn(c, 'removeSection');
-                    c.init(null);
-                    expect(c.removeSection).toHaveBeenCalled();
-                    });
-                });
+        it("contains the emailcode, title, length, and max students", function(){
+            var tooltip = c.tooltip();
+            expect(tooltip).toContain("S1111s1");
+            expect(tooltip).toContain("Ben Bitdiddle");
+            expect(tooltip).toContain("Alyssa P. Hacker");
+            expect(tooltip).toContain("Fascinating Science Phenomena");
+            expect(tooltip).toContain("Class size max: 150");
+            expect(tooltip).toContain("Length: 1");
+        });
+    });
 
 
-        describe("select", function() {
-                it("adds the class selected-section", function() {
-                    c.addSection(section);
-                    c.select();
-                    expect(c.el.hasClass("selected-section")).toBeTrue();
-
-                    });
-                });
-
-        describe("unselect", function() {
-                it("removes the class selected-section", function() {
-                    c.addSection(section);
-                    c.select();
-                    c.unselect();
-                    expect(c.el.hasClass("selected-section")).toBeFalse();
-                    });
-
-                it("does nothing if class was not already selected", function() {
-                    c.addSection(section);
-                    c.unselect();
-                    expect(c.el.hasClass("selected-section")).toBeFalse();
-                    });
-
-                });
-
-        describe("tooltip", function(){
-                beforeEach(function(){
-                    var s = c.matrix.sections.getById(1);
-                    c.addSection(s);
-                    });
-
-                it("contains the emailcode, title, length, and max students", function(){
-                    var tooltip = c.tooltip();
-                    expect(tooltip).toContain("S1111s1");
-                    expect(tooltip).toContain("Ben Bitdiddle");
-                    expect(tooltip).toContain("Alyssa P. Hacker");
-                    expect(tooltip).toContain("Fascinating Science Phenomena");
-                    expect(tooltip).toContain("Class size max: 150");
-                    expect(tooltip).toContain("Length: 1");
-                    });
-                });
-
-
-        describe("adding a section", function(){
-                beforeEach(function(){
-                    c.removeSection();
-                    });
-
-                it("saves off the section", function(){
-                    c.addSection(section);
-                    expect(c.section).toEqual(section);
-                    });
-
-                it("adds the section to the element", function(){
-                    c.addSection(section);
-                    expect(c.el[0].innerHTML).toContain(section.emailcode);
-                    });
-
-                it("adds styling to the el", function(){
-                    c.addSection(section);
-                    expect(c.el.hasClass("occupied-cell")).toBeTrue();
-                    expect(c.el.hasClass("available-cell")).toBeFalse();
-                    });
-
-                it("adds the section to the el data", function(){
-                        c.addSection(section);
-                        expect(c.el.data("section")).toEqual(section);
-                        });
-
+    describe("adding a section", function(){
+        beforeEach(function(){
+            c.removeSection();
         });
 
-        describe("removing a section", function(){
-                beforeEach(function(){
-                    c.addSection(section);
-                    });
-
-                it("removes the section", function(){
-                    c.removeSection();
-                    expect(c.section).toBeNull();
-                    });
-
-                it("changes the el contents", function(){
-                    c.removeSection();
-                    expect(c.el[0].innerHTML).not.toMatch(section.emailcode);
-                    });
-
-                it("removes the section from the el data", function(){
-                    c.removeSection();
-                    expect(c.el.data("section")).not.toBeDefined();
-                    });
-
-                it("changes the cell styling", function(){
-                    c.removeSection();
-                    expect(c.el.hasClass("occupied-cell")).toBeFalse();
-                    expect(c.el.hasClass("available-cell")).toBeTrue();
-                    });
+        it("saves off the section", function(){
+            c.addSection(section);
+            expect(c.section).toEqual(section);
         });
 
-        describe("addGhostSection", function() {
-            it("adds the correct styling to the cell", function() {
-                c.addSection(section);
-                c.addGhostSection(section2);
-                expect(c.el[0].innerHTML).toMatch(section2.emailcode);
-                expect(c.el[0].innerHTML).not.toMatch(section.emailcode);
-                expect($j(c.el[0]).css('background-color')).toEqual('rgb(32, 32, 32)');
-                expect(c.el.hasClass("ghost-section")).toBeTrue();
-            });
-
+        it("adds the section to the element", function(){
+            c.addSection(section);
+            expect(c.el[0].innerHTML).toContain(section.emailcode);
         });
 
-        describe("removeGhostSection", function() {
-            var originalBackgroundColor;
-            beforeEach(function() {
-                originalBackgroundColor = $j(c.el[0]).css('background-color');
-                c.addSection(section);
-                c.addGhostSection(section2);
-            });
-            it("removes the styling from the cell", function() {
-                c.removeGhostSection();
-                expect(c.el[0].innerHTML).not.toMatch(section2.emailcode);
-                expect(c.el.hasClass("ghost-section")).toBeFalse();
-            });
-
-            it("puts back the section previously scheduled if it exists", function() {
-                c.removeGhostSection();
-                expect(c.el[0].innerHTML).toMatch(section.emailcode);
-                expect(c.el[0].innerHTML).toMatch("</a>");
-                expect($j(c.el[0]).css('background-color')).toEqual('rgb(16, 16, 16)');
-                expect($j(c.el[0]).css('color')).toEqual('rgb(255, 255, 255)');
-            });
-
-            it("returns the cell to its previous styling otherwise", function() {
-                c.removeSection(section);
-                c.removeGhostSection();
-                expect(c.el[0].innerHTML).toEqual("");
-                expect($j(c.el[0]).css('background-color')).toEqual(originalBackgroundColor);
-            });
+        it("adds styling to the el", function(){
+            c.addSection(section);
+            expect(c.el.hasClass("occupied-cell")).toBeTrue();
+            expect(c.el.hasClass("available-cell")).toBeFalse();
         });
+
+        it("adds the section to the el data", function(){
+            c.addSection(section);
+            expect(c.el.data("section")).toEqual(section);
+        });
+
+    });
+
+    describe("removing a section", function(){
+        beforeEach(function(){
+            c.addSection(section);
+        });
+
+        it("removes the section", function(){
+            c.removeSection();
+            expect(c.section).toBeNull();
+        });
+
+        it("changes the el contents", function(){
+            c.removeSection();
+            expect(c.el[0].innerHTML).not.toMatch(section.emailcode);
+        });
+
+        it("removes the section from the el data", function(){
+            c.removeSection();
+            expect(c.el.data("section")).not.toBeDefined();
+        });
+
+        it("changes the cell styling", function(){
+            c.removeSection();
+            expect(c.el.hasClass("occupied-cell")).toBeFalse();
+            expect(c.el.hasClass("available-cell")).toBeTrue();
+        });
+    });
+
+    describe("addGhostSection", function() {
+        it("adds the correct styling to the cell", function() {
+            c.addSection(section);
+            c.addGhostSection(section2);
+            expect(c.el[0].innerHTML).toMatch(section2.emailcode);
+            expect(c.el[0].innerHTML).not.toMatch(section.emailcode);
+            expect($j(c.el[0]).css('background-color')).toEqual('rgb(32, 32, 32)');
+            expect(c.el.hasClass("ghost-section")).toBeTrue();
+        });
+
+    });
+
+    describe("removeGhostSection", function() {
+        var originalBackgroundColor;
+        beforeEach(function() {
+            originalBackgroundColor = $j(c.el[0]).css('background-color');
+            c.addSection(section);
+            c.addGhostSection(section2);
+        });
+        it("removes the styling from the cell", function() {
+            c.removeGhostSection();
+            expect(c.el[0].innerHTML).not.toMatch(section2.emailcode);
+            expect(c.el.hasClass("ghost-section")).toBeFalse();
+        });
+
+        it("puts back the section previously scheduled if it exists", function() {
+            c.removeGhostSection();
+            expect(c.el[0].innerHTML).toMatch(section.emailcode);
+            expect(c.el[0].innerHTML).toMatch("</a>");
+            expect($j(c.el[0]).css('background-color')).toEqual('rgb(16, 16, 16)');
+            expect($j(c.el[0]).css('color')).toEqual('rgb(255, 255, 255)');
+        });
+
+        it("returns the cell to its previous styling otherwise", function() {
+            c.removeSection(section);
+            c.removeGhostSection();
+            expect(c.el[0].innerHTML).toEqual("");
+            expect($j(c.el[0]).css('background-color')).toEqual(originalBackgroundColor);
+        });
+    });
 
 
 });

--- a/esp/public/media/scripts/ajaxschedulingmodule/spec/ChangelogFetcherSpec.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/spec/ChangelogFetcherSpec.js
@@ -1,7 +1,7 @@
 describe("ChangelogFetcher", function() {
     var c = new ChangelogFetcher(generateFakeMatrix(), new FakeApiClient(), 32);
 
- 	var changelog_entry = {
+    var changelog_entry = {
         id: 2,
         index: 2,
         room_name: "room-2",

--- a/esp/public/media/scripts/ajaxschedulingmodule/spec/DirectorySpec.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/spec/DirectorySpec.js
@@ -1,112 +1,112 @@
 describe("Directory", function(){
-        var d, m;
+    var d, m;
 
+    beforeEach(function(){
+        m = generateFakeMatrix();
+        d = new Directory(m.sections,
+            $j("<div/>"), schedule_assignment_fixture(), m);
+    });
+
+    it("should have a list of sections and an el", function(){
+        expect(d.sections).toBeObject();
+        expect(d.el[0]).toBeHtmlNode();
+    });
+
+    describe("render", function(){
         beforeEach(function(){
-            m = generateFakeMatrix();
-            d = new Directory(m.sections,
-                $j("<div/>"), schedule_assignment_fixture(), m);
-            });
+            d.render();
+        });
 
-        it("should have a list of sections and an el", function(){
-            expect(d.sections).toBeObject();
-            expect(d.el[0]).toBeHtmlNode();
-            });
-
-        describe("render", function(){
+        describe("when there are classes scheduled", function(){
             beforeEach(function(){
+                d = new Directory(m.sections, $j("<div/>"), schedule_assignment_fixture(), m);
                 d.render();
-                });
+                })
 
-            describe("when there are classes scheduled", function(){
-                beforeEach(function(){
-                    d = new Directory(m.sections, $j("<div/>"), schedule_assignment_fixture(), m);
-                    d.render();
-                    })
-
-                it("should not show them in the directory", function(){
-                    expect(d.el.children().length).toEqual(1);
-                    var table = d.el.children()[0];
-                    expect(table.rows.length).toEqual(4);
-                    expect(table.rows[0].innerHTML).toMatch("Fascinating Science Phenomena");
-                    expect(table.rows[0].innerHTML).toMatch("manageclass/");
-                    expect(table.rows[0].innerHTML).toMatch("editclass/");
-                    });
-                });
-
-            it("should present a list of classes with emailcodes", function (){
+            it("should not show them in the directory", function(){
                 expect(d.el.children().length).toEqual(1);
                 var table = d.el.children()[0];
                 expect(table.rows.length).toEqual(4);
                 expect(table.rows[0].innerHTML).toMatch("Fascinating Science Phenomena");
-                expect(table.rows[0].innerHTML).toMatch("S11s2");
-                });
-
-            it("should be able to render twice without duplicating content", function(){
-                    runs(function(){
-                        d.render();
-                        d.render();
-                        });
-                    //since we delete the old nodes asynchronously
-                    //need to add some asynchrony here
-                    waits(0);
-                    runs(function(){
-                        expect(d.el.children().length).toEqual(1);
-                        });
-                    });
+                expect(table.rows[0].innerHTML).toMatch("manageclass/");
+                expect(table.rows[0].innerHTML).toMatch("editclass/");
+            });
         });
+
+        it("should present a list of classes with emailcodes", function (){
+            expect(d.el.children().length).toEqual(1);
+            var table = d.el.children()[0];
+            expect(table.rows.length).toEqual(4);
+            expect(table.rows[0].innerHTML).toMatch("Fascinating Science Phenomena");
+            expect(table.rows[0].innerHTML).toMatch("S11s2");
+        });
+
+        it("should be able to render twice without duplicating content", function(){
+            runs(function(){
+                d.render();
+                d.render();
+            });
+            //since we delete the old nodes asynchronously
+            //need to add some asynchrony here
+            waits(0);
+            runs(function(){
+                expect(d.el.children().length).toEqual(1);
+            });
+        });
+    });
 });
 
 describe("TableRow", function(){
-        var m, d, tr;
+    var m, d, tr;
 
-        beforeEach(function(){
-            m = generateFakeMatrix();
-            d = new Directory(m.sections, $j("<div/>"), schedule_assignment_fixture(), m);
-            tr = new TableRow({title: "my-title", emailcode: "my-emailcode", parent_class: 1234}, $j("<tr/>"), d);
-            })
+    beforeEach(function(){
+        m = generateFakeMatrix();
+        d = new Directory(m.sections, $j("<div/>"), schedule_assignment_fixture(), m);
+        tr = new TableRow({title: "my-title", emailcode: "my-emailcode", parent_class: 1234}, $j("<tr/>"), d);
+    })
 
-        it("should have an el", function(){
-            expect(tr.el[0]).toBeHtmlNode();
+    it("should have an el", function(){
+        expect(tr.el[0]).toBeHtmlNode();
+    });
+
+    it("should have a section", function(){
+        expect(tr.section).toBeObject();
+    });
+
+    it("should have a cell", function(){
+        expect(tr.cell).toBeObject();
+    });
+
+    describe("render", function(){
+        it("should display the section name", function(){
+            tr.render();
+            expect(tr.el[0].innerHTML).toContain("my-title");
             });
 
-        it("should have a section", function(){
-            expect(tr.section).toBeObject();
+        it("should display the section email code", function(){
+            tr.render();
+            expect(tr.el[0].innerHTML).toContain("my-emailcode");
             });
 
-        it("should have a cell", function(){
-            expect(tr.cell).toBeObject();
-            });
+        it("has edit and manage links", function(){
+            tr.render();
+            expect(tr.el[0].innerHTML).toContain("editclass/");
+            expect(tr.el[0].innerHTML).toContain("manageclass/");
+        });
+    });
 
-        describe("render", function(){
-                it("should display the section name", function(){
-                    tr.render();
-                    expect(tr.el[0].innerHTML).toContain("my-title");
-                    });
+    describe("hide", function(){
+        it("sets the display style to 'none'", function(){
+            tr.hide();
+            expect(tr.el[0].style.display).toEqual("none");
+        });
+    });
 
-                it("should display the section email code", function(){
-                    tr.render();
-                    expect(tr.el[0].innerHTML).toContain("my-emailcode");
-                    });
-
-                it("has edit and manage links", function(){
-                    tr.render();
-                    expect(tr.el[0].innerHTML).toContain("editclass/");
-                    expect(tr.el[0].innerHTML).toContain("manageclass/");
-                    });
-                });
-
-        describe("hide", function(){
-                it("sets the display style to 'none'", function(){
-                    tr.hide();
-                    expect(tr.el[0].style.display).toEqual("none");
-                    });
-                });
-
-        describe("unHide", function(){
-                it("unsets the display style from 'none'", function(){
-                    tr.hide();
-                    tr.unHide();
-                    expect(tr.el[0].style.display).not.toEqual("none");
-                    });
-                });
+    describe("unHide", function(){
+        it("unsets the display style from 'none'", function(){
+            tr.hide();
+            tr.unHide();
+            expect(tr.el[0].style.display).not.toEqual("none");
+        });
+    });
 });

--- a/esp/public/media/scripts/ajaxschedulingmodule/spec/FakeApiClient.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/spec/FakeApiClient.js
@@ -1,26 +1,26 @@
 function FakeApiClient() {
     this.schedule_section = function(a, b, c, callback){
-	callback();
-	return true;
+        callback();
+        return true;
     };
 
     this.unschedule_section = function(a, callback){
-	callback();
-	return true;
+        callback();
+        return true;
     };
 
     this.get_change_log = function(index, callback){
-	console.log("hi i'm here")
-	callback();
+        console.log("hi i'm here")
+        callback();
     };
 };
 
 function FakeFailingApiClient() {
     this.schedule_section = function(a, b, c, callback){
-	return false;
+        return false;
     };
 
     this.unschedule_section = function(a, callback){
-	return false;
+        return false;
     };
 };

--- a/esp/public/media/scripts/ajaxschedulingmodule/spec/FakeMatrix.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/spec/FakeMatrix.js
@@ -1,12 +1,12 @@
 function generateFakeMatrix(){
-    var sections = new Sections(section_fixture(), 
-                                 teacher_fixture(), 
-                                 schedule_assignment_fixture(), 
+    var sections = new Sections(section_fixture(),
+                                 teacher_fixture(),
+                                 schedule_assignment_fixture(),
                                  new ApiClient());
-    var messagePanel = new MessagePanel($j("<div>"), 
+    var messagePanel = new MessagePanel($j("<div>"),
                                          "Welcome to the Ajax Scheduler!");
-    var sectionInfoPanel = new SectionInfoPanel($j("<div>"), 
-                                                 sections, 
+    var sectionInfoPanel = new SectionInfoPanel($j("<div>"),
+                                                 sections,
                                                  messagePanel)
     var matrix = new Matrix(new Timeslots(time_fixture()),
                   room_fixture(),

--- a/esp/public/media/scripts/ajaxschedulingmodule/spec/HelpersSpec.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/spec/HelpersSpec.js
@@ -3,8 +3,10 @@ describe("Helpers", function(){
             it("puts the timeslots in order", function() {
                 var original_timeslots = time_fixture();
                 var ordered_timeslots = helpers_add_timeslots_order(original_timeslots);
-                expect(ordered_timeslots['3'].order).toEqual(0);
-                expect(ordered_timeslots['5'].order).toEqual(1);
+                expect(original_timeslots['3'].order).toEqual(0);
+                expect(original_timeslots['5'].order).toEqual(1);
+                expect(ordered_timeslots[0].id).toEqual(3);
+                expect(ordered_timeslots[1].id).toEqual(5);
                 });
             });
 

--- a/esp/public/media/scripts/ajaxschedulingmodule/spec/HelpersSpec.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/spec/HelpersSpec.js
@@ -29,11 +29,10 @@ describe("Helpers", function(){
                 expect(intersection1.length).toEqual(1);
                 expect(intersection1[0]).toEqual(1);
 
-                var arrays2 = [[1, 5, 7, 9], 
+                var arrays2 = [[1, 5, 7, 9],
                 [2 , 3]];
                 var intersection2 = helpersIntersection(arrays2, true);
                 expect(intersection2.length).toEqual(0);
                 });
             });
 });
-

--- a/esp/public/media/scripts/ajaxschedulingmodule/spec/MatrixSpec.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/spec/MatrixSpec.js
@@ -1,180 +1,180 @@
 describe("Matrix", function(){
-        var m;
+    var m;
 
-        beforeEach(function(){
-            m = generateFakeMatrix();
+    beforeEach(function(){
+        m = generateFakeMatrix();
+    });
+
+    it("should have an element", function(){
+        expect(m.el[0]).toBeHtmlNode();
+    });
+
+    it("should have times, rooms, teachers, and schedule assignments", function(){
+        expect(m.timeslots).toBeObject();
+        expect(m.rooms).toBeObject();
+        expect(m.sections).toBeObject();
+    });
+
+    describe("highlightTimeslots", function() {
+        it("adds the correct classes to the timeslots given for a single hour class", function() {
+            m.highlightTimeslots([[5], [3]], m.sections.getById(2));
+            expect(m.getCell("room-1", 5).el.hasClass("teacher-available-cell")).toBe(true);
+            expect(m.getCell("room-1", 5).el.hasClass("teacher-teaching-cell")).toBe(false);
+
+            expect(m.getCell("room-2", 5).el.hasClass("teacher-available-cell")).toBe(true);
+            expect(m.getCell("room-2", 5).el.hasClass("teacher-teaching-cell")).toBe(false);
+
+            expect(m.getCell("room-3", 5).el.hasClass("teacher-available-cell")).toBe(false);
+            expect(m.getCell("room-3", 5).el.hasClass("teacher-teaching-cell")).toBe(false);
+
+            expect(m.getCell("room-1", 3).el.hasClass("teacher-available-cell")).toBe(false);
+            expect(m.getCell("room-1", 3).el.hasClass("teacher-teaching-cell")).toBe(false);
+
+            expect(m.getCell("room-2", 3).el.hasClass("teacher-available-cell")).toBe(false);
+            expect(m.getCell("room-2", 3).el.hasClass("teacher-teaching-cell")).toBe(true);
+
+            expect(m.getCell("room-3", 3).el.hasClass("teacher-available-cell")).toBe(false);
+            expect(m.getCell("room-3", 3).el.hasClass("teacher-teaching-cell")).toBe(true);
+
+            expect(m.getCell("room-1", 7).el.hasClass("teacher-available-cell")).toBe(false);
+            expect(m.getCell("room-3", 11).el.hasClass("teacher-teaching-cell")).toBe(false);
+        })
+
+        it("adds a striped gradient for cells that are available, but can't be clicked", function() {
+            m.highlightTimeslots([[11, 13], []], m.sections.getById(3));
+            expect(m.getCell("room-3", 13).el.hasClass("teacher-available-not-first-cell")).toBeTrue();
+        });
+    });
+
+    describe("unhighlightTimeslots", function() {
+        it("removes the correct classes from the timeslots given", function() {
+            m.highlightTimeslots([[5], [3]], m.sections.getById(2));
+            m.unhighlightTimeslots([[5], [3]]);
+
+            expect(m.getCell("room-1", 3).el.hasClass("teacher-available-cell")).toBe(false);
+            expect(m.getCell("room-1", 3).el.hasClass("teacher-teaching-cell")).toBe(false);
+
+            expect(m.getCell("room-2", 3).el.hasClass("teacher-available-cell")).toBe(false);
+            expect(m.getCell("room-2", 3).el.hasClass("teacher-teaching-cell")).toBe(false);
+
+            expect(m.getCell("room-3", 3).el.hasClass("teacher-available-cell")).toBe(false);
+            expect(m.getCell("room-3", 3).el.hasClass("teacher-teaching-cell")).toBe(false);
+
+            expect(m.getCell("room-1", 5).el.hasClass("teacher-available-cell")).toBe(false);
+            expect(m.getCell("room-1", 5).el.hasClass("teacher-teaching-cell")).toBe(false);
+
+            expect(m.getCell("room-2", 5).el.hasClass("teacher-available-cell")).toBe(false);
+            expect(m.getCell("room-2", 5).el.hasClass("teacher-teaching-cell")).toBe(false);
+
+            expect(m.getCell("room-3", 5).el.hasClass("teacher-available-cell")).toBe(false);
+            expect(m.getCell("room-3", 5).el.hasClass("teacher-teaching-cell")).toBe(false);
+
+            expect(m.getCell("room-1", 7).el.hasClass("teacher-available-cell")).toBe(false);
+            expect(m.getCell("room-3", 11).el.hasClass("teacher-teaching-cell")).toBe(false);
+        });
+        it("removes the striped gradient too", function() {
+            m.highlightTimeslots([[11, 13], []], m.sections.getById(3));
+            m.unhighlightTimeslots([[3, 5], []], m.sections.getById(3));
+
+            expect(m.getCell("room-2", 5).el.hasClass("teacher-available-not-first-cell")).toBeFalse();
+            expect(m.getCell("room-3", 3).el.hasClass("teacher-available-not-first-cell")).toBeFalse();
+        });
+    });
+
+    describe("getCell", function(){
+        it("returns the html cell for the requested room and time", function(){
+            var s1 = section_1();
+            s1.teacher_data = [teacher_fixture()[1], teacher_fixture()[2]];
+            expect(m.getCell("room-1", 3).section).toEqual(s1);
+            expect(m.getCell("room-1", 3).room_name).toEqual("room-1");
+            expect(m.getCell("room-3", 3).timeslot_id).toEqual(3);
+
+            expect(m.getCell("room-1", 11).room_name).toEqual("room-1");
+            expect(m.getCell("room-1", 11).timeslot_id).toEqual(11);
+
+            expect(m.getCell("room-2", 7).innerHTML).toEqual(null);
+            expect(m.getCell("room-2", 7).room_name).toEqual("room-2");
+            expect(m.getCell("room-3", 7).timeslot_id).toEqual(7);
+
+            expect(m.getCell("room-2", 5).innerHTML).toEqual(null);
+            expect(m.getCell("room-2", 5).room_name).toEqual("room-2");
+            expect(m.getCell("room-1", 5).timeslot_id).toEqual(5);
+        });
+    });
+
+
+    describe("when a room doesn't exist for some times", function(){
+        it("should have disabled cells around it", function(){
+            expect(m.getCell("room-2", 11).disabled).toBeFalse();
+            expect(m.getCell("room-1", 11).disabled).toBeTrue();
+            expect(m.getCell("room-1", 3).disabled).toBeFalse();
+            expect(m.getCell("room-2", 3).disabled).toBeFalse();
+        });
+
+    });
+
+    describe("validateAssignment", function(){
+        describe("when a class is already scheduled in a room", function(){
+            beforeEach(function(){
+                m.sections.scheduleSection(m.sections.getById(2), "room-1", 5);
             });
 
-        it("should have an element", function(){
-            expect(m.el[0]).toBeHtmlNode();
-            });
-
-        it("should have times, rooms, teachers, and schedule assignments", function(){
-            expect(m.timeslots).toBeObject();
-            expect(m.rooms).toBeObject();
-            expect(m.sections).toBeObject();
-            });
-
-        describe("highlightTimeslots", function() {
-            it("adds the correct classes to the timeslots given for a single hour class", function() {
-                m.highlightTimeslots([[5], [3]], m.sections.getById(2));
-                expect(m.getCell("room-1", 5).el.hasClass("teacher-available-cell")).toBe(true);
-                expect(m.getCell("room-1", 5).el.hasClass("teacher-teaching-cell")).toBe(false);
-
-                expect(m.getCell("room-2", 5).el.hasClass("teacher-available-cell")).toBe(true);
-                expect(m.getCell("room-2", 5).el.hasClass("teacher-teaching-cell")).toBe(false);
-
-                expect(m.getCell("room-3", 5).el.hasClass("teacher-available-cell")).toBe(false);
-                expect(m.getCell("room-3", 5).el.hasClass("teacher-teaching-cell")).toBe(false);
-
-                expect(m.getCell("room-1", 3).el.hasClass("teacher-available-cell")).toBe(false);
-                expect(m.getCell("room-1", 3).el.hasClass("teacher-teaching-cell")).toBe(false);
-
-                expect(m.getCell("room-2", 3).el.hasClass("teacher-available-cell")).toBe(false);
-                expect(m.getCell("room-2", 3).el.hasClass("teacher-teaching-cell")).toBe(true);
-
-                expect(m.getCell("room-3", 3).el.hasClass("teacher-available-cell")).toBe(false);
-                expect(m.getCell("room-3", 3).el.hasClass("teacher-teaching-cell")).toBe(true);
-
-                expect(m.getCell("room-1", 7).el.hasClass("teacher-available-cell")).toBe(false);
-                expect(m.getCell("room-3", 11).el.hasClass("teacher-teaching-cell")).toBe(false);
-            })
-
-            it("adds a striped gradient for cells that are available, but can't be clicked", function() {
-                m.highlightTimeslots([[11, 13], []], m.sections.getById(3));
-                expect(m.getCell("room-3", 13).el.hasClass("teacher-available-not-first-cell")).toBeTrue();
+            it("returns false", function(){
+                var validObj = m.validateAssignment(m.sections.getById(3), "room-1", [3,5]);
+                expect(validObj.valid).toEqual(false);
+                expect(validObj.reason).toEqual("Error: timeslot3 already has a class in room-1.");
             });
         });
 
-        describe("unhighlightTimeslots", function() {
-                it("removes the correct classes from the timeslots given", function() {
-                    m.highlightTimeslots([[5], [3]], m.sections.getById(2));
-                    m.unhighlightTimeslots([[5], [3]]);
+        describe("when the assignment is valid", function(){
+            it("returns true", function(){
+                expect(m.validateAssignment(m.sections.getById(3), "room-3", [11, 13]).valid).toEqual(true);
+            });
+        });
 
-                    expect(m.getCell("room-1", 3).el.hasClass("teacher-available-cell")).toBe(false);
-                    expect(m.getCell("room-1", 3).el.hasClass("teacher-teaching-cell")).toBe(false);
-
-                    expect(m.getCell("room-2", 3).el.hasClass("teacher-available-cell")).toBe(false);
-                    expect(m.getCell("room-2", 3).el.hasClass("teacher-teaching-cell")).toBe(false);
-
-                    expect(m.getCell("room-3", 3).el.hasClass("teacher-available-cell")).toBe(false);
-                    expect(m.getCell("room-3", 3).el.hasClass("teacher-teaching-cell")).toBe(false);
-
-                    expect(m.getCell("room-1", 5).el.hasClass("teacher-available-cell")).toBe(false);
-                    expect(m.getCell("room-1", 5).el.hasClass("teacher-teaching-cell")).toBe(false);
-
-                    expect(m.getCell("room-2", 5).el.hasClass("teacher-available-cell")).toBe(false);
-                    expect(m.getCell("room-2", 5).el.hasClass("teacher-teaching-cell")).toBe(false);
-
-                    expect(m.getCell("room-3", 5).el.hasClass("teacher-available-cell")).toBe(false);
-                    expect(m.getCell("room-3", 5).el.hasClass("teacher-teaching-cell")).toBe(false);
-
-                    expect(m.getCell("room-1", 7).el.hasClass("teacher-available-cell")).toBe(false);
-                    expect(m.getCell("room-3", 11).el.hasClass("teacher-teaching-cell")).toBe(false);
-                }); 
-                it("removes the striped gradient too", function() {
-                    m.highlightTimeslots([[11, 13], []], m.sections.getById(3));
-                    m.unhighlightTimeslots([[3, 5], []], m.sections.getById(3));
-    
-                    expect(m.getCell("room-2", 5).el.hasClass("teacher-available-not-first-cell")).toBeFalse();
-                    expect(m.getCell("room-3", 3).el.hasClass("teacher-available-not-first-cell")).toBeFalse();
+        describe("when the timeslots are null", function(){
+            it("returns false", function(){
+                var validObj = m.validateAssignment(m.sections.getById(3), "room-2", null)
+                expect(validObj.valid).toEqual(false);
+                expect(validObj.reason).toEqual('Error: Not scheduled during a timeblock');
                 });
         });
- 
-        describe("getCell", function(){
-            it("returns the html cell for the requested room and time", function(){
-                var s1 = section_1();
-                s1.teacher_data = [teacher_fixture()[1], teacher_fixture()[2]];
-                expect(m.getCell("room-1", 3).section).toEqual(s1);
-                expect(m.getCell("room-1", 3).room_name).toEqual("room-1");
-                expect(m.getCell("room-3", 3).timeslot_id).toEqual(3);
+    });
 
-                expect(m.getCell("room-1", 11).room_name).toEqual("room-1");
-                expect(m.getCell("room-1", 11).timeslot_id).toEqual(11);
+    describe("render", function(){
+        it("should have a row for each room", function(){
+            expect(m.el.children().length).toEqual(1);
+            var table = m.el.children()[0];
+            expect(m.getTable().rows.length).toEqual(4);
+            //TODO:  ordering should probably be deterministic, but I'm not sure how
+            expect(m.getTable().rows[1].cells[0].innerHTML).toMatch("room-1");
+            expect(m.getTable().rows[2].cells[0].innerHTML).toMatch("room-2");
+        })
 
-                expect(m.getCell("room-2", 7).innerHTML).toEqual(null);
-                expect(m.getCell("room-2", 7).room_name).toEqual("room-2");
-                expect(m.getCell("room-3", 7).timeslot_id).toEqual(7);
+        it("should have a column each timeslot", function(){
+            var table = m.el.children()[0];
 
-                expect(m.getCell("room-2", 5).innerHTML).toEqual(null);
-                expect(m.getCell("room-2", 5).room_name).toEqual("room-2");
-                expect(m.getCell("room-1", 5).timeslot_id).toEqual(5);
-                });
+            var header = m.getTable().tHead;
+            expect(header).toBeHtmlNode();
+            headers = header.rows[0].cells;
+            expect(headers.length).toEqual(6);
+            //the corner block should be empty
+            expect(headers[1].innerHTML).toMatch("first timeslot");
+            expect(headers[2].innerHTML).toMatch("second timeslot");
         });
 
-
-        describe("when a room doesn't exist for some times", function(){
-            it("should have disabled cells around it", function(){
-                expect(m.getCell("room-2", 11).disabled).toBeFalse();
-                expect(m.getCell("room-1", 11).disabled).toBeTrue();
-                expect(m.getCell("room-1", 3).disabled).toBeFalse();
-                expect(m.getCell("room-2", 3).disabled).toBeFalse();
-                });
-
-            });
-
-        describe("validateAssignment", function(){
-                describe("when a class is already scheduled in a room", function(){
-                    beforeEach(function(){
-                        m.sections.scheduleSection(m.sections.getById(2), "room-1", 5);
-                        });
-
-                    it("returns false", function(){
-                        var validObj = m.validateAssignment(m.sections.getById(3), "room-1", [3,5]);
-                        expect(validObj.valid).toEqual(false);
-                        expect(validObj.reason).toEqual("Error: timeslot3 already has a class in room-1.");
-                        }); 
-                    });
-
-                describe("when the assignment is valid", function(){
-                    it("returns true", function(){
-                        expect(m.validateAssignment(m.sections.getById(3), "room-3", [11, 13]).valid).toEqual(true);
-                        });
-                    });
-
-                describe("when the timeslots are null", function(){
-                    it("returns false", function(){
-                        var validObj = m.validateAssignment(m.sections.getById(3), "room-2", null)
-                        expect(validObj.valid).toEqual(false);
-                        expect(validObj.reason).toEqual('Error: Not scheduled during a timeblock');
-                        });
-                    });
+        it("should have a cell for every timeslot/room combination", function(){
+            var table = m.el.children()[0];
+            expect(m.getTable().rows[1].cells[1]).toBeDefined();
+            expect(m.getTable().rows[1].cells[2]).toBeDefined();
+            expect(m.getTable().rows[2].cells[1]).toBeDefined();
+            expect(m.getTable().rows[2].cells[2]).toBeDefined();
         });
 
-        describe("render", function(){
-                it("should have a row for each room", function(){
-                    expect(m.el.children().length).toEqual(1);
-                    var table = m.el.children()[0];
-                    expect(m.getTable().rows.length).toEqual(4);
-                    //TODO:  ordering should probably be deterministic, but I'm not sure how
-                    expect(m.getTable().rows[1].cells[0].innerHTML).toMatch("room-1");
-                    expect(m.getTable().rows[2].cells[0].innerHTML).toMatch("room-2");
-                    })
-
-                it("should have a column each timeslot", function(){
-                    var table = m.el.children()[0];
-
-                    var header = m.getTable().tHead;
-                    expect(header).toBeHtmlNode();
-                    headers = header.rows[0].cells;
-                    expect(headers.length).toEqual(6);
-                    //the corner block should be empty
-                    expect(headers[1].innerHTML).toMatch("first timeslot");
-                    expect(headers[2].innerHTML).toMatch("second timeslot");
-                    });
-
-                it("should have a cell for every timeslot/room combination", function(){
-                        var table = m.el.children()[0];
-                        expect(m.getTable().rows[1].cells[1]).toBeDefined();
-                        expect(m.getTable().rows[1].cells[2]).toBeDefined();
-                        expect(m.getTable().rows[2].cells[1]).toBeDefined();
-                        expect(m.getTable().rows[2].cells[2]).toBeDefined();
-                        });
-
-                it("should show already scheduled sections", function(){
-                        var table = m.el.children()[0];
-                        expect(table.innerHTML).toMatch('S11s1');
-                        });
+        it("should show already scheduled sections", function(){
+            var table = m.el.children()[0];
+            expect(table.innerHTML).toMatch('S11s1');
         });
+    });
 
 });

--- a/esp/public/media/scripts/ajaxschedulingmodule/spec/SchedulerSpec.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/spec/SchedulerSpec.js
@@ -1,37 +1,37 @@
 describe("Scheduler", function(){
-        var s;
+    var s;
 
-        beforeEach(function(){
-            s = new Scheduler({schedule_assignments: {}, rooms: {}, timeslots: {}, sections: {}}, $j("<div/>"), $j("<div/>"), $j("<div/>"), $j("<div/>"), 11, 12345678);
-            });
+    beforeEach(function(){
+        s = new Scheduler({schedule_assignments: {}, rooms: {}, timeslots: {}, sections: {}}, $j("<div/>"), $j("<div/>"), $j("<div/>"), $j("<div/>"), 11, 12345678);
+    });
 
-        it("should have a directory and a matrix", function(){
-            expect(s.directory).toBeDefined();
-            expect(s.matrix).toBeDefined();
-            });
+    it("should have a directory and a matrix", function(){
+        expect(s.directory).toBeDefined();
+        expect(s.matrix).toBeDefined();
+    });
 
-        it("should have a changelogFetcher with the right initial index", function(){
-            expect(s.changelogFetcher).toBeDefined()
-            expect(s.changelogFetcher.last_applied_index).toEqual(11)
-            })
+    it("should have a changelogFetcher with the right initial index", function(){
+        expect(s.changelogFetcher).toBeDefined()
+        expect(s.changelogFetcher.last_applied_index).toEqual(11)
+    })
 
-        describe("render", function(){
-            it("calls render on the directory and matrix",  function(){
-                spyOn(s.directory, "render");
-                spyOn(s.matrix, "render");
-                s.render();
-                expect(s.directory.render).toHaveBeenCalled();
-                expect(s.matrix.render).toHaveBeenCalled();
-                });
+    describe("render", function(){
+        it("calls render on the directory and matrix",  function(){
+            spyOn(s.directory, "render");
+            spyOn(s.matrix, "render");
+            s.render();
+            expect(s.directory.render).toHaveBeenCalled();
+            expect(s.matrix.render).toHaveBeenCalled();
+        });
 
-            it("starts the changelog fetcher", function(){
-                spyOn(s.changelogFetcher, "pollForChanges")
+        it("starts the changelog fetcher", function(){
+            spyOn(s.changelogFetcher, "pollForChanges")
 
-                s.render()
-                expect(s.changelogFetcher.pollForChanges).toHaveBeenCalled()
+            s.render()
+            expect(s.changelogFetcher.pollForChanges).toHaveBeenCalled()
 
-                args = s.changelogFetcher.pollForChanges.argsForCall[0]
-                expect(args[0]).toEqual(12345678)
-                })
-            });
+            args = s.changelogFetcher.pollForChanges.argsForCall[0]
+            expect(args[0]).toEqual(12345678)
+        })
+    });
 });

--- a/esp/public/media/scripts/ajaxschedulingmodule/spec/SectionInfoPanelSpec.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/spec/SectionInfoPanelSpec.js
@@ -3,7 +3,7 @@ describe("SectionInfoPanel", function() {
     var sipNoToggle;
     var sections;
     beforeEach(function() {
-        sections = new Sections(section_fixture(), teacher_fixture(), 
+        sections = new Sections(section_fixture(), teacher_fixture(),
                                     schedule_assignment_fixture(), new FakeApiClient());
         sipNoToggle = new SectionInfoPanel($j("<div>"), sections, null);
         sipToggle = new SectionInfoPanel($j("<div>"), sections, new MessagePanel($j("<div>"), "Initial Message"));
@@ -21,7 +21,7 @@ describe("SectionInfoPanel", function() {
 
         });
     });
-    
+
     describe("show", function() {
         it("should remove a ui-helper-hidden class", function() {
             sipNoToggle.show();
@@ -48,5 +48,5 @@ describe("SectionInfoPanel", function() {
 
         });
     });
-             
+
 });

--- a/esp/public/media/scripts/ajaxschedulingmodule/spec/SectionsSpec.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/spec/SectionsSpec.js
@@ -1,234 +1,234 @@
 describe("SectionsSpec", function() {
-        var sections, matrix;
+    var sections, matrix;
 
-        beforeEach(function() {
-            sections = new Sections(section_fixture(), teacher_fixture(),
-                schedule_assignment_fixture(), new FakeApiClient());
-            matrix = generateFakeMatrix();
+    beforeEach(function() {
+        sections = new Sections(section_fixture(), teacher_fixture(),
+            schedule_assignment_fixture(), new FakeApiClient());
+        matrix = generateFakeMatrix();
+        sections.bindMatrix(matrix);
+    });
+
+    it("adds teacher_data property to each section", function() {
+        var teachers = teacher_fixture();
+        var section1 = sections.getById(1);
+        expect(section1.teacher_data).toEqual([teachers[1], teachers[2]]);
+    });
+
+    describe("bindMatrix", function() {
+        it("adds the property matrix to the sections object", function() {
+            sections.matrix = null;
             sections.bindMatrix(matrix);
-            });
+            expect(sections.matrix).toEqual(matrix);
+        });
+    });
+    describe("getById", function() {
+        it("gets the correct section", function() {
+            var s = section_fixture()[1];
+            s.teacher_data = [teacher_fixture()[1], teacher_fixture()[2]]
+            expect(sections.getById(1)).toEqual(s);
+        });
+    });
 
-        it("adds teacher_data property to each section", function() {
-            var teachers = teacher_fixture();
-            var section1 = sections.getById(1);
-            expect(section1.teacher_data).toEqual([teachers[1], teachers[2]]);
-            });
+    describe("filtered_sections", function() {
+        it("returns the unscheduled sections", function() {
+            var unscheduledSections = sections.filtered_sections();
+            expect(unscheduledSections).toEqual([sections.getById(2), sections.getById(4),
+                                                 sections.getById(5), sections.getById(6)]);
+        });
+    });
 
-        describe("bindMatrix", function() {
-            it("adds the property matrix to the sections object", function() {
-                sections.matrix = null;
-                sections.bindMatrix(matrix);
-                expect(sections.matrix).toEqual(matrix);
-                });
-            });
-        describe("getById", function() {
-                it("gets the correct section", function() {
-                    var s = section_fixture()[1];
-                    s.teacher_data = [teacher_fixture()[1], teacher_fixture()[2]]
-                    expect(sections.getById(1)).toEqual(s);
-                });
+    describe("selectSection", function() {
+        it("selects all cells that hold the section", function() {
+            var cell1 = matrix.getCell("room-2", 11);
+            var cell2 = matrix.getCell("room-2", 13);
+            spyOn(cell1, "select");
+            spyOn(cell2, "select");
+            sections.selectSection(sections.getById(3));
+            expect(cell1.select).toHaveBeenCalled();
+            expect(cell2.select).toHaveBeenCalled();
         });
 
-        describe("filtered_sections", function() {
-            it("returns the unscheduled sections", function() {
-                var unscheduledSections = sections.filtered_sections();
-                expect(unscheduledSections).toEqual([sections.getById(2), sections.getById(4),
-                                                     sections.getById(5), sections.getById(6)]);
-            });
+        it("highlights the available cells", function() {
+            spyOn(matrix, "highlightTimeslots");
+            sections.selectSection(sections.getById(3));
+            expect(matrix.highlightTimeslots).toHaveBeenCalled();
         });
 
-        describe("selectSection", function() {
-            it("selects all cells that hold the section", function() {
-                var cell1 = matrix.getCell("room-2", 11);
-                var cell2 = matrix.getCell("room-2", 13);
-                spyOn(cell1, "select");
-                spyOn(cell2, "select");
-                sections.selectSection(sections.getById(3));
-                expect(cell1.select).toHaveBeenCalled();
-                expect(cell2.select).toHaveBeenCalled();                
-            });
-
-            it("highlights the available cells", function() {
-                spyOn(matrix, "highlightTimeslots");
-                sections.selectSection(sections.getById(3));
-                expect(matrix.highlightTimeslots).toHaveBeenCalled();    
-            });
-
-            it("displays the section's information on the panel", function() {
-                spyOn(matrix.sectionInfoPanel, "displaySection");
-                sections.selectSection(sections.getById(3));
-                expect(matrix.sectionInfoPanel.displaySection).toHaveBeenCalled();
-            });
-
+        it("displays the section's information on the panel", function() {
+            spyOn(matrix.sectionInfoPanel, "displaySection");
+            sections.selectSection(sections.getById(3));
+            expect(matrix.sectionInfoPanel.displaySection).toHaveBeenCalled();
         });
 
-        describe("unselectSection", function() {
-            beforeEach(function() {
-                sections.selectSection(sections.getById(3));
-            });
-            
-            it("unselects all cells that hold the section", function() {
-                var cell1 = matrix.getCell("room-2", 11);
-                var cell2 = matrix.getCell("room-2", 13);
-                spyOn(cell1, "unselect");
-                spyOn(cell2, "unselect");
-                sections.unselectSection(sections.getById(3));
-                expect(cell1.unselect).toHaveBeenCalled();
-                expect(cell2.unselect).toHaveBeenCalled();                
-            });
+    });
 
-            it("unhighlights the available cells", function() {
-                spyOn(matrix, "unhighlightTimeslots");
-                sections.unselectSection(sections.getById(3));
-                expect(matrix.unhighlightTimeslots).toHaveBeenCalled();    
-            });
+    describe("unselectSection", function() {
+        beforeEach(function() {
+            sections.selectSection(sections.getById(3));
+        });
 
-            it("hides the section information panel", function() {
-                spyOn(matrix.sectionInfoPanel, "hide");
-                sections.unselectSection(sections.getById(3));
-                expect(matrix.sectionInfoPanel.hide).toHaveBeenCalled();
- 
-            });
+        it("unselects all cells that hold the section", function() {
+            var cell1 = matrix.getCell("room-2", 11);
+            var cell2 = matrix.getCell("room-2", 13);
+            spyOn(cell1, "unselect");
+            spyOn(cell2, "unselect");
+            sections.unselectSection(sections.getById(3));
+            expect(cell1.unselect).toHaveBeenCalled();
+            expect(cell2.unselect).toHaveBeenCalled();
+        });
+
+        it("unhighlights the available cells", function() {
+            spyOn(matrix, "unhighlightTimeslots");
+            sections.unselectSection(sections.getById(3));
+            expect(matrix.unhighlightTimeslots).toHaveBeenCalled();
+        });
+
+        it("hides the section information panel", function() {
+            spyOn(matrix.sectionInfoPanel, "hide");
+            sections.unselectSection(sections.getById(3));
+            expect(matrix.sectionInfoPanel.hide).toHaveBeenCalled();
 
         });
 
-        describe("getAvailableTimeslots", function() {
-            it("gets the timeslots available for the section", function() {
-                expect(sections.getAvailableTimeslots(sections.getById(2))).toEqual([[5], [3, 3]]); 
+    });
+
+    describe("getAvailableTimeslots", function() {
+        it("gets the timeslots available for the section", function() {
+            expect(sections.getAvailableTimeslots(sections.getById(2))).toEqual([[5], [3, 3]]);
+        });
+    });
+
+    describe("getTeachersString", function() {
+        it("gets all teachers for the section separated by a comma", function() {
+            expect(sections.getTeachersString(sections.getById(1))).toEqual("Alyssa P. Hacker, Ben Bitdiddle");
+        });
+
+    });
+
+
+    describe("scheduleSection", function(){
+        describe("when validations return true", function(){
+            it("calls out to the api", function() {
+                spyOn(sections.apiClient, 'schedule_section');
+                spyOn(matrix, 'validateAssignment').andReturn({valid: true});
+                sections.scheduleSection(sections.getById(2), "room-2", 5);
+                expect(sections.apiClient.schedule_section).toHaveBeenCalled();
+
+                var args = sections.apiClient.schedule_section.argsForCall[0];
+                expect(args[0]).toEqual(2);
+                expect(args[1]).toEqual([5]);
+                expect(args[2]).toEqual("room-2");
             });
         });
 
-        describe("getTeachersString", function() {
-            it("gets all teachers for the section separated by a comma", function() {
-                expect(sections.getTeachersString(sections.getById(1))).toEqual("Alyssa P. Hacker, Ben Bitdiddle");
+        describe("when validations return false", function(){
+            it("doesn't call out to the api", function() {
+                spyOn(sections.apiClient, 'schedule_section');
+                spyOn(matrix, 'validateAssignment').andReturn(false);
+                sections.scheduleSection(sections.getById(2), "room-2", 3);
+                expect(sections.apiClient.schedule_section).not.toHaveBeenCalled();
             });
+        });
+    });
 
+    describe("unscheduleSection", function(){
+        it("calls out to the api", function() {
+            spyOn(sections.apiClient, 'unschedule_section');
+            sections.unscheduleSection(sections.getById(2));
+            expect(sections.apiClient.unschedule_section).toHaveBeenCalled();
+
+            var args = sections.apiClient.unschedule_section.argsForCall[0];
+            expect(args[0]).toEqual(2);
+        });
+    });
+
+
+    describe("scheduleSectionLocal", function(){
+        it("inserts the class into the matrix", function(){
+            var cell1 = matrix.getCell("room-2", 5);
+            var cell2 = matrix.getCell("room-2", 3);
+            spyOn(cell1, 'addSection');
+            spyOn(cell2, 'addSection');
+            sections.scheduleSectionLocal(sections.getById(2), "room-2", [5]);
+            expect(cell1.addSection).toHaveBeenCalledWith(sections.getById(2));
+            expect(cell2.addSection).not.toHaveBeenCalledWith(sections.getById(2));
+            expect(sections.scheduleAssignments[2]).toEqual({room_name: "room-2", timeslots: [5], id: 2});
         });
 
-
-        describe("scheduleSection", function(){
-                describe("when validations return true", function(){
-                    it("calls out to the api", function() {
-                        spyOn(sections.apiClient, 'schedule_section');
-                        spyOn(matrix, 'validateAssignment').andReturn({valid: true});
-                        sections.scheduleSection(sections.getById(2), "room-2", 5);
-                        expect(sections.apiClient.schedule_section).toHaveBeenCalled();
-
-                        var args = sections.apiClient.schedule_section.argsForCall[0];
-                        expect(args[0]).toEqual(2);
-                        expect(args[1]).toEqual([5]);
-                        expect(args[2]).toEqual("room-2");
-                        });
-                    });
-
-                describe("when validations return false", function(){
-                    it("doesn't call out to the api", function() {
-                        spyOn(sections.apiClient, 'schedule_section');
-                        spyOn(matrix, 'validateAssignment').andReturn(false);
-                        sections.scheduleSection(sections.getById(2), "room-2", 3);
-                        expect(sections.apiClient.schedule_section).not.toHaveBeenCalled();
-                        });
-                    });
+        it("unschedules the class from the old location", function(){
+            var cell = matrix.getCell("room-1", 3);
+            spyOn(cell, 'removeSection');
+            sections.scheduleSectionLocal(sections.getById(1), "room-2", [5]);
+            expect(cell.removeSection).toHaveBeenCalled();
+            expect(sections.scheduleAssignments[1]).toEqual({room_name: "room-2", timeslots: [5], id: 1});
         });
 
-        describe("unscheduleSection", function(){
-                it("calls out to the api", function() {
-                    spyOn(sections.apiClient, 'unschedule_section');
-                    sections.unscheduleSection(sections.getById(2));
-                    expect(sections.apiClient.unschedule_section).toHaveBeenCalled();
+        describe("when the class is already scheduled in the same spot", function(){
+            beforeEach(function(){
+                sections.scheduleSectionLocal(sections.getById(1), "room-1", [3]);
+            })
 
-                    var args = sections.apiClient.unschedule_section.argsForCall[0];
-                    expect(args[0]).toEqual(2);
-                    });
-                });
+            it("doesn't change anything when the assignment is the same as the old one", function(){
+                expect(matrix.getCell("room-1", 3).section).toEqual(sections.getById(1));
+            })
+        })
 
-
-        describe("scheduleSectionLocal", function(){
-                it("inserts the class into the matrix", function(){
-                    var cell1 = matrix.getCell("room-2", 5);
-                    var cell2 = matrix.getCell("room-2", 3);
-                    spyOn(cell1, 'addSection');
-                    spyOn(cell2, 'addSection');
-                    sections.scheduleSectionLocal(sections.getById(2), "room-2", [5]);
-                    expect(cell1.addSection).toHaveBeenCalledWith(sections.getById(2));
-                    expect(cell2.addSection).not.toHaveBeenCalledWith(sections.getById(2));
-                    expect(sections.scheduleAssignments[2]).toEqual({room_name: "room-2", timeslots: [5], id: 2});
-                    });
-
-                it("unschedules the class from the old location", function(){
-                    var cell = matrix.getCell("room-1", 3);
-                    spyOn(cell, 'removeSection');
-                    sections.scheduleSectionLocal(sections.getById(1), "room-2", [5]);
-                    expect(cell.removeSection).toHaveBeenCalled();
-                    expect(sections.scheduleAssignments[1]).toEqual({room_name: "room-2", timeslots: [5], id: 1});
-                    });
-
-                describe("when the class is already scheduled in the same spot", function(){
-                        beforeEach(function(){
-                            sections.scheduleSectionLocal(sections.getById(1), "room-1", [3]);
-                            })
-
-                        it("doesn't change anything when the assignment is the same as the old one", function(){
-                            expect(matrix.getCell("room-1", 3).section).toEqual(sections.getById(1));
-                            })
-                        })
-
-                it("fires a schedule-changed event", function(){
-                        var event_fired = false;
-                        $j("body").on("schedule-changed", function(){
-                            event_fired = true;
-                            })
-                        sections.scheduleSection(sections.getById(3), "room-3", 11);
-                        expect(event_fired).toBeTrue();
-                        });
-
-                afterEach(function() {
-                        matrix.getCell("room-2", 3).removeSection();
-                        matrix.getCell("room-2", 5).removeSection();
-                        });
+        it("fires a schedule-changed event", function(){
+            var event_fired = false;
+            $j("body").on("schedule-changed", function(){
+                event_fired = true;
+            })
+            sections.scheduleSection(sections.getById(3), "room-3", 11);
+            expect(event_fired).toBeTrue();
         });
 
-        describe("unscheduleSectionLocal", function(){
-                it("removes the class from the matrix", function(){
-                    sections.unscheduleSectionLocal(sections.getById(1));
-                    expect(matrix.getCell("room-2", 3).section).not.toEqual(sections.getById(1));
-                    });
+        afterEach(function() {
+            matrix.getCell("room-2", 3).removeSection();
+            matrix.getCell("room-2", 5).removeSection();
+        });
+    });
 
-                it("fires a schedule-changed event", function(){
-                    var event_fired = false;
-                    $j("body").on("schedule-changed", function(){
-                        event_fired = true;
-                        })
-                    sections.unscheduleSectionLocal(sections.getById(1));
-                    expect(event_fired).toBeTrue();
-                    });
-
-                it("modifies the schedule_assignments data structure", function(){
-                    expect(sections.scheduleAssignments[1]).toEqual({room_name: "room-1", timeslots: [3], id: 1});
-                    sections.unscheduleSectionLocal(sections.getById(1));
-                    expect(sections.scheduleAssignments[1]).toEqual({room_name: null, timeslots: [], id: 1});
-                    });
+    describe("unscheduleSectionLocal", function(){
+        it("removes the class from the matrix", function(){
+            sections.unscheduleSectionLocal(sections.getById(1));
+            expect(matrix.getCell("room-2", 3).section).not.toEqual(sections.getById(1));
         });
 
-
-        describe("scheduleAsGhost", function() {
-                it("displays the section as a ghost", function() {
-                    var section = sections.getById(3);
-                    console.log(sections);
-                    sections.selectSection(section);
-                    sections.scheduleAsGhost("room-3", 11);
-                    expect(matrix.getCell("room-3", 11).el.hasClass("ghost-section")).toBeTrue();
-                    expect(matrix.getCell("room-3", 13).el.hasClass("ghost-section")).toBeTrue();
-                });
-
+        it("fires a schedule-changed event", function(){
+            var event_fired = false;
+            $j("body").on("schedule-changed", function(){
+                event_fired = true;
+            })
+            sections.unscheduleSectionLocal(sections.getById(1));
+            expect(event_fired).toBeTrue();
         });
 
-        describe("unscheduleAsGhost", function() {
-                it("removes section from all cells", function() {
-                    var section = sections.getById(3);
-                    sections.selectSection(section);    
-                    sections.scheduleAsGhost("room-3", 11);
-                    sections.unscheduleAsGhost(); 
-                });
+        it("modifies the schedule_assignments data structure", function(){
+            expect(sections.scheduleAssignments[1]).toEqual({room_name: "room-1", timeslots: [3], id: 1});
+            sections.unscheduleSectionLocal(sections.getById(1));
+            expect(sections.scheduleAssignments[1]).toEqual({room_name: null, timeslots: [], id: 1});
         });
+    });
+
+
+    describe("scheduleAsGhost", function() {
+        it("displays the section as a ghost", function() {
+            var section = sections.getById(3);
+            console.log(sections);
+            sections.selectSection(section);
+            sections.scheduleAsGhost("room-3", 11);
+            expect(matrix.getCell("room-3", 11).el.hasClass("ghost-section")).toBeTrue();
+            expect(matrix.getCell("room-3", 13).el.hasClass("ghost-section")).toBeTrue();
+        });
+
+    });
+
+    describe("unscheduleAsGhost", function() {
+        it("removes section from all cells", function() {
+            var section = sections.getById(3);
+            sections.selectSection(section);
+            sections.scheduleAsGhost("room-3", 11);
+            sections.unscheduleAsGhost();
+        });
+    });
 });

--- a/esp/public/media/scripts/ajaxschedulingmodule/spec/TestFixtures.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/spec/TestFixtures.js
@@ -20,9 +20,9 @@
  * Classes:
  * --------------------
  *   code    length   availability       teachers
- * - S11s1   1        3, 5               1, 2          
+ * - S11s1   1        3, 5               1, 2
  * - S11s2   1        3, 5               1, 2
- * - A22s1   2        11, 13             4        
+ * - A22s1   2        11, 13             4
  * - S33s1   2        3, 5, 7, 11        1
  * - A44s1   1        7, 11, 13          3
  * - M55S1   1        7, 11              1, 3
@@ -36,7 +36,7 @@ function teacher_fixture() {
             last_name: "Hacker",
             username: "aphacker",
             availability: [3, 5, 7, 11],
-            sections: [1, 2, 4, 6], 
+            sections: [1, 2, 4, 6],
         },
         2: {
             id: 2,
@@ -60,7 +60,7 @@ function teacher_fixture() {
             last_name: "Beaver",
             username: "tbeaver",
             availability: [11, 13],
-            sections: [3],            
+            sections: [3],
         },
     };
 };
@@ -302,4 +302,3 @@ function schedule_assignment_fixture() {
         }
     };
 };
-

--- a/esp/public/media/scripts/ajaxschedulingmodule/spec/TestFixtures.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/spec/TestFixtures.js
@@ -138,121 +138,127 @@ function room_fixture() {
 
 function section_1() {
     return {
-	    status: 10, 
-	    category: 'S', 
-	    parent_class: 11, 
-	    emailcode: 'S11s1', 
-	    index: 1, 
-	    title: "Fascinating Science Phenomena", 
-	    category_id: 1, 
-	    class_size_max: 150, 
-	    length: .83, 
-	    grade_min: 9, 
-	    num_students: 0, 
-	    grade_max: 12, 
-	    id: 1, 
-	    teachers: [1, 2]
-	};
+        status: 10,
+        category: 'S',
+        parent_class: 11,
+        emailcode: 'S11s1',
+        index: 1,
+        title: "Fascinating Science Phenomena",
+        category_id: 1,
+        class_size_max: 150,
+        length: .83,
+        grade_min: 9,
+        num_students: 0,
+        grade_max: 12,
+        id: 1,
+        teachers: [1, 2],
+        resource_requests: {1: []}
+    };
 };
 
 function section_1b() {
     return {
-        status: 10, 
-        category: 'S', 
-        parent_class: 11, 
-        emailcode: 'S11s2', 
-        index: 1, 
-        title: "Fascinating Science Phenomena", 
-        category_id: 1, 
-        class_size_max: 150, 
-        length: .83, 
-        grade_min: 9, 
-        num_students: 0, 
-        grade_max: 12, 
-        id: 2, 
-        teachers: [1, 2]
+        status: 10,
+        category: 'S',
+        parent_class: 11,
+        emailcode: 'S11s2',
+        index: 1,
+        title: "Fascinating Science Phenomena",
+        category_id: 1,
+        class_size_max: 150,
+        length: .83,
+        grade_min: 9,
+        num_students: 0,
+        grade_max: 12,
+        id: 2,
+        teachers: [1, 2],
+        resource_requests: {2: []}
     };
 };
 
 function section_2() {
     return {
-        status: 10, 
-        category: 'A', 
-        parent_class: 22, 
-        emailcode: 'A22s1', 
-        index: 2, 
-        title: "Art History", 
-        category_id: 2, 
-        class_size_max: 75, 
-        length: 1.83, 
-        grade_min: 10, 
-        num_students: 0, 
-        grade_max: 11, 
-        id: 3, 
-        teachers: [4]
+        status: 10,
+        category: 'A',
+        parent_class: 22,
+        emailcode: 'A22s1',
+        index: 2,
+        title: "Art History",
+        category_id: 2,
+        class_size_max: 75,
+        length: 1.83,
+        grade_min: 10,
+        num_students: 0,
+        grade_max: 11,
+        id: 3,
+        teachers: [4],
+        resource_requests: {3: []}
     };
 };
 
 function section_3() {
     return {
-        status: 10, 
-        category: 'S', 
-        parent_class: 33, 
-        emailcode: 'S33s1', 
+        status: 10,
+        category: 'S',
+        parent_class: 33,
+        emailcode: 'S33s1',
         index: 4,
-        title: "Hands on Science", 
-        category_id: 1, 
-        class_size_max: 3, 
-        length: 1.83, 
-        grade_min: 9, 
-        num_students: 0, 
-        grade_max: 10, 
-        id: 4, 
-        teachers: [1]
+        title: "Hands on Science",
+        category_id: 1,
+        class_size_max: 3,
+        length: 1.83,
+        grade_min: 9,
+        num_students: 0,
+        grade_max: 10,
+        id: 4,
+        teachers: [1],
+        resource_requests: {4: []}
     };
 };
 
 function section_4() {
     return {
-        status: 10, 
+        status: 10,
         category: 'A',
-        parent_class: 44, 
-        emailcode: 'A44s1', 
-        index: 5, 
-        title: "Drawing 101", 
-        category_id: 2, 
-        class_size_max: 50, 
-        length: 1.83, 
-        grade_min: 9, 
-        num_students: 0, 
-        grade_max: 12, 
-        id: 5, 
-        teachers: [3]
+        parent_class: 44,
+        emailcode: 'A44s1',
+        index: 5,
+        title: "Drawing 101",
+        category_id: 2,
+        class_size_max: 50,
+        length: 1.83,
+        grade_min: 9,
+        num_students: 0,
+        grade_max: 12,
+        id: 5,
+        teachers: [3],
+        resource_requests: {5: []}
     };
 };
 
 function section_5() {
     return {
-        status: 10, 
-        category: 'M', 
-        parent_class: 55, 
-        emailcode: 'M55s1', 
-        index: 6, 
-        title: "Representation Theory", 
-        category_id: 3, 
-        class_size_max: 25, 
-        length: 1.83, 
-        grade_min: 10, 
-        num_students: 0, 
-        grade_max: 12, 
-        id: 6, 
-        teachers: [1, 3]
+        status: 10,
+        category: 'M',
+        parent_class: 55,
+        emailcode: 'M55s1',
+        index: 6,
+        title: "Representation Theory",
+        category_id: 3,
+        class_size_max: 25,
+        length: 1.83,
+        grade_min: 10,
+        num_students: 0,
+        grade_max: 12,
+        id: 6,
+        teachers: [1, 3],
+        resource_requests: {6: []}
     };
 };
 
 function section_fixture() {
     return {
-        1: section_1(), 
+        1: section_1(),
         2: section_1b(),
         3: section_2(),
         4: section_3(),

--- a/esp/public/media/scripts/ajaxschedulingmodule/spec/TimeslotsSpec.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/spec/TimeslotsSpec.js
@@ -5,7 +5,7 @@ describe("Timeslots", function(){
 
     beforeEach(function() {
         times = time_fixture();
-        t = new Timeslots(times, []);
+        t = new Timeslots(times);
         one_hour_section = section_1();
         two_hour_section = section_2();
     });
@@ -47,7 +47,7 @@ describe("Timeslots", function(){
 
         it("returns 1 for a 1 hour timeslot", function(){
             times[3].length = 1;
-            t = new Timeslots(times, []);
+            t = new Timeslots(times);
             expect(t.get_hours_spanned(3, 3)).toEqual(1);
         });
 

--- a/esp/public/media/scripts/ajaxschedulingmodule/spec/TimeslotsSpec.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/spec/TimeslotsSpec.js
@@ -5,9 +5,9 @@ describe("Timeslots", function(){
 
         beforeEach(function() {
             times = time_fixture();
-            t = new Timeslots(times);
+            t = new Timeslots(times, []);
             one_hour_section = section_1();
-            two_hour_section = section_2(); 
+            two_hour_section = section_2();
         });
 
         it("returns timeslots by id", function(){

--- a/esp/public/media/scripts/ajaxschedulingmodule/spec/TimeslotsSpec.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/spec/TimeslotsSpec.js
@@ -1,58 +1,58 @@
 describe("Timeslots", function(){
-        var t, times;
-        var one_hour_section;
-        var two_hour_section;
+    var t, times;
+    var one_hour_section;
+    var two_hour_section;
 
-        beforeEach(function() {
-            times = time_fixture();
-            t = new Timeslots(times, []);
-            one_hour_section = section_1();
-            two_hour_section = section_2();
+    beforeEach(function() {
+        times = time_fixture();
+        t = new Timeslots(times, []);
+        one_hour_section = section_1();
+        two_hour_section = section_2();
+    });
+
+    it("returns timeslots by id", function(){
+        expect(t.get_by_id(3)).toEqual(times[3]);
+        expect(t.get_by_id(5)).toEqual(times[5]);
+    });
+
+    it("returns timeslots by order", function(){
+        expect(t.get_by_order(0)).toEqual(times[3]);
+        expect(t.get_by_order(1)).toEqual(times[5]);
+    });
+
+    describe("get_timeslots_to_schedule_section", function(){
+        describe("a one hour class", function(){
+            it("returns the timeslot passed", function(){
+                expect(t.get_timeslots_to_schedule_section(one_hour_section, 3)).toEqual([3]);
+            });
         });
 
-        it("returns timeslots by id", function(){
-            expect(t.get_by_id(3)).toEqual(times[3]);
-            expect(t.get_by_id(5)).toEqual(times[5]);
+        describe("a two hour class", function(){
+            it("returns the timeslot passed and the next one", function(){
+                expect(t.get_timeslots_to_schedule_section(two_hour_section, 3)).toEqual([3,5]);
             });
+        });
 
-        it("returns timeslots by order", function(){
-            expect(t.get_by_order(0)).toEqual(times[3]);
-            expect(t.get_by_order(1)).toEqual(times[5]);
+        describe("when scheduling over the day break", function(){
+            it("returns null", function(){
+                expect(t.get_timeslots_to_schedule_section(two_hour_section, 5)).toEqual(null);
             });
+        });
+    });
 
-        describe("get_timeslots_to_schedule_section", function(){
-                describe("a one hour class", function(){
-                    it("returns the timeslot passed", function(){
-                        expect(t.get_timeslots_to_schedule_section(one_hour_section, 3)).toEqual([3]);
-                        });
-                    });
+    describe("get_timeslot_length", function(){
+        it("returns 1 for a .83 hour timeslot", function(){
+            expect(t.get_hours_spanned(3, 3)).toEqual(1);
+        });
 
-                describe("a two hour class", function(){
-                    it("returns the timeslot passed and the next one", function(){
-                        expect(t.get_timeslots_to_schedule_section(two_hour_section, 3)).toEqual([3,5]);
-                        });
-                    });
+        it("returns 1 for a 1 hour timeslot", function(){
+            times[3].length = 1;
+            t = new Timeslots(times, []);
+            expect(t.get_hours_spanned(3, 3)).toEqual(1);
+        });
 
-                describe("when scheduling over the day break", function(){
-                    it("returns null", function(){
-                        expect(t.get_timeslots_to_schedule_section(two_hour_section, 5)).toEqual(null);
-                        });
-                    });
-                });
-
-        describe("get_timeslot_length", function(){
-                it("returns 1 for a .83 hour timeslot", function(){
-                    expect(t.get_hours_spanned(3, 3)).toEqual(1);
-                    });
-
-                it("returns 1 for a 1 hour timeslot", function(){
-                    times[3].length = 1;
-                    t = new Timeslots(times, []);
-                    expect(t.get_hours_spanned(3, 3)).toEqual(1);
-                    });
-
-                it("returns 2 for a 1.83 hour timeslot", function(){
-                    expect(t.get_hours_spanned(3, 5)).toEqual(2);
-                    });
-                });
+        it("returns 2 for a 1.83 hour timeslot", function(){
+            expect(t.get_hours_spanned(3, 5)).toEqual(2);
+        });
+    });
 });

--- a/esp/public/media/scripts/ajaxschedulingmodule/spec/TimeslotsSpec.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/spec/TimeslotsSpec.js
@@ -42,17 +42,17 @@ describe("Timeslots", function(){
 
         describe("get_timeslot_length", function(){
                 it("returns 1 for a .83 hour timeslot", function(){
-                    expect(t.get_time_between(3, 3)).toEqual(1);
+                    expect(t.get_hours_spanned(3, 3)).toEqual(1);
                     });
 
                 it("returns 1 for a 1 hour timeslot", function(){
                     times[3].length = 1;
-                    t = new Timeslots(times);
-                    expect(t.get_time_between(3, 3)).toEqual(1);
+                    t = new Timeslots(times, []);
+                    expect(t.get_hours_spanned(3, 3)).toEqual(1);
                     });
 
                 it("returns 2 for a 1.83 hour timeslot", function(){
-                    expect(t.get_time_between(3, 5)).toEqual(2);
+                    expect(t.get_hours_spanned(3, 5)).toEqual(2);
                     });
                 });
 });

--- a/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
+++ b/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
@@ -56,16 +56,16 @@
       <div id="matrix-div" class="component-div"></div>
     </td>
     <td class="no-border">
-      <div id="side-panel-wrapper" class="component-div ui-widget">
+      <div id="side-panel-wrapper" class="ui-widget">
         <div id="section-info-div" class="component-div ui-widget ui-corner-all ui-helper-hidden"></div>
         <div id="message-div" class="component-div ui-widget-content ui-corner-all"></div>
 
-        <div id="side-panel" class="ui-widget">
-          <ul> 
+        <div id="side-panel" class="component-div ui-widget">
+          <ul>
             <li><a href="#classes">Classes</a></li>
             <li><a href="#filters">Filters</a></li>
           </ul>
-          <div id="side-panel">
+          <div id="side-panel-inner">
                 <div id="classes">
                     <div id="class-search">
                         <form>

--- a/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
+++ b/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
@@ -42,6 +42,7 @@
 <script type="text/javascript" src="/media/scripts/ajaxschedulingmodule/ESP/Directory.js"></script>
 <script type="text/javascript" src="/media/scripts/ajaxschedulingmodule/ESP/Matrix.js"></script>
 <script type="text/javascript" src="/media/scripts/ajaxschedulingmodule/ESP/MessagePanel.js"></script>
+<script type="text/javascript" src="/media/scripts/ajaxschedulingmodule/ESP/SectionCommentDialog.js"></script>
 <script type="text/javascript" src="/media/scripts/ajaxschedulingmodule/ESP/SectionInfoPanel.js"></script>
 <script type="text/javascript" src="/media/scripts/ajaxschedulingmodule/ESP/ChangelogFetcher.js"></script>
 <script type="text/javascript" src="/media/scripts/ajaxschedulingmodule/ESP/Scheduler.js"></script>
@@ -115,6 +116,17 @@
     </td>
   </tr>
 </table>
+
+<div id="commentDialog">
+  <form>
+    <fieldset>
+      <label for="commentDialog-comment">Comment</label>
+      <input type="text" id="commentDialog-comment" class="ui-widget-content ui-corner-all" />
+      <input type="checkbox" id="commentDialog-lock" class="ui-widget-content ui-corner-all" />
+      <label for="commentDialog-lock">Lock</label>
+    </fieldset>
+  </form>
+</div>
 
 </body>
 </html>


### PR DESCRIPTION
A few improvements to AJAX scheduler code:

* Fix test suite
* Don't allow scheduling over non-contiguous timeslots (e.g. for dinner block) -- #1797 
* Make spacing consistent...