### PR TITLE
Program module extension cleanup

### DIFF
--- a/esp/esp/application/admin.py
+++ b/esp/esp/application/admin.py
@@ -44,16 +44,16 @@ from esp.application.models import FormstackAppSettings, FormstackStudentProgram
 from esp.utils.admin_user_search import default_user_search
 
 class FormstackAppSettingsAdmin(admin.ModelAdmin):
-    fields = ['module', 'api_key', 'forms_for_api_key',
+    fields = ['program', 'api_key', 'forms_for_api_key',
               'form_id', 'form_fields',
               'username_field', 'coreclass_fields',
               'autopopulated_fields', 'teacher_view_template',
               'finaid_form_id', 'finaid_form_fields',
               'finaid_user_id_field', 'finaid_username_field',
               'app_is_open']
-    readonly_fields = ['module', 'forms_for_api_key', 'form_fields', 'finaid_form_fields']
-    list_display = ['module', 'app_is_open']
-    search_fields = ('module__program__name',)
+    readonly_fields = ['program', 'forms_for_api_key', 'form_fields', 'finaid_form_fields']
+    list_display = ['program', 'app_is_open']
+    search_fields = ('program__name',)
 
     def forms_for_api_key(self, fsas):
         if fsas.api_key == '':

--- a/esp/esp/application/apps.py
+++ b/esp/esp/application/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+class ApplicationConfig(AppConfig):
+    name = 'esp.application'
+
+    def ready(self):
+        import esp.application.signals

--- a/esp/esp/application/migrations/0004_formstackappsettings_program.py
+++ b/esp/esp/application/migrations/0004_formstackappsettings_program.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('program', '0004_auto_20151126_2220'),
+        ('application', '0003_auto_20151004_1715'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='formstackappsettings',
+            name='program',
+            field=models.OneToOneField(null=True, to='program.Program'),
+        ),
+    ]

--- a/esp/esp/application/migrations/0005_populate_program.py
+++ b/esp/esp/application/migrations/0005_populate_program.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+# This is kinda duplicated from modules 0006, but having migrations import
+# things is a bit fragile.
+def populate_program(apps, schema_editor):
+    Program = apps.get_model("program", "Program")
+    FormstackAppSettings = apps.get_model("application",
+                                          "FormstackAppSettings")
+    for program in Program.objects.all():
+        fsass = FormstackAppSettings.objects.filter(module__program=program)
+        if fsass:
+            # The old getModuleExtension just looked at the first one, so
+            # that's the one we'll keep around and update, and we'll delete
+            # the others.  This module extension is new enough that there
+            # wasn't any weird stuff in the DB already anyway.
+            good_fsas = fsass[0]
+            good_fsas.program = program
+            good_fsas.save()
+            for fsas in fsass[1:]:
+                fsas.delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('application', '0004_formstackappsettings_program'),
+        ('program', '0004_auto_20151126_2220'),
+    ]
+
+    operations = [
+        migrations.RunPython(populate_program, migrations.RunPython.noop)
+    ]

--- a/esp/esp/application/migrations/0006_auto_20151211_0329.py
+++ b/esp/esp/application/migrations/0006_auto_20151211_0329.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('application', '0005_populate_program'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='formstackappsettings',
+            name='program',
+            field=models.OneToOneField(to='program.Program'),
+        ),
+    ]

--- a/esp/esp/application/migrations/0007_remove_formstackappsettings_module.py
+++ b/esp/esp/application/migrations/0007_remove_formstackappsettings_module.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('application', '0006_auto_20151211_0329'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='formstackappsettings',
+            name='module',
+        ),
+    ]

--- a/esp/esp/application/models.py
+++ b/esp/esp/application/models.py
@@ -204,7 +204,7 @@ class StudentClassApp(models.Model):
 class FormstackStudentProgramAppManager(models.Manager):
     def create_from_submission(self, submission, settings):
         """ Takes a FormstackSubmission and creates an app from it. """
-        program = settings.module.program
+        program = settings.program
         data_dict = { int(entry['field']): entry['value']
                       for entry in submission.data() }
 

--- a/esp/esp/application/models.py
+++ b/esp/esp/application/models.py
@@ -5,7 +5,6 @@ from django.dispatch import receiver
 from argcache import cache_function
 from esp.users.models import ESPUser
 from esp.program.models import Program, ClassSubject
-from esp.program.modules.base import ProgramModuleObj
 from esp.formstack.api import Formstack
 from esp.formstack.objects import FormstackForm, FormstackSubmission
 from esp.formstack.signals import formstack_post_signal
@@ -16,7 +15,6 @@ class FormstackAppSettings(models.Model):
     module.
     """
 
-    module = models.ForeignKey(ProgramModuleObj)
     program = models.OneToOneField(Program)
 
     # formstack settings
@@ -44,6 +42,12 @@ include the content of a field, use {{field.12345}} where 12345 is the
 field id.""")
 
     app_is_open = models.BooleanField(default=False, verbose_name="Application is currently open")
+
+    @property
+    def module(self):
+        """Deprecated; you probably shouldn't need this."""
+        # TODO(benkraft): remove.
+        return self.program.getModule('FormstackAppModule')
 
     def formstack(self):
         """

--- a/esp/esp/application/models.py
+++ b/esp/esp/application/models.py
@@ -268,7 +268,7 @@ class FormstackStudentProgramAppManager(models.Manager):
         """ Get apps for a particular program from the Formstack API. """
 
         # get submissions from the API
-        settings = program.getModuleExtension('FormstackAppSettings')
+        settings = program.formstackappsettings
         submissions = settings.form().submissions(use_cache=False)
 
         # parse submitted data and make model instances
@@ -306,7 +306,7 @@ class FormstackStudentProgramApp(StudentProgramApp):
         self.app_type = 'Formstack'
 
     def program_settings(self):
-        return self.program.getModuleExtension('FormstackAppSettings')
+        return self.program.formstackappsettings
 
     def submission(self):
         return FormstackSubmission(self.submission_id, self.program_settings().formstack())

--- a/esp/esp/application/models.py
+++ b/esp/esp/application/models.py
@@ -17,6 +17,7 @@ class FormstackAppSettings(models.Model):
     """
 
     module = models.ForeignKey(ProgramModuleObj)
+    program = models.OneToOneField(Program)
 
     # formstack settings
     form_id = models.IntegerField(null=True)

--- a/esp/esp/application/signals.py
+++ b/esp/esp/application/signals.py
@@ -1,0 +1,4 @@
+from esp.program.models import maybe_create_module_ext
+from esp.application.models import FormstackAppSettings
+
+maybe_create_module_ext('FormstackAppModule', FormstackAppSettings)

--- a/esp/esp/django_settings.py
+++ b/esp/esp/django_settings.py
@@ -249,7 +249,7 @@ INSTALLED_APPS = (
     'bootstrapform',
     'django_nose',
     'esp.formstack',
-    'esp.application',
+    'esp.application.apps.ApplicationConfig',
 )
 
 import os

--- a/esp/esp/program/controllers/classreg.py
+++ b/esp/esp/program/controllers/classreg.py
@@ -38,7 +38,7 @@ class ClassCreationValidationError(Exception):
 class ClassCreationController(object):
     def __init__(self, prog):
         self.program = prog
-        self.crmi = prog.getModuleExtension('ClassRegModuleInfo')
+        self.crmi = prog.classregmoduleinfo
 
     @transaction.atomic
     def makeaclass(self, user, reg_data, form_class=TeacherClassRegForm):

--- a/esp/esp/program/controllers/confirmation.py
+++ b/esp/esp/program/controllers/confirmation.py
@@ -43,7 +43,7 @@ from esp.dbmail.models import send_mail
 
 class ConfirmationEmailController(object):
     def send_confirmation_email(self, user, program, repeat=False, override=False):
-        options = program.getModuleExtension('StudentClassRegModuleInfo')
+        options = program.studentclassregmoduleinfo
         ## Get or create a userbit indicating whether or not email's been sent.
         try:
             record, created = Record.objects.get_or_create(user=user, event="conf_email", program=program)

--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -539,7 +539,7 @@ class Program(models.Model, CustomFormsLinkModel):
 
     @cache_function
     def open_class_registration(self):
-        return self.getModuleExtension('ClassRegModuleInfo').open_class_registration
+        return self.classregmoduleinfo.open_class_registration
     open_class_registration.depend_on_row('modules.ClassRegModuleInfo', lambda crmi: {'self': crmi.program})
     open_class_registration = property(open_class_registration)
 
@@ -773,7 +773,7 @@ class Program(models.Model, CustomFormsLinkModel):
         from decimal import Decimal
 
         times = Event.group_contiguous(list(self.getTimeSlots()))
-        crmi = self.getModuleExtension(ClassRegModuleInfo)
+        crmi = self.classregmoduleinfo
         if crmi and crmi.class_max_duration is not None:
             max_seconds = crmi.class_max_duration * 60
         else:
@@ -895,24 +895,12 @@ class Program(models.Model, CustomFormsLinkModel):
         return result
     getModuleViews.depend_on_cache(getModules_cached, lambda **kwargs: {})
 
-    def getModuleExtension(self, ext_name_or_cls):
-        """ Get the specified extension (e.g. ClassRegModuleInfo) for a program.
-        This avoids actually looking up the program module first. """
-        # TODO(benkraft): this is no longer necessary; update all callers to
-        # use the related lookup and remove.
-        if isinstance(ext_name_or_cls, basestring):
-            ext_name = ext_name_or_cls
-        else:
-            ext_name = ext_name_or_cls.__name__
-
-        return getattr(self, ext_name.lower(), None)
-
     @cache_function
     def getColor(self):
         if hasattr(self, "_getColor"):
             return self._getColor
 
