### PR TITLE
Refactor of user_classes.js

### DIFF
--- a/esp/esp/themes/theme_data/barebones/scripts/sidebar.js
+++ b/esp/esp/themes/theme_data/barebones/scripts/sidebar.js
@@ -1,0 +1,15 @@
+function show_hide_sidebar() {
+    if (esp_user.cur_username != null) {
+        $j("#main.resizable").removeClass("span12");
+        $j("#main.resizable").addClass("span9");
+        $j("#sidebar").removeClass("hidden");
+        $j("#sidebar").addClass("span3");
+    } else {
+        $j("#sidebar").addClass("hidden");
+        $j("#sidebar").removeClass("span3");
+        $j("#main.resizable").removeClass("span9");
+        $j("#main.resizable").addClass("span12");
+    }
+}
+
+$j(document).ready(show_hide_sidebar);

--- a/esp/esp/themes/theme_data/barebones/templates/main.html
+++ b/esp/esp/themes/theme_data/barebones/templates/main.html
@@ -17,6 +17,7 @@ Customize your title formatting here.  For example:
 
 {% block javascript %}
 {{ block.super }}
+<script type="text/javascript" src="/media/scripts/theme/sidebar.js"></script>
 {# Customize your scripts here #}
 {% endblock %}
 

--- a/esp/esp/themes/theme_data/circles/less/main.less
+++ b/esp/esp/themes/theme_data/circles/less/main.less
@@ -376,3 +376,7 @@ div .error
      font-size: 1.2em	
 }
 
+#user_data {
+    color: #444;
+    font-style: italic;
+}

--- a/esp/esp/themes/theme_data/circles/templates/users/loginbox_content.html
+++ b/esp/esp/themes/theme_data/circles/templates/users/loginbox_content.html
@@ -13,7 +13,7 @@
 <div class="logged_in hidden">
 <div id="divnav">
   <p align="center">
-    <div id="loginbox_user_name"></div>
+    {% include "users/loginbox_userinfo.html" %}
     <div class="admin hidden">
         <a href="/admin/">Administration pages</a> <br />
         <a href="/manage/programs/">Manage programs</a> <br />

--- a/esp/esp/themes/theme_data/fruitsalad/less/main.less
+++ b/esp/esp/themes/theme_data/fruitsalad/less/main.less
@@ -918,3 +918,8 @@ div .adminbar_user {
     width: 160px;
     padding: 2px;
 }
+
+#user_data {
+    color: #444;
+    font-style: italic;
+}

--- a/esp/esp/themes/theme_data/fruitsalad/templates/main.html
+++ b/esp/esp/themes/theme_data/fruitsalad/templates/main.html
@@ -129,7 +129,7 @@
 </form>
 </div>
 <div class="logged_in hidden">
-  <div id="loginbox_user_name"></div>
+  {% include "users/loginbox_userinfo.html" %}
   <span class="accentcolor"><a href="/myesp/signout/">Logout</a> | <a href="/myesp/accountmanage.html">My Profile</a></span>
 </div>
 

