### PR TITLE
Frontend for unenroll_students

### DIFF
--- a/esp/esp/program/modules/handlers/unenrollmodule.py
+++ b/esp/esp/program/modules/handlers/unenrollmodule.py
@@ -92,9 +92,10 @@ class UnenrollModule(ProgramModuleObj):
         hour = datetime.timedelta(minutes=60)
         selections = [{
             'slot': timeslot,
+            'seq': seq,
             'passed': timeslot.start < now - hour,
             'upcoming': timeslot.start < now + hour,
-        } for timeslot in timeslots]
+        } for seq, timeslot in enumerate(timeslots)]
         context = {}
         context['selections'] = selections
         return render_to_response(

--- a/esp/esp/program/modules/handlers/unenrollmodule.py
+++ b/esp/esp/program/modules/handlers/unenrollmodule.py
@@ -1,0 +1,68 @@
+
+__author__    = "Individual contributors (see AUTHORS file)"
+__date__      = "$DATE$"
+__rev__       = "$REV$"
+__license__   = "AGPL v.3"
+__copyright__ = """
+This file is part of the ESP Web Site
+Copyright (c) 2007 by the individual contributors
+  (see AUTHORS file)
+
+The ESP Web Site is free software; you can redistribute it and/or
+modify it under the terms of the GNU Affero General Public License
+as published by the Free Software Foundation; either version 3
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public
+License along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+Contact information:
+MIT Educational Studies Program
+  84 Massachusetts Ave W20-467, Cambridge, MA 02139
+  Phone: 617-253-4882
+  Email: esp-webmasters@mit.edu
+Learning Unlimited, Inc.
+  527 Franklin St, Cambridge, MA 02139
+  Phone: 617-379-0178
+  Email: web-team@learningu.org
+"""
+from esp.program.modules.base import ProgramModuleObj, needs_admin, main_call
+from esp.program.models import StudentRegistration, RegistrationType
+from esp.users.models import ESPUser
+from esp.utils.web import render_to_response
+
+class UnenrollModule(ProgramModuleObj):
+    """ Frontend to kick students from classes. """
+
+    @classmethod
+    def module_properties(cls):
+        return {
+            "admin_title": "Unenroll Students",
+            "link_title": "Unenroll Students",
+            "module_type": "manage",
+            "seq": 10,
+        }
+
+    class Meta:
+        proxy = True
+        app_label = 'modules'
+
+    @main_call
+    @needs_admin
+    def unenroll_students(self, request, tl, one, two, module, extra, prog):
+        """
+        A form for selecting which students to kick from which sections,
+        based on the students' first class times and the sections' start
+        times.
+
+        """
+        context = {}
+        context['timeslots'] = prog.getTimeSlotList()
+        return render_to_response(
+            self.baseDir()+'select.html', request, context)

--- a/esp/esp/program/modules/handlers/unenrollmodule.py
+++ b/esp/esp/program/modules/handlers/unenrollmodule.py
@@ -87,8 +87,16 @@ class UnenrollModule(ProgramModuleObj):
             return render_to_response(
                 self.baseDir()+'result.html', request, context)
 
+        timeslots = prog.getTimeSlotList()
+        now = datetime.datetime.now()
+        hour = datetime.timedelta(minutes=60)
+        selections = [{
+            'slot': timeslot,
+            'passed': timeslot.start < now - hour,
+            'upcoming': timeslot.start < now + hour,
+        } for timeslot in timeslots]
         context = {}
-        context['timeslots'] = prog.getTimeSlotList()
+        context['selections'] = selections
         return render_to_response(
             self.baseDir()+'select.html', request, context)
 

--- a/esp/esp/program/modules/handlers/unenrollmodule.py
+++ b/esp/esp/program/modules/handlers/unenrollmodule.py
@@ -51,8 +51,8 @@ class UnenrollModule(ProgramModuleObj):
         return {
             "admin_title": "Unenroll Students",
             "link_title": "Unenroll Students",
-            "module_type": "manage",
-            "seq": 10,
+            "module_type": "onsite",
+            "seq": 100,
         }
 
     class Meta:

--- a/esp/esp/program/modules/tests/__init__.py
+++ b/esp/esp/program/modules/tests/__init__.py
@@ -49,3 +49,4 @@ from esp.program.modules.tests.admincore import RegistrationTypeManagementTest
 from esp.program.modules.tests.adminclass import CancelClassTest
 from esp.program.modules.tests.classsearchmodule import ClassSearchModuleTest
 from esp.program.modules.tests.auth import ProgramModuleAuthTest
+from esp.program.modules.tests.unenrollmodule import UnenrollModuleTest

--- a/esp/esp/program/modules/tests/unenrollmodule.py
+++ b/esp/esp/program/modules/tests/unenrollmodule.py
@@ -34,14 +34,14 @@ class UnenrollModuleTest(ProgramFrameworkTest):
 
     def test_page(self):
         self.client.login(username='admin', password='password')
-        r = self.client.get('/manage/' + self.program.url + '/unenroll_students')
+        r = self.client.get('/onsite/' + self.program.url + '/unenroll_students')
         self.assertContains(r, "Select Students to Unenroll")
         for timeslot in self.program.getTimeSlotList():
             self.assertContains(r, timeslot.short_description)
 
     def test_json_view(self):
         self.client.login(username='admin', password='password')
-        r = self.client.get('/manage/' + self.program.url + '/unenroll_status')
+        r = self.client.get('/onsite/' + self.program.url + '/unenroll_status')
         data = json.loads(r.content)
 
         self.assertGreaterEqual(len(data['student_timeslots']), 20)
@@ -72,11 +72,11 @@ class UnenrollModuleTest(ProgramFrameworkTest):
 
     def test_submit(self):
         self.client.login(username='admin', password='password')
-        r = self.client.get('/manage/' + self.program.url + '/unenroll_status')
+        r = self.client.get('/onsite/' + self.program.url + '/unenroll_status')
         data = json.loads(r.content)
         enrollment_ids = data['enrollments'].keys()
 
-        r = self.client.post('/manage/' + self.program.url + '/unenroll_students', {'selected_enrollments': ','.join(enrollment_ids)})
+        r = self.client.post('/onsite/' + self.program.url + '/unenroll_students', {'selected_enrollments': ','.join(enrollment_ids)})
         self.assertContains(r, 'Expired %d student registrations' % len(enrollment_ids))
         self.assertContains(r, ', '.join(enrollment_ids))
 

--- a/esp/esp/program/modules/tests/unenrollmodule.py
+++ b/esp/esp/program/modules/tests/unenrollmodule.py
@@ -1,0 +1,86 @@
+import json
+import random
+
+from esp.program.models import ClassSection, StudentRegistration
+from esp.program.modules.base import ProgramModule, ProgramModuleObj
+from esp.program.tests import ProgramFrameworkTest
+from esp.users.models import ESPUser, Record
+
+class UnenrollModuleTest(ProgramFrameworkTest):
+    def setUp(self, *args, **kwargs):
+        kwargs.update({
+            'num_timeslots': 3, 'timeslot_length': 50, 'timeslot_gap': 10,
+            'num_students': 30
+        })
+        super(UnenrollModuleTest, self).setUp(*args, **kwargs)
+
+        self.add_student_profiles()
+        self.schedule_randomly()
+        self.classreg_students()
+
+        # mark some of the students as checked in
+        for student in random.sample(self.students, 10):
+            Record.objects.create(
+                event='attended', program=self.program, user=student)
+
+        self.timeslots = self.program.getTimeSlots()
+
+        pm = ProgramModule.objects.get(handler='UnenrollModule')
+        self.module = ProgramModuleObj.getFromProgModule(self.program, pm)
+
+        self.admin, created = ESPUser.objects.get_or_create(username='admin')
+        self.admin.set_password('password')
+        self.admin.makeAdmin()
+
+    def test_page(self):
+        self.client.login(username='admin', password='password')
+        r = self.client.get('/manage/' + self.program.url + '/unenroll_students')
+        self.assertContains(r, "Select Students to Unenroll")
+        for timeslot in self.program.getTimeSlotList():
+            self.assertContains(r, timeslot.short_description)
+
+    def test_json_view(self):
+        self.client.login(username='admin', password='password')
+        r = self.client.get('/manage/' + self.program.url + '/unenroll_status')
+        data = json.loads(r.content)
+
+        self.assertGreaterEqual(len(data['student_timeslots']), 20)
+        self.assertGreater(len(data['section_timeslots']), 0)
+        self.assertGreater(len(data['enrollments']), 0)
+
+        for student_id, ts_id in data['student_timeslots'].items():
+            self.assertTrue(self.timeslots.filter(id=ts_id).exists())
+            self.assertTrue(StudentRegistration.valid_objects().filter(
+                user=student_id, section__meeting_times=ts_id).exists())
+            self.assertFalse(Record.objects.filter(
+                event='attended', program=self.program,
+                user=student_id).exists())
+
+        for section_id, ts_id in data['section_timeslots'].items():
+            self.assertTrue(self.timeslots.filter(id=ts_id).exists())
+            sec = ClassSection.objects.get(id=section_id)
+            self.assertTrue(sec.meeting_times.filter(id=ts_id).exists())
+            self.assertTrue(StudentRegistration.valid_objects().filter(
+                section=section_id).exists())
+
+        for sr_id, (user_id, section_id) in data['enrollments'].items():
+            sr = StudentRegistration.objects.get(id=sr_id)
+            self.assertEqual(sr.user_id, user_id)
+            self.assertEqual(sr.section_id, section_id)
+            self.assertIn(str(user_id), data['student_timeslots'])
+            self.assertIn(str(section_id), data['section_timeslots'])
+
+    def test_submit(self):
+        self.client.login(username='admin', password='password')
+        r = self.client.get('/manage/' + self.program.url + '/unenroll_status')
+        data = json.loads(r.content)
+        enrollment_ids = data['enrollments'].keys()
+
+        r = self.client.post('/manage/' + self.program.url + '/unenroll_students', {'selected_enrollments': ','.join(enrollment_ids)})
+        self.assertContains(r, 'Expired %d student registrations' % len(enrollment_ids))
+        self.assertContains(r, ', '.join(enrollment_ids))
+
+        enrollments = StudentRegistration.objects.filter(id__in=enrollment_ids)
+        self.assertFalse(enrollments.filter(StudentRegistration.is_valid_qobject()).exists())
+
+        enrollments.update(end_date=None)

--- a/esp/esp/utils/decorators.py
+++ b/esp/esp/utils/decorators.py
@@ -136,7 +136,8 @@ class CachedModuleViewDecorator(object):
                 for i in range(len(param_list)):
                     if param_name_list[i] in parent_obj.params:
                         args_for_func.append(param_list[i])
-                return parent_obj.cached_function(*args_for_func)
+                cache_only = 'cache_only' in request.GET
+                return parent_obj.cached_function(*args_for_func, cache_only=cache_only)
 
             return actual_func
 

--- a/esp/public/media/scripts/program/modules/unenroll.js
+++ b/esp/public/media/scripts/program/modules/unenroll.js
@@ -19,7 +19,12 @@ function handle_status(data) {
     handle_update.call(this);
 }
 
-function handle_update() {
+function handle_update(event) {
+    // toggle timeslots before/after the current one
+    if (event !== undefined) {
+        update_checkboxes.call(this, event);
+    }
+
     // recalculate data
     var students = selected_students.call(this);
     var sections = selected_sections.call(this);
@@ -75,6 +80,21 @@ function selected_timeslots(name) {
 
 function setup_handlers() {
     $j('#program_form').change(handle_update.bind(this));
+}
+
+function update_checkboxes(event) {
+    // get all checkboxes in the same group
+    var group = $j('#program_form').prop(event.target.name);
+    var seq = parseInt(event.target.getAttribute('data-seq'), 10);
+    _.each(group, function (other) {
+        var other_seq = parseInt(other.getAttribute('data-seq'), 10);
+        // if checked, check all earlier timeslots as well
+        // if not checked, uncheck all later timeslots
+        if (event.target.checked && other_seq <= seq ||
+           !event.target.checked && other_seq >= seq) {
+            other.checked = event.target.checked;
+        }
+    });
 }
 
 $j(document).ready(function () {

--- a/esp/public/media/scripts/program/modules/unenroll.js
+++ b/esp/public/media/scripts/program/modules/unenroll.js
@@ -29,6 +29,9 @@ function handle_update() {
     var submission = $j('#program_form').prop('selected_enrollments');
     submission.value = _.keys(enrollments);
 
+    // enable the submit button if submissions is non-empty
+    $j('#program_form [type=submit]').prop('disabled', _.isEmpty(enrollments));
+
     // display a message
     $j('#message').text("You have selected " + _.size(students) + " students to be dropped from " + _.size(sections) + " sections (" + _.size(enrollments) + " enrollments total)");
 }

--- a/esp/public/media/scripts/program/modules/unenroll.js
+++ b/esp/public/media/scripts/program/modules/unenroll.js
@@ -1,7 +1,79 @@
+function setup() {
+    // entry point
+    setup_handlers.call(this);
+    fetch_status.call(this);
+}
+
 function fetch_status() {
-    $j.getJSON(program_base_url + 'unenroll_status', function (data) {
-        console.log(data);
+    $j.getJSON(program_base_url + 'unenroll_status',
+               handle_status.bind(this));
+}
+
+function handle_status(data) {
+    // enrollments: { enrollment id -> (user id, section id) }
+    // student_timeslots: { user id -> event id of first class timeslot }
+    // section_timeslots: { section id -> event id of first timeslot }
+    this.enrollments = data.enrollments;
+    this.student_timeslots = data.student_timeslots;
+    this.section_timeslots = data.section_timeslots;
+    handle_update.call(this);
+}
+
+function handle_update() {
+    // recalculate data
+    var students = selected_students.call(this);
+    var sections = selected_sections.call(this);
+    var enrollments = selected_enrollments.call(this, students, sections);
+
+    // populate the form field to be submitted
+    var submission = $j('#program_form').prop('selected_enrollments');
+    submission.value = _.keys(enrollments);
+
+    // display a message
+    $j('#message').text("You have selected " + _.size(students) + " students to be dropped from " + _.size(sections) + " sections (" + _.size(enrollments) + " enrollments total)");
+}
+
+function selected_enrollments(students, sections) {
+    // set of students x set of sections -> set of enrollment ids
+    return _.pick(this.enrollments, function (student_section) {
+        var student = student_section[0];
+        var section = student_section[1];
+        return _.has(students, student) && _.has(sections, section);
     });
 }
 
-$j(document).ready(fetch_status);
+function selected_students() {
+    // return the set of selected students, as an object
+    // { user id -> value if student is selected }
+    var timeslot_selected = selected_timeslots('student_timeslots');
+    return _.pick(this.student_timeslots, function (ts) {
+        return timeslot_selected[ts];
+    });
+}
+
+function selected_sections() {
+    // return the set of selected sections, as an object
+    // { section id -> value if section is selected }
+    var timeslot_selected = selected_timeslots('section_timeslots');
+    return _.pick(this.section_timeslots, function (ts) {
+        return timeslot_selected[ts];
+    });
+}
+
+function selected_timeslots(name) {
+    // return the set of selected timeslots, as an object
+    // { timeslot id -> whether the timeslot is selected }
+    // name is either "student_timeslots" or "section_timeslots"
+    var elements = $j('#program_form').prop(name);
+    return _.zipObject(_.map(elements, function (el) {
+        return [el.value, el.checked];
+    }));
+}
+
+function setup_handlers() {
+    $j('#program_form').change(handle_update.bind(this));
+}
+
+$j(document).ready(function () {
+    setup.call({});
+});

--- a/esp/public/media/scripts/program/modules/unenroll.js
+++ b/esp/public/media/scripts/program/modules/unenroll.js
@@ -1,0 +1,7 @@
+function fetch_status() {
+    $j.getJSON(program_base_url + 'unenroll_status', function (data) {
+        console.log(data);
+    });
+}
+
+$j(document).ready(fetch_status);

--- a/esp/templates/program/modules/unenrollmodule/result.html
+++ b/esp/templates/program/modules/unenrollmodule/result.html
@@ -1,0 +1,15 @@
+{% extends "main.html" %}
+
+{% block title %}Unenroll Students{% endblock %}
+
+{% block content %}
+
+<p>Expired {{ ids|length }} student registrations. If this was a mistake, you can ask a webmin to undo it by running:</p>
+
+<pre><code>ids = {{ ids }}
+StudentRegistration.objects.filter(id__in=ids).update(end_date=None)
+</code></pre>
+
+<p><a href="/manage/{{ program.getUrlBase }}/unenroll_students">Go back</a> or <a href="/manage/{{ program.getUrlBase }}/main">return to the main program management page</a>.</p>
+
+{% endblock %}

--- a/esp/templates/program/modules/unenrollmodule/result.html
+++ b/esp/templates/program/modules/unenrollmodule/result.html
@@ -10,6 +10,6 @@
 StudentRegistration.objects.filter(id__in=ids).update(end_date=None)
 </code></pre>
 
-<p><a href="/manage/{{ program.getUrlBase }}/unenroll_students">Go back</a> or <a href="/manage/{{ program.getUrlBase }}/main">return to the main program management page</a>.</p>
+<p><a href="/onsite/{{ program.getUrlBase }}/unenroll_students">Back</a></p>
 
 {% endblock %}

--- a/esp/templates/program/modules/unenrollmodule/select.html
+++ b/esp/templates/program/modules/unenrollmodule/select.html
@@ -1,0 +1,43 @@
+{% extends "main.html" %}
+
+{% block title %}Unenroll Students{% endblock %}
+
+{% block content %}
+
+<link rel="stylesheet" href="/media/styles/forms.css" type="text/css" />
+
+<h1>Select Students to Unenroll</h1>
+
+<p>Use the form below to unenroll students who have not checked into the program. Before using this, make sure that the latest check-ins have been recorded in the website.</p>
+
+<form id="program_form" method="post" action="{{ request.path }}">
+  <input type="hidden" name="selected_enrollments" value="" />
+  <table cellpadding="4" cellspacing="0" align="center" width="300">
+    <tr>
+      <th>Kick students whose first class starts at...</th>
+      <th>from sections starting at...</th>
+    </tr>
+    {% for timeslot in timeslots %}
+    <tr>
+      <td>
+        <input type="checkbox" name="student_timeslots" value="{{ timeslot.id }}"
+               id="student_timeslot_{{ timeslot.id }}" />
+        <label for="student_timeslot_{{ timeslot.id }}">
+          {{ timeslot.short_description }}
+        </label>
+      </td>
+      <td>
+        <input type="checkbox" name="section_timeslots" value="{{ timeslot.id }}"
+               id="section_timeslot_{{ timeslot.id }}" />
+        <label for="section_timeslot_{{ timeslot.id }}">
+          {{ timeslot.short_description }}
+        </label>
+      </td>
+    </tr>
+    {% endfor %}
+  </table>
+</form>
+
+{% include "program/modules/admincore/returnlink.html" %}
+
+{% endblock %}

--- a/esp/templates/program/modules/unenrollmodule/select.html
+++ b/esp/templates/program/modules/unenrollmodule/select.html
@@ -5,6 +5,11 @@
 {% block content %}
 
 <link rel="stylesheet" href="/media/styles/forms.css" type="text/css" />
+<script type="text/javascript"
+        src="/media/scripts/program/modules/unenroll.js"></script>
+<script type="text/javascript">
+    var program_base_url = "/manage/{{ program.getUrlBase }}/";
+</script>
 
 <h1>Select Students to Unenroll</h1>
 

--- a/esp/templates/program/modules/unenrollmodule/select.html
+++ b/esp/templates/program/modules/unenrollmodule/select.html
@@ -8,7 +8,7 @@
 <script type="text/javascript"
         src="/media/scripts/program/modules/unenroll.js"></script>
 <script type="text/javascript">
-    var program_base_url = "/manage/{{ program.getUrlBase }}/";
+    var program_base_url = "/onsite/{{ program.getUrlBase }}/";
 </script>
 
 <h1>Select Students to Unenroll</h1>
@@ -54,7 +54,5 @@
     </tr>
   </table>
 </form>
-
-{% include "program/modules/admincore/returnlink.html" %}
 
 {% endblock %}

--- a/esp/templates/program/modules/unenrollmodule/select.html
+++ b/esp/templates/program/modules/unenrollmodule/select.html
@@ -43,7 +43,7 @@
     </tr>
     {% endfor %}
     <tr>
-      <td colspan="2" align="center"><input class="fancybutton" value="Submit" type="submit"></td>
+      <td colspan="2" align="center"><input class="fancybutton" value="Submit" type="submit" disabled></td>
     </tr>
   </table>
 </form>

--- a/esp/templates/program/modules/unenrollmodule/select.html
+++ b/esp/templates/program/modules/unenrollmodule/select.html
@@ -28,6 +28,7 @@
     <tr>
       <td>
         <input type="checkbox" name="student_timeslots" value="{{ t.slot.id }}"
+               data-seq="{{ t.seq }}"
                {% if t.passed %} checked {% endif %}
                id="student_timeslot_{{ t.slot.id }}" />
         <label for="student_timeslot_{{ t.slot.id }}">
@@ -36,6 +37,7 @@
       </td>
       <td>
         <input type="checkbox" name="section_timeslots" value="{{ t.slot.id }}"
+               data-seq="{{ t.seq }}"
                {% if t.upcoming %} checked {% endif %}
                id="section_timeslot_{{ t.slot.id }}" />
         <label for="section_timeslot_{{ t.slot.id }}">

--- a/esp/templates/program/modules/unenrollmodule/select.html
+++ b/esp/templates/program/modules/unenrollmodule/select.html
@@ -15,7 +15,10 @@
 
 <p>Use the form below to unenroll students who have not checked into the program. Before using this, make sure that the latest check-ins have been recorded in the website.</p>
 
-<p id="message">Loading enrollment numbers...</p>
+<p>
+  <span id="message">Loading enrollment numbers...</span>
+  <button id="refresh">Refresh Data</button>
+</p>
 
 <form id="program_form" method="post" action="{{ request.path }}">
   <input type="hidden" name="selected_enrollments" value="" />

--- a/esp/templates/program/modules/unenrollmodule/select.html
+++ b/esp/templates/program/modules/unenrollmodule/select.html
@@ -24,20 +24,22 @@
       <th>Kick students whose first class starts at...</th>
       <th>from sections starting at...</th>
     </tr>
-    {% for timeslot in timeslots %}
+    {% for t in selections %}
     <tr>
       <td>
-        <input type="checkbox" name="student_timeslots" value="{{ timeslot.id }}"
-               id="student_timeslot_{{ timeslot.id }}" />
-        <label for="student_timeslot_{{ timeslot.id }}">
-          {{ timeslot.short_description }}
+        <input type="checkbox" name="student_timeslots" value="{{ t.slot.id }}"
+               {% if t.passed %} checked {% endif %}
+               id="student_timeslot_{{ t.slot.id }}" />
+        <label for="student_timeslot_{{ t.slot.id }}">
+          {{ t.slot.short_description }}
         </label>
       </td>
       <td>
-        <input type="checkbox" name="section_timeslots" value="{{ timeslot.id }}"
-               id="section_timeslot_{{ timeslot.id }}" />
-        <label for="section_timeslot_{{ timeslot.id }}">
-          {{ timeslot.short_description }}
+        <input type="checkbox" name="section_timeslots" value="{{ t.slot.id }}"
+               {% if t.upcoming %} checked {% endif %}
+               id="section_timeslot_{{ t.slot.id }}" />
+        <label for="section_timeslot_{{ t.slot.id }}">
+          {{ t.slot.short_description }}
         </label>
       </td>
     </tr>

--- a/esp/templates/program/modules/unenrollmodule/select.html
+++ b/esp/templates/program/modules/unenrollmodule/select.html
@@ -15,6 +15,8 @@
 
 <p>Use the form below to unenroll students who have not checked into the program. Before using this, make sure that the latest check-ins have been recorded in the website.</p>
 
+<p id="message">Loading enrollment numbers...</p>
+
 <form id="program_form" method="post" action="{{ request.path }}">
   <input type="hidden" name="selected_enrollments" value="" />
   <table cellpadding="4" cellspacing="0" align="center" width="300">

--- a/esp/templates/program/modules/unenrollmodule/select.html
+++ b/esp/templates/program/modules/unenrollmodule/select.html
@@ -42,6 +42,9 @@
       </td>
     </tr>
     {% endfor %}
+    <tr>
+      <td colspan="2" align="center"><input class="fancybutton" value="Submit" type="submit"></td>
+    </tr>
   </table>
 </form>
 


### PR DESCRIPTION
This is a module for kicking students from classes, subsuming the existing unenroll_students script. It adds some new/enhanced functionality, including the ability for the user to customize the kicking policy by selecting a combination of timeslots and preview the number of enrollments it would touch before it does it. 

Also includes some ajax/caching shenanigans to detect when the page is stale, because I felt like it.