### PR TITLE
Fabfile: use the actual manage.py

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -365,7 +365,7 @@ def manage(cmd):
     ensure_environment()
 
     if cmd.split(" ")[0] in ["shell", "shell_plus"]:
-        interactive(env.rbase + "esp/esp/manage.py " + cmd)
+        interactive(env.rbase + "esp/manage.py " + cmd)
     else:
         with cd(env.rbase + "esp"):
             run("python manage.py " + cmd)


### PR DESCRIPTION
On Windows, the `esp/esp/manage.py -> esp/manage.py` symlink isn't translated properly into the VM. Don't use it.