### PR TITLE
Add a custom management command to create superusers properly

### DIFF
--- a/esp/esp/utils/management/commands/createsuperuseresp.py
+++ b/esp/esp/utils/management/commands/createsuperuseresp.py
@@ -1,0 +1,19 @@
+""" Overridden version of createsuperuser """
+
+from django.contrib.auth.management.commands.createsuperuser \
+    import Command as BaseSuperUserCommand
+
+from esp.users.models import ESPUser
+
+class Command(BaseSuperUserCommand):
+    def handle(self, *args, **options):
+        print "HELLO!"
+        super(Command, self).handle(*args, **options)
+
+        # All superusers should be members of the group "Administrator". We
+        # don't have the name of the one that was just created, so apply this
+        # action to all superusers in the database.
+        superusers = ESPUser.objects.filter(is_superuser=True)
+        for user in superusers:
+            user.makeRole("Administrator")
+        print "GOODBYE!"


### PR DESCRIPTION
Right now, running `manage.py createsuperuser` (which is done when starting from an empty database in development) results in an account that isn't a member of `Administrators`. The first problem this creates is that the user can't use the theme editor, which is the first step of setting up an empty site.

It's really hard to override an existing `manage.py` command, so we create our own: `createsuperuseresp`.