### PR TITLE
Clean up our URL patterns

### DIFF
--- a/esp/esp/accounting/urls.py
+++ b/esp/esp/accounting/urls.py
@@ -33,9 +33,9 @@ Learning Unlimited, Inc.
   Email: web-team@learningu.org
 """
 
-from django.conf.urls import *
+from django.conf.urls import url
 from esp.accounting.views import summary
 
-urlpatterns = patterns('esp.accounting',
-    (r'^$', summary),
-)
+urlpatterns = [
+    url(r'^$', summary),
+]

--- a/esp/esp/customforms/urls.py
+++ b/esp/esp/customforms/urls.py
@@ -1,0 +1,19 @@
+from django.conf.urls import url
+
+from esp.customforms import views
+
+urlpatterns = [
+    url(r'^/?$', views.landing),
+    url(r'^/create/$', views.formBuilder),
+    url(r'^/submit/$', views.onSubmit),
+    url(r'^/modify/$', views.onModify),
+    url(r'^/view/(?P<form_id>\d{1,6})/$', views.viewForm),
+    url(r'^/success/(?P<form_id>\d{1,6})/$', views.success),
+    url(r'^/responses/(?P<form_id>\d{1,6})/$', views.viewResponse),
+    url(r'^/getData/$', views.getData),
+    url(r'^/metadata/$', views.getRebuildData),
+    url(r'^/getperms/$', views.getPerms),
+    url(r'^/getlinks/$', views.get_links),
+    url(r'^/builddata/$', views.formBuilderData),
+    url(r'^/exceldata/(?P<form_id>\d{1,6})/$', views.getExcelData),
+]

--- a/esp/esp/formstack/urls.py
+++ b/esp/esp/formstack/urls.py
@@ -1,0 +1,8 @@
+from django.conf.urls import url
+
+from esp.formstack import views
+
+urlpatterns = [
+    url(r'^medicalsyncapi$', views.medicalsyncapi),
+    url(r'^formstack_webhook/?$', views.formstack_webhook)
+]

--- a/esp/esp/program/urls.py
+++ b/esp/esp/program/urls.py
@@ -1,17 +1,20 @@
-from django.conf.urls import *
+from django.conf.urls import url
 
-urlpatterns = patterns('',
-                       # manage stuff
-                       (r'^manage/programs/?$', 'esp.program.views.manage_programs'),
-                       (r'^manage/newprogram/?$', 'esp.program.views.newprogram'),
-                       (r'^manage/submit_transaction/?$', 'esp.program.views.submit_transaction'),
-                       (r'^manage/pages/?$', 'esp.program.views.manage_pages'),
-                       (r'^manage/userview/?$', 'esp.program.views.userview'),
-                       (r'^manage/deactivate_user/?$', 'esp.program.views.deactivate_user'),
-                       (r'^manage/activate_user/?$', 'esp.program.views.activate_user'),
-                       (r'^manage/usersearch/?$', 'esp.program.views.usersearch'),
-                       (r'^manage/flushcache/?$', 'esp.program.views.flushcache'),
-                       (r'^manage/statistics/?$', 'esp.program.views.statistics'),
-                       (r'^manage/preview/?$', 'esp.program.views.template_preview'),
-                       (r'^manage/mergeaccounts/?$', 'esp.users.views.merge.merge_accounts'),
-                       )
+from esp.program import views
+import esp.users.views.merge
+
+urlpatterns = [
+    # manage stuff
+    url(r'^manage/programs/?$', views.manage_programs),
+    url(r'^manage/newprogram/?$', views.newprogram),
+    url(r'^manage/submit_transaction/?$', views.submit_transaction),
+    url(r'^manage/pages/?$', views.manage_pages),
+    url(r'^manage/userview/?$', views.userview),
+    url(r'^manage/deactivate_user/?$', views.deactivate_user),
+    url(r'^manage/activate_user/?$', views.activate_user),
+    url(r'^manage/usersearch/?$', views.usersearch),
+    url(r'^manage/flushcache/?$', views.flushcache),
+    url(r'^manage/statistics/?$', views.statistics),
+    url(r'^manage/preview/?$', views.template_preview),
+    url(r'^manage/mergeaccounts/?$', esp.users.views.merge.merge_accounts),
+]

--- a/esp/esp/qsdmedia/urls.py
+++ b/esp/esp/qsdmedia/urls.py
@@ -1,0 +1,7 @@
+from django.conf.urls import url
+
+from esp.qsdmedia import views
+
+urlpatterns = [
+    url(r'^\/([^/]+)/?$', views.qsdmedia2),
+    url(r'^\/([^/]+)\/([^/]+)/?$', views.qsdmedia2)]

--- a/esp/esp/survey/urls.py
+++ b/esp/esp/survey/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import *
+from django.conf.urls import url
 from esp.survey.views import survey_view
 
 
-urlpatterns = patterns('',
-                       # Program stuff
-                       (r'^(onsite|manage|teach|learn)/(.*?)/(.*?)/program.survey$', survey_view),
-                       )
+urlpatterns = [
+    # Program stuff
+    url(r'^(onsite|manage|teach|learn)/(.*?)/(.*?)/program.survey$', survey_view),
+]

--- a/esp/esp/tests/urls.py
+++ b/esp/esp/tests/urls.py
@@ -1,0 +1,5 @@
+from django.conf.urls import url
+
+from esp.tests import views
+
+urlpatterns = [url('^/?$', views.javascript_tests)]

--- a/esp/esp/themes/theme_data/fruitsalad/config_form.py
+++ b/esp/esp/themes/theme_data/fruitsalad/config_form.py
@@ -39,7 +39,6 @@ from esp.middleware.threadlocalrequest import get_current_request
 
 from django import forms
 from django.conf import settings
-from django.core.urlresolvers import reverse
 
 class ConfigForm(ThemeConfigurationForm):
     titlebar_prefix = forms.CharField()
@@ -71,5 +70,5 @@ class ConfigForm(ThemeConfigurationForm):
             host = settings.SITE_INFO[1]
         self.fields['front_page_style'].help_text = \
             self.fields['front_page_style'].help_text % \
-                {'home': reverse('esp.web.views.main.home'), 'host': host}
+                {'home': '/', 'host': host}
 

--- a/esp/esp/themes/urls.py
+++ b/esp/esp/themes/urls.py
@@ -1,13 +1,13 @@
 
 from esp.themes.views import editor, selector, configure, confirm_overwrite, landing, recompile
 
-from django.conf.urls import *
+from django.conf.urls import url
 
-urlpatterns = patterns('',
-                        (r'^/?$', landing),
-                        (r'^/select', selector),
-                        (r'^/setup', configure),
-                        (r'^/confirm_overwrite', confirm_overwrite),
-                        (r'^/customize', editor),
-                        (r'^/recompile', recompile),
-                      )
+urlpatterns = [
+    url(r'^/?$', landing),
+    url(r'^/select', selector),
+    url(r'^/setup', configure),
+    url(r'^/confirm_overwrite', confirm_overwrite),
+    url(r'^/customize', editor),
+    url(r'^/recompile', recompile),
+]

--- a/esp/esp/urls.py
+++ b/esp/esp/urls.py
@@ -32,7 +32,7 @@ Learning Unlimited, Inc.
   Email: web-team@learningu.org
 """
 
