### PR TITLE
Remove mentions of plato from deploy docs

### DIFF
--- a/docs/dev/deploying.rst
+++ b/docs/dev/deploying.rst
@@ -19,8 +19,7 @@ instructions to set up the site.  For the site directory name, choose something
 short that's likely to stay unique and understandable as we add more chapters.
 When it does the "create superuser", you should create yourself an account;
 afterwards chapter admins can create their own accounts and you can make them
-admins.  At the end, it will give you instructions for setting up DNS,
-currently on ``plato``.
+admins.
 
 If something doesn't work, and you need to re-run a particular step, you can do
 so by passing the appropriate flag to ``new_site.sh``.  Note that some steps
@@ -38,8 +37,8 @@ Deactivating a site
 
 To deactivate a site, simply remove or comment out its lines in
 ``/etc/apache2/sites-available/esp_sites.conf``, ``/etc/crontab``, and
-``/etc/exim4/update-exim4.conf.conf``, remove it from the DNS config on
-``plato``, and move its site directory to ``/lu/sites/inactive``.
+``/etc/exim4/update-exim4.conf.conf``, and move its site directory to
+``/lu/sites/inactive``.
 
 TODO(benkraft): write a quick script for this.
 


### PR DESCRIPTION
We've now set things up so we don't need to update DNS for every new site.