### PR TITLE
Add file for release 8 docs

### DIFF
--- a/docs/admin/releases/08/README.rst
+++ b/docs/admin/releases/08/README.rst
@@ -1,0 +1,11 @@
+============================================
+ ESP Website Stable Release 08 release notes
+============================================
+
+.. contents:: :local:
+
+Changelog
+=========
+
+Improvements to user search
+~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
@btidor, there's a blank section for you to fill in.

Explanation, copied from email:

One of the major steps in doing a stable release is making a list of all the features that have been added and getting all their authors to document them. However, there's no reason why this has to happen at release time.

I propose that going forward, we create a file for the release n+1 changelog as soon as we branch for release n, and everyone can add notes to it in the same pull request where they write the feature. If you're writing something admins should hear about, write docs. If you're reviewing a change admins should hear about and the author didn't write docs, remind them.

To start, I created a file for release 8, with a blank entry for user search improvements (there are a lot more changes, including some big ones, but none of them are things admins are likely to care about, although if you feel like documenting those too, you can).