### PR TITLE
Properly import django.forms.utils.ErrorList.

### DIFF
--- a/esp/esp/program/modules/forms/teacherreg.py
+++ b/esp/esp/program/modules/forms/teacherreg.py
@@ -34,6 +34,7 @@ Learning Unlimited, Inc.
 """
 
 from django import forms
+from django.forms.utils import ErrorList
 from django.core import validators
 from django.core.exceptions import ObjectDoesNotExist
 from esp.utils.forms import StrippedCharField, FormWithRequiredCss, FormUnrestrictedOtherUser
@@ -254,8 +255,8 @@ class TeacherClassRegForm(FormWithRequiredCss):
             grade_max = int(grade_max)
             if grade_min > grade_max:
                 msg = u'Minimum grade must be less than the maximum grade.'
-                self._errors['grade_min'] = forms.util.ErrorList([msg])
-                self._errors['grade_max'] = forms.util.ErrorList([msg])
+                self._errors['grade_min'] = ErrorList([msg])
+                self._errors['grade_max'] = ErrorList([msg])
                 del cleaned_data['grade_min']
                 del cleaned_data['grade_max']
 
@@ -267,8 +268,8 @@ class TeacherClassRegForm(FormWithRequiredCss):
             class_size_max = int(class_size_max)
             if class_size_optimal > class_size_max:
                 msg = u'Optimal class size must be less than or equal to the maximum class size.'
-                self._errors['class_size_optimal'] = forms.util.ErrorList([msg])
-                self._errors['class_size_max'] = forms.util.ErrorList([msg])
+                self._errors['class_size_optimal'] = ErrorList([msg])
+                self._errors['class_size_max'] = ErrorList([msg])
                 del cleaned_data['class_size_optimal']
                 del cleaned_data['class_size_max']
 

--- a/esp/esp/users/forms/user_profile.py
+++ b/esp/esp/users/forms/user_profile.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.forms.utils import ErrorList
 from esp.tagdict.models import Tag
 from esp.utils.forms import SizedCharField, FormWithRequiredCss, FormUnrestrictedOtherUser, FormWithTagInitialValues, StrippedCharField
 from esp.db.forms import AjaxForeignKeyNewformField
@@ -428,7 +429,7 @@ class TeacherInfoForm(FormWithRequiredCss):
 
         if from_here == "False" and school == "":
             msg = u'Please enter your affiliation if you are not from %s.' % settings.INSTITUTION_NAME
-            self._errors['school'] = forms.util.ErrorList([msg])
+            self._errors['school'] = ErrorList([msg])
             del cleaned_data['from_here']
             del cleaned_data['school']
 


### PR DESCRIPTION
Addresses https://sentry.mit.edu/esp/esp-website/group/122/

```
AttributeError: 'module' object has no attribute 'util'
(6 additional frame(s) were not displayed)
...
  File "django/forms/forms.py", line 176, in errors
    self.full_clean()
  File "django/forms/forms.py", line 393, in full_clean
    self._clean_form()
  File "django/forms/forms.py", line 417, in _clean_form
    cleaned_data = self.clean()
  File "esp/users/forms/user_profile.py", line 66, in clean
    super(UserContactForm, self).clean()
  File "esp/users/forms/user_profile.py", line 431, in clean
    self._errors['school'] = forms.util.ErrorList([msg])
```