### PR TITLE
Only display "class is full" if there is at least one scheduled section.

### DIFF
--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -1545,6 +1545,17 @@ class ClassSubject(models.Model, CustomFormsLinkModel):
                 return False
         return True
 
+    def hasScheduledSections(self):
+        """ Return whether the class has at least one scheduled section.
+
+        Only display the "class is full" message if this is true.
+        """
+        sections = self.get_sections()
+        for s in sections:
+            if len(s.get_meeting_times()) > 0:
+                return True
+        return False
+
     @cache_function
     def get_capacity_factor():
         tag_val = Tag.getTag('nearly_full_threshold')

--- a/esp/templates/inclusion/program/class_catalog_core.html
+++ b/esp/templates/inclusion/program/class_catalog_core.html
@@ -2,7 +2,7 @@
           {% if class.got_index_qsd %}
            <a href="Classes/{{ class.emailcode }}/index.html">{% if show_emailcodes %}{{ class.emailcode }}: {% endif %}{{ class.title|escape }}</a>
           {% else %}
-           {% if show_emailcodes %}{{ class.emailcode }}: {% endif %}{{ class.title|escape }} {% if class.isFull and collapse_full %}<font color="#990000" style="font-size: 14px">Full!</font>{% else %}{% if class.isRegClosed %}<font color="#990000" style="font-size: 14px">Closed!</font>{% endif %}{% endif %}
+           {% if show_emailcodes %}{{ class.emailcode }}: {% endif %}{{ class.title|escape }} {% if class.hasScheduledSections and class.isFull and collapse_full %}<font color="#990000" style="font-size: 14px">Full!</font>{% else %}{% if class.isRegClosed %}<font color="#990000" style="font-size: 14px">Closed!</font>{% endif %}{% endif %}
           {% endif %}
 	 </div>
      <div class="class_subtitle_row">


### PR DESCRIPTION
Fix #1647.