### PR TITLE
Add a lint test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,6 @@ before_script:
   - psql -c "CREATE DATABASE test_django OWNER testuser;" -U postgres
 script: 
   - cd esp
+  - useful_scripts/run_lint.sh
   - ./manage.py collectstatic --noinput -v 0
   - ./manage.py test

--- a/esp/requirements.txt
+++ b/esp/requirements.txt
@@ -37,6 +37,7 @@ Pygments==2.0.2
 twilio==3.6.5
 shortuuid==0.4.2
 raven
+flake8==2.5.0
 
 # We are using the 2014-03-13 version of the Stripe API, which is v1.12.2.
 stripe==1.12.2

--- a/esp/useful_scripts/run_lint.sh
+++ b/esp/useful_scripts/run_lint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+
+BASE_DIR="$(dirname "$(dirname "$(readlink -e "$0")")")" # /esp
+
+echo "Running lint checks..."
+
+# For now, ignore everything except:
+#   F82x: undefined name, local variable referenced before assignment
+#   F831: duplicate arg in function definition
+#   W601: `has_key` instead of `in`
+#   W603: <> instead of !=
+#   W604: backticks instead of `repr`
+# Errors I'd like to turn on sometime soon, but which still require some
+# cleanup first:
+#   E101: mixed tabs and spaces
+#   E11x: other indentation issues (expected indented block, unexpected indent, not a multiple of four)
+#   F811: redefinition of unused name
+#   F841: unused name
+#   W191: indentation contains tabs
+#   W291: whitespace at end of line
+#   W293: whitespace on blank line
+flake8 --ignore "E,F,W" --select "F82,F831,W601,W603,W604" $BASE_DIR
+
+echo "done."


### PR DESCRIPTION
Now that we don't have any undefined names (see #1944), let's keep it that way.
This adds a dependency on flake8 and script (`useful_scripts/run_lint.sh`) to
run a few `flake8` checks; travis should automatically run the script before
running tests.

We can add more checks as we clean up the codebase so that they pass.  (For
example, it looks like we still have a few trailing whitespace issues, so I
didn't turn those checks on.)  It should be trivial to add more `flake8`
checks; adding other linters (e.g.  `eslint` for our JS) shouldn't be too hard
either.

If you want to automatically run the linter before every commit, just make a
symlink from `.git/hooks/pre-commit` to the lint script.  It's a bit slower
than I'd like, unfortunately, so it might be good to have a git-hook version
that only lints changed files or something, but I'll leave that for another
day.

Replaces #1946; this version is a shell-script that travis runs, which means travis will fail faster in the case of lint errors, and makes the thing fast enough that one can plausibly run it as a commit hook.