### PR TITLE
Use EMAIL_HOST_SENDER instead of EMAIL_HOST in templates.

### DIFF
--- a/esp/esp/context_processors.py
+++ b/esp/esp/context_processors.py
@@ -17,7 +17,7 @@ def esp_user(request):
 def email_settings(request):
     context = {}
     context['DEFAULT_EMAIL_ADDRESSES'] = settings.DEFAULT_EMAIL_ADDRESSES
-    context['EMAIL_HOST'] = settings.EMAIL_HOST
+    context['EMAIL_HOST_SENDER'] = settings.EMAIL_HOST_SENDER
     context['settings'] = settings
     return context
 

--- a/esp/esp/program/templatetags/class_render_row.py
+++ b/esp/esp/program/templatetags/class_render_row.py
@@ -17,7 +17,7 @@ def render_class_teacher_list_row(cls):
             'crmi': cls.parent_program.classregmoduleinfo,
             'friendly_times_with_date': Tag.getBooleanTag(
                 'friendly_times_with_date', cls.parent_program, False),
-            'email_host': settings.EMAIL_HOST
+            'email_host_sender': settings.EMAIL_HOST_SENDER
             }
 render_class_teacher_list_row.cached_function.depend_on_row(ClassSubject, lambda cls: {'cls': cls})
 render_class_teacher_list_row.cached_function.depend_on_row(ClassSection, lambda sec: {'cls': sec.parent_class})

--- a/esp/esp/utils/web.py
+++ b/esp/esp/utils/web.py
@@ -98,7 +98,7 @@ def render_to_response(template, request, context, prog=None, auto_per_program_t
 def error404(request, template_name='404.html'):
     context = {'request_path': request.path}
     context['DEFAULT_EMAIL_ADDRESSES'] = settings.DEFAULT_EMAIL_ADDRESSES
-    context['EMAIL_HOST'] = settings.EMAIL_HOST
+    context['EMAIL_HOST_SENDER'] = settings.EMAIL_HOST_SENDER
     response = render_to_response(template_name, request, context)
     response.status_code = 404
     return response
@@ -107,7 +107,7 @@ def error500(request, template_name='500.html'):
     context = {}
     context['settings'] = settings # needed by elements/html
     context['DEFAULT_EMAIL_ADDRESSES'] = settings.DEFAULT_EMAIL_ADDRESSES
-    context['EMAIL_HOST'] = settings.EMAIL_HOST
+    context['EMAIL_HOST_SENDER'] = settings.EMAIL_HOST_SENDER
     context['request'] = request
     t = loader.get_template(template_name) # You need to create a 500.html template.
 

--- a/esp/templates/inclusion/program/class_teacher_list_row.html
+++ b/esp/templates/inclusion/program/class_teacher_list_row.html
@@ -109,7 +109,7 @@
   </td>
   <td class="clsright" valign="top">
   {% block cls_row_5_buttons %}
-    <a class="abutton" href="mailto:{{ sec.emailcode }}-students@{{ email_host }}">E-mail students</a>
+    <a class="abutton" href="mailto:{{ sec.emailcode }}-students@{{ email_host_sender }}">E-mail students</a>
   {% endblock %}
   </td>
 </tr>

--- a/esp/templates/program/modules/adminclass/listclasses.html
+++ b/esp/templates/program/modules/adminclass/listclasses.html
@@ -60,9 +60,9 @@ color: #3333FF;
     <div class="info" style="margin-left: 0; margin-right: 0">
       If you need to email a class, students, or teachers, just use its code!<br />
       For instance, if the code is M100:<br />
-      <tt>M100-students@{{ EMAIL_HOST }}</tt> will email the students,<br />
-      <tt>M100-teachers@{{ EMAIL_HOST }}</tt> will email the teachers,<br />
-      and <tt>M100-class@{{ EMAIL_HOST }}</tt> will email everyone in the class.
+      <tt>M100-students@{{ EMAIL_HOST_SENDER }}</tt> will email the students,<br />
+      <tt>M100-teachers@{{ EMAIL_HOST_SENDER }}</tt> will email the teachers,<br />
+      and <tt>M100-class@{{ EMAIL_HOST_SENDER }}</tt> will email everyone in the class.
     </div>
 
     <p>Notes: 

--- a/esp/templates/program/modules/adminclass/manageclass.html
+++ b/esp/templates/program/modules/adminclass/manageclass.html
@@ -38,9 +38,9 @@
     <tr>
         <th class="smaller">E-mail addresses: </th>
         <td>
-            Whole Class: <a href="mailto:{{ class.emailcode }}-class@{{ EMAIL_HOST }}">{{ class.emailcode }}-class@{{ EMAIL_HOST }}</a><br />
-            Teachers: <a href="mailto:{{ class.emailcode }}-teachers@{{ EMAIL_HOST }}">{{ class.emailcode }}-teachers@{{ EMAIL_HOST }}</a><br />
-            Students: <a href="mailto:{{ class.emailcode }}-students@{{ EMAIL_HOST }}">{{ class.emailcode }}-students@{{ EMAIL_HOST }}</a>
+            Whole Class: <a href="mailto:{{ class.emailcode }}-class@{{ EMAIL_HOST_SENDER }}">{{ class.emailcode }}-class@{{ EMAIL_HOST_SENDER }}</a><br />
+            Teachers: <a href="mailto:{{ class.emailcode }}-teachers@{{ EMAIL_HOST_SENDER }}">{{ class.emailcode }}-teachers@{{ EMAIL_HOST_SENDER }}</a><br />
+            Students: <a href="mailto:{{ class.emailcode }}-students@{{ EMAIL_HOST_SENDER }}">{{ class.emailcode }}-students@{{ EMAIL_HOST_SENDER }}</a>
         </td>
     </tr>
     <tr>

--- a/esp/templates/program/modules/adminclass/manageclass_ajax.html
+++ b/esp/templates/program/modules/adminclass/manageclass_ajax.html
@@ -78,9 +78,9 @@ View them</a>)</td>
 </tr>
 <tr>
   <th><label>Email Addresses:</label></th>
