### PR TITLE
Raise error instead of 500 when adminclass can't find a class.

### DIFF
--- a/esp/esp/program/modules/handlers/adminclass.py
+++ b/esp/esp/program/modules/handlers/adminclass.py
@@ -152,7 +152,7 @@ class AdminClass(ProgramModuleObj):
                     return (cls, False)
 
                 
-        return (render_to_response(self.baseDir()+'cannotfindclass.html', {}), False)
+        return (render_to_response(self.baseDir()+'cannotfindclass.html', request, {}), False)
 
     @aux_call
     @needs_admin


### PR DESCRIPTION
Fixes https://sentry.mit.edu/share/group/392e313134/