### PR TITLE
Exit early from assign_room on room-does-not-exist

### DIFF
--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -686,6 +686,8 @@ class ClassSection(models.Model):
         if rooms_to_assign.count() != self.meeting_times.count():
             status = False
             errors.append( u'Room %s does not exist at the times requested by %s.' % (base_room.name, self.emailcode()) )
+            if not allow_partial:
+                return (status, errors)
 
         for i, r in enumerate(rooms_to_assign):
             result = self.assignClassRoom(r, lock)


### PR DESCRIPTION
The function checks that rooms_to_assign is the same length as
meeting_times, but if it fails that check, it goes ahead and starts
assigning in the ones that exist anyway. (MIT ESP actually encountered
the case where there were duplicate room objects, so the rooms_to_assign
was presumably actually longer than meeting_times.)

It looks like there's an allow_partial option that controls whether or
not to keep going even if there are errors, so let's use that.