### PR TITLE
Add buttons to undo checkins after checking in

### DIFF
--- a/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
+++ b/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
@@ -157,7 +157,8 @@
         </td>
         <td class="checkin-column">
             {% if teacher.id not in arrived %}
-            <input id="checkin_{{ teacher.username }}" name="{{ teacher.last_name }}" 
+            <span class="message"></span>
+            <input id="checkin_{{ teacher.username }}" name="{{ teacher.last_name }}"
                    class="button checkin" type="button" value="Check In" {% if when %}disabled="disabled"{% endif %} /><span />
             {% else %}
             Already checked-in


### PR DESCRIPTION
On the way, combine it with the Ctrl-Z function and also rewrite the
jQuery to show/hide the input instead of swapping in/out an entirely new
`<td>`, as this makes it easier to not add messages repeatedly (previously
the "X is no longer checked in" message could be prepended multiple
times.)