### PR TITLE
Use sudo -H with npm so that it sets $HOME properly

### DIFF
--- a/esp/packages_base_manual_install.sh
+++ b/esp/packages_base_manual_install.sh
@@ -7,4 +7,4 @@ sudo apt-get install -y python-software-properties
 sudo add-apt-repository -y ppa:chris-lea/node.js
 sudo apt-get update
 sudo apt-get install -y nodejs
-sudo npm install -g less@1.3.1
+sudo -H npm install -g less@1.3.1

--- a/esp/packages_base_manual_install.sh
+++ b/esp/packages_base_manual_install.sh
@@ -7,4 +7,12 @@ sudo apt-get install -y python-software-properties
 sudo add-apt-repository -y ppa:chris-lea/node.js
 sudo apt-get update
 sudo apt-get install -y nodejs
-sudo -H npm install -g less@1.3.1
+
+if [[ ":$PATH:" == *":/usr/bin:"* ]]
+then
+    # explicitly pass --prefix /usr to npm
+    sudo -H npm install -g --prefix /usr less@1.3.1
+else
+    # no /usr/bin? hopefully this doesn't happen, let npm guess
+    sudo -H npm install -g less@1.3.1
+fi


### PR DESCRIPTION
Since npm tries to read and write $HOME/.npm, there can be issues
running sudo npm when root does not have permissions on $HOME/.npm
(such as if $HOME is in AFS). Fix this by using sudo -H, which sets
$HOME to root's home directory instead.