### PR TITLE
Cybersource: simplify the payment page

### DIFF
--- a/esp/templates/program/modules/creditcardmodule_cybersource/cardpay.html
+++ b/esp/templates/program/modules/creditcardmodule_cybersource/cardpay.html
@@ -6,97 +6,12 @@
     {{ block.super }}
     <link rel="stylesheet" type="text/css" href="/media/styles/forms.css" />
 {% endblock %}
-
-{% block xtrajs %}
-<style type="text/css">
-#divmaintext a { text-decoration: underline; }
-#divmaintext a:hover { text-decoration: none; }
-table.payproc1 {
-    font-family: Arial, Helvetica, sans-serif;
-    font-size: 13px;
-}
-
-input.button {
-    background-color: #c6def7;
-    border: 1px solid black;
-    font-weight: bold;
-    font-size: 13px;
-    font-family: Arial, Helvetica, sans-serif;
-}
-
-input.button:hover {
-    background-color: #333333;
-    color: #c6def7;
-}
-</style>
-<script type="text/javascript">
-<!--
-
-// user contact information
-user_contact =  [
-{% for contactitem in user.getLastProfile.contact_user.items %}
-  ['{{ contactitem.0|striptags|addslashes }}','{{contactitem.1|striptags|addslashes }}'],{% endfor %}
-  ['','']
-];
-
-// guardian contact information
-guardian_contact =  [
-{% for contactitem in user.getLastProfile.contact_guardian.items %}
-  ['{{ contactitem.0|striptags|addslashes }}','{{contactitem.1|striptags|addslashes }}'],{% endfor %}
-  ['','']
-];
-
-
-// get an item from the above lists
-function getItem(arr, key) {
-
-   for (var i=0; i<arr.length; i++) {
-      if (arr[i][0] == key) {
-         if (arr[i][1] == 'None') {
-           return '';
-         }
-         return arr[i][1];
-      }
-   }
-   return '';
-}
-
-
-// autofill with contact information
-function autofill(ci) {
-   document.getElementById('billTo_firstName').value =
-          getItem(ci, 'first_name');
-   document.getElementById('billTo_lastName').value =
-          getItem(ci, 'last_name');
-   document.getElementById('billTo_street1').value =
-          getItem(ci, 'address_street');
-   document.getElementById('billTo_city').value =
-          getItem(ci, 'address_city');
-   document.getElementById('billTo_postalCode').value =
-          getItem(ci, 'address_zip');
-   document.getElementById('billTo_phoneNumber').value =
-          getItem(ci, 'phone_day');
-   document.getElementById('billTo_state').value =
-          getItem(ci, 'address_state');
-   document.getElementById('billTo_email').value =
-          getItem(ci, 'e_mail');
-}
-
-// disable the submit button so that people pay once
-function payOnce() {
-  document.getElementById('submit_form').disabled = true;
-  return true;
-}
-
-//-->
-</script>
-{% endblock %}
 {% block content %}
 <h1>Credit Card Payment for {{ program.niceName }}</h1>
 
 {% if result == "success" %}
 <div class="alert alert-success">
-  <b>Your payment was successful!</b> <a href="/learn/{{ program.getUrlBase }}/studentreg" title="Return to main registration page">Return to the main registration page</a>.
+  <b>Your payment was successful!</b>
 </div>
 {% elif result == "declined" %}
 <div class="alert alert-danger">
