### PR TITLE
Added attribute_value field to resources model

### DIFF
--- a/esp/esp/resources/migrations/0004_resource_attribute_value.py
+++ b/esp/esp/resources/migrations/0004_resource_attribute_value.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('resources', '0003_remove_resourcetype_distancefunc'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='resource',
+            name='attribute_value',
+            field=models.TextField(default=b''),
+        ),
+    ]

--- a/esp/esp/resources/migrations/0004_resource_attribute_value.py
+++ b/esp/esp/resources/migrations/0004_resource_attribute_value.py
@@ -14,6 +14,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='resource',
             name='attribute_value',
-            field=models.TextField(default=b''),
+            field=models.TextField(default=b'', blank=True),
         ),
     ]

--- a/esp/esp/resources/models.py
+++ b/esp/esp/resources/models.py
@@ -169,6 +169,7 @@ class Resource(models.Model):
     is_unique = models.BooleanField(default=False)
     user = AjaxForeignKey(ESPUser, null=True, blank=True)
     event = models.ForeignKey(Event)
+    attribute_value = models.TextField()
 
     def __unicode__(self):
         if self.user is not None:

--- a/esp/esp/resources/models.py
+++ b/esp/esp/resources/models.py
@@ -169,7 +169,7 @@ class Resource(models.Model):
     is_unique = models.BooleanField(default=False)
     user = AjaxForeignKey(ESPUser, null=True, blank=True)
     event = models.ForeignKey(Event)
-    attribute_value = models.TextField()
+    attribute_value = models.TextField(default="")
 
     def __unicode__(self):
         if self.user is not None:

--- a/esp/esp/resources/models.py
+++ b/esp/esp/resources/models.py
@@ -169,7 +169,9 @@ class Resource(models.Model):
     is_unique = models.BooleanField(default=False)
     user = AjaxForeignKey(ESPUser, null=True, blank=True)
     event = models.ForeignKey(Event)
-    attribute_value = models.TextField(default="")
+    # If the resource has a value, which one might request in the desired_value
+    # field of ResourceRequest.
+    attribute_value = models.TextField(default="", blank=True)
 
     def __unicode__(self):
         if self.user is not None:


### PR DESCRIPTION
ResourceTypes can specify attributes_pickled, and ResourceRequests can specify desired_value, but Resources can't specify anything. This fixes that.

Nothing uses this right now, but I'd therefore highly doubt this will break anything, and we can make changes to other things to use this as needed, such as the AJAX Scheduler, or classroom import scripts, or the "autoscheduler" I'm working on right now.