### PR TITLE
Cleanup, refactors, and better error-handling for LaTeX generation

### DIFF
--- a/esp/esp/utils/latex.py
+++ b/esp/esp/utils/latex.py
@@ -71,7 +71,7 @@ def render_to_latex(filepath, context_dict=None, filetype='pdf'):
     """
     if filetype not in FILE_MIME_TYPES:
         raise ESPError('Invalid type received for latex generation: %s should '
-                       'be one of %s' % (type, FILE_MIME_TYPES))
+                       'be one of %s' % (filetype, ', '.join(FILE_MIME_TYPES)))
 
     context_dict = context_dict or {}
 
@@ -175,8 +175,8 @@ def _gen_latex(texcode, stdout, stderr, type='pdf'):
         raise ESPError('LaTeX failed with code %s; try looking at the log '
                        'file.  Here are '
                        'the last 1000 characters of the log: %s'
-                       % tex_log[-1000:])
-    elif 'No pages if output' in tex_log:
+                       % (retcode, tex_log[-1000:]))
+    elif 'No pages of output' in tex_log:
         # One common problem (which LaTeX doesn't treat as an error) is
         # selecting no students, which results in no output (thus a nonexistent
         # file, and an error converting or reading it later).  We'll just exit

--- a/esp/esp/utils/latex.py
+++ b/esp/esp/utils/latex.py
@@ -179,22 +179,24 @@ def _gen_latex(texcode, stdout, stderr, type='pdf'):
               '%s.pdf' % file_base, '%s.png' % file_base])
 
 
+    out_file = file_base + '.' + type
     try:
-        if type is 'png' and not os.path.isfile(file_base+'.'+type):
-            #If the schedule is multiple pages (such as a schedule if the program is using barcode check-in), ImageMagick will generate files of the form file_base-n.png.  In this case, we will just return the first page.  Most of the time, if we expect something multi-page, we won't use PNG anyway; this is mostly for the benefit of the schedule printing script.
+        if type is 'png' and not os.path.isfile(out_file):
+            # If the schedule is multiple pages (such as a schedule if the
+            # program is using barcode check-in), ImageMagick will generate
+            # files of the form file_base-n.png.  In this case, we will just
+            # return the first page.  Most of the time, if we expect something
+            # multi-page, we won't use PNG anyway; this is mostly for the
+            # benefit of the schedule printing script.
             out_file = file_base + '-0.png'
-        else:
-            out_file = file_base + '.' + type
-        new_file     = open(out_file, 'rb')
-        new_contents = new_file.read()
-        new_file.close()
-
+        if not os.path.isfile(out_file):
+            raise ESPError('No output file %s found; try looking at the log '
+                           'file.' % out_file)
+        with open(out_file) as f:
+            return f.read()
     except:
-        raise ESPError('Could not read contents of %s. (Hint: try looking at the log file)' % (file_base+'.'+type))
-
-    return new_contents
-
-
+        raise ESPError('Could not read contents of %s. (Hint: try looking at '
+                       'the log file)' % out_file)
 
 
 def get_rand_file_base():


### PR DESCRIPTION
This includes a bunch of refactoring and cleanup in our LaTeX utils, and in particular better error handling for a number of classes of errors, especially those which are often caused by a bad template override as opposed to a server error.  We'll now return more specific error text with details of what failed.  Fixes #1875.