-        modinfo = self.getModuleExtension(ClassRegModuleInfo)
+        modinfo = self.classregmoduleinfo
         retVal = None
         if modinfo:
             retVal = modinfo.color_code
@@ -927,7 +915,7 @@ class Program(models.Model, CustomFormsLinkModel):
         This originally returned true if class registration was fully open.
         Now it's just a checkbox in the StudentClassRegModuleInfo.
         """
-        options = self.getModuleExtension('StudentClassRegModuleInfo')
+        options = self.studentclassregmoduleinfo
         return options.visible_enrollments
 
     def getVolunteerRequests(self):
@@ -971,14 +959,14 @@ class Program(models.Model, CustomFormsLinkModel):
     incrementGrade.depend_on_row('tagdict.Tag', lambda tag: {'self' :  tag.target})
 
     def priorityLimit(self):
-        studentregmodule = self.getModuleExtension('StudentClassRegModuleInfo')
+        studentregmodule = self.studentclassregmoduleinfo
         if studentregmodule and studentregmodule.priority_limit > 0:
             return studentregmodule.priority_limit
         else:
             return 1
 
     def useGradeRangeExceptions(self):
-        studentregmodule = self.getModuleExtension('StudentClassRegModuleInfo')
+        studentregmodule = self.studentclassregmoduleinfo
         if studentregmodule:
             return studentregmodule.use_grade_range_exceptions
         else:

--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -538,7 +538,7 @@ class Program(models.Model, CustomFormsLinkModel):
     @cache_function
     def open_class_registration(self):
         return self.getModuleExtension('ClassRegModuleInfo').open_class_registration
-    open_class_registration.depend_on_row('modules.ClassRegModuleInfo', lambda crmi: {'self': crmi.get_program()})
+    open_class_registration.depend_on_row('modules.ClassRegModuleInfo', lambda crmi: {'self': crmi.module.program})
     open_class_registration = property(open_class_registration)
 
     @cache_function

--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -538,7 +538,7 @@ class Program(models.Model, CustomFormsLinkModel):
     @cache_function
     def open_class_registration(self):
         return self.getModuleExtension('ClassRegModuleInfo').open_class_registration
-    open_class_registration.depend_on_row('modules.ClassRegModuleInfo', lambda crmi: {'self': crmi.module.program})
+    open_class_registration.depend_on_row('modules.ClassRegModuleInfo', lambda crmi: {'self': crmi.program})
     open_class_registration = property(open_class_registration)
 
     @cache_function
@@ -840,8 +840,8 @@ class Program(models.Model, CustomFormsLinkModel):
     getModules_cached.depend_on_row('modules.ProgramModuleObj', lambda mod: {'self': mod.program})
     # I've only included the module extensions we still seem to use.
     # Feel free to adjust. -ageng 2010-10-23
-    getModules_cached.depend_on_row('modules.ClassRegModuleInfo', lambda modinfo: {'self': modinfo.module.program})
-    getModules_cached.depend_on_row('modules.StudentClassRegModuleInfo', lambda modinfo: {'self': modinfo.module.program})
+    getModules_cached.depend_on_row('modules.ClassRegModuleInfo', lambda modinfo: {'self': modinfo.program})
+    getModules_cached.depend_on_row('modules.StudentClassRegModuleInfo', lambda modinfo: {'self': modinfo.program})
 
     def getModules(self, user = None, tl = None):
         """ Gets modules for this program, optionally attaching a user. """
@@ -917,7 +917,7 @@ class Program(models.Model, CustomFormsLinkModel):
 
         self._getColor = retVal
         return retVal
-    getColor.depend_on_row('modules.ClassRegModuleInfo', lambda crmi: {'self': crmi.module.program})
+    getColor.depend_on_row('modules.ClassRegModuleInfo', lambda crmi: {'self': crmi.program})
 
     def visibleEnrollments(self):
         """

--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -384,7 +384,7 @@ class ClassSection(models.Model):
         for r in rooms:
             rc += r.num_students
 
-        options = self.parent_program.getModuleExtension('StudentClassRegModuleInfo')
+        options = self.parent_program.studentclassregmoduleinfo
         if options.apply_multiplier_to_room_cap:
             rc = int(rc * options.class_cap_multiplier + options.class_cap_offset)
 
@@ -418,7 +418,7 @@ class ClassSection(models.Model):
             else:
                 ans = 0
 
-        options = self.parent_program.getModuleExtension('StudentClassRegModuleInfo')
+        options = self.parent_program.studentclassregmoduleinfo
 
         #   Apply dynamic capacity rule
         if not (ignore_changes or options.apply_multiplier_to_room_cap):
@@ -823,7 +823,7 @@ class ClassSection(models.Model):
 
         # Check if section is full
         if checkFull and self.isFull():
-            scrmi = self.parent_class.parent_program.getModuleExtension('StudentClassRegModuleInfo')
+            scrmi = self.parent_class.parent_program.studentclassregmoduleinfo
             return scrmi.temporarily_full_text
 
         # Test any scheduling constraints
@@ -841,7 +841,7 @@ class ClassSection(models.Model):
                 if not exp.evaluate(sm, recursive=autocorrect_constraints):
                     return u"Adding <i>%s</i> to your schedule requires that you %s.  You can go back and correct this." % (self.title(), exp.requirement.label)
 
-        scrmi = self.parent_program.getModuleExtension('StudentClassRegModuleInfo')
+        scrmi = self.parent_program.studentclassregmoduleinfo
         if not scrmi.use_priority:
             verbs = ['Enrolled']
             section_list = user.getEnrolledSectionsFromProgram(self.parent_program)
@@ -1191,7 +1191,7 @@ class ClassSection(models.Model):
 
     def preregister_student(self, user, overridefull=False, priority=1, prereg_verb = None, fast_force_create=False):
         if prereg_verb == None:
-            scrmi = self.parent_program.getModuleExtension('StudentClassRegModuleInfo')
+            scrmi = self.parent_program.studentclassregmoduleinfo
             if scrmi and scrmi.use_priority:
                 prereg_verb = 'Priority/%d' % priority
             else:
@@ -1589,7 +1589,7 @@ class ClassSubject(models.Model, CustomFormsLinkModel):
             return u'This program cannot accept any more students!  Please try again in its next session.'
 
         if checkFull and self.isFull():
-            scrmi = self.parent_program.getModuleExtension('StudentClassRegModuleInfo')
+            scrmi = self.parent_program.studentclassregmoduleinfo
             return scrmi.temporarily_full_text
 
         if user.getGrade(self.parent_program) < self.grade_min or \
@@ -1598,7 +1598,7 @@ class ClassSubject(models.Model, CustomFormsLinkModel):
                 return u'You are not in the requested grade range for this class.'
 
         # student has no classes...no conflict there.
-        if user.getClasses(self.parent_program, verbs=[self.parent_program.getModuleExtension('StudentClassRegModuleInfo').signup_verb.name]).count() == 0:
+        if user.getClasses(self.parent_program, verbs=[self.parent_program.studentclassregmoduleinfo.signup_verb.name]).count() == 0:
             return False
 
         for section in self.get_sections():

--- a/esp/esp/program/modules/admin.py
+++ b/esp/esp/program/modules/admin.py
@@ -47,19 +47,15 @@ class Admin_DBReceipt(admin.ModelAdmin):
 admin_site.register(DBReceipt, Admin_DBReceipt)
 
 class SCRMIAdmin(admin.ModelAdmin):
-    def program(obj):
-        return obj.module.program
-    list_display = ('module', program)
-    list_filter = ('module__program',)
-    search_fields = ('module__program__name',)
+    list_display = ('program',)
+    list_filter = ('program',)
+    search_fields = ('program__name',)
 admin_site.register(StudentClassRegModuleInfo, SCRMIAdmin)
 
 class CRMIAdmin(admin.ModelAdmin):
-    def program(obj):
-        return obj.module.program
-    list_display = ('module', program)
-    list_filter = ('module__program',)
-    search_fields = ('module__program__name',)
+    list_display = ('program',)
+    list_filter = ('program',)
+    search_fields = ('program__name',)
 admin_site.register(ClassRegModuleInfo, CRMIAdmin)
 
 class ProgramModelObjAdmin(admin.ModelAdmin):

--- a/esp/esp/program/modules/apps.py
+++ b/esp/esp/program/modules/apps.py
@@ -2,3 +2,9 @@ from esp.utils.apps import InstallConfig
 
 class ModulesConfig(InstallConfig):
     name = 'esp.program.modules'
+
+    def ready(self):
+        super(ModulesConfig, self).ready()
+        # TODO(benkraft): add a thing to InstallConfig that imports a signals
+        # file if one exists.
+        import esp.program.modules.signals

--- a/esp/esp/program/modules/base.py
+++ b/esp/esp/program/modules/base.py
@@ -253,16 +253,6 @@ class ProgramModuleObj(models.Model):
                 for attr in dir(ext):
                     self._ext_map[attr] = key
 
