### PR TITLE
Make the approve/unreview/reject buttons on the status popup behave correctly in all cases

### DIFF
--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -1731,19 +1731,30 @@ was approved! Please go to http://esp.mit.edu/teach/%s/class_status/%s to view y
             user = AnonymousUser()
         return True
 
+    def set_all_sections_to_status(self, status):
+        self.status = status
+        self.save()
+        for sec in self.sections.all():
+            sec.status = status
+            sec.save()
+
+    def accept_all_sections(self):
+        """ Accept all sections of this class, without any of the checks or messages that are in accept() """
+        self.set_all_sections_to_status(ACCEPTED)
+
     def propose(self):
         """ Mark this class as just `proposed' """
         self.status = UNREVIEWED
         self.save()
 
+    def unreview_all_sections(self):
+        """ Mark all sections of this class as unreviewed """
+        self.set_all_sections_to_status(UNREVIEWED)
+
     def reject(self):
         """ Mark this class as rejected; also kicks out students from each section. """
-        for sec in self.sections.all():
-            sec.status = REJECTED
-            sec.save()
         self.clearStudents()
-        self.status = REJECTED
-        self.save()
+        self.set_all_sections_to_status(REJECTED)
 
     def cancel(self, email_students=True, include_lottery_students=False, explanation=None, unschedule=False):
         """ Cancel this class by cancelling all of its sections. """

--- a/esp/esp/program/modules/handlers/adminclass.py
+++ b/esp/esp/program/modules/handlers/adminclass.py
@@ -154,22 +154,13 @@ class AdminClass(ProgramModuleObj):
             review_status = request.POST['review_status']
 
             if review_status == 'ACCEPT':
-                # We can't just do class_subject.accept() since this only
-                # accepts sections that were previously unreviewed
-                for sec in class_subject.sections.all():
-                    sec.status = 10
-                    sec.save()
-                class_subject.accept()
+                class_subject.accept_all_sections()
             elif review_status == 'UNREVIEW':
-                class_subject.status = 0
-                for sec in class_subject.sections.all():
-                    sec.status = 0
-                    sec.save()
+                class_subject.unreview_all_sections()
             elif review_status == 'REJECT':
                 class_subject.reject()
             else:
                 raise ESPError("Error: invalid review status")
-            class_subject.save()
 
         return HttpResponse('')
 


### PR DESCRIPTION
This fixes issue #2089 by creating a new accept_all_sections() function in class_.py that doesn't do any special checks (unlike accept()), then calling that function from adminclass.py.  While I was at it, I refactored some similar code in class_.py.