### PR TITLE
Class styles

### DIFF
--- a/esp/esp/program/migrations/0008_classsubject_class_style.py
+++ b/esp/esp/program/migrations/0008_classsubject_class_style.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('program', '0007_auto_20160709_1856'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='classsubject',
+            name='class_style',
+            field=models.TextField(null=True, blank=True),
+        ),
+    ]

--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -1261,6 +1261,7 @@ class ClassSubject(models.Model, CustomFormsLinkModel):
     grade_min = models.IntegerField()
     grade_max = models.IntegerField()
     class_size_min = models.IntegerField(blank=True, null=True)
+    class_style = models.TextField(blank=True, null=True)
     hardness_rating = models.TextField(blank=True, null=True)
     class_size_max = models.IntegerField(blank=True, null=True)
     schedule = models.TextField(blank=True)

--- a/esp/esp/program/modules/forms/teacherreg.py
+++ b/esp/esp/program/modules/forms/teacherreg.py
@@ -64,9 +64,7 @@ class TeacherClassRegForm(FormWithRequiredCss):
     # Tag class_style_choices with value in the following JSON format, where the first element of each list
     # is the value stored in the database, and the second value is the option shown on the form.
     #     [["Lecture", "Lecture Style Class"], ["Seminar", "Seminar Style Class"]]
-    style_choices = [
-        ("Style", "Style")
-    ]
+    style_choices = []
 
     # Grr, TypedChoiceField doesn't seem to exist yet
     title          = StrippedCharField(    label='Course Title', length=50, max_length=200 )

--- a/esp/esp/program/modules/forms/teacherreg.py
+++ b/esp/esp/program/modules/forms/teacherreg.py
@@ -60,11 +60,12 @@ class TeacherClassRegForm(FormWithRequiredCss):
         ("****", "**** - You should not expect to be able to understand most of this class.",),
     ]
 
+    # The following is a dummy list (because using None causes an error). To enable class styles, admins should set the
+    # Tag class_style_choices with value in the following JSON format, where the first element of each list
+    # is the value stored in the database, and the second value is the option shown on the form.
+    #     [["Lecture", "Lecture Style Class"], ["Seminar", "Seminar Style Class"]]
     style_choices = [
-        ("Lecture", "Lecture"),
-        ("Seminar", "Seminar"),
-        ("Discussion", "Discussion"),
-        ("Activity", "Activity")
+        ("Style", "Style")
     ]
 
     # Grr, TypedChoiceField doesn't seem to exist yet
@@ -93,7 +94,7 @@ class TeacherClassRegForm(FormWithRequiredCss):
     optimal_class_size_range = forms.ChoiceField( label='Optimal Class Size Range', choices=[(0, 0)], widget=BlankSelectWidget() )
     allowable_class_size_ranges = forms.MultipleChoiceField( label='Allowable Class Size Ranges', choices=[(0, 0)], widget=forms.CheckboxSelectMultiple(),
                                                              help_text="Please select all class size ranges you are comfortable teaching." )
-    class_style = forms.ChoiceField( label='Class Style', choices=style_choices)
+    class_style = forms.ChoiceField( label='Class Style', choices=style_choices, required=False)
     hardness_rating = forms.ChoiceField( label='Difficulty',choices=hardness_choices, initial="**",
         help_text="Which best describes how hard your class will be for your students?")
     allow_lateness = forms.ChoiceField( label='Punctuality', choices=lateness_choices, widget=forms.RadioSelect() )
@@ -238,9 +239,11 @@ class TeacherClassRegForm(FormWithRequiredCss):
         if Tag.getTag('teacherreg_difficulty_choices'):
             self.fields['hardness_rating'].choices = json.loads(Tag.getTag('teacherreg_difficulty_choices'))
 
+        # Get class_style_choices from tag, otherwise hide the field
         if Tag.getTag('class_style_choices'):
             self.fields['class_style'].choices = json.loads(Tag.getTag('class_style_choices'))
-
+        else:
+            hide_field(self.fields['class_style'])
         # plus subprogram section wizard
 
     def clean(self):

--- a/esp/esp/program/modules/forms/teacherreg.py
+++ b/esp/esp/program/modules/forms/teacherreg.py
@@ -60,6 +60,13 @@ class TeacherClassRegForm(FormWithRequiredCss):
         ("****", "**** - You should not expect to be able to understand most of this class.",),
     ]
 
+    style_choices = [
+        ("Lecture", "Lecture"),
+        ("Seminar", "Seminar"),
+        ("Discussion", "Discussion"),
+        ("Activity", "Activity")
+    ]
+
     # Grr, TypedChoiceField doesn't seem to exist yet
     title          = StrippedCharField(    label='Course Title', length=50, max_length=200 )
     category       = forms.ChoiceField( label='Course Category', choices=[], widget=BlankSelectWidget() )