-    def __getattr__(self, attr):
-        # backward compatibility
-        if hasattr(self, '_ext_map') and attr in self._ext_map:
-            key = self._ext_map[attr]
-            ext = getattr(self, key)
-            import warnings
-            warnings.warn('Direct access of module extension attributes from module objects is deprecated. Use <module>.%s.%s instead.' % (key, attr), DeprecationWarning, stacklevel=2)
-            return getattr(ext, attr)
-        raise AttributeError('%r object has no attribute %r' % (self.__class__, attr))
-
     def deadline_met(self, extension=''):
 
         #   Short-circuit the request middleware during testing, when we call

--- a/esp/esp/program/modules/base.py
+++ b/esp/esp/program/modules/base.py
@@ -235,22 +235,7 @@ class ProgramModuleObj(models.Model):
         ModuleObj   = mod.getPythonClass()()
         ModuleObj.__dict__.update(BaseModule.__dict__)
 
-        # This used to make sure that every module had an appropriate
-        # module extension created if it wanted one, because this was where the
-        # module extension's attributes got populated onto the PMO.  We no
-        # longer want the attributes, but we need to make sure the thing still
-        # gets created, because other things may depend on it.  For now, do
-        # that manually.
-        # TODO(benkraft): Remove this, and make sure we always create the
-        # module extension in some more reasonable fashion, or handle it better
-        # if we don't.
-        if ModuleObj.module_ext:
-            ModuleObj.module_ext.objects.get_or_create(program=prog)
-
         return ModuleObj
-
-    # A hack, see the comment in getFromProgModule.
-    module_ext = None
 
     def baseDir(self):
         return 'program/modules/'+self.__class__.__name__.lower()+'/'

--- a/esp/esp/program/modules/base.py
+++ b/esp/esp/program/modules/base.py
@@ -245,8 +245,7 @@ class ProgramModuleObj(models.Model):
         # module extension in some more reasonable fashion, or handle it better
         # if we don't.
         if ModuleObj.module_ext:
-            ModuleObj.module_ext.objects.get_or_create(module=ModuleObj,
-                                                       program=prog)
+            ModuleObj.module_ext.objects.get_or_create(program=prog)
 
         return ModuleObj
 

--- a/esp/esp/program/modules/base.py
+++ b/esp/esp/program/modules/base.py
@@ -192,7 +192,7 @@ class ProgramModuleObj(models.Model):
         #   Put the user through a sequence of all required modules in the same category.
         #   Only do so if we've not blocked this behavior, though
         if tl not in ["manage", "json", "volunteer"] and isinstance(moduleobj, CoreModule):
-            scrmi = prog.getModuleExtension('StudentClassRegModuleInfo')
+            scrmi = prog.studentclassregmoduleinfo
             if scrmi.force_show_required_modules:
                 if not_logged_in(request):
                     return HttpResponseRedirect('%s?%s=%s' % (LOGIN_URL, REDIRECT_FIELD_NAME, quote(request.get_full_path())))

--- a/esp/esp/program/modules/base.py
+++ b/esp/esp/program/modules/base.py
@@ -245,7 +245,8 @@ class ProgramModuleObj(models.Model):
         # module extension in some more reasonable fashion, or handle it better
         # if we don't.
         if ModuleObj.module_ext:
-            ModuleObj.module_ext.objects.get_or_create(module=ModuleObj)
+            ModuleObj.module_ext.objects.get_or_create(module=ModuleObj,
+                                                       program=prog)
 
         return ModuleObj
 

--- a/esp/esp/program/modules/base.py
+++ b/esp/esp/program/modules/base.py
@@ -83,10 +83,6 @@ class ProgramModuleObj(models.Model):
     def __unicode__(self):
         return '"%s" for "%s"' % (self.module.admin_title, str(self.program))
 
