### PR TITLE
Monospace Font for QSD

### DIFF
--- a/esp/templates/qsd/qsd_edit.html
+++ b/esp/templates/qsd/qsd_edit.html
@@ -64,7 +64,7 @@
   <p>Please use <a href="http://daringfireball.net/projects/markdown/syntax">
      Markdown</a> whenever possible. (Although HTML will work.)
   </p>
-  <p><textarea class="wide" name="content" class="markdown" rows="50" style="font-family: monospace;">{{ content|escape }}</textarea></p>
+  <p><textarea class="wide" name="content" class="markdown" rows="50">{{ content|escape }}</textarea></p>
   <p><input type="submit" name="post_edit" value="Save Changes!" /> &nbsp;| <a href="{{ target_url }}">Cancel</a> | <a href="{{ return_to_view }}">Back to Page View</a></p>
 </form>
 <div id="divmainqsddatetimestamp">

--- a/esp/templates/qsd/qsd_edit.html
+++ b/esp/templates/qsd/qsd_edit.html
@@ -64,7 +64,7 @@
   <p>Please use <a href="http://daringfireball.net/projects/markdown/syntax">
      Markdown</a> whenever possible. (Although HTML will work.)
   </p>
-  <p><textarea class="wide" name="content" class="markdown" rows="50">{{ content|escape }}</textarea></p>
+  <p><textarea class="wide markdown" name="content" rows="50">{{ content|escape }}</textarea></p>
   <p><input type="submit" name="post_edit" value="Save Changes!" /> &nbsp;| <a href="{{ target_url }}">Cancel</a> | <a href="{{ return_to_view }}">Back to Page View</a></p>
 </form>
 <div id="divmainqsddatetimestamp">

--- a/esp/templates/qsd/qsd_edit.html
+++ b/esp/templates/qsd/qsd_edit.html
@@ -64,7 +64,7 @@
   <p>Please use <a href="http://daringfireball.net/projects/markdown/syntax">
      Markdown</a> whenever possible. (Although HTML will work.)
   </p>
-  <p><textarea class="wide" name="content" class="markdown" rows="50">{{ content|escape }}</textarea></p>
+  <p><textarea class="wide" name="content" class="markdown" rows="50" style="font-family: monospace;">{{ content|escape }}</textarea></p>
   <p><input type="submit" name="post_edit" value="Save Changes!" /> &nbsp;| <a href="{{ target_url }}">Cancel</a> | <a href="{{ return_to_view }}">Back to Page View</a></p>
 </form>
 <div id="divmainqsddatetimestamp">


### PR DESCRIPTION
Set standalone QSD edit page to use a monospace font for editing the HTML/markdown.