### PR TITLE
Add grade min/max to teacherreg fields with customizable help text

### DIFF
--- a/esp/esp/program/modules/forms/teacherreg.py
+++ b/esp/esp/program/modules/forms/teacherreg.py
@@ -199,7 +199,11 @@ class TeacherClassRegForm(FormWithRequiredCss):
             self.fields[field_name] = custom_fields[field_name]
 
         #   Modify help text on these fields if necessary.
-        custom_helptext_fields = ['duration', 'class_size_max', 'num_sections', 'requested_room', 'message_for_directors', 'purchase_requests', 'class_info'] + custom_fields.keys()
+        #   TODO(benkraft): Is there a reason not to allow this on all fields?
+        custom_helptext_fields = [
+            'duration', 'class_size_max', 'num_sections', 'requested_room',
+            'message_for_directors', 'purchase_requests', 'class_info',
+            'grade_max', 'grade_min'] + custom_fields.keys()
         for field in custom_helptext_fields:
             tag_data = Tag.getProgramTag('teacherreg_label_%s' % field, prog)
             if tag_data:


### PR DESCRIPTION
Not entirely sure why we don't have this for all fields, but in any case these
were requested by Clark (and I've put this change on their site).