### PR TITLE
Prettify front page login box for logged in users

### DIFF
--- a/esp/esp/themes/theme_data/fruitsalad/less/splash_page.less
+++ b/esp/esp/themes/theme_data/fruitsalad/less/splash_page.less
@@ -77,6 +77,11 @@ height: 70px;
 background: @tabcolor0_base_color;
 }
 
+#login_greeting_index {
+margin-top: 18px;
+text-align: center;
+}
+
 #login_user_index {
 position: absolute;
 top: 12px; left: 8px;

--- a/esp/esp/themes/theme_data/fruitsalad/templates/bubblesfront.html
+++ b/esp/esp/themes/theme_data/fruitsalad/templates/bubblesfront.html
@@ -102,8 +102,10 @@ document.cookie = 'teachlearn=' + tl + '; expires=' + new Date("January 1, 2025"
 </form>
 {% else %}
 <!-- logout -->
-  Hello, {{ request.user.first_name }} {{ request.user.last_name }}!<br />
+<div id="login_greeting_index">
+  Hello, <strong>{{ request.user.first_name }} {{ request.user.last_name }}</strong>!<br />
   (<a href="/myesp/signout/">Logout</a>)
+</div>
 {% endif %}
 
 </div>


### PR DESCRIPTION
- center text
- put name in \<strong\>s
- add an 18px margin, matching the login form for users that aren't
  logged in

<img width="762" alt="pretty-login-box" src="https://cloud.githubusercontent.com/assets/3482833/13481390/47210738-e0b3-11e5-928c-5c49bca9304c.png">

This is an utterly trivial change, but doesn't it look so much prettier?

(We can apparently correctly vertically center the text with some combination of `display: table` and `display: table-cell` and `vertical-align: middle`, but I didn't think it was worth it; the form that appears if you're not logged in uses 18px anyway.)