### PR TITLE
Remove bizarre broken symlink

### DIFF
--- a/esp/public/media/theme_editor/less/.#bootstrap-test.css
+++ b/esp/public/media/theme_editor/less/.#bootstrap-test.css
@@ -1,1 +1,0 @@
-ludev@devserver.8975:1339419718


### PR DESCRIPTION
I don't know what this was for, but I don't think it's doing us any good, and it makes `chmod -RL` whine.