### PR TITLE
Move cf_cache import to inside ready()

### DIFF
--- a/esp/esp/customforms/apps.py
+++ b/esp/esp/customforms/apps.py
@@ -1,5 +1,4 @@
 from esp.utils.apps import InstallConfig
-from esp.customforms.linkfields import cf_cache
 
 class CustomformsConfig(InstallConfig):
     name = 'esp.customforms'
@@ -8,4 +7,8 @@ class CustomformsConfig(InstallConfig):
         super(CustomformsConfig, self).ready()
 
         # Initialize the model cache for customforms
+        # This import needs to go here because it will indirectly
+        # import some models and that shouldn't happen yet when
+        # this file is imported
+        from esp.customforms.linkfields import cf_cache
         cf_cache._populate()


### PR DESCRIPTION
This makes a deprecation warning go away.

For everyone's future reference, if you need to debug one of those, put 'raise Exception' at the top of the file with the model it's complaining about and now you have a traceback.