### PR TITLE
Update new_site.sh some more and add deployment docs

### DIFF
--- a/docs/dev/deploying.rst
+++ b/docs/dev/deploying.rst
@@ -13,12 +13,14 @@ To deploy a new site, first make sure you know:
 
 Then ssh to ``diogenes``, grab the latest version of
 ``esp/useful_scripts/server_setup/new_site.sh``, ``cd`` to ``/lu/sites``, and
-run ``sudo new_site.sh --all``.  Follow the instructions to set up the site.
-For the site directory name, choose something short that's likely to stay
-unique and understandable as we add more chapters.  When it does the "create
-superuser", you should create yourself an account; afterwards chapter admins
-can create their own accounts and you can make them admins.  At the end, it
-will give you instructions for setting up DNS, currently on ``plato``.
+run ``sudo new_site.sh --all``.  (You may instead clone the repository
+yourself, ``cd`` into it, and run the script from there.)  Follow the
+instructions to set up the site.  For the site directory name, choose something
+short that's likely to stay unique and understandable as we add more chapters.
+When it does the "create superuser", you should create yourself an account;
+afterwards chapter admins can create their own accounts and you can make them
+admins.  At the end, it will give you instructions for setting up DNS,
+currently on ``plato``.
 
 If something doesn't work, and you need to re-run a particular step, you can do
 so by passing the appropriate flag to ``new_site.sh``.  Note that some steps

--- a/docs/dev/deploying.rst
+++ b/docs/dev/deploying.rst
@@ -1,0 +1,47 @@
+Deploying to production
+=======================
+
+Deploying a new site
+--------------------
+
+To deploy a new site, first make sure you know:
+
+#. the hostname the chapter prefers
+#. the chapter's contact email address
+#. the group's name (e.g. "MIT ESP" or "Yale Splash")
+#. the chapter's preferred theme
+
+Then ssh to ``diogenes``, grab the latest version of
+``esp/useful_scripts/server_setup/new_site.sh``, ``cd`` to ``/lu/sites``, and
+run ``sudo new_site.sh --all``.  Follow the instructions to set up the site.
+For the site directory name, choose something short that's likely to stay
+unique and understandable as we add more chapters.  When it does the "create
+superuser", you should create yourself an account; afterwards chapter admins
+can create their own accounts and you can make them admins.  At the end, it
+will give you instructions for setting up DNS, currently on ``plato``.
+
+If something doesn't work, and you need to re-run a particular step, you can do
+so by passing the appropriate flag to ``new_site.sh``.  Note that some steps
+won't work if you run them twice, so if a step fails partway through you may
+need to complete or undo it manually.  The script will remember your settings;
+you just need to tell it the same directory again.
+
+Finally, email the chapter to let them know that you've set up their site, and
+with instructions to set up their accounts, whatever parts of their theme you
+didn't set up.  You can also point them at the documentation in the repository
+and on the LU wiki and at websupport.
+
+Deactivating a site
+-------------------
+
+To deactivate a site, simply remove or comment out its lines in
+``/etc/apache2/sites-available/esp_sites.conf``, ``/etc/crontab``, and
+``/etc/exim4/update-exim4.conf.conf``, remove it from the DNS config on
+``plato``, and move its site directory to ``/lu/sites/inactive``.
+
+TODO(benkraft): write a quick script for this.
+
+Setting up a new server
+-----------------------
+
+TODO

--- a/esp/useful_scripts/server_setup/new_site.sh
+++ b/esp/useful_scripts/server_setup/new_site.sh
@@ -1,20 +1,35 @@
 #!/bin/bash
 
 # ESP site creation script
-# Michael Price, December 2010
+# See /docs/dev/deploying.rst for documentation on how to deploy.
+
+set -e -o pipefail
 
 # Parameters
 GIT_REPO="git://github.com/learning-unlimited/ESP-Website.git"
-GIT_BRANCH="stable/1.5.x"
+GIT_BRANCH="stable-release-7"
 APACHE_CONF_FILE="/etc/apache2/sites-available/esp_sites.conf"
