### PR TITLE
Alert messages after submitting volunteer form

### DIFF
--- a/esp/templates/program/modules/volunteersignup/signup.html
+++ b/esp/templates/program/modules/volunteersignup/signup.html
@@ -46,26 +46,30 @@ $j(document).ready(function () {
 
 {% block content %}
 
-{% load render_qsd %}
-{% render_inline_program_qsd program "volunteer_signup" %}
-
 {% if complete %}
+<div class="alert alert-success">
 <h3>Thanks!</h3>
 <p>
-Thank you, {{ complete_name }}, for volunteering! You will receive reminder emails on {{ complete_email }} as the program nears. (And, we have your phone number, {{ complete_phone }}, in case there are any emergencies or we need to contact you ugrently.)
+Thank you, {{ complete_name }}, for volunteering! You will receive reminder emails on {{ complete_email }} as the program nears. (And, we have your phone number, {{ complete_phone }}, in case there are any emergencies or we need to contact you urgently.)
 </p>
 <p>If you would like to change your volunteer commitments, please fill out the form below again.</p>
+</div>
 {% load render_qsd %}
 {% render_inline_program_qsd program "volunteer_complete" %}
 {% endif %}
 {% if cancelled %}
+<div class="alert alert-info">
 <h3>Volunteer Shifts Cancelled</h3>
 <p>
 The directors have been notified that you are no longer able to volunteer at {{ program.name }}.
 </p>
+</div>
 {% load render_qsd %}
 {% render_inline_program_qsd program "volunteer_cancelled" %}
 {% endif %}
+
+{% load render_qsd %}
+{% render_inline_program_qsd program "volunteer_signup" %}
 
 <div id="program_form">
 <form method="POST" id="volunteer_shift_form" action="{{ request.path }}">


### PR DESCRIPTION
make messages for volunteers after submitting the form more visible by
moving them to the top and styling with alert classes; also fix typo
("ugrently")
<img width="791" alt="alert-volunteer" src="https://cloud.githubusercontent.com/assets/3482833/13483510/f10f1776-e0c2-11e5-88c0-8d21b9893393.png">

this screenshot was generated with a hacked template to skip around the {{ if }}s, but it probably works, right?

we might also want to move the QSD things into the alert box, but I'll leave that judgment to somebody who knows the system better.