### PR TITLE
Add another migration that doesn't affect the DB

### DIFF
--- a/esp/esp/program/migrations/0003_auto_20151108_1612.py
+++ b/esp/esp/program/migrations/0003_auto_20151108_1612.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('program', '0002_auto_20151004_1715'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='program',
+            name='program_size_max',
+            field=models.IntegerField(help_text=b'Set to 0 for no cap. Student registration performance is best when no cap is set.', null=True),
+        ),
+    ]


### PR DESCRIPTION
Similar to a7cc69d8, apparently django 1.8 migrations want to keep track of
help_text now too, despite it not being in the database.