### PR TITLE
Add unique_together constraint on ProgramModuleObj.

### DIFF
--- a/esp/esp/program/modules/base.py
+++ b/esp/esp/program/modules/base.py
@@ -377,6 +377,7 @@ class ProgramModuleObj(models.Model):
 
     class Meta:
         app_label = 'modules'
+        unique_together = ('program', 'module')
 
 
 # will check and depending on the value of tl

--- a/esp/esp/program/modules/migrations/0009_auto_20160202_2141.py
+++ b/esp/esp/program/modules/migrations/0009_auto_20160202_2141.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('modules', '0008_auto_20151211_0349'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='programmoduleobj',
+            unique_together=set([('program', 'module')]),
+        ),
+    ]


### PR DESCRIPTION
It's silly that we keep having to deal with "Too many module objects!" errors caused by people misconfiguring their program modules.