### PR TITLE
Add (optional) Sentry integration

### DIFF
--- a/esp/esp/django_settings.py
+++ b/esp/esp/django_settings.py
@@ -78,6 +78,7 @@ TEMPLATE_DEBUG = False
 SHOW_TEMPLATE_ERRORS = False
 CACHE_DEBUG = False
 USE_PROFILER = False
+SENTRY_DSN = ""  # (disabled)
 
 INTERNAL_IPS = (
     '127.0.0.1',

--- a/esp/esp/settings.py
+++ b/esp/esp/settings.py
@@ -78,7 +78,7 @@ MANAGERS = ADMINS
 
 TEMPLATE_DIRS = (
     os.path.join(PROJECT_ROOT, 'templates'),
-    
+
 )
 
 DEFAULT_HOST = SITE_INFO[1]
@@ -115,3 +115,18 @@ if not getattr(tempfile, 'alreadytwiddled', False): # Python appears to run this
 CSRF_COOKIE_NAME = 'esp_csrftoken'
 
 SKIP_SOUTH_TESTS = True # To disable South's own unit tests
+
+if SENTRY_DSN:
+    # If SENTRY_DSN is set, send errors to Sentry via the Raven exception
+    # handler. Note that our exception middleware (i.e., ESPErrorMiddleware
+    # and PrettyErrorEmailMiddlware) will remain enabled and will receive
+    # exceptions before Raven does.
+    import raven
+
+    INSTALLED_APPS += (
+        'raven.contrib.django.raven_compat',
+    )
+    RAVEN_CONFIG = {
+        'dsn': SENTRY_DSN,
+        'release': raven.fetch_git_sha(os.path.join(PROJECT_ROOT, '..')),
+    }

--- a/esp/templates/500.html
+++ b/esp/templates/500.html
@@ -13,6 +13,14 @@
    This probably means we messed up. Please email us at
      <pre>{{ DEFAULT_EMAIL_ADDRESSES.support }}</pre>
    explaining to us how you got this message, and we'll try to fix it.
+
+   {% if request.sentry %}
+   <br />
+   <br />
+   Please include the following error ID:
+     <pre>{{ request.sentry.id }}</pre>
+   {% endif %}
+
    <br />
    <br />
    <br />


### PR DESCRIPTION
Enable sites to log errors to Sentry. This shouldn't interfere with the existing email/serverlog logging. In addition, the Sentry error ID is displayed on the 500 page, so we can connect user reports to their tracebacks.