@@ -104,17 +19,15 @@ function payOnce() {
 </div>
 {% endif %}
 
-{% if result != "success" %}
+{% if itemizedcosttotal > 0 %}
 {% load render_qsd %}
 {% inline_program_qsd_block program "cybersource_header" %}
-<h2>Instructions for paying by credit card:</h2>
-<p>
-<ol>
-<li>Please review the costs below and make sure they are correct.  If you are concerned that there is a problem, please email <a href="mailto:{{ contact_email }}">{{ contact_email }}</a>.
-<li>Click "Continue to Payment" at the bottom of the page.  You will be taken to a secure third party Web site where you can enter and submit your credit card information.  Please fill out and submit the form; you will be returned to a receipt page and then back to student registration.</li>
-</ol>
-</p>
+<p>Please review the costs below and make sure they are correct, then click "Continue to Payment" to be taken to our payment processor's site.</p>
+
+<p>We also accept payment by <b>cash or check</b> on the day of the program. To pay later, <a href="/learn/{{ program.getUrlBase }}/studentreg">return to the main registration page</a>.</p>
 {% end_inline_program_qsd_block %}
+{% else %}
+<p>You have no outstanding balance! <a href="/learn/{{ program.getUrlBase }}/studentreg">Return to the main registration page</a>.</p>
 {% endif %}
 
 <form>
@@ -122,110 +35,15 @@ function payOnce() {
 </form>
 
 <br />
-{% if itemizedcosttotal <= 0 %}
-
-<p>You have no outstanding balance for this program.  Please <a href="/learn/{{ program.getUrlBase }}/studentreg" title="Return to main registration page">return to the main registration page</a>.</p>
-
-{% else %}
-
-<p>If you would like to cancel at this time, you can <a href="/learn/{{ program.getUrlBase }}/studentreg" title="Return to main registration page">return to the main registration page</a>.</p>
-
-<form onsubmit="return payOnce();" action="{{ post_url }}" method="post" autocomplete="off">
-
-<br />
-<p>Please fill out the form below.  Required fields are boxed in a red border and marked with an asterisk.</p>
-
-<input type="hidden" name="comments" value="ESP Invoice {{ module.program.id }}/{{ user.id }} (for {{ program.niceName }})" />
-<input type="hidden" name="merchantDefinedData1" value="{{ identifier }}" />
-
-<input type="hidden" name="amount" value="{{ itemizedcosttotal|floatformat:2 }}" />
+{% if itemizedcosttotal > 0 %}
+<form action="{{ post_url }}" method="post" autocomplete="off">
 <input type="hidden" name="merchant_id" value="{{ merchant_id }}" />
-
-<!-- Defaults -->
+<input type="hidden" name="amount" value="{{ itemizedcosttotal|floatformat:2 }}" />
+<input type="hidden" name="merchantDefinedData1" value="{{ identifier }}" />
+<input type="hidden" name="comments" value="ESP Invoice {{ module.program.id }}/{{ user.id }} (for {{ program.niceName }})" />
 <input type="hidden" name="billTo_country" value="US" />
-
-<p>
-Autofill contact information:
-<a href="javascript:autofill(guardian_contact);"
-   title="Autofill with parent information">with Guardian Information</a> |
-<a href="javascript:autofill(user_contact);"
-   title="Autofill with student information">with Student Information</a>
-<br />
-</p>
-
-
-<div id="program_form">
-<table align="center" width="450">
-<tr>
-    <th colspan="2">Credit Card Information</th>
-</tr>
-<tr>
- <th><label>Name *</label></th>
- <td>
-    <label for="billTo_firstName">First: </label><input class="required" type="text" id="billTo_firstName" name="billTo_firstName" maxlength="60" size="40" required> <br />
-    <label for="billTo_lastName">Last: </label><input class="required" type="text" id="billTo_lastName" name="billTo_lastName" maxlength="60" size="40" required>
- </td>
-</tr>
-
-<tr>
- <th><label for="billTo_street1">Address Line 1 *</label></th>
- <td><input class="required" type="text" id="billTo_street1" name="billTo_street1" maxlength=60 size=40 required></td>
-</tr>
-
-<tr>
- <th><label for="billTo_street2">Address Line 2</label></th>
- <td><input type="text" name="billTo_street2" maxlength=60 size=40></td>
-
-</tr>
-
-<tr>
- <th><label for="billTo_city">City *</label></th>
- <td><input class="required" type="text" id="billTo_city" name="billTo_city" maxlength=25 size=25 required></td>
-</tr>
-
-<tr>
- <th><label for="billTo_state">State *</label></th>
- <td><input class="required" type="text" id="billTo_state" name="billTo_state" maxlength=2 size=2 required></td>
-</tr>
-
-<tr>
- <th><label for="billTo_postalCode">Zipcode *</label></th>
- <td><input class="required" type="text" id="billTo_postalCode" name="billTo_postalCode" maxlength=10 size=15 required></td>
-</tr>
-
-<tr>
- <th><label for="billTo_phoneNumber">Telephone</label></th>
- <td><input type="tel" name="billTo_phoneNumber" id="billTo_phoneNumber" maxlength=30 size=20></td>
-
-</tr>
-
-<tr>
- <th><label for="billTo_email">Email Address*</label></th>
- <td><input class="required" type="email" id="billTo_email" name="billTo_email" maxlength=64 size=34 required></td>
-</tr>
-
-
-<tr>
-<td>&nbsp;</td>
-
-<td>&nbsp;</td>
-</tr>
-
-<tr>
-<td colspan="2" align="center" style="padding: 10px !important"><b>Total charge: </b><tt style="border: 1px solid black; padding: 1px 20px 1px 1px; font-size: 140%" width="0px"> ${{ itemizedcosttotal|floatformat:2 }} </tt><br /></td>
-</tr>
-
-<tr>
-<td colspan="2" align="center">
-    <input id="submit_form" class="fancybutton" type="submit" value="Continue to Payment"><br/>
-</td>
-</tr>
-
-</table>
-</div>
-
+<center><input id="submit_form" class="btn btn-primary" type="submit" value="Continue to Payment"></center>
 </form>
-
 {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
Entering invalid information (e.g. an incorrect state abbreviation) causes Cybersource to return with an ERROR code. Because we auto-fill the country as `US`, this makes it impossible for non-U.S. students to pay. The simplest way to solve this problem is to get rid of all the fields and have people enter this information directly into Cybersource.