### PR TITLE
Change catalog button default to hidden

### DIFF
--- a/esp/public/media/default_styles/catalog.css
+++ b/esp/public/media/default_styles/catalog.css
@@ -99,10 +99,6 @@ input.button {
     display: none;
 }
 
-input.addbutton.show{
-    display: block;
-}
-
 input.button:hover {
     background-color: #333399;
     color: #c6def7;

--- a/esp/public/media/default_styles/catalog.css
+++ b/esp/public/media/default_styles/catalog.css
@@ -96,6 +96,11 @@ input.button {
     font-weight: bold;
     font-size: 13px;
     font-family: Arial, Helvetica, sans-serif;
+    display: none;
+}
+
+input.addbutton.show{
+    display: block;
 }
 
 input.button:hover {

--- a/esp/templates/program/modules/studentclassregmodule/catalog.html
+++ b/esp/templates/program/modules/studentclassregmodule/catalog.html
@@ -159,7 +159,7 @@ function configure_addbuttons()
 {
     {% if register_from_catalog %}
     //  Registration from the catalog is allowed
-    $j("input.addbutton").addClass("show");
+    $j("input.addbutton").show();
     {% endif %}
 }
 $j(document).ready(configure_addbuttons);

--- a/esp/templates/program/modules/studentclassregmodule/catalog.html
+++ b/esp/templates/program/modules/studentclassregmodule/catalog.html
@@ -153,15 +153,13 @@ function hideClassesOutOfGradeRange(stu_grade) {
 hideClassesOutOfGradeRange(student_grade);
 </script>
 
+
 <script type="text/javascript">
 function configure_addbuttons()
 {
     {% if register_from_catalog %}
     //  Registration from the catalog is allowed
-    $j("input.addbutton").removeClass("addbutton_hidden");
-    {% else %}
-    //  Registration from the catalog is not allowed
-    $j("input.addbutton").addClass("addbutton_hidden");
+    $j("input.addbutton").addClass("show");
     {% endif %}
 }
 $j(document).ready(configure_addbuttons);


### PR DESCRIPTION
Makes `display: none` the default for register buttons in catalog. Buttons are shown when student class reg settings indicate them to be shown.

(See #2205)