### PR TITLE
Bugfix: cannot loaddb using saved settings

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -284,7 +284,7 @@ def loaddb(filename=None):
         # easier for people to work with different chapters' databasees in
         # different VMs.
         if files.exists(env.encfab + "dbconfig"):
-            contents = run(env.encfab + "dbconfig")
+            contents = run("cat " + env.encfab + "dbconfig")
             config = json.loads(contents)
         else:
             url = prompt("Download URL:")


### PR DESCRIPTION
Error message:
```
/bin/bash: /mnt/encrypted/fabric/dbconfig: Permission denied
```

Cause: instead of `cat`-ing a file, we try to execute it. Oops!

I'm going to merge this to `main` and `mit-prod`, since those are the two branches I know are affected.