### PR TITLE
Serve favicon at /favicon.ico

### DIFF
--- a/esp/useful_scripts/server_setup/new_site.sh
+++ b/esp/useful_scripts/server_setup/new_site.sh
@@ -410,6 +410,7 @@ WSGIDaemonProcess $SITENAME processes=2 threads=1 maximum-requests=500 display-n
     #   Static files
     Alias /media $BASEDIR/esp/public/media
     Alias /static $BASEDIR/esp/public/static
+    Alias /favicon.ico $BASEDIR/esp/public/media/images/favicon.ico
 
     #   WSGI scripted Python
     DocumentRoot $BASEDIR/esp/public


### PR DESCRIPTION
Unfortunately some browsers are happier with a favicon at /favicon.ico rather than in a `<link rel="shortcut icon">`.  So we'll do that too.  I've already added the corresponding line manually to existing sites on diogenes.

Fixes #2128.