### PR TITLE
Fix onsite create user

### DIFF
--- a/esp/esp/program/modules/handlers/onsiteregister.py
+++ b/esp/esp/program/modules/handlers/onsiteregister.py
@@ -88,9 +88,7 @@ class OnSiteRegister(ProgramModuleObj):
                 new_user = ESPUser.objects.create_user(username = username,
                                 first_name = new_data['first_name'],
                                 last_name  = new_data['last_name'],
-                                email      = new_data['email'],
-                                is_staff   = False,
-                                is_superuser = False)
+                                email      = new_data['email'])
 
                 self.student = new_user
 


### PR DESCRIPTION
Onsite user creation was erroring with
```
TypeError: _create_user() got multiple values for keyword argument 'is_superuser'
```
(see https://sentry.mit.edu/esp/esp-website/issues/230/).  I'm not entirely
sure why, but specifying `is_staff` and `is_superuser` is unnecessary, since
they both default to `False` anyway, so we can just leave it out, and things
work fine.

(cherry picked and cleaned up a bit from commit b0ac8af59 in mit-prod)