### PR TITLE
Fix grade options in OnSiteRegForm

### DIFF
--- a/esp/esp/program/modules/forms/onsite.py
+++ b/esp/esp/program/modules/forms/onsite.py
@@ -2,7 +2,7 @@ from django import forms
 from esp.program.models import RegistrationProfile
 from esp.db.forms import AjaxForeignKeyNewformField
 from esp.utils.widgets import DateTimeWidget
-from esp.users.models import K12School
+from esp.users.models import K12School, ESPUser
 import datetime
 
 class OnSiteRegForm(forms.Form):
@@ -17,6 +17,11 @@ class OnSiteRegForm(forms.Form):
     paid = forms.BooleanField(required = False)
     medical = forms.BooleanField(required = False)
     liability = forms.BooleanField(required = False)
+
+    def __init__(self, *args, **kwargs):
+        super(OnSiteRegForm, self).__init__(*args, **kwargs)
+        self.fields['grade'].choices = (
+            [('', '')] + [(x, x) for x in ESPUser.grade_options()])
 
 class OnSiteRapidCheckinForm(forms.Form):
     user = AjaxForeignKeyNewformField(field=RegistrationProfile.user.field, label='Student')


### PR DESCRIPTION
The onsite new registration form doesn't use the usual student info profile
form, so it wasn't picking up a custom grade range, as StudentInfoForm does.
Now it should.  (Fixes an issue reported by Clark.)