-from django.conf.urls import patterns, include, handler500, handler404
+from django.conf.urls import include, handler500, handler404, url
 from django.contrib import admin
 from esp.admin import admin_site, autodiscover
 from django.conf import settings
@@ -40,7 +40,26 @@ from django.conf.urls.static import static
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.views.generic.base import RedirectView
 from filebrowser.sites import site as filebrowser_site
+
+# main list of apps
+import argcache.urls
 import debug_toolbar
+import esp.accounting.urls
+import esp.customforms.urls
+import esp.formstack.urls
+import esp.program.urls
+import esp.qsdmedia.urls
+import esp.survey.urls
+import esp.tests.urls
+import esp.themes.urls
+import esp.users.urls
+import esp.varnish.urls
+
+#TODO: move these out of the main urls.py
+from esp.web.views import main
+import esp.qsd.views
+import esp.db.views
+import esp.users.views
 
 autodiscover(admin_site)
 
@@ -52,131 +71,69 @@ handler500 = 'esp.utils.web.error500'
 urlpatterns = static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT) + staticfiles_urlpatterns()
 
 # Admin stuff
-urlpatterns += patterns('',
-                     (r'^admin/doc/', include('django.contrib.admindocs.urls')),
-                     (r'^admin/ajax_qsd/?', 'esp.qsd.views.ajax_qsd'),
-                     (r'^admin/ajax_autocomplete/?', 'esp.db.views.ajax_autocomplete'),
-                     (r'^grappelli/', include('grappelli.urls')),
-                     (r'^admin/filebrowser/', include(filebrowser_site.urls)),
-                     (r'^admin/', include(admin_site.urls)),
-                     (r'^accounts/login/$', 'esp.users.views.login_checked',),
-                     #(r'^learn/Junction/2007_Spring/catalog/?$',RedirectView.as_view(url='/learn/Junction/2007_Summer/catalog/')),
-                     (r'^(?P<subsection>(learn|teach|program|help|manage|onsite))/?$',RedirectView.as_view(url='/%(subsection)s/index.html', permanent=True)),
-                        )
+urlpatterns += [
+    url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
+    url(r'^admin/ajax_qsd/?', esp.qsd.views.ajax_qsd),
+    url(r'^admin/ajax_autocomplete/?', esp.db.views.ajax_autocomplete),
+    url(r'^grappelli/', include('grappelli.urls')),
+    url(r'^admin/filebrowser/', include(filebrowser_site.urls)),
+    url(r'^admin/', include(admin_site.urls)),
+    url(r'^accounts/login/$', esp.users.views.login_checked),
+    url(r'^(?P<subsection>(learn|teach|program|help|manage|onsite))/?$',RedirectView.as_view(url='/%(subsection)s/index.html', permanent=True)),
+]
 
 # Adds missing trailing slash to any admin urls that haven't been matched yet.