+APACHE_REDIRECT_CONF_FILE="/etc/apache2/sites-available/esp_sites/https_redirect.conf"
+DNS_CONF_FILE="/etc/bind/pri/learningu.zone"
+AUTH_USER_FILE="/lu/auth/dav_auth"
+EXIMDIR="/etc/exim4"
 LOGDIR="/lu/logs"
 CRON_FILE="/etc/crontab"
+WWW_USER="www-data"
+DOMAIN="learningu.org"
+TIMEZONE_DEFAULT="America/New_York"
 
 #CURDIR=`dirname $0`
+# This should probably be /lu/sites
+# TODO(benkraft): should we hardcode that we install to /lu/sites?
 CURDIR=`pwd`
 
+# TODO(benkraft): it would be nice if more of these steps were idempotent, so
+# that if something failed somewhere you could just rerun it instead of
+# completing or undoing it manually.
+
 # Parse options
-OPTSETTINGS=`getopt -o 'ah' -l 'reset,git,settings,db,apache,cron,help' -- "$@"`
+OPTSETTINGS=`getopt -o 'ah' -l 'reset,all,git,settings,db,apache,cron,exim,help' -- "$@"`
 E_OPTERR=65
 if [ "$#" -eq 0 ]
 then   # Script needs at least one command-line argument.
@@ -38,6 +53,7 @@ do
     --settings) MODE_SETTINGS=true;;
     --apache) MODE_APACHE=true;;
     --cron) MODE_CRON=true;;
+    --exim) MODE_EXIM=true;;
      *) break;;
   esac
 
@@ -57,7 +73,8 @@ Options:
     --db:       Set up a PostgreSQL database
     --settings: Write settings files
     --apache:   Set up Apache to serve the site using mod_wsgi
-    --cron:     Add appropriate entry to cron for comm panel e-mail sending
+    --cron:     Add appropriate entry to cron for comm panel email sending
+    --exim:     Add appropriate exim4 config for email handling
 "
     exit 0
 fi
@@ -113,8 +130,10 @@ echo "#!/bin/bash" > $BASEDIR/.espsettings
 # To manually reset: Remove '.espsettings' file in site directory
 while [[ ! -n $ESPHOSTNAME ]]; do
     echo
-    echo -n "Enter your site's hostname (without the http://) --> "
+    echo "Enter your site's hostname (without the https://)"
+    echo -n "  (default = $SITENAME.$DOMAIN) --> "
     read ESPHOSTNAME
+    ESPHOSTNAME=${ESPHOSTNAME:-$SITENAME.$DOMAIN}
 done
 echo "The Web site address will be http://$ESPHOSTNAME."
 echo "ESPHOSTNAME=\"$ESPHOSTNAME\"" >> $BASEDIR/.espsettings
@@ -154,16 +173,6 @@ done
 echo "Selected e-mail host: $EMAILHOST"
 echo "EMAILHOST=\"$EMAILHOST\"" >> $BASEDIR/.espsettings
 
-while [[ ! -n $ADMINEMAIL ]]; do
-    echo
-    echo "Please enter the e-mail address of the initial site administrator"
-    echo -n "  --> "
-    read ADMINEMAIL
-done
-echo "Selected admin e-mail: $ADMINEMAIL"
-echo "ADMINEMAIL=\"$ADMINEMAIL\"" >> $BASEDIR/.espsettings
-
-TIMEZONE_DEFAULT="America/New_York"
 while [[ ! -n $TIMEZONE ]]; do
     echo
     echo "Please enter your group's time zone"
@@ -203,45 +212,52 @@ else
 fi
 echo "DBPASS=\"$DBPASS\"" >> $BASEDIR/.espsettings
 
