### PR TITLE
Add sort key for student reg ranking priorities

### DIFF
--- a/esp/esp/program/modules/handlers/studentregtwophase.py
+++ b/esp/esp/program/modules/handlers/studentregtwophase.py
@@ -142,7 +142,8 @@ class StudentRegTwoPhase(ProgramModuleObj):
 
             if timeslot.id in timeslot_dict:
                 priority_dict = timeslot_dict[timeslot.id]
-                priority_list = sorted(priority_dict.items())
+                # (relationship, class_title) -> relationship.name
+                priority_list = sorted(priority_dict.items(), key=lambda item: item[0].name)
             else:
                 priority_list = []
             if timeslot.id in star_counts:


### PR DESCRIPTION
Currently , student registration is sorted by `RegistrationType`, which doesn't define a sort order. As a result, the ranking is essentially random when listed on the student reg page . Explicitly sort it by `relationship.name`, which is of the form `"Priority/1"`, `"Priority/2"`, `"Priority/3"`.

Discussed with @betaveros, tested locally.

Fixes #2194