-urlpatterns += patterns('',
-(r'^(?P<url>admin($|(.*[^/]$)))', RedirectView.as_view(url='/%(url)s/', permanent=True)),)
+urlpatterns += [
+    url(r'^(?P<url>admin($|(.*[^/]$)))', RedirectView.as_view(url='/%(url)s/', permanent=True))]
 
 # generic stuff
-urlpatterns += patterns('esp.web.views.main',
-                        (r'^$', 'home'), # index
-                        (r'^set_csrf_token', 'set_csrf_token'), # tiny view used to set csrf token
-                        )
+urlpatterns += [
+    url(r'^$', main.home), # index
+    url(r'^set_csrf_token', main.set_csrf_token), # tiny view used to set csrf token
+]
 
-urlpatterns += patterns('', ('^javascript_tests', 'esp.tests.views.javascript_tests'))
+# main list of apps (please consolidate more things into this!)
+urlpatterns += [
+    url(r'^cache/', include(argcache.urls)),
+    url(r'^__debug__/', include(debug_toolbar.urls)),
+    url(r'^accounting/', include(esp.accounting.urls)),
+    url(r'^customforms', include(esp.customforms.urls)),
+    url(r'^', include(esp.formstack.urls)),
+    url(r'^',  include(esp.program.urls)),
+    url(r'^download', include(esp.qsdmedia.urls)),
+    url(r'^',  include(esp.survey.urls)),
+    url('^javascript_tests', include(esp.tests.urls)),
+    url(r'^themes', include(esp.themes.urls)),
+    url(r'^myesp/', include(esp.users.urls)),
+    url(r'^varnish/', include(esp.varnish.urls)),
+]
 
-# program stuff
-urlpatterns += patterns('',
-                        (r'^',  include('esp.program.urls')),
-                        )
+urlpatterns += [
+    # bios
+    url(r'^(?P<tl>teach|learn)/teachers/', include('esp.web.urls')),
+]
 
-urlpatterns += patterns('esp.web.views.bio',
-
-                        # bios (/learn URLs are deprecated)
-                        (r'^(?P<tl>teach|learn)/teachers/(?P<username>[^/]+)/bio\.html$', 'bio'),
-                        (r'^myesp/teacherbio/?$', 'bio_edit'),
-                        (r'^(?P<tl>teach|learn)/teachers/(?P<username>[^/]+)/bio\.edit\.html/?(.*)$', 'bio_edit'),
-                        # more deprecated URLs for bios
-                        (r'^(?P<tl>teach|learn)/teachers/(?P<last>[-A-Za-z0-9_ \.]+)/(?P<first>[-A-Za-z_ \.]+)(?P<usernum>[0-9]*)/bio\.html$', 'bio'),
-                        (r'^(?P<tl>teach|learn)/teachers/(?P<last>[-A-Za-z0-9_ ]+)/(?P<first>[-A-Za-z_ ]+)(?P<usernum>[0-9]*)/bio\.edit\.html/?(.*)$', 'bio_edit'),
-                        )
-
-urlpatterns += patterns('',
-                        (r'^myesp/', include('esp.users.urls'),)
-                        )
-
-urlpatterns += patterns('',
-                        (r'^cache/', include('argcache.urls')),
-                        (r'^varnish/', include('esp.varnish.urls'))
-                        )
-
-urlpatterns += patterns('esp.qsd.views',
-                        #(r'^(?P<subsection>(learn|teach|programs|manage|onsite))/(?P<url>.*)\.html$', 'qsd'),
-                        (r'^(?P<url>.*)\.html$', 'qsd'),
-                        )
-
-#urlpatterns += patterns('',
-#                        (r'^(?P<subsection>(learn|teach|programs|manage|onsite))/?$', RedirectView.as_view(url='/%(subsection)s/index.html')),
-#                        )
-
-# other apps
-urlpatterns += patterns('',
-                        (r'^',  include('esp.survey.urls')),
-                        )
+urlpatterns += [
+    url(r'^(?P<url>.*)\.html$', esp.qsd.views.qsd),
+]
 
 # QSD Media
 # aseering 8/14/2007: This ought to be able to be written in a simpler way...
