### PR TITLE
Fix shebang lines

### DIFF
--- a/esp/dbmail_cron.py
+++ b/esp/dbmail_cron.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 import os

--- a/esp/esp/utils/no_autocookie.py
+++ b/esp/esp/utils/no_autocookie.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from functools import wraps
 
 def disable_csrf_cookie_update(fn):

--- a/esp/esp/utils/try_multi.py
+++ b/esp/esp/utils/try_multi.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 def try_multi(n_tries):
     """

--- a/esp/mailgates/mailgate.py
+++ b/esp/mailgates/mailgate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Main mailgate for ESP.
 # Handles incoming messages etc.

--- a/esp/useful_scripts/crlf-merge-driver.py
+++ b/esp/useful_scripts/crlf-merge-driver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 ## Written by David Benjamin
 

--- a/esp/useful_scripts/excitement_sep6.py
+++ b/esp/useful_scripts/excitement_sep6.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from esp.survey.models import *
 

--- a/esp/useful_scripts/merging_sep6.py
+++ b/esp/useful_scripts/merging_sep6.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 Identify groups of accounts to merge.

--- a/esp/useful_scripts/pqf_from_emails.py
+++ b/esp/useful_scripts/pqf_from_emails.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from esp.users.models import User, ESPUser, PersistentQueryFilter
 from django.db.models.query import Q

--- a/esp/useful_scripts/schedule_check_sep30.py
+++ b/esp/useful_scripts/schedule_check_sep30.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from esp.program.models import *
 


### PR DESCRIPTION
Several of our `#!` lines are `#!/usr/bin/python` which doesn't do the right
thing if you are in a virtualenv.  (In particular, most of the scripts will
auto-activate the virtualenv if you run them from outside of any virtualenv,
but if you run them from inside the virtualenv but with /usr/bin/python as your
interpreter, they may do the wrong thing.)  This changes them to use
`#!/usr/bin/env python` which is more universal.