### PR TITLE
Revamp teacher checkin UI

### DIFF
--- a/esp/esp/program/modules/handlers/teachercheckinmodule.py
+++ b/esp/esp/program/modules/handlers/teachercheckinmodule.py
@@ -216,6 +216,7 @@ class TeacherCheckinModule(ProgramModuleObj):
         sections = sections.select_related(
             'parent_class',
             'parent_class__category',
+            'parent_class__parent_program',
         ).prefetch_related(
             'parent_class__teachers',
             'parent_class__sections',

--- a/esp/templates/program/modules/classsearchmodule/class_detail.html
+++ b/esp/templates/program/modules/classsearchmodule/class_detail.html
@@ -4,6 +4,7 @@
             <th class="smaller">Sections:</th>
             <td>
                 {{class.sections.count}}
+                ({% for section in class.get_sections %}{{section.duration}} hrs{% if not forloop.last %}, {% endif%}{% endfor %})
             </td>
         </tr>
         <tr>

--- a/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
+++ b/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
@@ -15,44 +15,62 @@
             border: 1px solid gray;
             padding: 5px;
             z-index: 100;
-            background-color: white
+            background-color: white;
+            opacity: 0.75;
+            transition: opacity 0.25s ease;
         }
-        
+        #shortcuts-box:hover {
+            opacity: 1;
+        }
+
+        .section-first-row {
+            border-top: 4px solid #ccc;
+        }
+
+        .section-code {
+            background-color: #c6def7;
+            background: linear-gradient(to bottom, white, #c6def7);
+        }
+
         .not-checked-in a {
             font-weight: bold;
         }
-        
+
         .checked-in {
             text-decoration: line-through;
         }
-        
+
         .selected .checkin + span:after {
             content: "◀"; font-weight: bold;
         }
-        
+
         .selected .not-checked-in, .selected .checkin-column, .selected .phone {
             background-color: #FFFF00;
         }
-        
+
         .checkin-column {
             min-width: 90px;
         }
-        
+
         input.found {
             background-color: #AAFFAA;
         }
-        
+
         input.not-found {
             background-color: #FFAAAA;
         }
 
+        .section-detail-td {
+            background-color: #c6def7;
+        }
+
         .section-detail {
             display: inline-block;
-            border: 1px solid #ccc;
+            border-width: 0;
             margin: 0px;
             width: 100%;
         }
-        
+
         .section-detail-header {
             background-color: #c6def7;
             font-size: 1.2em;
@@ -63,6 +81,10 @@
             display: inline-block;
             width: 470px;
             vertical-align: middle;
+        }
+
+        .section-detail-include {
+            background-color: white;
         }
     </style>
 {% endblock %}
@@ -111,11 +133,11 @@
         {% else %} scheduled for the program{% if date %} on {{ date|date:"D m/d/Y" }}{% endif %}
         {% endif %}.
     </td>
-</tr>    
+</tr>
 {% endif %}
 {% for section in sections %}
-<tr>
-    <td rowspan="{{ section.teachers|length }}">
+<tr class="section-first-row">
+    <td rowspan="{{ section.teachers|length }}" class="section-code">
         {{ section.parent_class.emailcode }}: {{ section.name }}
     </td>
     <td class="room" rowspan="{{ section.teachers|length }}">
@@ -145,11 +167,12 @@
         </tr>
         <tr>
     {% endfor %}
-    <td colspan="5">
+    <td colspan="5" class="section-detail-td">
         <div class="section-detail fqr-class">
             <div class="section-detail-header"
                  onclick="$j(this).siblings('.section-detail-info').toggle('blink');">
                 {{section.title}}
+                (<a href="{{section.get_absolute_url|urlencode}}">manage</a> | <a href="{{section.get_edit_absolute_url|urlencode}}">edit</a>)
             </div>
             <div class="section-detail-info" style="display: none;">
                 {% with section.parent_class as class %}
@@ -163,7 +186,7 @@
                             </div>
                         </span>
                     {% endif %}
-                    <div>
+                    <div class="section-detail-include">
                         {% include "program/modules/classsearchmodule/class_detail.html" %}
                     </div>
                     {% if show_flags %}
@@ -176,9 +199,6 @@
             </div>
         </div>
     </td>
-</tr>
-<tr>
-    <td colspan="5"><hr/></td>
 </tr>
 {% endfor %}
 </table>


### PR DESCRIPTION
- make sections much more compact by using borders instead of a row with
  an `<hr>`
- redistribute paddings and background colors to look prettier and
  visually connect rows with class codes to the class below them
- add manage and edit links to the class row
- make instructions slightly transparent for some usability in a narrow
  window (not shown in screenshot)

<img width="581" alt="screen shot 2016-11-21 at 9 45 11 pm" src="https://cloud.githubusercontent.com/assets/3482833/20509202/0ad5dc20-b035-11e6-9cf3-19b9059d090c.png">