### PR TITLE
Add links to manage/edit classes from userview

### DIFF
--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -360,6 +360,9 @@ class ClassSection(models.Model):
     def get_absolute_url(self):
         return self.parent_class.get_absolute_url()
 
+    def get_edit_absolute_url(self):
+        return self.parent_class.get_edit_absolute_url()
+
     @cache_function
     def get_meeting_times(self):
         return self.meeting_times.all()
@@ -1297,6 +1300,9 @@ class ClassSubject(models.Model, CustomFormsLinkModel):
 
     def get_absolute_url(self):
         return "/manage/"+self.parent_program.url+"/manageclass/"+str(self.id)
+
+    def get_edit_absolute_url(self):
+        return "/manage/"+self.parent_program.url+"/editclass/"+str(self.id)
 
     @classmethod
     def ajax_autocomplete(cls, data):

--- a/esp/templates/users/userview_class_entry.html
+++ b/esp/templates/users/userview_class_entry.html
@@ -3,6 +3,7 @@
 {% if class.isRejected %}(Rejected){% endif %}
 {% if class.isCancelled %}(Cancelled){% endif %}
 {{ class.emailcode }}: {{ class.title }}
+(<a href="{{ class.get_absolute_url|urlencode }}">manage</a> | <a href="{{ class.get_edit_absolute_url|urlencode }}">edit</a>)
 {% if show_class_details %}
 {% if class.get_sections %}
 {# This is a ClassSubject #}


### PR DESCRIPTION
Adds (manage | edit) links to each class in the `userview_class_entry`
template when enabled, and enable them in userview.

<img width="427" alt="screen shot 2016-11-21 at 4 30 52 pm" src="https://cloud.githubusercontent.com/assets/3482833/20501431/ed007e94-b007-11e6-8033-873563ef83a1.png">

<img width="482" alt="screen shot 2016-11-21 at 4 31 00 pm" src="https://cloud.githubusercontent.com/assets/3482833/20501439/f242b214-b007-11e6-9b89-2e02d7a2c002.png">