-    def get_program(self):
-        """ Backward compatibility; see ClassRegModuleInfo.get_program """
-        return self.program
-
     def get_views_by_call_tag(self, tags):
         """ We define decorators below (aux_call, main_call, etc.) which allow
             methods within the ProgramModuleObj subclass to be tagged with

--- a/esp/esp/program/modules/base.py
+++ b/esp/esp/program/modules/base.py
@@ -45,20 +45,15 @@ from esp.program.models import Program, ProgramModule
 from esp.users.models import ESPUser, Permission
 from esp.utils.web import render_to_response
 from argcache import cache_function
-from esp.tagdict.models import Tag
 from django.http import HttpResponseRedirect, Http404
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.conf import settings
 from urllib import quote
-from django.db.models.query import Q
-from django.core.cache import cache
 from django.template.loader import get_template
 from django.template import TemplateDoesNotExist
 
 from esp.middleware import ESPError
 from esp.middleware.threadlocalrequest import get_current_request
-
-from os.path import exists
 
 LOGIN_URL = settings.LOGIN_URL
 
@@ -94,12 +89,9 @@ class ProgramModuleObj(models.Model):
 
         result = []
 
-        #   Filter out attributes that we don't want to look at:
-        #   - Attributes of ProgramMdouleObj, including Django stuff
-        #   - Module extension attributes
+        #   Filter out attributes that we don't want to look at: attributes of
+        #   ProgramModuleObj, including Django stuff
         key_set = set(dir(self)) - set(dir(ProgramModuleObj)) - set(self.__class__._meta.get_all_field_names())
-        for exclude_class in [ClassRegModuleInfo, StudentClassRegModuleInfo]:
-            key_set = filter(lambda key: key not in dir(exclude_class), key_set)
         for key in key_set:
             #   Fetch the attribute, now that we're confident it's safe to look at.
             item = getattr(self, key)

--- a/esp/esp/program/modules/base.py
+++ b/esp/esp/program/modules/base.py
@@ -245,13 +245,10 @@ class ProgramModuleObj(models.Model):
         """ Find module extensions that this program module inherits from, and
         incorporate those into its attributes. """
 
-        self._ext_map = {}
         if self.program:
             for key, x in self.extensions().items():
                 ext = self.program.getModuleExtension(x, module_id=self.id)
                 setattr(self, key, ext)
-                for attr in dir(ext):
-                    self._ext_map[attr] = key
 
     def deadline_met(self, extension=''):
 

--- a/esp/esp/program/modules/forms/teacherreg.py
+++ b/esp/esp/program/modules/forms/teacherreg.py
@@ -118,12 +118,13 @@ class TeacherClassRegForm(FormWithRequiredCss):
 
         super(TeacherClassRegForm, self).__init__(*args, **kwargs)
 
+        # TODO(benkraft): clean this up and do one or the other.
         if isinstance(module, ClassRegModuleInfo):
             crmi = module
+            prog = module.module.program
         else:
             crmi = module.crmi
-
-        prog = crmi.get_program()
+            prog = module.program
 
         section_numbers = crmi.allowed_sections_actual
         section_numbers = zip(section_numbers, section_numbers)
@@ -289,7 +290,7 @@ class TeacherOpenClassRegForm(TeacherClassRegForm):
                 field.initial = default
 
         super(TeacherOpenClassRegForm, self).__init__(module, *args, **kwargs)
-        open_class_category = module.get_program().open_class_category
+        open_class_category = module.program.open_class_category
         self.fields['category'].choices += [(open_class_category.id, open_class_category.category)]
 
         # Re-enable the requested special resources field as a space needs .
@@ -301,7 +302,7 @@ class TeacherOpenClassRegForm(TeacherClassRegForm):
         self.fields['duration'].help_text = "For how long are you willing to teach this class?"
 
         fields = [('category', open_class_category.id),
-                  ('prereqs', ''), ('session_count', 1), ('grade_min', module.get_program().grade_min), ('grade_max', module.get_program().grade_max),
+                  ('prereqs', ''), ('session_count', 1), ('grade_min', module.program.grade_min), ('grade_max', module.program.grade_max),
                   ('class_size_max', 200), ('class_size_optimal', ''), ('optimal_class_size_range', ''),
                   ('allowable_class_size_ranges', ''), ('hardness_rating', '**'), ('allow_lateness', True),
                   ('requested_room', '')]

--- a/esp/esp/program/modules/forms/teacherreg.py
+++ b/esp/esp/program/modules/forms/teacherreg.py
@@ -104,7 +104,7 @@ class TeacherClassRegForm(FormWithRequiredCss):
                                                    help_text='Please explain any special circumstances and equipment requests. Remember that you can be reimbursed for up to $30 (or more with the directors\' approval) for class expenses if you submit itemized receipts.' )
 
 
-    def __init__(self, module, *args, **kwargs):
+    def __init__(self, crmi, *args, **kwargs):
         from esp.program.controllers.classreg import get_custom_fields
 
         def hide_field(field, default=None):
@@ -118,13 +118,7 @@ class TeacherClassRegForm(FormWithRequiredCss):
 
         super(TeacherClassRegForm, self).__init__(*args, **kwargs)
 
-        # TODO(benkraft): clean this up and do one or the other.
-        if isinstance(module, ClassRegModuleInfo):
-            crmi = module
-            prog = module.module.program
-        else:
-            crmi = module.crmi
-            prog = module.program
+        prog = crmi.module.program
 
         section_numbers = crmi.allowed_sections_actual
         section_numbers = zip(section_numbers, section_numbers)
@@ -282,15 +276,16 @@ class TeacherClassRegForm(FormWithRequiredCss):
 
 class TeacherOpenClassRegForm(TeacherClassRegForm):
 
-    def __init__(self, module, *args, **kwargs):
+    def __init__(self, crmi, *args, **kwargs):
         """ Initialize the teacher class reg form, and then remove irrelevant fields. """
         def hide_field(field, default=None):
             field.widget = forms.HiddenInput()
             if default is not None:
                 field.initial = default
 
-        super(TeacherOpenClassRegForm, self).__init__(module, *args, **kwargs)
-        open_class_category = module.program.open_class_category
+        super(TeacherOpenClassRegForm, self).__init__(crmi, *args, **kwargs)
+        program = crmi.module.program
+        open_class_category = program.open_class_category
         self.fields['category'].choices += [(open_class_category.id, open_class_category.category)]
 
         # Re-enable the requested special resources field as a space needs .
@@ -302,7 +297,7 @@ class TeacherOpenClassRegForm(TeacherClassRegForm):
         self.fields['duration'].help_text = "For how long are you willing to teach this class?"
 
         fields = [('category', open_class_category.id),
-                  ('prereqs', ''), ('session_count', 1), ('grade_min', module.program.grade_min), ('grade_max', module.program.grade_max),
+                  ('prereqs', ''), ('session_count', 1), ('grade_min', program.grade_min), ('grade_max', program.grade_max),
                   ('class_size_max', 200), ('class_size_optimal', ''), ('optimal_class_size_range', ''),
                   ('allowable_class_size_ranges', ''), ('hardness_rating', '**'), ('allow_lateness', True),
                   ('requested_room', '')]

--- a/esp/esp/program/modules/forms/teacherreg.py
+++ b/esp/esp/program/modules/forms/teacherreg.py
@@ -118,7 +118,7 @@ class TeacherClassRegForm(FormWithRequiredCss):
 
         super(TeacherClassRegForm, self).__init__(*args, **kwargs)
 
-        prog = crmi.module.program
+        prog = crmi.program
 
         section_numbers = crmi.allowed_sections_actual
         section_numbers = zip(section_numbers, section_numbers)
@@ -284,7 +284,7 @@ class TeacherOpenClassRegForm(TeacherClassRegForm):
                 field.initial = default
 
         super(TeacherOpenClassRegForm, self).__init__(crmi, *args, **kwargs)
-        program = crmi.module.program
+        program = crmi.program
         open_class_category = program.open_class_category
         self.fields['category'].choices += [(open_class_category.id, open_class_category.category)]
 

--- a/esp/esp/program/modules/handlers/adminreviewapps.py
+++ b/esp/esp/program/modules/handlers/adminreviewapps.py
@@ -154,7 +154,7 @@ class AdminReviewApps(ProgramModuleObj):
     @aux_call
     @needs_admin
     def view_app(self, request, tl, one, two, module, extra, prog):
-        scrmi = prog.getModuleExtension('StudentClassRegModuleInfo')
+        scrmi = prog.studentclassregmoduleinfo
         reg_nodes = scrmi.reg_verbs()
 
         try:

--- a/esp/esp/program/modules/handlers/availabilitymodule.py
+++ b/esp/esp/program/modules/handlers/availabilitymodule.py
@@ -117,11 +117,6 @@ class AvailabilityModule(ProgramModuleObj):
     def teacherDesc(self):
         return {'availability': """Teachers who have indicated their scheduled availability for the program."""}
 
-    def getTimes(self):
-        #   Get a list of tuples with the id and name of each of the program's timeslots
-        times = self.program.getTimeSlots(types=[self.event_type()])
-        return [(str(t.id), t.short_description) for t in times]
-
     def prettyTime(self, time, inc_date=True):
         if inc_date:
             return time.strftime('%A, %b %d, ').decode('utf-8') + time.strftime('%I:%M %p').lower().strip('0').decode('utf-8')

--- a/esp/esp/program/modules/handlers/formstackappmodule.py
+++ b/esp/esp/program/modules/handlers/formstackappmodule.py
@@ -77,7 +77,7 @@ class FormstackAppModule(ProgramModuleObj):
     @main_call
     @needs_student
     def studentapp(self, request, tl, one, two, module, extra, prog):
-        fsas = prog.getModuleExtension(FormstackAppSettings)
+        fsas = prog.formstackappsettings
         context = {}
         context['form'] = fsas.form()
         context['username_field'] = fsas.username_field
@@ -99,7 +99,7 @@ class FormstackAppModule(ProgramModuleObj):
     @aux_call
     @needs_student
     def finaidapp(self, request, tl, one, two, module, extra, prog):
-        fsas = prog.getModuleExtension(FormstackAppSettings)
+        fsas = prog.formstackappsettings
         if not fsas.finaid_form():
             return # no finaid form
         app = FormstackStudentProgramApp.objects.filter(user=request.user, program=prog)

--- a/esp/esp/program/modules/handlers/formstackappmodule.py
+++ b/esp/esp/program/modules/handlers/formstackappmodule.py
@@ -35,10 +35,9 @@ Learning Unlimited, Inc.
 
 from django.db.models.query import Q
 from esp.program.modules.base import ProgramModuleObj, needs_teacher, needs_student, needs_admin, usercheck_usetl, meets_deadline, meets_any_deadline, main_call, aux_call
-from esp.program.modules import module_ext
 from esp.utils.web import render_to_response
 from esp.users.models    import ESPUser
-from esp.application.models import FormstackStudentProgramApp
+from esp.application.models import FormstackStudentProgramApp, FormstackAppSettings
 from urllib import urlencode
 
 class FormstackAppModule(ProgramModuleObj):
@@ -58,9 +57,7 @@ class FormstackAppModule(ProgramModuleObj):
             "required": True,
             }]
 
-    @classmethod
-    def extensions(cls):
-        return {'fsas': module_ext.FormstackAppSettings}
+    module_ext = FormstackAppSettings
 
     def students(self, QObject = False):
         result = {}
@@ -82,7 +79,7 @@ class FormstackAppModule(ProgramModuleObj):
     @main_call
     @needs_student
     def studentapp(self, request, tl, one, two, module, extra, prog):
-        fsas = prog.getModuleExtension(module_ext.FormstackAppSettings)
+        fsas = prog.getModuleExtension(FormstackAppSettings)
         context = {}
         context['form'] = fsas.form()
         context['username_field'] = fsas.username_field
@@ -104,7 +101,7 @@ class FormstackAppModule(ProgramModuleObj):
     @aux_call
     @needs_student
     def finaidapp(self, request, tl, one, two, module, extra, prog):
-        fsas = prog.getModuleExtension(module_ext.FormstackAppSettings)
+        fsas = prog.getModuleExtension(FormstackAppSettings)
         if not fsas.finaid_form():
             return # no finaid form
         app = FormstackStudentProgramApp.objects.filter(user=request.user, program=prog)

--- a/esp/esp/program/modules/handlers/formstackappmodule.py
+++ b/esp/esp/program/modules/handlers/formstackappmodule.py
@@ -37,7 +37,7 @@ from django.db.models.query import Q
 from esp.program.modules.base import ProgramModuleObj, needs_teacher, needs_student, needs_admin, usercheck_usetl, meets_deadline, meets_any_deadline, main_call, aux_call
 from esp.utils.web import render_to_response
 from esp.users.models    import ESPUser
-from esp.application.models import FormstackStudentProgramApp, FormstackAppSettings
+from esp.application.models import FormstackStudentProgramApp
 from urllib import urlencode
 
 class FormstackAppModule(ProgramModuleObj):
@@ -56,8 +56,6 @@ class FormstackAppModule(ProgramModuleObj):
             "seq": 10,
             "required": True,
             }]
-
-    module_ext = FormstackAppSettings
 
     def students(self, QObject = False):
         result = {}

--- a/esp/esp/program/modules/handlers/jsondatamodule.py
+++ b/esp/esp/program/modules/handlers/jsondatamodule.py
@@ -729,7 +729,7 @@ teachers[key].filter(is_active = True).distinct().count()))
         dictOut["stats"].append(shirt_data);
 
         Q_categories = Q(program=prog)
-        crmi = prog.getModuleExtension('ClassRegModuleInfo')
+        crmi = prog.classregmoduleinfo
         if crmi.open_class_registration:
             Q_categories |= Q(pk=prog.open_class_category.pk)
         #   Introduce a separate query to get valid categories, since the single query seemed to introduce duplicates

--- a/esp/esp/program/modules/handlers/lotterystudentregmodule.py
+++ b/esp/esp/program/modules/handlers/lotterystudentregmodule.py
@@ -103,7 +103,7 @@ class LotteryStudentRegModule(ProgramModuleObj):
         import json
         from django.utils.safestring import mark_safe
 
-        crmi = prog.getModuleExtension('ClassRegModuleInfo')
+        crmi = prog.classregmoduleinfo
 
         open_class_category = prog.open_class_category
         # Convert the open_class_category ClassCategory object into a dictionary, only including the attributes the lottery needs or might need
@@ -113,7 +113,7 @@ class LotteryStudentRegModule(ProgramModuleObj):
 
         context = {'prog': prog, 'support': settings.DEFAULT_EMAIL_ADDRESSES['support'], 'open_class_registration': {False: 0, True: 1}[crmi.open_class_registration], 'open_class_category': open_class_category}
 
-        ProgInfo = prog.getModuleExtension('StudentClassRegModuleInfo')
+        ProgInfo = prog.studentclassregmoduleinfo
 
         #HSSP-style lottery
         if ProgInfo.use_priority == True and ProgInfo.priority_limit > 1:

--- a/esp/esp/program/modules/handlers/schedulingcheckmodule.py
+++ b/esp/esp/program/modules/handlers/schedulingcheckmodule.py
@@ -371,7 +371,7 @@ class SchedulingCheckRunner:
           if len(self.d_grades) > 0:
              return self.d_grades
 
-          self.grades = self.p.getModuleExtension('ClassRegModuleInfo').getClassGrades()
+          self.grades = self.p.classregmoduleinfo.getClassGrades()
           grades_d = {}
           for grade in self.grades:
                grades_d[grade] = 0

--- a/esp/esp/program/modules/handlers/studentclassregmodule.py
+++ b/esp/esp/program/modules/handlers/studentclassregmodule.py
@@ -50,7 +50,6 @@ from django.core.cache import cache
 from esp.program.modules.base import ProgramModuleObj, needs_teacher, needs_student, needs_admin, usercheck_usetl, meets_deadline, meets_any_deadline, main_call, aux_call
 from esp.program.modules.handlers.onsiteclasslist import OnSiteClassList
 from esp.program.models  import ClassSubject, ClassSection, ClassCategories, RegistrationProfile, ClassImplication, StudentRegistration, StudentSubjectInterest
-from esp.program.modules.module_ext import StudentClassRegModuleInfo
 from esp.utils.web import render_to_response
 from esp.middleware      import ESPError, AjaxError, ESPError_Log, ESPError_NoLog
 from esp.users.models    import ESPUser, Permission, Record
@@ -142,8 +141,6 @@ class StudentClassRegModule(ProgramModuleObj):
     @property
     def scrmi(self):
         return self.program.getModuleExtension('StudentClassRegModuleInfo')
-
-    module_ext = StudentClassRegModuleInfo
 
     def students(self, QObject = False):
 

--- a/esp/esp/program/modules/handlers/studentclassregmodule.py
+++ b/esp/esp/program/modules/handlers/studentclassregmodule.py
@@ -141,7 +141,7 @@ class StudentClassRegModule(ProgramModuleObj):
 
     @property
     def scrmi(self):
-        return self.program.getModuleExtension('StudentClassRegModuleInfo', self.id)
+        return self.program.getModuleExtension('StudentClassRegModuleInfo')
 
     module_ext = StudentClassRegModuleInfo
 

--- a/esp/esp/program/modules/handlers/studentclassregmodule.py
+++ b/esp/esp/program/modules/handlers/studentclassregmodule.py
@@ -140,7 +140,7 @@ class StudentClassRegModule(ProgramModuleObj):
 
     @property
     def scrmi(self):
-        return self.program.getModuleExtension('StudentClassRegModuleInfo')
+        return self.program.studentclassregmoduleinfo
 
     def students(self, QObject = False):
 
@@ -208,7 +208,7 @@ class StudentClassRegModule(ProgramModuleObj):
 
         user = get_current_request().user
         is_onsite = user.isOnsite(self.program)
-        scrmi = self.program.getModuleExtension('StudentClassRegModuleInfo')
+        scrmi = self.program.studentclassregmoduleinfo
 
         #   Filter out volunteer timeslots
         timeslots = [x for x in timeslots if x.event_type.description != 'Volunteer']
@@ -329,7 +329,7 @@ class StudentClassRegModule(ProgramModuleObj):
             Return True if there are no errors.
         """
         reg_perm = 'Student/Classes'
