### PR TITLE
Fix .less regexes: don't include variables_foo.less twice

### DIFF
--- a/esp/esp/themes/controllers.py
+++ b/esp/esp/themes/controllers.py
@@ -183,9 +183,17 @@ class ThemeController(object):
             result.append(os.path.join(themes_settings.less_dir, 'bootstrap.less'))
             result.append(os.path.join(themes_settings.less_dir, 'variables_custom.less'))
             result.append(os.path.join(themes_settings.less_dir, 'main.less'))
+
         #   Make sure variables.less is included first, before any other custom LESS code
-        result += self.list_filenames(os.path.join(self.base_dir(theme_name), 'less'), r'variables(.*?)\.less')
-        result += self.list_filenames(os.path.join(self.base_dir(theme_name), 'less'), r'(?<!variables)\.less$')
+        theme_files = self.list_filenames(os.path.join(self.base_dir(theme_name), 'less'), r'\.less$')
+        nonvariable_files = []
+        for theme_file in theme_files:
+            if os.path.basename(theme_file).startswith('variables'):
+                result.append(theme_file)
+            else:
+                nonvariable_files.append(theme_file)
+        result += nonvariable_files
+
         return result
 
     def find_less_variables(self, theme_name=None, theme_only=False, flat=False):


### PR DESCRIPTION
The code tries to include all variables*.less first and then all other
files second, but the regex used to match the latter type of file name
isn't correct and inverting a regex is too damn hard to do or verify
anyway. Make the code do that.