### PR TITLE
Add migration for change of QSD to Editable

### DIFF
--- a/esp/esp/qsd/migrations/0003_auto_20151108_1613.py
+++ b/esp/esp/qsd/migrations/0003_auto_20151108_1613.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('qsd', '0002_auto_20151004_1715'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='quasistaticdata',
+            options={'verbose_name': 'Editable'},
+        ),
+    ]


### PR DESCRIPTION
Apparently we were supposed to have a migration for the change of the model's
`verbose_name` in d336fba2, even though it doesn't affect the DB:
https://docs.djangoproject.com/en/1.8/ref/migration-operations/#altermodeloptions
This commit adds that migration.