### PR TITLE
Deprecate `Resource.distance()`

### DIFF
--- a/esp/esp/resources/admin.py
+++ b/esp/esp/resources/admin.py
@@ -42,9 +42,9 @@ class ResourceTypeAdmin(admin.ModelAdmin):
         return "%s" % str(obj.choices)
     rt_choices.short_description = 'Choices'
 
-    list_display = ('name', 'description', 'only_one', 'consumable', 'autocreated', 'priority_default', 'rt_choices', 'distancefunc', 'program')
+    list_display = ('name', 'description', 'only_one', 'consumable', 'autocreated', 'priority_default', 'rt_choices', 'program')
     search_fields = ['name', 'description', 'consumable', 'priority_default',
-            'attributes_pickled', 'distancefunc', 'program__name']
+            'attributes_pickled', 'program__name']
 
 class ResourceRequestAdmin(admin.ModelAdmin):
     list_display = ('target', 'res_type', 'desired_value')

--- a/esp/esp/resources/migrations/0003_remove_resourcetype_distancefunc.py
+++ b/esp/esp/resources/migrations/0003_remove_resourcetype_distancefunc.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('resources', '0002_resource_user'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='resourcetype',
+            name='distancefunc',
+        ),
+    ]


### PR DESCRIPTION
This was extracted from the resources branch; I hadn't included it in #1828 because it includes a migration.  The function in question isn't used nontrivially anymore.  Unfortunately, since it's set as `Resource.__sub__`, it's hard to check that it is never called, so now it just does nothing.