--- a/esp/public/media/scripts/content/user_classes.js
+++ b/esp/public/media/scripts/content/user_classes.js
@@ -1,44 +1,40 @@
 function update_user_classes() {
     if (esp_user.cur_admin == "1") {
-	$j(".admin").removeClass("hidden");
-    $j(".onsite").removeClass("hidden");
-	$j(".hide-if-admin").addClass("hidden");
+        $j(".admin").removeClass("hidden");
+        $j(".onsite").removeClass("hidden");
+        $j(".hide-if-admin").addClass("hidden");
     }
     if (esp_user.cur_retTitle) {
-	$j(".unmorph").removeClass("hidden");
-	$j("#unmorph_text").html("Click above to return to your administrator account - " + esp_user.cur_retTitle);
+        $j(".unmorph").removeClass("hidden");
+        $j("#unmorph_text").html("Click above to return to your administrator account - " + esp_user.cur_retTitle);
     }
     if (esp_user.cur_qsd_bits == "1") {
-	$j(".qsd_bits").removeClass("hidden");
+        $j(".qsd_bits").removeClass("hidden");
     }
     if (esp_user.cur_username != null) {
-	$j(".not_logged_in").addClass("hidden");
-	$j(".logged_in").removeClass("hidden");
-	$j("#main.resizable").removeClass("span12");
-	$j("#main.resizable").addClass("span9");
-	$j("#sidebar").removeClass("hidden");
-	$j("#sidebar").addClass("span3");
-    }
-    else {
-	$j(".not_logged_in").removeClass("hidden");
-	$j(".logged_in").addClass("hidden");
-	$j("#sidebar").addClass("hidden");
-	$j("#sidebar").removeClass("span3");
-	$j("#main.resizable").removeClass("span9");
-	$j("#main.resizable").addClass("span12");
+        $j(".not_logged_in").addClass("hidden");
+        $j(".logged_in").removeClass("hidden");
+    } else {
+        $j(".not_logged_in").removeClass("hidden");
+        $j(".logged_in").addClass("hidden");
     }
 
     var type_name = '';
     var hidden_name = '';
     for (var i = 0; i < esp_user.cur_roles.length; i++) {
-	type_name = "." + esp_user.cur_roles[i];
-	try {
-		// This is wrapped in a try/catch block, because custom user
-		// role names might not be in a format that jQuery accepts.
-		$j(type_name).removeClass("hidden");
-	} catch (e) {}
+        type_name = "." + esp_user.cur_roles[i];
+        try {
+            // This is wrapped in a try/catch block, because custom user
+            // role names might not be in a format that jQuery accepts.
+            $j(type_name).removeClass("hidden");
+        } catch (e) {}
     }
     
     //    Write user's name in the appropriate spot in the login box
-  $j("#loginbox_user_name").html("Hello, " + esp_user.cur_first_name + " " + esp_user.cur_last_name + "<br /><span style='color: #444; font-style: italic;'>" + esp_user.cur_username + " / " + esp_user.cur_userid + "</span>");
+    $j("#user_first_name").text(esp_user.cur_first_name);
+    $j("#user_last_name").text(esp_user.cur_last_name);
+    $j("#user_username").text(esp_user.cur_username);
+    $j("#user_userid").text(esp_user.cur_userid);
 }
+
+$j(document).ready(update_user_classes)

--- a/esp/templates/elements/html
+++ b/esp/templates/elements/html
@@ -79,17 +79,6 @@
     <script type="text/javascript"> window.jsprettify.run(); </script>
     {% endblock js1 %}
 
-
-    {% block user_classes %}
-    <script type="text/javascript">
-      /* <![CDATA[ */
-      $j(document).ready(function() {
-      update_user_classes();
-      });
-      /* ]]> */
-    </script>
-    {% endblock user_classes %}
-
     {% block xtrajs %}{% endblock xtrajs %}
 
     {% endblock javascript %}

--- a/esp/templates/users/loginbox_content.html
+++ b/esp/templates/users/loginbox_content.html
@@ -7,7 +7,12 @@
 
   <div class="logged_in hidden">
     <ul class="nav">
-      <li><a id="loginbox_user_name"></a></li>
+      <li>
+          <a id="loginbox_user_name">
+              Hello, <span id="user_first_name"></span>
+              <span id="user_last_name"></span>!
+          </a>
+      </li>
       <li><form class="navbar-form form-inline" action="/myesp/signout">
         <a href="/myesp/signout"><button class="btn btn-inverse" style="margin-right:0px;">Logout</button></a>
         <span class="dropdown">

--- a/esp/templates/users/loginbox_userinfo.html
+++ b/esp/templates/users/loginbox_userinfo.html
@@ -1,0 +1,7 @@
+<div id="loginbox_user_name">
+    Hello, <span id="user_first_name"></span> <span id="user_last_name"></span>
+    <br />
+    <span id="user_data">
+        <span id="user_username"></span> / <span id="user_userid"></span>
+    </span>
+</div>


### PR DESCRIPTION
In order to decrease the amount of custom code needed for the way different
themes handle the login box, I did a refactor of `user_classes.js`.  Now,
instead of prefilling the entire login box with a blob of HTML for logged-in
users, we'll inject individual user variables into specific `<span>`s.

For sites with the themes, this should not be a functionality change.  For
sites with custom themes, we'll need to adapt their template overrides.  This
will consist of replacing the `div#loginbox_user_name`, if they use it, with
`{% include "users/loginbox_userinfo.html" %}`.  For sites that don't use it,
we'll want to migrate their templates to the new system to remove some of their
custom javascript, but it will work as-is.  This will also simplify things when
we add the `berkeley-alpha` theme.

I also moved some `barebones`-specific bits of JS from the shared
`user_classes.js` to a theme-specific script.  Finally, I moved the binding of
`update_user_classes` to document ready into the script itself rather than
having it in a JS snippet in `elements/html`, along with some other stylistic
cleanup.  None of this should involve functionality changes.