### PR TITLE
Remove a trivial function

### DIFF
--- a/esp/esp/program/modules/base.py
+++ b/esp/esp/program/modules/base.py
@@ -152,10 +152,6 @@ class ProgramModuleObj(models.Model):
     def goToCore(self, tl):
         return HttpResponseRedirect(self.getCoreURL(tl))
 
-    def getQForUser(self, QRestriction):
-        # Let's not do anything and say we did...
-        return QRestriction
-
     @cache_function
     def findModuleObject(tl, call_txt, prog):
         """ This function caches the customized (augmented) program module object

--- a/esp/esp/program/modules/handlers/availabilitymodule.py
+++ b/esp/esp/program/modules/handlers/availabilitymodule.py
@@ -108,7 +108,7 @@ class AvailabilityModule(ProgramModuleObj):
 
         qf = Q(useravailability__event__program=self.program, useravailability__role__name='Teacher')
         if QObject is True:
-            return {'availability': self.getQForUser(qf)}
+            return {'availability': qf}
 
         teacher_list = ESPUser.objects.filter(qf).distinct()
 

--- a/esp/esp/program/modules/handlers/regprofilemodule.py
+++ b/esp/esp/program/modules/handlers/regprofilemodule.py
@@ -59,7 +59,7 @@ class RegProfileModule(ProgramModuleObj):
 
     def students(self, QObject = False):
         if QObject:
-            return {'student_profile': self.getQForUser(Q(registrationprofile__program = self.program, registrationprofile__student_info__isnull = False))
+            return {'student_profile': Q(registrationprofile__program = self.program, registrationprofile__student_info__isnull = False)
                     }
         students = ESPUser.objects.filter(registrationprofile__program = self.program, registrationprofile__student_info__isnull = False).distinct()
         return {'student_profile': students }
@@ -69,8 +69,8 @@ class RegProfileModule(ProgramModuleObj):
 
     def teachers(self, QObject = False):
         if QObject:
-            return {'teacher_profile': self.getQForUser(Q(registrationprofile__program = self.program) & \
-                               Q(registrationprofile__teacher_info__isnull = False))}
+            return {'teacher_profile': Q(registrationprofile__program=self.program) & 
+                                       Q(registrationprofile__teacher_info__isnull=False)}
         teachers = ESPUser.objects.filter(registrationprofile__program = self.program, registrationprofile__teacher_info__isnull = False).distinct()
         return {'teacher_profile': teachers }
 

--- a/esp/esp/program/modules/handlers/studentregcore.py
+++ b/esp/esp/program/modules/handlers/studentregcore.py
@@ -74,9 +74,9 @@ class StudentRegCore(ProgramModuleObj, CoreModule):
     def students(self, QObject = False):
         now = datetime.now()
 
-        q_confirmed = self.getQForUser(Q(record__event = "reg_confirmed", record__program=self.program))
-        q_attended = self.getQForUser(Q(record__event= "attended", record__program=self.program))
-        q_studentrep = self.getQForUser(Q(groups__name="StudentRep"))
+        q_confirmed = Q(record__event = "reg_confirmed", record__program=self.program)
+        q_attended = Q(record__event= "attended", record__program=self.program)
+        q_studentrep = Q(groups__name="StudentRep")
 
         if QObject:
             retVal = {'confirmed': q_confirmed,
@@ -85,7 +85,7 @@ class StudentRegCore(ProgramModuleObj, CoreModule):
 
 
             if self.program.program_allow_waitlist:
-                retVal['waitlisted_students'] = self.getQForUser(Q(record__event="waitlist",record__program=self.program))
+                retVal['waitlisted_students'] = Q(record__event="waitlist",record__program=self.program)
 
             return retVal
 

--- a/esp/esp/program/modules/handlers/surveymodule.py
+++ b/esp/esp/program/modules/handlers/surveymodule.py
@@ -65,7 +65,7 @@ class SurveyModule(ProgramModuleObj):
         program=self.program
 
         if QObject:
-            return {'student_survey': self.getQForUser(Q(record__program = program) & Q(record__event = event))}
+            return {'student_survey': Q(record__program=program) & Q(record__event=event)}
         return {'student_survey': ESPUser.objects.filter(record__program=program, record__event=event).distinct()}
 
     def teachers(self, QObject = False):
@@ -73,7 +73,7 @@ class SurveyModule(ProgramModuleObj):
         program=self.program
 
         if QObject:
-            return {'teacher_survey': self.getQForUser(Q(record__program = program) & Q(record__event = event))}
+            return {'teacher_survey': Q(record__program=program) & Q(record__event=event)}
         return {'teacher_survey': ESPUser.objects.filter(record__program=program, record__event=event).distinct()}
 
     def studentDesc(self):

--- a/esp/esp/program/modules/handlers/teacheracknowledgementmodule.py
+++ b/esp/esp/program/modules/handlers/teacheracknowledgementmodule.py
@@ -59,7 +59,7 @@ class TeacherAcknowledgementModule(ProgramModuleObj):
         from datetime import datetime
         qo = Q(record__program=self.program, record__event="teacheracknowledgement")
         if QObject is True:
-            return {'acknowledgement': self.getQForUser(qo)}
+            return {'acknowledgement': qo}
 
         teacher_list = ESPUser.objects.filter(qo).distinct()
 

--- a/esp/esp/program/modules/handlers/teacherbiomodule.py
+++ b/esp/esp/program/modules/handlers/teacherbiomodule.py
@@ -52,7 +52,7 @@ class TeacherBioModule(ProgramModuleObj):
 
     def teachers(self, QObject = False):
         if QObject:
-            return {'teacher_biographies': self.getQForUser(Q(teacherbio__program = self.program))}
+            return {'teacher_biographies': Q(teacherbio__program = self.program)}
 
         teachers = ESPUser.objects.filter(teacherbio__program = self.program).distinct()
         return {'teacher_biographies': teachers }

--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -140,16 +140,16 @@ class TeacherClassRegModule(ProgramModuleObj):
 
         if QObject:
             result = {
-                'class_submitted': self.getQForUser(Q_isteacher),
-                'class_approved': self.getQForUser(Q_approved_teacher),
-                'class_proposed': self.getQForUser(Q_proposed_teacher),
-                'class_rejected': self.getQForUser(Q_rejected_teacher),
-                'class_nearly_full': self.getQForUser(Q_nearly_full_teacher),
-                'class_full': self.getQForUser(Q_full_teacher),
-                'taught_before': self.getQForUser(Q_taught_before),     #   not exactly correct, see above
+                'class_submitted': Q_isteacher,
+                'class_approved': Q_approved_teacher,
+                'class_proposed': Q_proposed_teacher,
+                'class_rejected': Q_rejected_teacher,
+                'class_nearly_full': Q_nearly_full_teacher,
+                'class_full': Q_full_teacher,
+                'taught_before': Q_taught_before,     #   not exactly correct, see above
             }
             for key in additional_qs:
-                result[key] = self.getQForUser(additional_qs[key])
+                result[key] = additional_qs[key]
         else:
             result = {
                 'class_submitted': ESPUser.objects.filter(Q_isteacher).distinct(),

--- a/esp/esp/program/modules/handlers/teachereventsmodule.py
+++ b/esp/esp/program/modules/handlers/teachereventsmodule.py
@@ -83,8 +83,8 @@ class TeacherEventsModule(ProgramModuleObj):
         """ Returns lists of teachers who've signed up for interviews and for teacher training. """
         if QObject is True:
             return {
-                'interview': self.getQForUser(Q( useravailability__event__event_type=self.event_types()['interview'], useravailability__event__program=self.program )),
-                'training': self.getQForUser(Q( useravailability__event__event_type=self.event_types()['training'], useravailability__event__program=self.program ))
+                'interview': Q(useravailability__event__event_type=self.event_types()['interview'], useravailability__event__program=self.program),
+                'training': Q(useravailability__event__event_type=self.event_types()['training'], useravailability__event__program=self.program)
             }
         else:
             return {

--- a/esp/esp/program/modules/handlers/teacherquizmodule.py
+++ b/esp/esp/program/modules/handlers/teacherquizmodule.py
@@ -109,7 +109,7 @@ class TeacherQuizModule(ProgramModuleObj):
                record__program=self.program)
         if QObject is True:
             return {
-                'quiz_done': self.getQForUser(qo),
+                'quiz_done': qo,
             }
         else:
             return {

--- a/esp/esp/program/modules/handlers/volunteersignup.py
+++ b/esp/esp/program/modules/handlers/volunteersignup.py
@@ -92,7 +92,7 @@ class VolunteerSignup(ProgramModuleObj, CoreModule):
         result = {}
         for key in queries:
             if QObject:
-                result[key] = self.getQForUser(queries[key])
+                result[key] = queries[key]
             else:
                 result[key] = ESPUser.objects.filter(queries[key]).distinct()
         return result


### PR DESCRIPTION
Presumably at some point in the past, `ProgramModuleObj.getQForUser()` was
intended to either do something, or to be overridden by subclasses to do
something.  It did not and was not; it was simply the identity function.  This
removes it and all callers.