### PR TITLE
Add Django admin links to navbar for edit/add entry

### DIFF
--- a/esp/esp/context_processors.py
+++ b/esp/esp/context_processors.py
@@ -3,7 +3,6 @@ from django.conf import settings
 
 from esp.program.models import Program
 from esp.users.models import ESPUser
-from esp.web.views.navBar import makeNavBar
 
 def media_url(request):
     return {'media_url': settings.MEDIA_URL}

--- a/esp/esp/qsd/views.py
+++ b/esp/esp/qsd/views.py
@@ -34,7 +34,6 @@ Learning Unlimited, Inc.
 """
 from esp.qsd.models import QuasiStaticData
 from esp.users.models import ContactInfo, Permission
-from esp.web.views.navBar import makeNavBar
 from esp.web.models import NavBarEntry, NavBarCategory, default_navbarcategory
 from esp.utils.web import render_to_response
 from django.http import HttpResponse, Http404, HttpResponseNotAllowed

--- a/esp/esp/themes/theme_data/fruitsalad/less/main.less
+++ b/esp/esp/themes/theme_data/fruitsalad/less/main.less
@@ -594,6 +594,29 @@ content: '*';
 color: #fff;
 }
 
+#submenu li.navbar-manage {
+  position: absolute;
+  top: 0;
+  right: 0;
+  line-height: normal;
+}
+#submenu li.navbar-manage:before {
+  content: '';
+}
+#submenu li.navbar-manage a, #submenu li.navbar-manage .navbar-manage-expander {
+  color: white;
+  display: block;
+  padding: 2px 5px 5px;
+  background-color: rgba(0, 0, 0, 75%);
+}
+#submenu li.navbar-manage .navbar-manage-expander {
+  font-weight: bold;
+  cursor: pointer;
+}
+#submenu li.navbar-manage a:hover, #submenu li.navbar-manage .navbar-manage-expander:hover {
+  background-color: #000;
+}
+
 /* ANNOUNCEMENTS */
 
 #divannouncements {

--- a/esp/esp/web/templatetags/navbar.py
+++ b/esp/esp/web/templatetags/navbar.py
@@ -4,9 +4,9 @@ from esp.utils.cache_inclusion_tag import cache_inclusion_tag
 register = template.Library()
 
 @cache_inclusion_tag(register,'inclusion/web/navbar_left.html')
-def navbar_gen(request_path, user, navbar_list, navbar_type='left'):
+def navbar_gen(request_path, user, navbar_list):
 
     return {'navbar_list': navbar_list,
             'request_path': request_path,
             'user': user,
-            'navbar_type': navbar_type}
+            }

--- a/esp/esp/web/views/navBar.py
+++ b/esp/esp/web/views/navBar.py
@@ -41,8 +41,14 @@ def makeNavBar(section=None, category=None, path=None):
 
     navbars = list(category.get_navbars().order_by('sort_rank'))
     navbar_context = [{'entry': x} for x in navbars]
+    if navbars:
+        next_sort_rank = navbars[-1].sort_rank + 10
+    else:
+        next_sort_rank = 0
     context = { 'entries': navbar_context,
-                'section': section }
+                'section': section,
+                'category': category,
+                'next_sort_rank': next_sort_rank }
     return context
 
 

--- a/esp/public/media/scripts/nav.js
+++ b/esp/public/media/scripts/nav.js
@@ -15,3 +15,8 @@ $j('#side-dashboard a').prop('href', function() {
 //page, and make it active.
 $j('ul.nav li a[href="'+window.location.pathname+'"]').parent().addClass('active');
 $j('ul.nav li a[href="'+window.location.pathname+'/"]').parent().addClass('active');
+
+$j('.navbar-manage-contractible').hide();
+$j('.navbar-manage-expander').click(function () {
+  $j('.navbar-manage-contractible').toggle();
+});

--- a/esp/templates/inclusion/web/navbar_left.html
+++ b/esp/templates/inclusion/web/navbar_left.html
@@ -13,6 +13,15 @@
       {% endif %}
    </li>
   {% endfor %}
+  {% if navbar_list.category %}
+  {% with navbar_list.category as cat %}
+  <li class="hidden navbar-manage admin">
+      <span role="button" class="navbar-manage-expander"><span class="glyphicon glyphicon-option-horizontal" aria-hidden="true"></span> <span class="navbar-manage-contractible">Navbar Category: {{ cat.name }}</span></span>
+      <a href="/admin/web/navbarcategory/{{ cat.id }}/" class="navbar-manage-contractible"><span class="glyphicon glyphicon-cog" aria-hidden="true"></span> Set navbar name/path/description</a>
+      <a href="/admin/web/navbarentry/?category__id__exact={{ cat.id }}&amp;o=2" class="navbar-manage-contractible"><span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> Edit navbar contents</a>
+      <a href="/admin/web/navbarentry/add/?category={{ cat.id }}&amp;sort_rank={{ navbar_list.next_sort_rank }}" class="navbar-manage-contractible"><span class="glyphicon glyphicon-plus" aria-hidden="true"></span> Add navbar entry</a>
+  </li>
+  {% endwith %}
+  {% endif %}
   </ul>
 {% endif %}
-


### PR DESCRIPTION
Add links to the navbar that link to the Django administration pages for
editing entries in the navbar category, and for addding an entry with a
prepopulated sort order.

Also clean up dead code related to navbar.

Fixes #2004.

Some force-pushes later here's the UI I have now:

<img width="618" alt="screen shot 2016-12-19 at 11 10 11 pm" src="https://cloud.githubusercontent.com/assets/3482833/21338034/79b7b62e-c640-11e6-9894-326021f5fb4a.png">
<img width="619" alt="screen shot 2016-12-19 at 11 10 06 pm" src="https://cloud.githubusercontent.com/assets/3482833/21338035/7b703aa4-c640-11e6-802c-a2edfef84754.png">
