### PR TITLE
Recolor class search buttons about approval, group together

### DIFF
--- a/esp/esp/themes/theme_data/fruitsalad/less/main.less
+++ b/esp/esp/themes/theme_data/fruitsalad/less/main.less
@@ -939,3 +939,5 @@ div .adminbar_user {
 .not-done-sign { color: red; }
 
 .glyphicon.glyphicon-btn-height:before { line-height: 18px; }
+
+.fqr-class-buttons.btn-toolbar { margin: 0; }

--- a/esp/public/media/theme_editor/less/buttons.less
+++ b/esp/public/media/theme_editor/less/buttons.less
@@ -167,6 +167,18 @@
 .btn-inverse {
   .buttonBackground(@btnInverseBackground, @btnInverseBackgroundHighlight);
 }
+// Approve appears as light green
+.btn-approve {
+  .buttonBackground(@btnApproveBackground, @btnApproveBackgroundHighlight);
+}
+// Unreview appears as light yellow
+.btn-unreview {
+  .buttonBackground(@btnUnreviewBackground, @btnUnreviewBackgroundHighlight);
+}
+// Reject appears as light red
+.btn-reject {
+  .buttonBackground(@btnRejectBackground, @btnRejectBackgroundHighlight);
+}
 
 
 // Cross-browser Jank

--- a/esp/public/media/theme_editor/less/variables.less
+++ b/esp/public/media/theme_editor/less/variables.less
@@ -97,6 +97,14 @@
 //@btnInverseBackground:              @gray;
 @btnInverseBackgroundHighlight:     @grayDarker;
 
+@btnApproveBackground:              #def7c6;
+@btnApproveBackgroundHighlight:     darken(@btnApproveBackground, 15%);
+
+@btnUnreviewBackground:             #ffeccc;
+@btnUnreviewBackgroundHighlight:    darken(@btnUnreviewBackground, 15%);
+
+@btnRejectBackground:               #ffeeee;
+@btnRejectBackgroundHighlight:      darken(@btnRejectBackground, 15%);
 
 // Forms
 // -------------------------

--- a/esp/templates/program/modules/classsearchmodule/class_search.html
+++ b/esp/templates/program/modules/classsearchmodule/class_search.html
@@ -39,15 +39,27 @@ Your query returned {{queryset|length}} of {{program.classsubject_set.count}} cl
                     {% include "program/modules/classflagmodule/flag_name.html" %}
                 {% endfor %}
             </div>
-            <div class="fqr-class-buttons">
-                <button class="btn btn-default" onclick="manage({{class.id}});">manage</button>
-                <button class="btn btn-default" onclick="edit({{class.id}});">edit</button>
-                <button class="btn btn-success" onclick="approve({{class.id}});">approve</button>
-                <button class="btn btn-warning" onclick="unreview({{class.id}});">unreview</button>
-                <button class="btn btn-danger" onclick="reject({{class.id}});">reject</button>
-                <button class="btn btn-danger" onclick="deleteClass({{class.id}}, '{{class.title}}');">delete</button>
-                <button class="btn btn-default" onclick="emailTeachers('{{class.emailcode}}-teachers@{{EMAIL_HOST_SENDER}}', 'Your {{program.program_type}} Class {{class.emailcode}}: {{class.title}}');">email</button>
-                <button class="add-flag btn btn-default">add flag</button>
+            <div class="fqr-class-buttons btn-toolbar">
+                <div class="btn-group">
+                    <button class="btn btn-default" onclick="manage({{class.id}});">manage</button>
+                </div>
+                <div class="btn-group">
+                    <button class="btn btn-default" onclick="edit({{class.id}});">edit</button>
+                </div>
+                <div class="btn-group">
+                    <button class="btn btn-approve" onclick="approve({{class.id}});">approve</button>
+                    <button class="btn btn-unreview" onclick="unreview({{class.id}});">unreview</button>
+                    <button class="btn btn-reject" onclick="reject({{class.id}});">reject</button>
+                </div>
+                <div class="btn-group">
+                    <button class="btn btn-danger" onclick="deleteClass({{class.id}}, '{{class.title}}');">delete</button>
+                </div>
+                <div class="btn-group">
+                    <button class="btn btn-default" onclick="emailTeachers('{{class.emailcode}}-teachers@{{EMAIL_HOST_SENDER}}', 'Your {{program.program_type}} Class {{class.emailcode}}: {{class.title}}');">email</button>
+                </div>
+                <div class="btn-group">
+                    <button class="add-flag btn btn-default">add flag</button>
+                </div>
             </div>
             <div class="fqr-class-detail" style="display: none;">
                 {% include "program/modules/classsearchmodule/class_detail.html" %}


### PR DESCRIPTION
As noted in #2235 the button colors are a little noisy and kind of
overemphasize the approve/unreview/reject triad while they are pretty
rarely used compared to the other buttons, plus "reject" and "delete"
have very different degrees of danger; so restyle them with new
light-colored semantic styles and group them together.
<img width="573" alt="screen shot 2016-12-19 at 12 25 40 am" src="https://cloud.githubusercontent.com/assets/3482833/21302164/7bbe94ce-c582-11e6-9055-371f82de199a.png">
