### PR TITLE
Use Save/Cancel buttons to save editable text

### DIFF
--- a/esp/public/media/scripts/qsd.js
+++ b/esp/public/media/scripts/qsd.js
@@ -22,6 +22,7 @@ function qsd_inline_edit(qsd_url, edit_id)
 {
     //  Switch the visibility of the edit and view areas.
     document.getElementById("inline_edit_" + edit_id).className = "qsd_edit_visible";
+    $j("#inline_edit_msg_" + edit_id).hide();
     document.getElementById("qsd_content_" + edit_id).focus();
     document.getElementById("inline_qsd_" + edit_id).className = "hidden";
 }
@@ -54,15 +55,18 @@ function qsd_send_command(qsd_url, edit_id, postdata)
     $j.post("/varnish/purge_page", { page: $j(location).attr('pathname'), csrfmiddlewaretoken: csrf_token()});
 }
 
-function qsd_inline_upload(qsd_url, edit_id)
+function qsd_inline_finish(qsd_url, edit_id, do_upload)
 {
     //  Switch the visibility of the edit and view areas.
     document.getElementById("inline_edit_" + edit_id).className = "hidden";
+    $j("#inline_edit_msg_" + edit_id).show();
     document.getElementById("inline_qsd_" + edit_id).className = "qsd_view_visible";
 
-    var content = document.getElementById("qsd_content_" + edit_id).value;
-    var postdata = {cmd: "update", url: qsd_url, data: content};
-    qsd_send_command(qsd_url, edit_id, postdata);
+    if (do_upload) {
+        var content = document.getElementById("qsd_content_" + edit_id).value;
+        var postdata = {cmd: "update", url: qsd_url, data: content};
+        qsd_send_command(qsd_url, edit_id, postdata);
+    }
 }
 
 function qsd_inline_update(qsd_url, edit_id, data)

--- a/esp/templates/inclusion/qsd/render_qsd.html
+++ b/esp/templates/inclusion/qsd/render_qsd.html
@@ -1,16 +1,17 @@
 {% load markup %}
 
 <div class="qsd_bits hidden">
-    <div class="qsd_header qsd_bits hidden" onclick="qsd_inline_edit('{{ qsdrec.url }}', '{{ qsdrec.edit_id }}');">
+    <div class="qsd_header qsd_bits hidden" id="inline_edit_msg_{{ qsdrec.edit_id }}" onclick="qsd_inline_edit('{{ qsdrec.url }}', '{{ qsdrec.edit_id }}');">
         {% if qsdrec.id %}
-            This is editable text.  Click here to edit the text; click outside the box to save changes.
+            This is editable text.
         {% else %}
-            This is a placeholder for editable text that has not yet been added.  Click here to edit the text; click outside the box to save changes.
+            This is a placeholder for editable text that has not yet been added.
         {% endif %}
+        Click here to edit the text.
     </div>
     <div class="hidden" id="inline_edit_{{ qsdrec.edit_id }}">
+        <button type="button" class="btn btn-success" onclick="qsd_inline_finish('{{ qsdrec.url }}', '{{ qsdrec.edit_id }}', true);">Save changes</button> <button type="button" class="btn btn-danger" onclick="qsd_inline_finish('{{ qsdrec.url }}', '{{ qsdrec.edit_id }}', false);">Cancel</button>
         <textarea rows="8" cols="80" id="qsd_content_{{ qsdrec.edit_id }}"
-                  onblur="qsd_inline_upload('{{ qsdrec.url }}', '{{ qsdrec.edit_id }}');"
                   class="qsd_editor {% if not inline %}qsd_fullsize{% endif %} qsd_bits hidden {% if inline and not qsdrec.id %}qsd_halfsize{% endif %}"
                   name="qsd_content">{% autoescape on %}{{ qsdrec.content }}{% endautoescape %}</textarea>
         {% comment %}


### PR DESCRIPTION
instead of the old onblur behavior, which is easy to accidentally
trigger after you accidentally click into editable text

<img width="578" alt="screen shot 2016-12-05 at 1 34 37 am" src="https://cloud.githubusercontent.com/assets/3482833/20875744/20d21c72-ba8b-11e6-979c-c06b7d957325.png">

(That was easier than expected.)