### PR TITLE
Delete or mark uses of Form._errors

### DIFF
--- a/esp/esp/program/modules/forms/teacherreg.py
+++ b/esp/esp/program/modules/forms/teacherreg.py
@@ -34,7 +34,6 @@ Learning Unlimited, Inc.
 """
 
 from django import forms
-from django.forms.utils import ErrorList
 from django.core import validators
 from django.core.exceptions import ObjectDoesNotExist
 from esp.utils.forms import StrippedCharField, FormWithRequiredCss, FormUnrestrictedOtherUser
@@ -245,10 +244,8 @@ class TeacherClassRegForm(FormWithRequiredCss):
             grade_max = int(grade_max)
             if grade_min > grade_max:
                 msg = u'Minimum grade must be less than the maximum grade.'
-                self._errors['grade_min'] = ErrorList([msg])
-                self._errors['grade_max'] = ErrorList([msg])
-                del cleaned_data['grade_min']
-                del cleaned_data['grade_max']
+                self.add_error('grade_min', msg)
+                self.add_error('grade_max', msg)
 
         # Make sure the optimal class size <= maximum class size.
         class_size_optimal = cleaned_data.get('class_size_optimal')
@@ -258,10 +255,8 @@ class TeacherClassRegForm(FormWithRequiredCss):
             class_size_max = int(class_size_max)
             if class_size_optimal > class_size_max:
                 msg = u'Optimal class size must be less than or equal to the maximum class size.'
-                self._errors['class_size_optimal'] = ErrorList([msg])
-                self._errors['class_size_max'] = ErrorList([msg])
-                del cleaned_data['class_size_optimal']
-                del cleaned_data['class_size_max']
+                self.add_error('class_size_optimal', msg)
+                self.add_error('class_size_max', msg)
 
         if class_size_optimal == '':
             cleaned_data['class_size_optimal'] = None

--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -735,9 +735,11 @@ class TeacherClassRegModule(ProgramModuleObj):
 
                 if action=='edit':
                     reg_form = TeacherClassRegForm(self.crmi, current_data)
+                    # TODO: remove private API use
                     if populateonly: reg_form._errors = ErrorDict()
                 elif action=='editopenclass':
                     reg_form = TeacherOpenClassRegForm(self.crmi, current_data)
+                    # TODO: remove private API use
                     if populateonly: reg_form._errors = ErrorDict()
 
                 #   Todo...

--- a/esp/esp/users/forms/user_profile.py
+++ b/esp/esp/users/forms/user_profile.py
@@ -1,5 +1,4 @@
 from django import forms
-from django.forms.utils import ErrorList
 from esp.tagdict.models import Tag
 from esp.utils.forms import SizedCharField, FormWithRequiredCss, FormUnrestrictedOtherUser, FormWithTagInitialValues, StrippedCharField
 from esp.db.forms import AjaxForeignKeyNewformField
@@ -346,9 +345,7 @@ class TeacherInfoForm(FormWithRequiredCss):
 
         if from_here == "False" and school == "":
             msg = u'Please enter your affiliation if you are not from %s.' % settings.INSTITUTION_NAME
-            self._errors['school'] = ErrorList([msg])
-            del cleaned_data['from_here']
-            del cleaned_data['school']
+            self.add_error('school', msg)
 
         return cleaned_data
 


### PR DESCRIPTION
Form.add_errors() was added in Django 1.7. Some of the uses are more weird and I left comments instead of fixing them now.