### PR TITLE
Clean up expand_display.js and use legit &minus;

### DIFF
--- a/esp/public/media/scripts/expand_display.js
+++ b/esp/public/media/scripts/expand_display.js
@@ -1,17 +1,24 @@
 function expand_disp(loc){
    if(document.getElementById){
-      var foc=loc.firstChild;
-      foc=loc.firstChild.innerHTML?
+      var sign = loc.firstChild.innerHTML ?
          loc.firstChild:
          loc.firstChild.nextSibling;
-      foc.innerHTML=foc.innerHTML=='+'?'-':'+';
-      foc=loc.parentNode.nextSibling.style?
+      var target = loc.parentNode.nextSibling.style ?
          loc.parentNode.nextSibling:
          loc.parentNode.nextSibling.nextSibling;
-      foc.style.display=foc.style.display=='block'?'none':'block';}}
+      if (target.style.display === 'none') {
+        target.style.display = 'block';
+        sign.innerHTML = '&minus;';
+      } else {
+        target.style.display = 'none';
+        sign.innerHTML = '+';
+      }
+   }
+}
 
 
-if(!document.getElementById)
-	document.write('<style type="text/css"><!--\n'+
-		'.dspcont{display:block;}\n'+
-		'//--></style>');
+if(!document.getElementById) {
+  document.write('<style type="text/css"><!--\n' +
+    '.dspcont{display:block;}\n' +
+    '//--></style>');
+}


### PR DESCRIPTION
Unify the two different sources of state in the DOM.  Plus and hyphen
have different widths and makes the expansion/contraction ugly; use a
real minus sign instead for the expanded display.