-  <td>Whole Class: {{class.emailcode}}-class@{{ EMAIL_HOST }}<br />
-Teachers: {{class.emailcode}}-teachers@{{ EMAIL_HOST }}<br />
-Students: {{class.emailcode}}-students@{{ EMAIL_HOST }}
+  <td>Whole Class: {{class.emailcode}}-class@{{ EMAIL_HOST_SENDER }}<br />
+Teachers: {{class.emailcode}}-teachers@{{ EMAIL_HOST_SENDER }}<br />
+Students: {{class.emailcode}}-students@{{ EMAIL_HOST_SENDER }}
   </td>
 </tr>
 <tr>

--- a/esp/templates/program/modules/classsearchmodule/class_search.html
+++ b/esp/templates/program/modules/classsearchmodule/class_search.html
@@ -46,7 +46,7 @@ Your query returned {{queryset|length}} of {{program.classsubject_set.count}} cl
                 <button class="btn btn-default" onclick="unreview({{class.id}});">unreview</button>
                 <button class="btn btn-default" onclick="reject({{class.id}});">reject</button>
                 <button class="btn btn-default" onclick="deleteClass({{class.id}}, '{{class.title}}');">delete</button>
-                <button class="btn btn-default" onclick="emailTeachers('{{class.emailcode}}-teachers@{{EMAIL_HOST}}', 'Your {{program.program_type}} Class {{class.emailcode}}: {{class.title}}');">email</button>
+                <button class="btn btn-default" onclick="emailTeachers('{{class.emailcode}}-teachers@{{EMAIL_HOST_SENDER}}', 'Your {{program.program_type}} Class {{class.emailcode}}: {{class.title}}');">email</button>
                 <button class="add-flag btn btn-default">add flag</button>
             </div>
             <div class="fqr-class-detail" style="display: none;">

