### PR TITLE
Fix a stray `esp.cache`

### DIFF
--- a/esp/esp/program/modules/handlers/studentregcore.py
+++ b/esp/esp/program/modules/handlers/studentregcore.py
@@ -51,7 +51,6 @@ from esp.middleware.threadlocalrequest import AutoRequestContext as Context
 from django.http import HttpResponse
 from django.template.loader import render_to_string, get_template, select_template
 import operator
-from esp.cache import cache_function
 
 class StudentRegCore(ProgramModuleObj, CoreModule):
     @classmethod


### PR DESCRIPTION
It was added after #1850 was written but before it was merged, it appears.