-urlpatterns += patterns('esp.web.views.main',
-
+urlpatterns += [
     # aseering - Is it worth consolidating these?  Two entries for the single "contact us! widget
     # Contact Us! pages
-    (r'^contact/contact/?$', 'contact'),
-    (r'^contact/contact/(?P<section>[^/]+)/?$', 'contact'),
-#    (r'^contact/submit\.html$', 'contact_submit'),
-
+    url(r'^contact/contact/?$', main.contact),
+    url(r'^contact/contact/(?P<section>[^/]+)/?$', main.contact),
 
     # Program stuff
-    (r'^(onsite|manage|teach|learn|volunteer|json)/([-A-Za-z0-9_ ]+)/([-A-Za-z0-9_ ]+)/([-A-Za-z0-9_ ]+)/([-A-Za-z0-9_ ]+)/?$', 'program'),
-    (r'^(onsite|manage|teach|learn|volunteer|json)/([-A-Za-z0-9_ ]+)/([-A-Za-z0-9_ ]+)/([-A-Za-z0-9_ ]+)/?$', 'program'),
-
-    #??? (axiak)
-    #(r'^program/Template/$', 'esp.program.views.programTemplateEditor'),
-    #(r'^program/(?P<program>[-A-Za-z0-9_ ]+)/(?P<session>[-A-Za-z0-9_ ]+)/Classes/Template/$', 'esp.program.views.classTemplateEditor'),
+    url(r'^(onsite|manage|teach|learn|volunteer|json)/([-A-Za-z0-9_ ]+)/([-A-Za-z0-9_ ]+)/([-A-Za-z0-9_ ]+)/([-A-Za-z0-9_ ]+)/?$', main.program),
+    url(r'^(onsite|manage|teach|learn|volunteer|json)/([-A-Za-z0-9_ ]+)/([-A-Za-z0-9_ ]+)/([-A-Za-z0-9_ ]+)/?$', main.program),
 
     # all the archives
-    (r'^archives/([-A-Za-z0-9_ ]+)/?$', 'archives'),
-    (r'^archives/([-A-Za-z0-9_ ]+)/([-A-Za-z0-9_ ]+)/?$', 'archives'),
-    (r'^archives/([-A-Za-z0-9_ ]+)/([-A-Za-z0-9_ ]+)/([-A-Za-z0-9_ ]+)/?$', 'archives'),
-)
+    url(r'^archives/([-A-Za-z0-9_ ]+)/?$', main.archives),
+    url(r'^archives/([-A-Za-z0-9_ ]+)/([-A-Za-z0-9_ ]+)/?$', main.archives),
+    url(r'^archives/([-A-Za-z0-9_ ]+)/([-A-Za-z0-9_ ]+)/([-A-Za-z0-9_ ]+)/?$', main.archives),
+]
 