-        scrmi = self.program.getModuleExtension('StudentClassRegModuleInfo')
+        scrmi = self.program.studentclassregmoduleinfo
 
         if 'prereg_verb' in request.POST:
             proposed_verb = "V/Flags/Registration/%s" % request.POST['prereg_verb']
@@ -533,7 +533,7 @@ class StudentClassRegModule(ProgramModuleObj):
         collapse_full = ('false' not in Tag.getProgramTag('collapse_full_classes', prog, 'True').lower())
         context = {'classes': classes, 'one': one, 'two': two, 'categories': categories.values(), 'collapse_full': collapse_full}
 
-        scrmi = prog.getModuleExtension('StudentClassRegModuleInfo')
+        scrmi = prog.studentclassregmoduleinfo
         context['register_from_catalog'] = scrmi.register_from_catalog
 
         prog_color = prog.getColor()
@@ -600,7 +600,7 @@ class StudentClassRegModule(ProgramModuleObj):
 
     @cache_control(public=True, max_age=3600)
     def catalog_allowed_reg_verbs(self, request, tl, one, two, module, extra, prog, timeslot=None):
-        scrmi = prog.getModuleExtension('StudentClassRegModuleInfo')
+        scrmi = prog.studentclassregmoduleinfo
         signup_verb_uri = scrmi.signup_verb.get_uri().replace('V/Flags/Registration/', '')
 
         if scrmi.use_priority:

--- a/esp/esp/program/modules/handlers/studentclassregmodule.py
+++ b/esp/esp/program/modules/handlers/studentclassregmodule.py
@@ -50,7 +50,7 @@ from django.core.cache import cache
 from esp.program.modules.base import ProgramModuleObj, needs_teacher, needs_student, needs_admin, usercheck_usetl, meets_deadline, meets_any_deadline, main_call, aux_call
 from esp.program.modules.handlers.onsiteclasslist import OnSiteClassList
 from esp.program.models  import ClassSubject, ClassSection, ClassCategories, RegistrationProfile, ClassImplication, StudentRegistration, StudentSubjectInterest
-from esp.program.modules import module_ext
+from esp.program.modules.module_ext import StudentClassRegModuleInfo
 from esp.utils.web import render_to_response
 from esp.middleware      import ESPError, AjaxError, ESPError_Log, ESPError_NoLog
 from esp.users.models    import ESPUser, Permission, Record
@@ -139,10 +139,11 @@ class StudentClassRegModule(ProgramModuleObj):
             "required": True,
             }]
 
-    @classmethod
-    def extensions(cls):
-        return {'scrmi': module_ext.StudentClassRegModuleInfo}
+    @property
+    def scrmi(self):
+        return self.program.getModuleExtension('StudentClassRegModuleInfo', self.id)
 
+    module_ext = StudentClassRegModuleInfo
 
     def students(self, QObject = False):
 

--- a/esp/esp/program/modules/handlers/studentregcore.py
+++ b/esp/esp/program/modules/handlers/studentregcore.py
@@ -224,7 +224,7 @@ class StudentRegCore(ProgramModuleObj, CoreModule):
             rec.delete()
 
         #   If the appropriate flag is set, remove the student from their classes.
-        scrmi = prog.getModuleExtension('StudentClassRegModuleInfo')
+        scrmi = prog.studentclassregmoduleinfo
         if scrmi.cancel_button_dereg:
             sections = request.user.getSections()
             for sec in sections:
@@ -275,7 +275,7 @@ class StudentRegCore(ProgramModuleObj, CoreModule):
         context['one'] = one
         context['two'] = two
         context['coremodule'] = self
-        context['scrmi'] = prog.getModuleExtension('StudentClassRegModuleInfo')
+        context['scrmi'] = prog.studentclassregmoduleinfo
         context['can_confirm'] = _checkDeadline_helper(None, '/Confirm', self, request, tl)[0]
         context['isConfirmed'] = self.program.isConfirmed(request.user)
         context['have_paid'] = self.have_paid(request.user)

--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -35,7 +35,6 @@ Learning Unlimited, Inc.
 from collections import defaultdict
 
 from esp.program.modules.base    import ProgramModuleObj, needs_teacher, meets_deadline, main_call, aux_call, user_passes_test
-from esp.program.modules.module_ext import ClassRegModuleInfo
 from esp.program.modules.forms.teacherreg   import TeacherClassRegForm, TeacherOpenClassRegForm
 from esp.program.models          import ClassSubject, ClassSection, Program, ProgramModule, StudentRegistration, RegistrationType, ClassFlagType
 from esp.program.controllers.classreg import ClassCreationController, ClassCreationValidationError, get_custom_fields
@@ -72,8 +71,6 @@ class TeacherClassRegModule(ProgramModuleObj):
     @property
     def crmi(self):
         return self.program.getModuleExtension('ClassRegModuleInfo')
-
-    module_ext = ClassRegModuleInfo
 
     def prepare(self, context={}):
         """ prepare returns the context for the main teacherreg page. """

--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -70,7 +70,7 @@ class TeacherClassRegModule(ProgramModuleObj):
 
     @property
     def crmi(self):
-        return self.program.getModuleExtension('ClassRegModuleInfo')
+        return self.program.classregmoduleinfo
 
     def prepare(self, context={}):
         """ prepare returns the context for the main teacherreg page. """

--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -737,10 +737,10 @@ class TeacherClassRegModule(ProgramModuleObj):
                     context['class'] = newclass
 
                 if action=='edit':
-                    reg_form = TeacherClassRegForm(self, current_data)
+                    reg_form = TeacherClassRegForm(self.crmi, current_data)
                     if populateonly: reg_form._errors = ErrorDict()
                 elif action=='editopenclass':
-                    reg_form = TeacherOpenClassRegForm(self, current_data)
+                    reg_form = TeacherOpenClassRegForm(self.crmi, current_data)
                     if populateonly: reg_form._errors = ErrorDict()
 
                 #   Todo...
@@ -762,9 +762,9 @@ class TeacherClassRegModule(ProgramModuleObj):
 
             else:
                 if action=='create':
-                    reg_form = TeacherClassRegForm(self)
+                    reg_form = TeacherClassRegForm(self.crmi)
                 elif action=='createopenclass':
-                    reg_form = TeacherOpenClassRegForm(self)
+                    reg_form = TeacherOpenClassRegForm(self.crmi)
 
                 #   Provide initial forms: a request for each provided type, but no requests for new types.
                 resource_formset = ResourceRequestFormSet(resource_type=resource_types, prefix='request')