--- a/esp/templates/program/modules/programprintables/classattend.html
+++ b/esp/templates/program/modules/programprintables/classattend.html
@@ -21,8 +21,8 @@
   <br />
   <div class="teachername"><span>Teacher:  {{ item.teacher.name }}</span></div>
   <br />
-  <div class="teachername">Class E-mail: &nbsp; &nbsp; <tt>{{ sec.emailcode }}-class@{{ EMAIL_HOST }}</tt><br />
-Students E-mail: &nbsp; &nbsp; <tt>{{ sec.emailcode }}-students@{{ EMAIL_HOST }}</tt>
+  <div class="teachername">Class E-mail: &nbsp; &nbsp; <tt>{{ sec.emailcode }}-class@{{ EMAIL_HOST_SENDER }}</tt><br />
+Students E-mail: &nbsp; &nbsp; <tt>{{ sec.emailcode }}-students@{{ EMAIL_HOST_SENDER }}</tt>
   </div>
   <br />
   <br />

--- a/esp/templates/program/modules/programprintables/classroster.html
+++ b/esp/templates/program/modules/programprintables/classroster.html
@@ -15,8 +15,8 @@
   <br />
   <div class="teachername"><span>{{ item.teacher.name }}</span></div>
   <br />
-  <div class="teachername">Class Email: <tt>{{ section.emailcode }}-class@{{ EMAIL_HOST }}</tt><br />
-Students Email: <tt>{{ section.emailcode }}-students@{{ EMAIL_HOST }}</tt>
+  <div class="teachername">Class Email: <tt>{{ section.emailcode }}-class@{{ EMAIL_HOST_SENDER }}</tt><br />
+Students Email: <tt>{{ section.emailcode }}-students@{{ EMAIL_HOST_SENDER }}</tt>
   </div>
   <br />
   <br />

--- a/esp/templates/program/modules/teacherclassregmodule/class_status.html
+++ b/esp/templates/program/modules/teacherclassregmodule/class_status.html
@@ -54,9 +54,9 @@ Here is some important information regarding your class:<br />
 </tr>
 <tr>
   <th>Email Addresses: </th>
-  <td>Whole Class: {{cls.emailcode}}-class@{{ EMAIL_HOST }}<br />
-Teachers: {{cls.emailcode}}-teachers@{{ EMAIL_HOST }}<br />
-Students: {{cls.emailcode}}-students@{{ EMAIL_HOST }}
+  <td>Whole Class: {{cls.emailcode}}-class@{{ EMAIL_HOST_SENDER }}<br />
+Teachers: {{cls.emailcode}}-teachers@{{ EMAIL_HOST_SENDER }}<br />
+Students: {{cls.emailcode}}-students@{{ EMAIL_HOST_SENDER }}
   </td>
 </tr>
 <tr>

--- a/esp/templates/program/modules/teacherclassregmodule/class_students.html
+++ b/esp/templates/program/modules/teacherclassregmodule/class_students.html
@@ -21,7 +21,7 @@ Here are your class' students.  Only those who have enrolled will show up on you
 {% end_inline_program_qsd_block %}
 
 <div class="info">
-  Note: You can email your students using <tt style="font-size: 130%;">{{ cls.emailcode }}-students@{{ EMAIL_HOST }}</tt>
+  Note: You can email your students using <tt style="font-size: 130%;">{{ cls.emailcode }}-students@{{ EMAIL_HOST_SENDER }}</tt>
 </div>
 
 <div id="program_form">


### PR DESCRIPTION
EMAIL_HOST is the hostname through which outgoing e-mail is routed by Django's SMTP mail backend. (From what I can tell,) EMAIL_HOST_SENDER is there so that we can have a different visible hostname; for example, the from address for availability e-mails is based on EMAIL_HOST_SENDER. This commit fixes the templates so that this setting is used instead of EMAIL_HOST whenever server e-mail addresses are displayed.

This is needed because e.g. MIT has a different mailserver hostname than the desired e-mail domain.