### PR TITLE
Fix handling of classroom names with commas

### DIFF
--- a/esp/esp/program/modules/handlers/ajaxschedulingmodule.py
+++ b/esp/esp/program/modules/handlers/ajaxschedulingmodule.py
@@ -222,7 +222,7 @@ class AJAXSchedulingModule(ProgramModuleObj):
             times = []
             classrooms = []
             for br in blockrooms:
-                timeslot, classroom = br.split(",")
+                timeslot, classroom = br.split(",", 1)
                 times.append(timeslot)
                 classrooms.append(classroom)
             retval = self.ajax_schedule_assignreg(prog, cls, times, classrooms, request.user)


### PR DESCRIPTION
Fixes #2201. Needs backport to stable-release-9. (This is based on an old branch so it can be merged rather than cherry-picked.)