--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -71,7 +71,7 @@ class TeacherClassRegModule(ProgramModuleObj):
 
     @property
     def crmi(self):
-        return self.program.getModuleExtension('ClassRegModuleInfo', self.id)
+        return self.program.getModuleExtension('ClassRegModuleInfo')
 
     module_ext = ClassRegModuleInfo
 

--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -35,7 +35,7 @@ Learning Unlimited, Inc.
 from collections import defaultdict
 
 from esp.program.modules.base    import ProgramModuleObj, needs_teacher, meets_deadline, main_call, aux_call, user_passes_test
-from esp.program.modules         import module_ext
+from esp.program.modules.module_ext import ClassRegModuleInfo
 from esp.program.modules.forms.teacherreg   import TeacherClassRegForm, TeacherOpenClassRegForm
 from esp.program.models          import ClassSubject, ClassSection, Program, ProgramModule, StudentRegistration, RegistrationType, ClassFlagType
 from esp.program.controllers.classreg import ClassCreationController, ClassCreationValidationError, get_custom_fields
@@ -69,10 +69,11 @@ class TeacherClassRegModule(ProgramModuleObj):
             "inline_template": "listclasses.html",
             }
 
-    @classmethod
-    def extensions(cls):
-        return {'crmi': module_ext.ClassRegModuleInfo}
+    @property
+    def crmi(self):
+        return self.program.getModuleExtension('ClassRegModuleInfo', self.id)
 
+    module_ext = ClassRegModuleInfo
 
     def prepare(self, context={}):
         """ prepare returns the context for the main teacherreg page. """

--- a/esp/esp/program/modules/handlers/teacherregcore.py
+++ b/esp/esp/program/modules/handlers/teacherregcore.py
@@ -62,7 +62,7 @@ class TeacherRegCore(ProgramModuleObj, CoreModule):
             context = module.prepare(context)
 
         context['modules'] = modules
-        context['options'] = prog.getModuleExtension('ClassRegModuleInfo')
+        context['options'] = prog.classregmoduleinfo
         context['one'] = one
         context['two'] = two
         context['extra_steps'] = "teach:extra_steps"

--- a/esp/esp/program/modules/handlers/teacherreviewapps.py
+++ b/esp/esp/program/modules/handlers/teacherreviewapps.py
@@ -180,7 +180,7 @@ class TeacherReviewApps(ProgramModuleObj):
     @needs_teacher
     @meets_deadline("/AppReview")
     def review_student(self, request, tl, one, two, module, extra, prog):
-        scrmi = prog.getModuleExtension('StudentClassRegModuleInfo')
+        scrmi = prog.studentclassregmoduleinfo
         reg_nodes = scrmi.reg_verbs()
 
         try:

--- a/esp/esp/program/modules/handlers/teacherreviewapps.py
+++ b/esp/esp/program/modules/handlers/teacherreviewapps.py
@@ -130,7 +130,7 @@ class TeacherReviewApps(ProgramModuleObj):
         """ Edit the subject-specific questions that students will respond to on
         their applications. """
         subjects = request.user.getTaughtClasses(prog)
-        clrmi = module_ext.ClassRegModuleInfo.objects.get(module__program=self.program)
+        clrmi = module_ext.ClassRegModuleInfo.objects.get(program=self.program)
         question_list = []
 
         #   Provide forms to modify existing questions, and also blank forms for new questions
@@ -244,7 +244,7 @@ class TeacherReviewApps(ProgramModuleObj):
                                    'form': form})
 
     def prepare(self, context):
-        clrmi = module_ext.ClassRegModuleInfo.objects.get(module__program=self.program)
+        clrmi = module_ext.ClassRegModuleInfo.objects.get(program=self.program)
         context['num_teacher_questions'] = clrmi.num_teacher_questions;
         context['classes'] = get_current_request().user.getTaughtClasses().filter(parent_program = self.program)
         return context

--- a/esp/esp/program/modules/migrations/0005_auto_20151211_0306.py
+++ b/esp/esp/program/modules/migrations/0005_auto_20151211_0306.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('program', '0004_auto_20151126_2220'),
+        ('modules', '0004_delete_checklistmodule'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='classregmoduleinfo',
+            name='program',
+            field=models.OneToOneField(null=True, to='program.Program'),
+        ),
+        migrations.AddField(
+            model_name='studentclassregmoduleinfo',
+            name='program',
+            field=models.OneToOneField(null=True, to='program.Program'),
+        ),
+    ]

--- a/esp/esp/program/modules/migrations/0006_populate_program.py
+++ b/esp/esp/program/modules/migrations/0006_populate_program.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def populate_program(apps, schema_editor):
+    Program = apps.get_model("program", "Program")
+    for model_name in ["StudentClassRegModuleInfo", "ClassRegModuleInfo"]:
+        ModuleInfo = apps.get_model("modules", model_name)
+        for program in Program.objects.all():
+            module_infos = ModuleInfo.objects.filter(module__program=program)
+            if module_infos:
+                # The old getModuleExtension just looked at the first one, so
+                # that's the one we'll keep around and update, and we'll delete
+                # the others.  (Actually, depending on how you called it,
+                # getModuleExtension looked at either the first one, or the
+                # first one that actually used the correct module.  I've
+                # manually cleaned up the ones that didn't use the correct
+                # module, and plus, having those in the first place was more or
+                # less undefined behavior, and in practice most callers just
+                # picked the first one, rather than the first one with the
+                # correct module.)
+                good_module_info = module_infos[0]
+                good_module_info.program = program
+                good_module_info.save()
+                for module_info in module_infos[1:]:
+                    module_info.delete()
+
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('modules', '0005_auto_20151211_0306'),
+        ('program', '0004_auto_20151126_2220'),
+    ]
+
+    operations = [
+        migrations.RunPython(populate_program, migrations.RunPython.noop),
+    ]

--- a/esp/esp/program/modules/migrations/0007_auto_20151211_0329.py
+++ b/esp/esp/program/modules/migrations/0007_auto_20151211_0329.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('modules', '0006_populate_program'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='classregmoduleinfo',
+            name='program',
+            field=models.OneToOneField(to='program.Program'),
+        ),
+        migrations.AlterField(
+            model_name='studentclassregmoduleinfo',
+            name='program',
+            field=models.OneToOneField(to='program.Program'),
+        ),
+    ]

--- a/esp/esp/program/modules/migrations/0008_auto_20151211_0349.py
+++ b/esp/esp/program/modules/migrations/0008_auto_20151211_0349.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('modules', '0007_auto_20151211_0329'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='classregmoduleinfo',
+            name='module',
+        ),
+        migrations.RemoveField(
+            model_name='studentclassregmoduleinfo',
+            name='module',
+        ),
+    ]

--- a/esp/esp/program/modules/module_ext.py
+++ b/esp/esp/program/modules/module_ext.py
@@ -213,28 +213,16 @@ class ClassRegModuleInfo(models.Model):
         # TODO(benkraft): remove.
         return self.program.getModule('TeacherClassRegModule')
 
-    def allowed_sections_ints_get(self):
-        return [ int(s.strip()) for s in self.allowed_sections.split(',') if s.strip() != '' ]
-
-    def allowed_sections_ints_set(self, value):
-        self.allowed_sections = ",".join([ str(n) for n in value ])
-
-    def allowed_sections_actual_get(self):
+    @property
+    def allowed_sections_actual(self):
         if self.allowed_sections:
-            return self.allowed_sections_ints_get()
+            return [int(s) for s in self.allowed_sections.split(',') if s.strip()]
         else:
-            return range( 1, self.program.getTimeSlots().count()+1 )
+            return range(1, self.program.getTimeSlots().count()+1)
 
-    # TODO: rename allowed_sections to... something and this to allowed_sections
-    allowed_sections_actual = property( allowed_sections_actual_get, allowed_sections_ints_set )
-
-    def session_counts_ints_get(self):
-        return [ int(s) for s in self.session_counts.split(',') ]
-
-    def session_counts_ints_set(self, value):
-        self.session_counts = ",".join([ str(n) for n in value ])
-
-    session_counts_ints = property( session_counts_ints_get, session_counts_ints_set )
+    @property
+    def session_counts_ints(self):
+        return [int(s) for s in self.session_counts.split(',')]
 
     def getClassSizes(self):
         #   Default values

--- a/esp/esp/program/modules/module_ext.py
+++ b/esp/esp/program/modules/module_ext.py
@@ -203,7 +203,7 @@ class ClassRegModuleInfo(models.Model):
         if self.allowed_sections:
             return self.allowed_sections_ints_get()
         else:
-            return range( 1, self.module.program.getTimeSlots().count()+1 )
+            return range( 1, self.program.getTimeSlots().count()+1 )
 
     # TODO: rename allowed_sections to... something and this to allowed_sections
     allowed_sections_actual = property( allowed_sections_actual_get, allowed_sections_ints_set )
@@ -241,15 +241,15 @@ class ClassRegModuleInfo(models.Model):
 
     def getClassGrades(self):
         min_grade, max_grade = (6, 12)
-        if self.module.program.grade_min:
-            min_grade = self.module.program.grade_min
-        if self.module.program.grade_max:
-            max_grade = self.module.program.grade_max
+        if self.program.grade_min:
+            min_grade = self.program.grade_min
+        if self.program.grade_max:
+            max_grade = self.program.grade_max
 
         return range(min_grade, max_grade+1)
 
     def getDurations(self):
