### PR TITLE
italicize and gray out attribution

### DIFF
--- a/esp/esp/themes/theme_data/fruitsalad/less/main.less
+++ b/esp/esp/themes/theme_data/fruitsalad/less/main.less
@@ -777,6 +777,10 @@ table.plaintable th {
 
 .statistics { font-family: arial; font-size: .6em; font-style: italic; text-align: center; color: #999; }
 
+#content p.attribution {
+  color: #666;
+  font-style: italic;
+}
 
 /*
  * Form elements


### PR DESCRIPTION
doesn't anybody else feel uncomfortable with the attribution and date
line perfectly stylistically blending in with the rest of the body text?

<img width="654" alt="style-attribution" src="https://cloud.githubusercontent.com/assets/3482833/13481970/b7b677f4-e0b7-11e5-828a-5c8866e2575f.png">

(I also kind of want to right-align the attribution but decided to make hopefully less controversial changes first)