-urlpatterns += patterns('',
-(r'^(?P<subsection>onsite|manage|teach|learn|volunteer)/(?P<program>[-A-Za-z0-9_ ]+)/?$', RedirectView.as_view(url='/%(subsection)s/%(program)s/index.html', permanent=True)),)
-
-urlpatterns += patterns('esp.qsdmedia.views',
-    (r'^download\/([^/]+)/?$', 'qsdmedia2'),
-    (r'^download\/([^/]+)\/([^/]+)/?$', 'qsdmedia2') )
-
-urlpatterns += patterns('',
-    (r'^accounting/', include('esp.accounting.urls')) )
-
-urlpatterns += patterns('',
-    (r'^__debug__/', include(debug_toolbar.urls)),
-)
-
-urlpatterns += patterns('esp.formstack.views',
-    (r'^medicalsyncapi$', 'medicalsyncapi'),)
-
-urlpatterns += patterns('esp.formstack.views',
-    (r'^formstack_webhook/?$', 'formstack_webhook'),)
-
-urlpatterns +=patterns('esp.customforms.views',
-    (r'^customforms/$','landing'),
-    (r'^customforms/create/$','formBuilder'),
-    (r'^customforms/submit/$','onSubmit'),
-    (r'^customforms/modify/$','onModify'),
-    (r'^customforms/view/(?P<form_id>\d{1,6})/$','viewForm'),
-    (r'^customforms/success/(?P<form_id>\d{1,6})/$', 'success'),
-    (r'^customforms/responses/(?P<form_id>\d{1,6})/$', 'viewResponse'),
-    (r'^customforms/getData/$', 'getData'),
-    (r'^customforms/metadata/$', 'getRebuildData'),
-    (r'^customforms/getperms/$', 'getPerms'),
-    (r'^customforms/getlinks/$', 'get_links'),
-    (r'^customforms/builddata/$', 'formBuilderData'),
-    (r'^customforms/exceldata/(?P<form_id>\d{1,6})/$', 'getExcelData'),
-    )
-
-#   Theme editor
-urlpatterns += patterns('',
-                        (r'^themes', include('esp.themes.urls'))
-                       )
+urlpatterns += [
+url(r'^(?P<subsection>onsite|manage|teach|learn|volunteer)/(?P<program>[-A-Za-z0-9_ ]+)/?$', RedirectView.as_view(url='/%(subsection)s/%(program)s/index.html', permanent=True))]

--- a/esp/esp/users/urls.py
+++ b/esp/esp/users/urls.py
@@ -1,43 +1,53 @@
-from django.conf.urls import *
+from django.conf.urls import url
 
+from esp.users import views
+from esp.users.views import login_byschool, login_by_bday
 from esp.users.views.registration import GradeChangeRequestView
+from esp.web.views import bio
+from esp.web.views import main
+from esp.web.views import myesp
 
-urlpatterns = patterns('esp.users.views',
-                       (r'^register/?$', 'user_registration_phase1',),
-                       (r'^register/information/?$', 'user_registration_phase2'),
-                       (r'^activate/?$', 'registration.activate_account',),
-                       (r'^passwdrecover/(success)?/?$', 'initial_passwd_request',),
-                       (r'^passwdrecover/?$', 'initial_passwd_request',),
-                       (r'^recoveremail/(success)?/?$', 'email_passwd_followup',),
-                       (r'^recoveremail/?$', 'email_passwd_followup',),
-                       (r'^cancelrecover/?$', 'email_passwd_cancel',),
-                       (r'^resend/?$', 'resend_activation_view',),
-                       (r'^signout/?$', 'signout',),
-                       (r'^signedout/?$', 'signed_out_message',),
-                       (r'^login/?$',   'login_checked',),
-                       (r'^login/byschool/?$',   'login_byschool.login_byschool',),
-                       (r'^login/byschool/([0-9]+)/?$',   'login_byschool.login_byschool_pickname',),
-                       (r'^login/byschool/new/?$',   'login_byschool.login_byschool_new',),
-                       (r'^login/bybday/?$',   'login_by_bday.login_by_bday',),
-                       (r'^login/bybday/([0-9]+)/([0-9]+)/?$',   'login_by_bday.login_by_bday_pickname',),
-                       (r'^login/bybday/new/?$',   'login_by_bday.login_by_bday_new',),
-                       (r'^disableaccount/?$', 'disable_account'),
-                       (r'^emailpref/?$', 'emailpref'),
-                       (r'^emailpref/(success)?/?$', 'emailpref'),
-                       url(r'^grade_change_request/?$', GradeChangeRequestView.as_view(), name = 'grade_change_request'),
-                       (r'^makeadmin/?$', 'make_admin'),
-                       (r'^morph/?$', 'morph_into_user'),
+urlpatterns = [
+    url(r'^register/?$', views.user_registration_phase1,
+        name='esp.users.views.user_registration_phase1'),
+    url(r'^register/information/?$', views.user_registration_phase2,
+        name='esp.users.views.user_registration_phase2'),
+    url(r'^activate/?$', views.registration.activate_account),
+    url(r'^passwdrecover/(success)?/?$', views.initial_passwd_request),
+    url(r'^passwdrecover/?$', views.initial_passwd_request),
+    url(r'^recoveremail/(success)?/?$', views.email_passwd_followup),
+    url(r'^recoveremail/?$', views.email_passwd_followup),
+    url(r'^cancelrecover/?$', views.email_passwd_cancel),
+    url(r'^resend/?$', views.resend_activation_view,
+        name='esp.users.views.resend_activation_view'),
+    url(r'^signout/?$', views.signout),
+    url(r'^signedout/?$', views.signed_out_message),
+    url(r'^login/?$',   views.login_checked),
+    url(r'^login/byschool/?$',   login_byschool.login_byschool),
+    url(r'^login/byschool/([0-9]+)/?$',   login_byschool.login_byschool_pickname),
+    url(r'^login/byschool/new/?$',   login_byschool.login_byschool_new),
+    url(r'^login/bybday/?$',   login_by_bday.login_by_bday),
+    url(r'^login/bybday/([0-9]+)/([0-9]+)/?$',   login_by_bday.login_by_bday_pickname),
+    url(r'^login/bybday/new/?$',   login_by_bday.login_by_bday_new),
+    url(r'^disableaccount/?$', views.disable_account),
+    url(r'^emailpref/?$', views.emailpref),
+    url(r'^emailpref/(success)?/?$', views.emailpref),
+    url(r'^grade_change_request/?$', GradeChangeRequestView.as_view(), name = 'grade_change_request'),
+    url(r'^makeadmin/?$', views.make_admin),
+    url(r'^morph/?$', views.morph_into_user),
+]
 
-                       )
+urlpatterns += [
+    url(r'^redirect/?$', main.registration_redirect),
+]
 