-        return self.module.program.getDurations()
+        return self.program.getDurations()
 
     def __unicode__(self):
         return 'Class Reg Ext. for %s' % str(self.module)

--- a/esp/esp/program/modules/module_ext.py
+++ b/esp/esp/program/modules/module_ext.py
@@ -245,16 +245,8 @@ class ClassRegModuleInfo(models.Model):
 
         return range(min_grade, max_grade+1)
 
-    def getTimes(self):
-        times = self.module.program.getTimeSlots()
-        return [(str(x.id),x.short_description) for x in times]
-
     def getDurations(self):
         return self.module.program.getDurations()
-
-    def getResources(self):
-        resources = self.module.program.getResources()
-        return [(str(x.id), x.name) for x in resources]
 
     def __unicode__(self):
         return 'Class Reg Ext. for %s' % str(self.module)

--- a/esp/esp/program/modules/module_ext.py
+++ b/esp/esp/program/modules/module_ext.py
@@ -196,35 +196,11 @@ class ClassRegModuleInfo(models.Model):
     def allowed_sections_ints_set(self, value):
         self.allowed_sections = ",".join([ str(n) for n in value ])
 
-    def get_program(self):
-        # Unfortunately, it turns out the ProgramModule system does obscene
-        # things with __dict__, so the class specification up there is a
-        # blatant lie. Why the designer didn't think of giving two
-        # different fields different names is a mystery sane people have no
-        # hope of fathoming. (Seriously, these models are INTENDED to be
-        # subclassed together with ProgramModuleObj! What were you
-        # thinking!?)
-        #
-        # see ProgramModuleObj.module, ClassRegModuleInfo.module, and
-        # ProgramModuleObj.fixExtensions
-        #
-        # TODO: Look into renaming the silly field and make sure no black
-        # magic depends on it
-        if hasattr(self, 'program'):
-            program = self.program
-        elif isinstance(self.module, ProgramModuleObj):
-            # Sadly, this probably never happens, but this function is
-            # going to work when called by a sane person, dammit!
-            program = self.module.program
-        else:
-            raise ESPError("Can't find program from ClassRegModuleInfo")
-        return program
-
     def allowed_sections_actual_get(self):
         if self.allowed_sections:
             return self.allowed_sections_ints_get()
         else:
-            return range( 1, self.get_program().getTimeSlots().count()+1 )
+            return range( 1, self.module.program.getTimeSlots().count()+1 )
 
     # TODO: rename allowed_sections to... something and this to allowed_sections
     allowed_sections_actual = property( allowed_sections_actual_get, allowed_sections_ints_set )
@@ -262,22 +238,22 @@ class ClassRegModuleInfo(models.Model):
 
     def getClassGrades(self):
         min_grade, max_grade = (6, 12)
-        if self.get_program().grade_min:
-            min_grade = self.get_program().grade_min
-        if self.get_program().grade_max:
-            max_grade = self.get_program().grade_max
+        if self.module.program.grade_min:
+            min_grade = self.module.program.grade_min
+        if self.module.program.grade_max:
+            max_grade = self.module.program.grade_max
 
         return range(min_grade, max_grade+1)
 
     def getTimes(self):
-        times = self.get_program().getTimeSlots()
+        times = self.module.program.getTimeSlots()
         return [(str(x.id),x.short_description) for x in times]
 
     def getDurations(self):
-        return self.get_program().getDurations()
+        return self.module.program.getDurations()
 
     def getResources(self):
-        resources = self.get_program().getResources()
+        resources = self.module.program.getResources()
         return [(str(x.id), x.name) for x in resources]
 
     def __unicode__(self):

--- a/esp/esp/program/modules/module_ext.py
+++ b/esp/esp/program/modules/module_ext.py
@@ -33,14 +33,25 @@ Learning Unlimited, Inc.
   Email: web-team@learningu.org
 """
 
-import time
 from datetime import timedelta
+import time
+
 from django.db import models
-from esp.middleware import ESPError
+
 from esp.db.fields import AjaxForeignKey
-from django.conf import settings
-from esp.users.models import ESPUser
 from esp.program.models import Program, RegistrationType
+from esp.users.models import ESPUser
+
+# If this module is a little confusingly named, or has some cruft in it, it's
+# because it used to work differently.  Back in the day, certain program
+# modules inherited from one of the below models in addition to
+# ProgramModuleObj, thus the name "module extensions".  These days, they're
+# basically just a settings model that may be attached to the program, which
+# happens to have a name that suggests it has something to do with a program
+# module.  They still have a little to do with modules -- they're autocreated
+# when the corresponding program modules get added to a program (see
+# esp.program.models.maybe_create_module_ext), but that's about it.
+# TODO(benkraft): rename this to "program settings" or something.
 
 class DBReceipt(models.Model):
     """ Per-program Receipt templates """
@@ -328,7 +339,7 @@ class AJAXChangeLog(models.Model):
         entry.update(next_index, timeslots, room_name, cls_id)
 
         if user:
-        	entry.user = user
+            entry.user = user
 
         entry.save()
         self.save()
@@ -358,5 +369,3 @@ class AJAXChangeLog(models.Model):
                                     'user'      : entry.getUserName() })
 
         return entry_list
-
-from esp.application.models import FormstackAppSettings

--- a/esp/esp/program/modules/module_ext.py
+++ b/esp/esp/program/modules/module_ext.py
@@ -37,7 +37,6 @@ import time
 from datetime import timedelta
 from django.db import models
 from esp.middleware import ESPError
-from esp.program.modules.base import ProgramModuleObj
 from esp.db.fields import AjaxForeignKey
 from django.conf import settings
 from esp.users.models import ESPUser
@@ -62,7 +61,6 @@ def get_regtype_enrolled():
 class StudentClassRegModuleInfo(models.Model):
     """ Define what happens when students add classes to their schedule at registration. """
 
-    module               = models.ForeignKey(ProgramModuleObj, editable=False)
     program = models.OneToOneField(Program)
 
     #   Set to true to prevent students from registering from full classes.
@@ -121,6 +119,12 @@ class StudentClassRegModuleInfo(models.Model):
     #   (They still have to fill them out before confirming their registration, regardless of this setting)
     force_show_required_modules = models.BooleanField(default=True, help_text = "Check this box to require that users see and fill out \"required\" modules before they can see the main StudentReg page")
 
+    @property
+    def module(self):
+        """Deprecated; you probably shouldn't need this."""
+        # TODO(benkraft): remove.
+        return self.program.getModule('StudentClassRegModule')
+
     def reg_verbs(self):
         verb_list = [self.signup_verb]
 
@@ -141,7 +145,6 @@ class StudentClassRegModuleInfo(models.Model):
         return 'Student Class Reg Ext. for %s' % str(self.module)
 
 class ClassRegModuleInfo(models.Model):
-    module               = models.ForeignKey(ProgramModuleObj)
     program = models.OneToOneField(Program)
 
     allow_coteach        = models.BooleanField(blank=True, default=True, help_text='Check this box to allow teachers to specify co-teachers.')
@@ -192,6 +195,12 @@ class ClassRegModuleInfo(models.Model):
     #   Choose which appears on teacher reg for the modules: checkbox list, progress bar, or nothing
     #   ((0, 'None'),(1, 'Checkboxes'), (2, 'Progress Bar'))
     progress_mode = models.IntegerField(default=1, help_text='Select which to use on teacher reg: 1=checkboxes, 2=progress bar, 0=neither.')
+
+    @property
+    def module(self):
+        """Deprecated; you probably shouldn't need this."""
+        # TODO(benkraft): remove.
+        return self.program.getModule('TeacherClassRegModule')
 
     def allowed_sections_ints_get(self):
         return [ int(s.strip()) for s in self.allowed_sections.split(',') if s.strip() != '' ]

--- a/esp/esp/program/modules/module_ext.py
+++ b/esp/esp/program/modules/module_ext.py
@@ -63,6 +63,7 @@ class StudentClassRegModuleInfo(models.Model):
     """ Define what happens when students add classes to their schedule at registration. """
 
     module               = models.ForeignKey(ProgramModuleObj, editable=False)
+    program = models.OneToOneField(Program)
 
     #   Set to true to prevent students from registering from full classes.
     enforce_max          = models.BooleanField(default=True, help_text='Check this box to prevent students from signing up for full classes.')
@@ -141,6 +142,8 @@ class StudentClassRegModuleInfo(models.Model):
 
 class ClassRegModuleInfo(models.Model):
     module               = models.ForeignKey(ProgramModuleObj)
+    program = models.OneToOneField(Program)
+
     allow_coteach        = models.BooleanField(blank=True, default=True, help_text='Check this box to allow teachers to specify co-teachers.')
     set_prereqs          = models.BooleanField(blank=True, default=True, help_text='Check this box to allow teachers to enter prerequisites for each class that are displayed separately on the catalog.')
 

--- a/esp/esp/program/modules/signals.py
+++ b/esp/esp/program/modules/signals.py
@@ -1,0 +1,11 @@
+from esp.program.models import maybe_create_module_ext
+from esp.program.modules.module_ext import StudentClassRegModuleInfo, ClassRegModuleInfo
+
+# TODO(benkraft): There are actually a lot more modules that depend on these
+# module extensions.  In practice it's probably fine because very few programs
+# don't have the SCRM and TCRM, but maybe we should have other modules that
+# also need these also autocreate them -- there's little harm in doing so.
+# Ideally, we might even assert that only those modules access the settings,
+# but doing that in practice might be hard.
+maybe_create_module_ext('StudentClassRegModule', StudentClassRegModuleInfo)
+maybe_create_module_ext('TeacherClassRegModule', ClassRegModuleInfo)