-SECRET_KEY = `openssl rand -base64 48`
-echo "Generated random secret key"
-echo "SECRET_KEY=\"$SECRET_KEY\"" >> $BASEDIR/.espsettings
-
 echo "Settings have been entered.  Please check them by looking over the output"
 echo -n "above, then press enter to continue or Ctrl-C to quit."
 read THROWAWAY
 
 # Git repository setup
 # To manually reset: Back up .espsettings file in [sitename].old directory, then remove site directory
-if [[ "$MODE_GIT" || "$MODE_ALL" ]]
-then
-    if [[ -e $CURDIR/$SITENAME/esp ]]
-    then
+if [[ "$MODE_GIT" || "$MODE_ALL" ]] ; then
+    if [[ -e "$BASEDIR/.git" ]] ; then
         echo "Updating code in $BASEDIR.  Please tend to any conflicts."
-        cd $BASEDIR
-        git stash
+        cd "$BASEDIR"
+        if ! git diff --exit-code >/dev/null ; then
+            DIFF=true
+            git stash
+        fi
         git pull origin ${GIT_BRANCH}
-        git stash apply
+        if [[ "$DIFF" ]] ; then
+            # Only apply the stash if we made one.
+            git stash apply
+        fi
     else
-        cd $CURDIR
-        if [[ -e $CURDIR/$SITENAME ]]
-        then
-            echo "Executing: rm -r $CURDIR/$SITENAME.old; mv $CURDIR/$SITENAME $CURDIR/$SITENAME.old"
-            rm -r $CURDIR/$SITENAME.old
-            mv $CURDIR/$SITENAME $CURDIR/$SITENAME.old
+        # We will almost certainly have created $BASEDIR already; get it out of
+        # the way for git.
+        if [[ -e "$BASEDIR" ]] ; then
+            echo "Executing: rm -rf $BASEDIR.old; mv $BASEDIR $BASEDIR.old"
+            rm -rf "$BASEDIR.old"
+            mv "$BASEDIR" "$BASEDIR.old"
         fi
         echo "Creating site $SITENAME in $CURDIR."
-        git clone $GIT_REPO $SITENAME
-        if [[ -e $CURDIR/$SITENAME.old/.espsettings ]]
-        then
-            echo "Executing: cp $CURDIR/$SITENAME.tmp/.espsettings $CURDIR/$SITENAME/"
-            cp $CURDIR/$SITENAME.old/.espsettings $CURDIR/$SITENAME/
+        git clone "$GIT_REPO" "$SITENAME"
+        cd "$BASEDIR"
+        git checkout "$GIT_BRANCH"
+        if [[ -e "$BASEDIR.old/.espsettings" ]] ; then
+            echo "Executing: cp $BASEDIR.tmp/.espsettings $BASEDIR/"
+            cp "$BASEDIR.old/.espsettings" "$BASEDIR/"
+        fi
+        if [[ "$(ls -A "$BASEDIR.old")" = ".espsettings" ]] ; then
+            # If all that's left in $BASEDIR.old is the .espsettings file,
+            # which we've now copied to $BASEDIR, get rid of it.
+            rm -rf "$BASEDIR.old"
         fi
     fi
 
-    cd $BASEDIR
+    
     ./esp/make_virtualenv.sh
     ./esp/update_deps.sh --prod
+    chown -R $WWW_USER:$WWW_USER "$BASEDIR"
 
     echo "Git repository has been checked out, and dependencies have been installed"
     echo "with Python libraries in a local virtualenv.  Please check them by looking"
@@ -267,10 +283,9 @@ EOF
 
 SITE_INFO = (1, '$ESPHOSTNAME', '$INSTITUTION $GROUPNAME Site')
 ADMINS = (
-    ('LU Web group','serverlog@learningu.org'),
+    ('LU Web group','serverlog@$DOMAIN'),
 )
 CACHE_PREFIX = "${SITENAME}ESP"
