### PR TITLE
Add buttons to rank classes in listing in phase 2 of reg

### DIFF
--- a/esp/templates/program/modules/studentregtwophase/rank_classes.html
+++ b/esp/templates/program/modules/studentregtwophase/rank_classes.html
@@ -73,5 +73,9 @@ for every priority slot to ensure a full schedule.
     <i class="star-fill icon-2x icon-star" data-bind="visible: interested"></i>
   </a>
   <label>Click the star to mark this class as interested.</label>
+  <br />
+  {% for pri, pri_display in priorities %}
+  <button data-bind="click: function(data) { $parent.prioritySelection[{{pri}}-1](data.id); $j('#pri-{{pri}}').trigger('change.select2'); }">Set as {{pri_display}}</button>
+  {% endfor %}
 </div>
 {% endblock %}


### PR DESCRIPTION
When choosing the top choices in step 2, adds buttons to the class's
listing to rank the class as each of the possible priorities.

Fixes #1041.
<img width="788" alt="screen shot 2016-10-04 at 8 52 38 pm" src="https://cloud.githubusercontent.com/assets/3482833/19097702/c4484d6e-8a74-11e6-9901-784115e22f31.png">
