### PR TITLE
Restyle "add class" button

### DIFF
--- a/esp/public/media/default_styles/catalog.css
+++ b/esp/public/media/default_styles/catalog.css
@@ -116,16 +116,9 @@ img.LaTeX {
     vertical-align: middle;
 }
 
-input.addbutton {
-    background-color: #D9EDF7;
-    color: #000000;
-    border: 1px solid #CCCCCC;
+.btn.addbutton {
     font-weight: bold;
-    font-size: 1.2em;
-    padding: 8px;
-    margin-bottom: 0px;
     width: 100%;
-    font-family: Helvetica, Arial, sans-serif;
     border-radius: 0px;
 }
 

--- a/esp/templates/inclusion/program/class_catalog.html
+++ b/esp/templates/inclusion/program/class_catalog.html
@@ -23,7 +23,10 @@
                   <input type="hidden" name="class_id" value="{{ class.id }}" />
                   <input type="hidden" name="section_id" value="{{ section.id }}" />
                   {% if not section.isFull %}
-                      <div id="addbutton_fillslot_sec{{ section.id }}"><input type="submit" class="addbutton" name="action" value="Click here to add this class" id="submitbutton{{ class.id }}" /></div>
+                  <div id="addbutton_fillslot_sec{{ section.id }}"><button type="submit" class="btn btn-primary btn-large addbutton" name="action" id="submitbutton{{ class.id }}">
+                          <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+                          Click here to add this class
+                          <span class="glyphicon glyphicon-plus" aria-hidden="true"></span></button></div>
                       <!--                      <div id="addbutton_fillslot_sec{{ section.id }}"><input type="submit" class="addbutton" name="action" value="Add this class" onclick="return submit_prereg({{ class.id }});" id="submitbutton{{ class.id }}" /></div>  -->
                   {% else %}
                       <!-- this branch is obsolete and probably can be removed; see 1b73e4538cc04cc55c4d8886f5b5d0d6f6791c95 (lua) -->


### PR DESCRIPTION
This looks way more like a button now

<img width="575" alt="screen shot 2016-12-14 at 12 37 43 pm" src="https://cloud.githubusercontent.com/assets/3482833/21193492/7cf78174-c1fa-11e6-9996-0ad720c14b3e.png">