### PR TITLE
Make Fabric dev setup a bit more fail-safe

### DIFF
--- a/esp/fabfile.py
+++ b/esp/fabfile.py
@@ -131,8 +131,9 @@ def link_media():
         return
 
     with cd('%s/esp/public/media' % REMOTE_PROJECT_DIR):
-        run('ln -s -T default_images images || true')
-        run('ln -s -T default_styles styles || true')
+        with settings(warn_only=True):
+            run('ln -s -T default_images images')
+            run('ln -s -T default_styles styles')
 
 def mount_encrypted_partition():
     if sudo('df | grep encrypted | wc -l').strip() == '1':

--- a/esp/fabfile.py
+++ b/esp/fabfile.py
@@ -144,15 +144,17 @@ def mount_encrypted_partition():
         sudo('cryptsetup luksOpen /dev/mapper/%s encrypted' % (ENCRYPTED_VG_NAME,))
     sudo('mount /dev/mapper/encrypted /mnt/encrypted')
 
-def create_encrypted_partition():
-
+def ensure_encrypted_partition():
     #   Check for the encrypted partition already existing on the
     #   VM, and quit if it does.
     if sudo('cryptsetup isLuks /dev/mapper/%s ; echo $?' % (ENCRYPTED_VG_NAME,)).strip() == '0':
         print 'Encrypted partition already exists; mounting.'
         mount_encrypted_partition()
         return
-    
+    create_encrypted_partition()
+
+@task
+def create_encrypted_partition():
     print 'Now creating encrypted partition for data storage.'
     print 'Please make up a passphrase and enter it when prompted.'
     
@@ -206,7 +208,7 @@ def load_db_dump(dbuser, dbfile):
         using that encrypted storage.   """
 
     with use_vagrant():
-        create_encrypted_partition()
+        ensure_encrypted_partition()
         load_encrypted_database(dbuser, dbfile)
 
 @task

--- a/esp/fabfile.py
+++ b/esp/fabfile.py
@@ -222,7 +222,7 @@ def load_db_dump(dbuser, dbfile):
 def recreate_encrypted_partition():
     """ Blow away any previous encrypted partition and create a new one. """
 
-    with use_container():
+    with use_vagrant():
         create_encrypted_partition()
 
 @task

--- a/esp/fabfile.py
+++ b/esp/fabfile.py
@@ -131,8 +131,8 @@ def link_media():
         return
 
     with cd('%s/esp/public/media' % REMOTE_PROJECT_DIR):
-        run('ln -s default_images images')
-        run('ln -s default_styles styles')
+        run('ln -s -T default_images images || true')
+        run('ln -s -T default_styles styles || true')
 
 def mount_encrypted_partition():
     if sudo('df | grep encrypted | wc -l').strip() == '1':


### PR DESCRIPTION
Handle a couple of exception cases.
- Add fab command to overwrite existing encrypted partition (in case someone loses the encryption password)
- Make link_media do the right thing if run multiple times (instead of erroring out because the symbolic link already exists)