### PR TITLE
Partial revert of #2283 to fix missing teacher reg buttons.

### DIFF
--- a/esp/public/media/default_styles/catalog.css
+++ b/esp/public/media/default_styles/catalog.css
@@ -96,7 +96,6 @@ input.button {
     font-weight: bold;
     font-size: 13px;
     font-family: Arial, Helvetica, sans-serif;
-    display: none;
 }
 
 input.button:hover {


### PR DESCRIPTION
Seems like incorrect CSS class was modified with display:none in #2283, the
same change was made to the correct CSS class in #2317 but the old
CSS class did not get fixed. This reverts the changes to the incorrect
CSS class.