### PR TITLE
A few json-related fixes

### DIFF
--- a/esp/esp/program/modules/handlers/jsondatamodule.py
+++ b/esp/esp/program/modules/handlers/jsondatamodule.py
@@ -604,13 +604,14 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
     @needs_admin
     @cached_module_view
     def message_requests():
-        earlier_requests = MessageRequest.objects.exclude(subject__icontains='password recovery')
-        data = earlier_requests.values('id', 'creator__first_name', 'creator__last_name', 'creator__username', 'subject', 'sender', 'processed_by', 'msgtext', 'recipients__useful_name').order_by('-id').distinct()
+        earlier_requests = MessageRequest.objects.all()
+        # Limit to 100 so the data doesn't get too big for memcached
+        data = earlier_requests.values('id', 'creator__first_name', 'creator__last_name', 'creator__username', 'subject', 'sender', 'processed_by', 'msgtext', 'recipients__useful_name').order_by('-id').distinct()[:100]
         for item in data:
             if isinstance(item['processed_by'], datetime):
                 item['processed_by'] = item['processed_by'].timetuple()[:6]
 
-        return {'message_requests': data}
+        return {'message_requests': list(data)}
 
     message_requests.method.cached_function.depend_on_model('dbmail.MessageRequest')
 

--- a/esp/esp/utils/decorators.py
+++ b/esp/esp/utils/decorators.py
@@ -91,8 +91,7 @@ def json_response(field_map={}):
             if isinstance(result, HttpResponse):
                 return result
             elif 'json_debug' in request.GET:
-                data = json.dumps(result, sort_keys=True,
-                                        indent = '    ')
+                data = json.dumps(result, sort_keys=True, indent=4)
                 return render_to_response('utils/jsondebug.html',
                                           request, {'data': data},
                                           content_type="text/html")


### PR DESCRIPTION
-json_debug apparently stopped working because of the switch from simplejson to json
-message_requests has been erroring on Yale's site because it's too big. Limit the number of messages returned, and also stop filtering out the password resets because those stopped in 2009 and they're not in the last 100 on any site.
-Converting the result of message_requests to a list makes it work with json_debug