-SECRET_KEY = '$SECRET_KEY'
 
 # Default addresses to send archive/bounce info to
 DEFAULT_EMAIL_ADDRESSES = {
@@ -285,17 +300,6 @@ INSTITUTION_NAME = '$INSTITUTION'
 EMAIL_HOST = '$EMAILHOST'
 EMAIL_HOST_SENDER = EMAIL_HOST
 
-# E-mail addresses for contact form
-email_choices = (
-    ('general','General ESP'),
-    ('esp-web','Web Site Problems'),
-    ('splash','Splash!'),
-    )
-email_addresses = {
-    'general': '$GROUPEMAIL',
-    'esp-web': '$GROUPEMAIL',
-    'splash': '$GROUPEMAIL',
-    }
 USE_MAILMAN = False
 TIME_ZONE = '$TIMEZONE'
 
@@ -310,8 +314,7 @@ DEBUG_TOOLBAR = True # set to False to globally disable the debug toolbar
 
 # Database
 DEFAULT_CACHE_TIMEOUT = 120
-DATABASE_ENGINE = 'postgresql_psycopg2'
-#DATABASE_ENGINE = 'esp.db.prepared'
+DATABASE_ENGINE = 'django.db.backends.postgresql_psycopg2'
 DATABASE_NAME = '$DBNAME'
 DATABASE_HOST = 'localhost'
 DATABASE_PORT = '5432'
@@ -324,8 +327,12 @@ from database_settings import *
 MIDDLEWARE_LOCAL = []
 
 SECRET_KEY = '`openssl rand -base64 48`'
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+ALLOWED_HOSTS = ['$ESPHOSTNAME', '$SITENAME-orig.$DOMAIN']
 
 EOF
+
+    chown -R $WWW_USER:$WWW_USER "$BASEDIR"
 
     echo "Generated Django settings overrides, saved to:"
     echo "  $BASEDIR/esp/esp/local_settings.py"
@@ -338,14 +345,14 @@ EOF
 
 fi
 
-MEDIADIR=${BASEDIR}/esp/public/media
-ln -s $MEDIADIR/default_images $MEDIADIR/images
-ln -s $MEDIADIR/default_styles $MEDIADIR/styles
+MEDIADIR="$BASEDIR/esp/public/media"
+[[ -e "$MEDIADIR/images" ]] || ln -s "$MEDIADIR/default_images" "$MEDIADIR/images"
+[[ -e "$MEDIADIR/styles" ]] || ln -s "$MEDIADIR/default_styles" "$MEDIADIR/styles"
 
 mkdir -p $MEDIADIR/uploaded
-chmod -R 777 $MEDIADIR
+chmod -R u+rwX,go+rX $MEDIADIR
 mkdir -p /tmp/esptmp__${SITENAME}ESP
-chmod -R 777 /tmp/esptmp__${SITENAME}ESP
+chmod -R u+rwX,go+rX /tmp/esptmp__${SITENAME}ESP
 echo "Default images and styles have been symlinked."
 
 # Database setup
@@ -361,12 +368,18 @@ then
     echo "$DBNAME database.  Please follow their directions."
 
     cd $BASEDIR/esp
-    ./manage.py syncdb
     ./manage.py migrate
-    ./manage.py collectstatic
+    ./manage.py createsuperuser
+    # This will prompt before it (potentially) clobbers files.  Since it's a
+    # new site, there's definitely nothing to clobber and we can just say yes
+    # automatically.  With `set -o pipefail`, this will exit 141 (SIGPIPE), so
+    # we need `|| true` to prevent the script from exiting failure.
+    yes yes | ./manage.py collectstatic || true
+    chown -R $WWW_USER:$WWW_USER "$BASEDIR"
     cd $CURDIR
 
     #   Set initial Site (used in password recovery e-mail)
+    # TODO(benkraft): do this in python.
     sudo -u postgres psql -c "DELETE FROM django_site; INSERT INTO django_site (id, domain, name) VALUES (1, '$ESPHOSTNAME', '$INSTITUTION $GROUPNAME Site');" $DBNAME
 
     echo "Database has been set up.  Please check them by looking over the"
@@ -378,40 +391,54 @@ fi
 # To reset: remove appropriate section from Apache config
 if [[ "$MODE_APACHE" || "$MODE_ALL" ]]
 then
+    # TODO(benkraft): what the heck does this DAV thing do, and do we need it?
+    # TODO(benkraft): we should put each site in a separate conf file, and just
+    # make sure they all get imported.
+    # TODO(benkraft): we should attempt to factor much of the shared config out
+    # into a single file used by all sites, so it's easier to update.
+    # TODO(benkraft): most existing sites have the $SITENAME-orig alias.  I'm
+    # not sure why; we should figure out if it's in use, and if not, remove it.
     cat >>$APACHE_CONF_FILE <<EOF
+
 #   $INSTITUTION $GROUPNAME (automatically generated)
-WSGIDaemonProcess $SITENAME processes=4 threads=1 maximum-requests=1000
+WSGIDaemonProcess $SITENAME processes=2 threads=1 maximum-requests=500 display-name=${SITENAME}wsgi
 <VirtualHost *:80 *:81>
     ServerName $ESPHOSTNAME
-    ServerAlias $SITENAME-orig.learningu.org
+    ServerAlias $SITENAME-orig.$DOMAIN
 
-    #   Redirect to be used for failover
-    # RedirectMatch (.*) http://$SITENAME-backup.learningu.org\$1
+    Include $APACHE_REDIRECT_CONF_FILE
 
     #   Caching - should use Squid if performance is really important
-    # CacheEnable disk /
-
-    #   Redirect HTTP requests to HTTPS for security
-    RewriteEngine On
-    RewriteCond %{HTTP:X-Forwarded-Proto} !^https
-    RewriteCond %{REQUEST_URI} !^/media
-    RewriteRule ^(.*)$ https://%{SERVER_NAME}%{REQUEST_URI} [R,L]
+    CacheEnable disk /
 
     #   Static files
     Alias /media $BASEDIR/esp/public/media
     Alias /static $BASEDIR/esp/public/static
 
+    <Location /media>
+        DAV on
+        <LimitExcept GET HEAD OPTIONS PROPFIND>
+            AuthType Basic
+            AuthUserFile $AUTH_USER_FILE
+            AuthName "$ESPHOSTNAME media files"
+            Require valid-user
+        </LimitExcept>
+        ExpiresActive on
+        ExpiresDefault "now plus 1 hour"
+    </Location>
+
     #   WSGI scripted Python
     DocumentRoot $BASEDIR/esp/public
     WSGIScriptAlias / $BASEDIR/esp.wsgi
     WSGIProcessGroup $SITENAME
+    WSGIApplicationGroup %{GLOBAL}
     ErrorLog $LOGDIR/$SITENAME-error.log
     CustomLog $LOGDIR/$SITENAME-access.log combined
     LogLevel warn
 </VirtualHost>
 
 EOF
-    /etc/init.d/apache2 reload
+    service apache2 graceful
     echo "Added VirtualHost to Apache configuration $APACHE_CONF_FILE"
 
     echo "Apache has been set up.  Please check them by looking over the"
@@ -421,20 +448,56 @@ fi
 
 if [[ "$MODE_CRON" || "$MODE_ALL" ]]
 then
-    cat >>$CRON_FILE <<EOF
-* * * * * root $BASEDIR/esp/dbmail_cron.py
+    # Rather than run all dbmail_cron procs every 5 minutes, we choose a random
+    # offset for each.
+    # TODO(benkraft): we should just figure out the right cron syntax to have
+    # cron do this magically, without having to do `sleep` ourselves, and
+    # update both this and existing cron jobs.
+    sleep_sec="$(( (RANDOM % 5) * 60))"
+    if [[ "$sleep_sec" -eq 0 ]] ; then
+        sleep_cmd=""
+    else
+        sleep_cmd="sleep $sleep_sec ; "
+    fi
+    cat >>"$CRON_FILE" <<EOF
+*/5 * * * * root $sleep_cmd$BASEDIR/esp/dbmail_cron.py
 EOF
+
+    # TODO(benkraft): actually echo the added line so there's something to
+    # check.
+    echo "cron has been set up.  Please check the config by looking over the"
+    echo -n "output above, then press enter to continue or Ctrl-C to quit."
+    read THROWAWAY
+fi
+
+if [[ "$MODE_EXIM" || "$MODE_ALL" ]] ; then
+    cat >>"$EXIMDIR/virtual/$ESPHOSTNAME" <<EOF
+*: "|$BASEDIR/esp/mailgates/mailgate.py"
+EOF
+    # The line we want to edit looks like
+    # dc_other_hostnames='foo.learningu.org;bar.learningu.org;baz.learningu.org'
+    # and we want to add another entry to it.
+    sed --in-place=.bak "s/^\\(dc_other_hostnames='.*\\)'$/\\1;$ESPHOSTNAME'/" "$EXIMDIR/update-exim4.conf.conf"
+    update-exim4.conf
+    exim -bt test@$ESPHOSTNAME
+
+    echo "exim4 has been set up.  Please check the config by looking over the"
+    echo -n "output above, then press enter to continue or Ctrl-C to quit."
+    read THROWAWAY
 fi
 
 # Done!
+# Let's let the human do the /etc commit since they may want to separate out
+# other changes, or make sure everything is right, before doing so.
 echo "=== Site setup complete: $ESPHOSTNAME ==="
-IP_ADDRESS=`ifconfig  | grep 'inet addr:'| grep -v '127.0.0.1' | cut -d: -f2 | awk '{ print $1}'`
-echo "Please ensure that DNS is configured to provide A and MX records for:"
-echo "  $ESPHOSTNAME -> $IP_ADDRESS"
-echo "  $SITENAME-orig.learningu.org -> $IP_ADDRESS"
-echo "  $SITENAME-backup.learningu.org -> $IP_ADDRESS"
-echo "You may also want to add some template overrides that establish"
-echo "the initial look and feel of the site."
-echo "Please also configure e-mail by adjusting the exim4 configuration as"
-echo "necessary."
+echo "You may wish to commit your changes to the /etc git repo."
+echo "Please ensure that DNS is configured to direct the correct hostnames"
+echo "to `hostname`.  To do this, log in to the DNS server and edit"
+echo "$DNS_CONF_FILE to increment the serial number in the header, and add"
+echo "the lines:"
+echo "  ${ESPHOSTNAME%%.$DOMAIN} CNAME `hostname`"
+echo "  $SITENAME-orig CNAME `hostname`"
+echo "near the other similar lines.  Then run 'sudo service bind9 restart';"
+echo "after a few minutes you should be able to access the site.  You may"
+echo "wish to also set up a theme and create additional administrators."
 echo

--- a/esp/useful_scripts/server_setup/new_site.sh
+++ b/esp/useful_scripts/server_setup/new_site.sh
@@ -411,17 +411,6 @@ WSGIDaemonProcess $SITENAME processes=2 threads=1 maximum-requests=500 display-n
     Alias /media $BASEDIR/esp/public/media
     Alias /static $BASEDIR/esp/public/static
 
-    <Location /media>
-        <LimitExcept GET HEAD OPTIONS PROPFIND>
-            AuthType Basic
-            AuthUserFile $AUTH_USER_FILE
-            AuthName "$ESPHOSTNAME media files"
-            Require valid-user
-        </LimitExcept>
-        ExpiresActive on
-        ExpiresDefault "now plus 1 hour"
-    </Location>
-
     #   WSGI scripted Python
     DocumentRoot $BASEDIR/esp/public
     WSGIScriptAlias / $BASEDIR/esp.wsgi


### PR DESCRIPTION
The changes in #1529 did the lion's share of the work, but there were some
more updates that were needed to bring the script in line with current
practice.  I also added a few steps for things that were done manually but
don't need to be; at this point it does nearly everything itself, and gives
instructions for the remainder.  I also added some brief docs on deploying.

Fixes #1040 and #1289 and the remainder of #1285 (cron was done a while ago; this adds exim).