--- a/esp/esp/program/templatetags/class_render.py
+++ b/esp/esp/program/templatetags/class_render.py
@@ -49,7 +49,7 @@ def render_class_core_helper(cls, prog=None, scrmi=None, colorstring=None, colla
 
     #   Show e-mail codes?  We need to look in the settings.
     if not scrmi:
-        scrmi = cls.parent_program.getModuleExtension('StudentClassRegModuleInfo')
+        scrmi = cls.parent_program.studentclassregmoduleinfo
 
     # Okay, chose a program? Good. Now fetch the color from its hiding place and format it...
     if not colorstring:
@@ -103,8 +103,8 @@ def render_class_helper(cls, user=None, prereg_url=None, filter=False, timeslot=
     else:
         section = None
 
-    scrmi = cls.parent_program.getModuleExtension('StudentClassRegModuleInfo')
-    crmi = cls.parent_program.getModuleExtension('ClassRegModuleInfo')
+    scrmi = cls.parent_program.studentclassregmoduleinfo
+    crmi = cls.parent_program.classregmoduleinfo
 
     #   Ensure cached catalog shows buttons and fillslots don't
 

--- a/esp/esp/program/templatetags/class_render_row.py
+++ b/esp/esp/program/templatetags/class_render_row.py
@@ -13,7 +13,7 @@ register = template.Library()
 def render_class_teacher_list_row(klass):
     return {'cls': klass,
             'program': klass.parent_program,
-            'crmi': klass.parent_program.getModuleExtension('ClassRegModuleInfo'),
+            'crmi': klass.parent_program.classregmoduleinfo,
             'friendly_times_with_date': (Tag.getProgramTag(key='friendly_times_with_date', program=klass.parent_program, default=False) == "True"),
             'email_host': settings.EMAIL_HOST
             }
@@ -26,7 +26,7 @@ render_class_teacher_list_row.cached_function.depend_on_cache(ClassSubject.get_t
 def render_class_copy_row(klass):
     return {'cls': klass,
             'program': klass.parent_program,
-            'crmi': klass.parent_program.getModuleExtension('ClassRegModuleInfo')}
+            'crmi': klass.parent_program.classregmoduleinfo}
 render_class_teacher_list_row.cached_function.depend_on_row(ClassSubject, lambda cls: {'klass': cls})
 render_class_teacher_list_row.cached_function.depend_on_row(ClassSection, lambda sec: {'klass': sec.parent_class})
 render_class_copy_row.cached_function.depend_on_cache(ClassSubject.get_teachers, lambda self=wildcard, **kwargs: {'klass': self})

--- a/esp/esp/program/tests.py
+++ b/esp/esp/program/tests.py
@@ -511,7 +511,7 @@ class ProgramHappenTest(TestCase):
         sr = StudentRegistration.objects.all()[0]
 
         self.assertTrue( StudentRegistration.valid_objects().filter(user=self.student, section=sec,
-            relationship=self.prog.getModuleExtension('StudentClassRegModuleInfo').signup_verb).count() > 0, 'Registration failed.')
+            relationship=self.prog.studentclassregmoduleinfo.signup_verb).count() > 0, 'Registration failed.')
 
         # Check that you're in it now
         self.assertEqual( self.student.getEnrolledClasses().count(), 1, "Student not enrolled in exactly one class" )
@@ -520,7 +520,7 @@ class ProgramHappenTest(TestCase):
         # Try dropping a class.
         self.client.get('%sclearslot/%s' % (self.prog.get_learn_url(), self.timeslot.id))
         self.assertFalse( StudentRegistration.valid_objects().filter(user=self.student, section=sec,
-            relationship=self.prog.getModuleExtension('StudentClassRegModuleInfo').signup_verb).count() > 0, 'Registration failed.')
+            relationship=self.prog.studentclassregmoduleinfo.signup_verb).count() > 0, 'Registration failed.')
 
         # Check that you're in no classes
         self.assertEqual( self.student.getEnrolledClasses().count(), 0, "Student incorrectly enrolled in a class" )
@@ -839,7 +839,7 @@ class ScheduleMapTest(ProgramFrameworkTest):
         ts1 = timeslot_list[0]
         ts2 = timeslot_list[1]
         modules = program.getModules()
-        scrmi = program.getModuleExtension('StudentClassRegModuleInfo')
+        scrmi = program.studentclassregmoduleinfo
 
         #   Check that the map starts out empty
         sm = ScheduleMap(student, program)
@@ -921,7 +921,7 @@ class ScheduleConstraintTest(ProgramFrameworkTest):
         program = self.program
         (section_list, timeslot_list) = randomized_attrs(program)
         modules = program.getModules()
-        scrmi = program.getModuleExtension('StudentClassRegModuleInfo')
+        scrmi = program.studentclassregmoduleinfo
 
         #   Prepare two sections
         section1 = section_list[0]
@@ -1010,7 +1010,7 @@ class DynamicCapacityTest(ProgramFrameworkTest):
         # have a separate unupdated copy of it around when we update it.
         # (Since self.program is a different copy of the same instance from
         # sec.parent_program, if we update one SCRMI, the other won't update.)
-        options = sec.parent_program.getModuleExtension('StudentClassRegModuleInfo')
+        options = sec.parent_program.studentclassregmoduleinfo
         sec.parent_class.class_size_max = initial_capacity
         sec.parent_class.save()
         sec.max_class_capacity = initial_capacity
@@ -1122,7 +1122,7 @@ class LSRAssignmentTest(ProgramFrameworkTest):
         self.interested_rt, created = RegistrationType.objects.get_or_create(name='Interested')
         self.waitlist_rt, created = RegistrationType.objects.get_or_create(name='Waitlist/1')
         self.priority_rts=[self.priority_rt]
-        scrmi = self.program.getModuleExtension('StudentClassRegModuleInfo')
+        scrmi = self.program.studentclassregmoduleinfo
         scrmi.priority_limit = 1
         scrmi.save()
 
@@ -1280,7 +1280,7 @@ class LSRAssignmentTest(ProgramFrameworkTest):
         self.priority_2_rt, created = RegistrationType.objects.get_or_create(name='Priority/2')
         self.priority_3_rt, created = RegistrationType.objects.get_or_create(name='Priority/3')
         self.priority_rts=[self.priority_rt, self.priority_2_rt, self.priority_3_rt]
-        scrmi = self.program.getModuleExtension('StudentClassRegModuleInfo')
+        scrmi = self.program.studentclassregmoduleinfo
         scrmi.priority_limit = 3
         scrmi.save()
 

--- a/esp/esp/program/tests.py
+++ b/esp/esp/program/tests.py
@@ -839,7 +839,7 @@ class ScheduleMapTest(ProgramFrameworkTest):
         ts1 = timeslot_list[0]
         ts2 = timeslot_list[1]
         modules = program.getModules()
-        scrmi = program.getModuleExtension('StudentClassRegModuleInfo', ProgramModuleObj.objects.filter(program=program, module__handler='StudentClassRegModule')[0].id)
+        scrmi = program.getModuleExtension('StudentClassRegModuleInfo')
 
         #   Check that the map starts out empty
         sm = ScheduleMap(student, program)
@@ -921,7 +921,7 @@ class ScheduleConstraintTest(ProgramFrameworkTest):
         program = self.program
         (section_list, timeslot_list) = randomized_attrs(program)
         modules = program.getModules()
-        scrmi = program.getModuleExtension('StudentClassRegModuleInfo', ProgramModuleObj.objects.filter(program=program, module__handler='StudentClassRegModule')[0].id)
+        scrmi = program.getModuleExtension('StudentClassRegModuleInfo')
 
         #   Prepare two sections
         section1 = section_list[0]

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -535,7 +535,7 @@ class BaseESPUser(object):
     def getAppliedClasses(self, program=None):
         #   If priority registration is enabled, add in more verbs.
         if program:
-            scrmi = program.getModuleExtension('StudentClassRegModuleInfo')
+            scrmi = program.studentclassregmoduleinfo
             verb_list = [v.name for v in scrmi.reg_verbs()]
         else:
             verb_list = ['Applied']


### PR DESCRIPTION
This is a cleanup of the program module extension system, completing some of the work started in #1232.

The major change (11b691b) is that module extension attributes are no longer accessible from the program module.  #1232 added a deprecation warning for this type of access, but unfortunately our setup doesn't seem to log those anywhere (see #1237).  So I decided to be bold and/or stupid and just grep for all possible fields and attributes that would be an issue and clean them up; luckily only a few were actually issues.

Removing this allowed a number of simplificiations.  The biggest one is a schema change: module extensions now point at programs, rather than at modules, and therefore are accessed like any other related model.  (The migration to do this involved a bit of cleanup; see the commit message and comments in 6a0cd37.)  They still have a slight tie to their former modules: if the module is added to a program, the corresponding module extension will be added too (see f5b1fd8).  But this is a very weak tie, and if we wanted we could easily sever it completely by creating all possible module extensions on program creation.

See individual commits for more details.  I tried to do things such that each commit is a valid, non-breaking change in and of itself, to make it easier to check correctness and do bisects; it may correspondingly be easier to review it commitwise.