-urlpatterns += patterns('esp.web.views.main',
-                        (r'^redirect/?$', 'registration_redirect',),
-                       )
+urlpatterns += [
+    url(r'^switchback/?$', myesp.myesp_switchback),
+    url(r'^onsite/?$', myesp.myesp_onsite),
+    url(r'^passwd/?$', myesp.myesp_passwd),
+    url(r'^profile/?$', myesp.edit_profile),
+]
 
-urlpatterns += patterns('esp.web.views.myesp',
-                        (r'^switchback/?$', 'myesp_switchback',),
-                        (r'^onsite/?$', 'myesp_onsite',),
-                        (r'^passwd/?$', 'myesp_passwd',),
-                        (r'^profile/?$', 'edit_profile',),
-                       )
-
+urlpatterns += [
+    url(r'^teacherbio/?$', bio.bio_edit)
+]

--- a/esp/esp/varnish/urls.py
+++ b/esp/esp/varnish/urls.py
@@ -1,5 +1,7 @@
-from django.conf.urls import *
+from django.conf.urls import url
 
-urlpatterns = patterns('',
-                        (r'^purge_page$', 'esp.varnish.views.varnish_purge'),
-                        )
+from esp.varnish import views
+
+urlpatterns = [
+    url(r'^purge_page$', views.varnish_purge),
+]

--- a/esp/esp/web/urls.py
+++ b/esp/esp/web/urls.py
@@ -1,0 +1,12 @@
+from django.conf.urls import url
+
+from esp.web.views import bio
+
+urlpatterns = [
+    # bios (/learn URLs are deprecated)
+    url(r'^(?P<username>[^/]+)/bio\.html$', bio.bio),
+    url(r'^(?P<username>[^/]+)/bio\.edit\.html/?(.*)$', bio.bio_edit),
+    # more deprecated URLs for bios
+    url(r'^(?P<last>[-A-Za-z0-9_ \.]+)/(?P<first>[-A-Za-z_ \.]+)(?P<usernum>[0-9]*)/bio\.html$', bio.bio),
+    url(r'^(?P<last>[-A-Za-z0-9_ ]+)/(?P<first>[-A-Za-z_ ]+)(?P<usernum>[0-9]*)/bio\.edit\.html/?(.*)$', bio.bio),
+]


### PR DESCRIPTION
The main goal of this commit is to remove uses of patterns() and string
view arguments to url(), both of which are deprecated. While I was doing
that, I moved some patterns into per-app files and cleaned up the main
urls.py a bit. Progress towards, but not a complete fix for, #1292.

(I still compulsively fix warnings.)