### PR TITLE
Added ability to specify description when creating teacher events.

### DIFF
--- a/esp/esp/program/modules/forms/teacherevents.py
+++ b/esp/esp/program/modules/forms/teacherevents.py
@@ -11,6 +11,7 @@ class TimeslotForm(forms.Form):
     start = forms.DateTimeField(label='Start Time', help_text='Format: MM/DD/YYYY HH:MM:SS <br />Example: 10/14/2007 14:00:00', widget=DateTimeWidget)
     hours = forms.IntegerField(widget=forms.TextInput(attrs={'size':'6'}))
     minutes = forms.IntegerField(widget=forms.TextInput(attrs={'size':'6'}))
+    description = forms.CharField(widget=forms.TextInput(attrs={'size':'100'}))
 
     def save_timeslot(self, program, slot, type):
         slot.start = self.cleaned_data['start']
@@ -25,7 +26,7 @@ class TimeslotForm(forms.Form):
 
         slot.program = program
         slot.short_description = slot.start.strftime('%A, %B %d %Y %I:%M %p') + " to " + slot.end.strftime('%I:%M %p')
-        slot.description = slot.short_description
+        slot.description = self.cleaned_data['description']
 
         slot.save()
 

--- a/esp/esp/program/modules/forms/teacherevents.py
+++ b/esp/esp/program/modules/forms/teacherevents.py
@@ -11,7 +11,7 @@ class TimeslotForm(forms.Form):
     start = forms.DateTimeField(label='Start Time', help_text='Format: MM/DD/YYYY HH:MM:SS <br />Example: 10/14/2007 14:00:00', widget=DateTimeWidget)
     hours = forms.IntegerField(widget=forms.TextInput(attrs={'size':'6'}))
     minutes = forms.IntegerField(widget=forms.TextInput(attrs={'size':'6'}))
-    description = forms.CharField(widget=forms.TextInput(attrs={'size':'100'}))
+    description = forms.CharField(widget=forms.TextInput(attrs={'size':'100'}), blank = True)
 
     def save_timeslot(self, program, slot, type):
         slot.start = self.cleaned_data['start']
@@ -26,7 +26,10 @@ class TimeslotForm(forms.Form):
 
         slot.program = program
         slot.short_description = slot.start.strftime('%A, %B %d %Y %I:%M %p') + " to " + slot.end.strftime('%I:%M %p')
-        slot.description = self.cleaned_data['description']
+        if not self.cleaned_data['description']:
+            slot.description == slot.short_description
+        else:
+            slot.description = self.cleaned_data['description']
 
         slot.save()
 

--- a/esp/esp/program/modules/forms/teacherevents.py
+++ b/esp/esp/program/modules/forms/teacherevents.py
@@ -11,7 +11,7 @@ class TimeslotForm(forms.Form):
     start = forms.DateTimeField(label='Start Time', help_text='Format: MM/DD/YYYY HH:MM:SS <br />Example: 10/14/2007 14:00:00', widget=DateTimeWidget)
     hours = forms.IntegerField(widget=forms.TextInput(attrs={'size':'6'}))
     minutes = forms.IntegerField(widget=forms.TextInput(attrs={'size':'6'}))
-    description = forms.CharField(widget=forms.TextInput(attrs={'size':'100'}), blank = True)
+    description = forms.CharField(widget=forms.TextInput(attrs={'size':'100'}), required = False)
 
     def save_timeslot(self, program, slot, type):
         slot.start = self.cleaned_data['start']


### PR DESCRIPTION
Only changed two lines to add a new field in the teacher training/interview creation form and to then assign that new field as the event's description (rather than just copying the short_description).

(See #2130)