### PR TITLE
Add raven to requirements.txt

### DIFF
--- a/esp/requirements.txt
+++ b/esp/requirements.txt
@@ -36,6 +36,7 @@ docutils==0.12
 Pygments==2.0.2
 twilio==3.6.5
 shortuuid==0.4.2
+raven
 
 # We are using the 2014-03-13 version of the Stripe API, which is v1.12.2.
 stripe==1.12.2


### PR DESCRIPTION
This is needed for the Sentry integration to work out of the box.

@benjaminjkraft -- this should go in SR7