### PR TITLE
Don't clear teacher interview or training signups when editing class availability (fix #2071)

### DIFF
--- a/esp/esp/program/modules/handlers/availabilitymodule.py
+++ b/esp/esp/program/modules/handlers/availabilitymodule.py
@@ -167,8 +167,8 @@ class AvailabilityModule(ProgramModuleObj):
             #   Process form
             post_vars = request.POST
 
-            #   Reset teacher's availability
-            teacher.clearAvailableTimes(self.program)
+            #   Reset teacher's availability (for classes, not interviews or other events)
+            teacher.clearAvailableClassTimes(self.program)
             #   But add back in the times they're teaching
             #   because those aren't submitted with the form
             for timeslot in avail_and_teaching:

--- a/esp/esp/program/modules/handlers/availabilitymodule.py
+++ b/esp/esp/program/modules/handlers/availabilitymodule.py
@@ -167,8 +167,8 @@ class AvailabilityModule(ProgramModuleObj):
             #   Process form
             post_vars = request.POST
 
-            #   Reset teacher's availability (for classes, not interviews or other events)
-            teacher.clearAvailableClassTimes(self.program)
+            #   Reset teacher's availability
+            teacher.clearAvailableTimes(self.program)
             #   But add back in the times they're teaching
             #   because those aren't submitted with the form
             for timeslot in avail_and_teaching:

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -64,7 +64,7 @@ from django.utils.functional import SimpleLazyObject
 
 
 
-from esp.cal.models import Event
+from esp.cal.models import Event, EventType
 from argcache import cache_function, wildcard
 from esp.customforms.linkfields import CustomFormsLinkModel
 from esp.customforms.forms import AddressWidget, NameWidget
@@ -496,6 +496,14 @@ class BaseESPUser(object):
     def clearAvailableTimes(self, program):
         """ Clear this teacher's availability for a program """
         self.useravailability_set.filter(event__program=program).delete()
+
+    def clearAvailableClassTimes(self, program):
+        """ Clear this teacher's class availability (but not interviews, etc.) for a program """
+        try:
+            class_time_block_event_type = EventType.objects.get(description='Class Time Block')
+        except EventType.DoesNotExist:
+            raise ESPError('There is no Class Time Block event type; this should always be there!')
+        self.useravailability_set.filter(event__program=program, event__event_type=class_time_block_event_type).delete()
 
     def addAvailableTime(self, program, timeslot, role=None):
         #   Because the timeslot has a program, the program is unnecessary.

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -494,10 +494,6 @@ class BaseESPUser(object):
     # though Event shouldn't change much
 
     def clearAvailableTimes(self, program):
-        """ Clear this teacher's availability for a program """
-        self.useravailability_set.filter(event__program=program).delete()
-
-    def clearAvailableClassTimes(self, program):
         """ Clear this teacher's class availability (but not interviews, etc.) for a program """
         try:
             class_time_block_event_type = EventType.objects.get(description='Class Time Block')


### PR DESCRIPTION
Add a function clearAvailableClassTimes() which clears only Class Time Block events, not all events (for a particular teacher and program).  This fixes #2071.

It's possible that this should just be the default behavior for clearAvailableTimes() since usually we think of "availability" as the times when a teacher can teach, not the times for attending other events.  But I wasn't sure if that would break anything so I created a separate function.