### PR TITLE
modify lunch constraints module to allow generating lunch sections without generating constraints

### DIFF
--- a/esp/esp/program/controllers/lunch_constraints.py
+++ b/esp/esp/program/controllers/lunch_constraints.py
@@ -39,8 +39,9 @@ import datetime
 
 class LunchConstraintGenerator(object):
     """ A class for finding issues with the scheduling of a program. """
-    def __init__(self, program, lunch_timeslots=[], include_conditions=True, autocorrect=True, **kwargs):
+    def __init__(self, program, lunch_timeslots=[], generate_constraints=True, include_conditions=True, autocorrect=True, **kwargs):
         self.program = program
+        self.generate_constraints = generate_constraints
         self.include_conditions = include_conditions
         self.autocorrect = autocorrect
 
@@ -258,5 +259,6 @@ else:
                 continue
             self.get_lunch_subject(day)
             self.get_lunch_sections(day)
-            self.generate_constraint(day)
+            if self.generate_constraints:
+                self.generate_constraint(day)
 

--- a/esp/esp/program/modules/forms/admincore.py
+++ b/esp/esp/program/modules/forms/admincore.py
@@ -5,7 +5,6 @@ from django.utils.safestring import mark_safe
 from esp.cal.models import Event
 from esp.program.models import RegistrationType
 from esp.program.controllers.lunch_constraints import LunchConstraintGenerator
-from esp.tagdict.models import Tag
 
 def get_rt_choices():
     choices = [("All","All")]
@@ -33,12 +32,6 @@ class LunchConstraintsForm(forms.Form):
     def load_data(self):
         lunch_timeslots = Event.objects.filter(meeting_times__parent_class__parent_program=self.program, meeting_times__parent_class__category__category='Lunch').distinct()
         self.initial['timeslots'] = lunch_timeslots.values_list('id', flat=True)
-        should_generate_constraints = True
-        if Tag.getTag('no_lunch_constraints'):
-            should_generate_constraints = False
-        self.initial['generate_constraints'] = should_generate_constraints
-        self.initial['autocorrect'] = should_generate_constraints
-        self.initial['include_conditions'] = should_generate_constraints
 
     def save_data(self):
         timeslots = Event.objects.filter(id__in=self.cleaned_data['timeslots']).order_by('start')

--- a/esp/templates/program/modules/admincore/lunch_constraints.html
+++ b/esp/templates/program/modules/admincore/lunch_constraints.html
@@ -11,7 +11,7 @@
     <h1>{{program.niceName}} Lunch Constraints</h1>
     <br />
     <p>Please select the timeslots you would like to be used for lunch.</p>
-    <p>If you would not like to set up lunch constraints, no action is necessary.</p>
+    <p>You can also use this page to setup lunch scheduling constraints, which will enforce that each student have at least one lunch block per day.</p>
 
 {% include "program/modules/admincore/returnlink.html" %}
 


### PR DESCRIPTION
Added an additional checkbox (generate_constraints) to the lunch constraints module which indicates whether to really generate lunch scheduling constraints, or generate lunch sections only.  Fix for #2103 

Also modified the instructions on lunch_constraints.html accordingly. 