### PR TITLE
Remove hidden classes in catalog-new.js (fixes #2086)

### DIFF
--- a/esp/public/media/scripts/catalog-new.js
+++ b/esp/public/media/scripts/catalog-new.js
@@ -292,8 +292,8 @@ var CatalogViewModel = function () {
         // update classes
         for (var key in data.classes) {
             var cls = data.classes[key];
-            if (cls.status <= 0) {
-                // remove unapproved classes
+            if (cls.status <= 5) {
+                // remove unapproved or hidden classes
                 delete data.classes[key];
             }
             else if (cls.category_id == open_class_category_id ||


### PR DESCRIPTION
Remove hidden classes in catalog-new.js.  This prevents hidden classes from showing up during the two-phase registration (#2086).