### PR TITLE
Added user group filter option to comm panel

### DIFF
--- a/esp/esp/users/controllers/usersearch.py
+++ b/esp/esp/users/controllers/usersearch.py
@@ -94,7 +94,7 @@ class UserSearchController(object):
                     group = criteria['group']
                     Q_include &= Q(registrationprofile__user__groups__name=group)
                     self.updated = True
-            
+
             for field in ['username','last_name','first_name', 'email']:
                 if criteria.get(field, '').strip():
                     #   Check that it's a valid regular expression

--- a/esp/esp/users/controllers/usersearch.py
+++ b/esp/esp/users/controllers/usersearch.py
@@ -89,11 +89,10 @@ class UserSearchController(object):
         else:
 
             ##  Select users based on all other criteria that was entered
-            if 'group' in criteria:
-                if criteria['group'] != "":
-                    group = criteria['group']
-                    Q_include &= Q(registrationprofile__user__groups__name=group)
-                    self.updated = True
+            if 'group' in criteria and criteria['group'] != "":
+                group = criteria['group']
+                Q_include &= Q(groups=group)
+                self.updated = True
 
             for field in ['username','last_name','first_name', 'email']:
                 if criteria.get(field, '').strip():

--- a/esp/esp/users/controllers/usersearch.py
+++ b/esp/esp/users/controllers/usersearch.py
@@ -40,6 +40,7 @@ from esp.dbmail.models import MessageRequest
 
 from django.db.models import Count
 from django.db.models.query import Q
+from django.contrib.auth.models import Group
 
 import collections
 import re
@@ -88,6 +89,12 @@ class UserSearchController(object):
         else:
 
             ##  Select users based on all other criteria that was entered
+            if 'group' in criteria:
+                if criteria['group'] != "":
+                    group = criteria['group']
+                    Q_include &= Q(registrationprofile__user__groups__name=group)
+                    self.updated = True
+            
             for field in ['username','last_name','first_name', 'email']:
                 if criteria.get(field, '').strip():
                     #   Check that it's a valid regular expression
@@ -357,6 +364,7 @@ class UserSearchController(object):
         if target_path is None:
             target_path = '/manage/%s/commpanel' % program.getUrlBase()
         context['action_path'] = target_path
+        context['groups'] = Group.objects.all()
 
         return context
 

--- a/esp/esp/users/controllers/usersearch.py
+++ b/esp/esp/users/controllers/usersearch.py
@@ -91,7 +91,8 @@ class UserSearchController(object):
             ##  Select users based on all other criteria that was entered
             if 'group' in criteria and criteria['group'] != "":
                 group = criteria['group']
-                Q_include &= Q(groups=group)
+                #Can't just filter by group because we are already filtering by group with user_type above. - willgearty, 2016-11-23
+                Q_include &= Q(registrationprofile__user__groups=group)
                 self.updated = True
 
             for field in ['username','last_name','first_name', 'email']:

--- a/esp/public/media/scripts/commpanel.js
+++ b/esp/public/media/scripts/commpanel.js
@@ -114,7 +114,7 @@ function clear_filters(form_name)
 {
     //  Remove any existing data in the "user filtering options" part of a comm panel form
     var form = $j("#"+form_name)[0];
-    field_names = ["userid", "username", "first_name", "last_name", "email", "zipcode", "zipdistance", "zipdistance_exclude", "states", "school", "grade_min", "grade_max", "gradyear_min", "gradyear_max"];
+    field_names = ["userid", "username", "first_name", "last_name", "email", "zipcode", "zipdistance", "zipdistance_exclude", "states", "school", "grade_min", "grade_max", "gradyear_min", "gradyear_max", "group"];
     for (var i = 0; i < field_names.length; i++)
     {
         var form_field = $j(form).find(':input[name=' + field_names[i] + ']')[0];

--- a/esp/templates/users/usersearch/list_selector.html
+++ b/esp/templates/users/usersearch/list_selector.html
@@ -72,14 +72,6 @@
             <div class="step_instructions">(For any criteria you don't need, just leave them blank.)</div>
             <div class="step_instructions step_highlight">Currently selected: <span id="filter_current_list"></span></div>
             <div id="filter_accordion">
-            
-                <h4><a href="#">User Group</a></h4>
-                <div><select id="group" name="group">
-                    {% for group in groups %}
-                    <option value="{{ group.name }}" id="{{ group.name }}">{{ group.name }}</option>
-                    {% endfor %}
-                    <option value="" id="" selected hidden></option>
-                </select></div>
                 
                 <h4><a href="#">User ID</a></h4>
                 <div>Enter an ID number: <input type="text" size="6" name="userid" id="userid" /></div>
@@ -121,6 +113,14 @@
                 Min: <input type="text" size="3" name="gradyear_min" value="" /> <br />
                 Max: <input type="text" size="3" name="gradyear_max" value="" />
                 </div>
+                
+                <h4><a href="#">User Group</a></h4>
+                <div><select name="group" id="user-search-group">
+                    {% for group in groups %}
+                    <option value="{{ group.id }}">{{ group.name }}</option>
+                    {% endfor %}
+                    <option value="" selected hidden></option>
+                </select></div>
                 
             </div>
             
@@ -199,14 +199,6 @@
             <div class="step_instructions">(For any criteria you don't need, just leave them blank.)</div>
             <div id="combo_filter_accordion">
             
-                <h4><a href="#">User Group</a></h4>
-                <div><select id="group" name="group">
-                    {% for group in groups %}
-                    <option value="{{ group.name }}" id="{{ group.name }}">{{ group.name }}</option>
-                    {% endfor %}
-                    <option value="" id="" selected hidden></option>
-                </select></div>
-            
                 <h4><a href="#">User ID</a></h4>
                 <div>Enter an ID number: <input type="text" size="6" name="userid" id="userid" /></div>
                 
@@ -247,6 +239,14 @@
                 Min: <input type="text" size="3" name="gradyear_min" value="" /> <br />
                 Max: <input type="text" size="3" name="gradyear_max" value="" />
                 </div>
+                
+                <h4><a href="#">User Group</a></h4>
+                <div><select name="group" id="user-search-group">
+                    {% for group in groups %}
+                    <option value="{{ group.id }}">{{ group.name }}</option>
+                    {% endfor %}
+                    <option value="" selected hidden></option>
+                </select></div>
                 
             </div>
             

--- a/esp/templates/users/usersearch/list_selector.html
+++ b/esp/templates/users/usersearch/list_selector.html
@@ -72,7 +72,7 @@
             <div class="step_instructions">(For any criteria you don't need, just leave them blank.)</div>
             <div class="step_instructions step_highlight">Currently selected: <span id="filter_current_list"></span></div>
             <div id="filter_accordion">
-                
+            
                 <h4><a href="#">User ID</a></h4>
                 <div>Enter an ID number: <input type="text" size="6" name="userid" id="userid" /></div>
                 

--- a/esp/templates/users/usersearch/list_selector.html
+++ b/esp/templates/users/usersearch/list_selector.html
@@ -73,6 +73,14 @@
             <div class="step_instructions step_highlight">Currently selected: <span id="filter_current_list"></span></div>
             <div id="filter_accordion">
             
+                <h4><a href="#">User Group</a></h4>
+                <div><select id="group" name="group">
+                    {% for group in groups %}
+                    <option value="{{ group.name }}" id="{{ group.name }}">{{ group.name }}</option>
+                    {% endfor %}
+                    <option value="" id="" selected hidden></option>
+                </select></div>
+                
                 <h4><a href="#">User ID</a></h4>
                 <div>Enter an ID number: <input type="text" size="6" name="userid" id="userid" /></div>
                 
@@ -190,6 +198,14 @@
             <div class="step_header"><span class="step_label">Step 3:</span> <span class="step_text">Do you need to filter this list down?</span></div>
             <div class="step_instructions">(For any criteria you don't need, just leave them blank.)</div>
             <div id="combo_filter_accordion">
+            
+                <h4><a href="#">User Group</a></h4>
+                <div><select id="group" name="group">
+                    {% for group in groups %}
+                    <option value="{{ group.name }}" id="{{ group.name }}">{{ group.name }}</option>
+                    {% endfor %}
+                    <option value="" id="" selected hidden></option>
+                </select></div>
             
                 <h4><a href="#">User ID</a></h4>
                 <div>Enter an ID number: <input type="text" size="6" name="userid" id="userid" /></div>


### PR DESCRIPTION
Only required a few tweaks and additions. This implementation provides a drop-down menu to select a single user group to then filter the users by. Everything seems to work as it should, and it seems to play nicely with other filters.

The only little bug is that the new filter option isn't hidden along with the other filter options. However, once you collapse the option, it then behaves as it should. Not sure why...