@@ -86,6 +93,7 @@ class TeacherClassRegForm(FormWithRequiredCss):
     optimal_class_size_range = forms.ChoiceField( label='Optimal Class Size Range', choices=[(0, 0)], widget=BlankSelectWidget() )
     allowable_class_size_ranges = forms.MultipleChoiceField( label='Allowable Class Size Ranges', choices=[(0, 0)], widget=forms.CheckboxSelectMultiple(),
                                                              help_text="Please select all class size ranges you are comfortable teaching." )
+    class_style = forms.ChoiceField( label='Class Style', choices=style_choices)
     hardness_rating = forms.ChoiceField( label='Difficulty',choices=hardness_choices, initial="**",
         help_text="Which best describes how hard your class will be for your students?")
     allow_lateness = forms.ChoiceField( label='Punctuality', choices=lateness_choices, widget=forms.RadioSelect() )
@@ -229,6 +237,9 @@ class TeacherClassRegForm(FormWithRequiredCss):
         #   Rewrite difficulty label/choices if desired:
         if Tag.getTag('teacherreg_difficulty_choices'):
             self.fields['hardness_rating'].choices = json.loads(Tag.getTag('teacherreg_difficulty_choices'))
+
+        if Tag.getTag('class_style_choices'):
+            self.fields['class_style'].choices = json.loads(Tag.getTag('class_style_choices'))
 
         # plus subprogram section wizard
 

--- a/esp/esp/program/modules/handlers/jsondatamodule.py
+++ b/esp/esp/program/modules/handlers/jsondatamodule.py
@@ -647,6 +647,7 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
             'title': cls.title,
             'class_info': cls.class_info,
             'category': cls.category.category,
+            'class_style': cls.class_style,
             'difficulty': cls.hardness_rating,
             'prereqs': cls.prereqs,
             'sections': section_info,

--- a/esp/esp/program/modules/handlers/jsondatamodule.py
+++ b/esp/esp/program/modules/handlers/jsondatamodule.py
@@ -384,6 +384,7 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
             classes.append(cls)
             if catalog:
                 cls['class_info'] = c.class_info
+                cls['class_style'] = c.class_style
                 cls['difficulty'] = c.hardness_rating
                 cls['prereqs'] = c.prereqs
             cls['emailcode'] = c.emailcode()

--- a/esp/public/media/scripts/catalog-new.js
+++ b/esp/public/media/scripts/catalog-new.js
@@ -11,6 +11,7 @@ var ClassSubject = function (data) {
     self.class_info  = data.class_info;
     self.grade_min   = data.grade_min;
     self.grade_max   = data.grade_max;
+    self.class_style = data.class_style;
     self.difficulty  = data.difficulty;
     self.prereqs     = data.prereqs;
     self.interested  = ko.observable(false);

--- a/esp/public/media/scripts/program/modules/adminclass.js
+++ b/esp/public/media/scripts/program/modules/adminclass.js
@@ -115,6 +115,7 @@ function fill_class_popup(clsid, classes_data) {
     .append(make_attrib_para("Location", class_info.location))
     .append(make_attrib_para("Grade Range", class_info.grade_range))
     .append(make_attrib_para("Category", class_info.category))
+    .append(make_attrib_para("Style", class_info.class_style))
     //.append("<p>Difficulty: " + class_info.difficulty))
     .append(make_attrib_para("Prereqs", class_info.prereqs))
     // Ensure the class description gets HTML-escaped

--- a/esp/templates/program/modules/studentregtwophase/catalog_new.html
+++ b/esp/templates/program/modules/studentregtwophase/catalog_new.html
@@ -55,6 +55,9 @@
       <dl>
         <dt>Grades</dt> <dd data-bind="text: grade_range"></dd>
         <dt>Difficulty</dt> <dd data-bind="text: difficulty"></dd>
+        <!-- ko if: class_style -->
+        <dt>Class Style</dt> <dd data-bind="text: class_style"></dd>
+        <!-- /ko -->
         <!-- ko if: prereqs -->
         <dt>Prerequisites</dt> <dd data-bind="text: prereqs"></dd>
         <!-- /ko -->


### PR DESCRIPTION
Requested by Stanford: Add a field to the teacher registration form for "class style".  Also add corresponding changes to the JSON data module, two-phase catalog, and program dashboard "Status" pop-up box.  

Disabled by default; chapter admin must set a tag "class_style_choices" with the list of dropdown choices to enable.
