### PR TITLE
Ignore constraints when removing classes as onsite morphed user.

### DIFF
--- a/esp/esp/program/modules/handlers/studentclassregmodule.py
+++ b/esp/esp/program/modules/handlers/studentclassregmodule.py
@@ -721,7 +721,7 @@ class StudentClassRegModule(ProgramModuleObj):
         #   Take the student out if constraints allow
         for sec in oldclasses:
             result = sec.cannotRemove(request.user)
-            if result:
+            if result and not hasattr(request.user, "onsite_local"):
                 return result
             else:
                 sec.unpreregister_student(request.user)


### PR DESCRIPTION
The backend already ignores constraints when adding classes as onsite
(the frontend displays the would-be error on the fillslot page, and
gives the volunteer a strictly-worded "are you sure?" prompt before
overriding it). I think such a warning is less necessary for removing
classes, and this fixes a situation where it's possible for an onsite
user to override constraints on multiple classes and then not be able
to undo their actions.