### PR TITLE
Add help text back to scheduling checks

### DIFF
--- a/esp/public/media/default_styles/scheduling_checks.css
+++ b/esp/public/media/default_styles/scheduling_checks.css
@@ -43,3 +43,8 @@ color: lightgray;
 .sortReversed {
   color: red;
 }
+
+.help-text {
+  margin: 10px;
+  font-style: italic;
+}

--- a/esp/public/media/scripts/program/modules/scheduling_checks.jsx
+++ b/esp/public/media/scripts/program/modules/scheduling_checks.jsx
@@ -147,10 +147,15 @@ var SchedulingCheck = React.createClass({
                   clickHeader = {this.sortColumn} clickRow = {this.greyRow} 
                   />;
       }
+      var helpText;
+      if (data.help_text) {
+        helpText = <div className="help-text">{data.help_text}</div>;
+      }
       body = <div>
         <div className="placeholder">
           (loaded {this.state.timestamp}, click title to close)
         </div>
+        {helpText}
         {table}
       </div>;
     }


### PR DESCRIPTION
This got dropped when we made it all fancy and async.  It often has useful info
about what the check means and how to set it up.  Fixes #2197.