### PR TITLE
Bump Reversion version to 1.10

### DIFF
--- a/esp/esp/program/views.py
+++ b/esp/esp/program/views.py
@@ -71,7 +71,7 @@ import operator
 import json
 from collections import defaultdict
 from decimal import Decimal
-import reversion
+from reversion import revisions as reversion
 
 try:
     from cStringIO import StringIO

--- a/esp/esp/qsd/admin.py
+++ b/esp/esp/qsd/admin.py
@@ -36,10 +36,10 @@ Learning Unlimited, Inc.
 from django.contrib import admin
 from esp.admin import admin_site
 from esp.qsd.models import QuasiStaticData
-import reversion
+from reversion.admin import VersionAdmin
 from esp.utils.admin_user_search import default_user_search
 
-class QuasiStaticDataAdmin(reversion.VersionAdmin):
+class QuasiStaticDataAdmin(VersionAdmin):
     search_fields = default_user_search('author') + ['title','name','keywords','description','url']
     list_display = ['nav_category', 'title', 'url', 'disabled', 'create_date', 'author']
     list_filter = ['nav_category',]

--- a/esp/esp/qsd/views.py
+++ b/esp/esp/qsd/views.py
@@ -52,7 +52,7 @@ from esp.varnish import purge_page
 
 from django.conf import settings
 
-import reversion
+from reversion import revisions as reversion
 
 # default edit permission
 EDIT_PERM = 'V/Administer/Edit'

--- a/esp/esp/utils/models.py
+++ b/esp/esp/utils/models.py
@@ -33,7 +33,7 @@ Learning Unlimited, Inc.
 """
 
 from django.db import models
-import reversion
+from reversion import revisions as reversion
 
 from esp.users.models import ESPUser
 from esp.db.fields import AjaxForeignKey

--- a/esp/esp/utils/tests.py
+++ b/esp/esp/utils/tests.py
@@ -13,7 +13,7 @@ except:
 import os
 import subprocess
 import sys
-import reversion
+from reversion import revisions as reversion
 import unittest
 
 from django.db.models.query import Q

--- a/esp/requirements.txt
+++ b/esp/requirements.txt
@@ -3,7 +3,7 @@ pillow==2.8.2
 cssutils==1.0
 django-extensions==1.5.5
 django-form-utils==1.0.3
-django-reversion==1.8.7
+django-reversion==1.10.0
 django-selenium==0.9.8
 django-localflavor==1.1
 flup==1.0.2


### PR DESCRIPTION
It introduced some backwards-incompatible changes in order to support Django 1.9. The `from reversion import revisions as reversion` is what's recommended in their documentation.