### PR TITLE
Restyle, add glyphicons to student reg submit buttons

### DIFF
--- a/esp/public/media/theme_editor/less/buttons.less
+++ b/esp/public/media/theme_editor/less/buttons.less
@@ -59,11 +59,19 @@
 // Disabled state
 .btn.disabled,
 .btn[disabled] {
-  cursor: default;
+  cursor: not-allowed; // backported
   background-color: darken(@white, 10%);
   background-image: none;
   .opacity(65);
   .box-shadow(none);
+
+  // override/suppress hover effect on disabled buttons;
+  // backported from future bootstrap
+  &:hover,
+  &:focus,
+  &.focus {
+    color: @grayDark;
+  }
 }
 
 

--- a/esp/templates/program/modules/studentregcore/mainpage.html
+++ b/esp/templates/program/modules/studentregcore/mainpage.html
@@ -46,7 +46,7 @@
 
 {% render_inline_program_qsd program "learn:studentregheader" %}
 <div class="alert alert-info">
-<i class="icon-info-sign"></i>
+<span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
 <b>Parents:</b> You should not be at this page!  Please let your kids fill out the registration forms.
 </div>
     
@@ -98,14 +98,36 @@
         </form>
     {% else %}
         {% if can_confirm %}
-        <input id="confirmbutton" class="button" type="submit" value="{% if not isConfirmed %}{{ scrmi.confirm_button_text }}{% else %}{{ scrmi.view_button_text }}{% endif %}" {% if not completedAll %}disabled{% endif %} {% if program.isFull and not canRegToFullProgram and not isConfirmed %}disabled{% endif %}/>
-        {% endif %}
+            {# disable if (you haven't completed all requirements) OR (you can't register for the program because it's full) #}
+            {% if not completedAll or program.isFull and not canRegToFullProgram and not isConfirmed %}
+                <button id="confirmbutton" type="submit"
+                        class="btn btn-default btn-large"
+                        disabled="disabled" />
+                    <span class="glyphicon glyphicon-ban-circle" aria-hidden="true"></span>
+                    {{ scrmi.confirm_button_text }}
+                </button>
+            {% else %}
+                <button id="confirmbutton" type="submit"
+                        class="btn btn-primary btn-large" />
+                    {% if isConfirmed %}
+                        <span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span>
+                        {{ scrmi.view_button_text }}
+                    {% else %}
+                        <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
+                        {{ scrmi.confirm_button_text }}
+                    {% endif %}
+                </button>
+            {% endif %}
         </form>
-        {% if isConfirmed or scrmi.cancel_button_dereg %}{% if not have_paid %}
-           <form action="/learn/{{one}}/{{two}}/cancelreg" method="get" onsubmit="return submit_cancel();" >
-           <input id="cancelbutton" class="button" type="submit" value="{{ scrmi.cancel_button_text }}" />
-            </form>
-        {% endif %}{% endif %}
+            {% if isConfirmed or scrmi.cancel_button_dereg %}{% if not have_paid %}
+                <form action="/learn/{{one}}/{{two}}/cancelreg" method="get" onsubmit="return submit_cancel();" >
+                    <button type="submit" id="cancelbutton" class="btn btn-danger btn-large">
+                        <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
+                        {{ scrmi.cancel_button_text }}
+                    </button>
+                </form>
+            {% endif %}{% endif %}
+        {% endif %}
     {% endif %}
     </center>
 {% endif %}


### PR DESCRIPTION
Includes a few sort-of-backported patches of some disabled button style
rules, and a glyphicon in the info alert.

<img width="577" alt="screen shot 2016-12-14 at 1 32 33 pm" src="https://cloud.githubusercontent.com/assets/3482833/21195598/6fd3d5a8-c202-11e6-8f3b-9fea0d9b2700.png">

<img width="576" alt="screen shot 2016-12-14 at 1 32 01 pm" src="https://cloud.githubusercontent.com/assets/3482833/21195604/77a7faf2-c202-11e6-8388-ef5a29cb79c1.png">

<img width="574" alt="screen shot 2016-12-14 at 1 31 34 pm" src="https://cloud.githubusercontent.com/assets/3482833/21195607/79b229e4-c202-11e6-8d02-c18b8e8f33f3.png">
