### PR TITLE
AJAX scheduler: option to hide unapproved classes.

### DIFF
--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
@@ -49,7 +49,7 @@ function Sections(sections_data, section_details_data, teacher_data, scheduleAss
         return result;
     }.bind(this);
     this.filter.classHideUnapproved.valid = function(a) {
-        return a.status === 10;
+        return a.status > 0;
     }.bind(this);
 
     $j.each(this.filter, function(filterName, filterObject) {

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
@@ -25,6 +25,7 @@ function Sections(sections_data, section_details_data, teacher_data, scheduleAss
         classCapacityMin: {active: false, el: $j("input#section-filter-capacity-min"), type: "number"},
         classCapacityMax: {active: false, el: $j("input#section-filter-capacity-max"), type: "number"},
         classTeacher: {active: false, el: $j("input#section-filter-teacher-text"), type: "string"},
+        classHideUnapproved: {active: false, el: $j("input#section-filter-unapproved"), type: "boolean"},
     };
     this.filter.classLengthMin.valid = function(a) {
         return Math.ceil(a.length) >= this.filter.classLengthMin.val;
@@ -47,6 +48,9 @@ function Sections(sections_data, section_details_data, teacher_data, scheduleAss
         }.bind(this));
         return result;
     }.bind(this);
+    this.filter.classHideUnapproved.valid = function(a) {
+        return a.status === 10;
+    }.bind(this);
 
     $j.each(this.filter, function(filterName, filterObject) {
         filterObject.el.change(function() {
@@ -55,8 +59,12 @@ function Sections(sections_data, section_details_data, teacher_data, scheduleAss
                 filterObject.val = parseInt(filterObject.val);
             } else if(filterObject.type==="string") {
                 filterObject.val = filterObject.val.replace(" ", "").toLowerCase()
+            } else if(filterObject.type==="boolean") {
+                filterObject.val = filterObject.el.prop('checked');
             }
-            if((filterObject.type==="number" && isNaN(filterObject.val)) || (filterObject.type==="string" && filterObject.val.trim()==="")) {
+            if((filterObject.type==="number" && isNaN(filterObject.val))
+                || (filterObject.type==="string" && filterObject.val.trim()==="")
+                || (filterObject.type==="boolean" && !filterObject.val)) {
                 filterObject.active = false;
             } else {
                 filterObject.active = true;

--- a/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
+++ b/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
@@ -108,6 +108,10 @@
                         <label for="section-filter-teacher-text"><b>Teacher</b></label></br>
                         <input id="section-filter-teacher-text"></input>
                     </div>
+                    <div id="section-filter-unapproved">
+                        <input id="section-filter-unapproved" type="checkbox"></input>
+                        <label for="section-filter-unapproved">Hide unapproved classes</label>
+                    </div>
                   </form>
                 </div>
           </div> 


### PR DESCRIPTION
This mimics the text and filtering strategy from the old AJAX scheduler.