### PR TITLE
Annotate request with permission info in checkDeadline, display it

### DIFF
--- a/esp/esp/themes/theme_data/fruitsalad/templates/main.html
+++ b/esp/esp/themes/theme_data/fruitsalad/templates/main.html
@@ -209,17 +209,29 @@ var currentProgram = undefined;
 {% endblock %}
 
       <div id="content">
+          {% if request.show_perm_info %}
+          <div class="alert alert-info">
+              <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+              Permission/deadline controlling this page: {{ request.perm_names|join:", " }}
+              <br />
+              {% if request.roles_with_perm %}
+                  Roles with permission to view this page: {{ request.roles_with_perm|join:", " }}
+              {% else %}
+                  No roles with permission to view this page!
+              {% endif %}
+          </div>
+          {% endif %}
 {% block content %}{% endblock %}
       </div>
       <!--[if lte IE 6]>
-	  <div id="ie6_warning">
+      <div id="ie6_warning">
 <p>You're using a really old Web browser!  This site will look a lot better if you <a href="http://www.microsoft.com/windows/internet-explorer/">upgrade</a>.</p>
-	  </div>
+      </div>
       <![endif]-->
       {% with request.path|split:"/"|index:1 as split_url %}
       {% if program and split_url|notequal:"manage" %}
       <div class="admin hidden" id="admin_link">
-	<a href="/manage/{{ program.getUrlBase }}/dashboard">Administer this program</a>
+          <a href="/manage/{{ program.getUrlBase }}/dashboard">Administer this program</a>
       </div>
       {% endif %}
       {% endwith %}

--- a/esp/esp/themes/theme_data/fruitsalad/templates/main.html
+++ b/esp/esp/themes/theme_data/fruitsalad/templates/main.html
@@ -212,12 +212,12 @@ var currentProgram = undefined;
           {% if request.show_perm_info %}
           <div class="alert alert-info">
               <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
-              Permission/deadline controlling this page: {{ request.perm_names|join:", " }}
+              <a href="/manage/{{ one }}/{{ two }}/deadline_management/">Permission/deadline</a> required to view this page: {{ request.perm_names|join:", " }}
               <br />
               {% if request.roles_with_perm %}
                   Roles with permission to view this page: {{ request.roles_with_perm|join:", " }}
               {% else %}
-                  No roles with permission to view this page!
+                  <strong>No roles have permission to view this page!</strong>
               {% endif %}
           </div>
           {% endif %}

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -2321,6 +2321,8 @@ class Permission(ExpirableModel):
     @classmethod
     def q_permissions_on_program(cls, perm_q, name, program=None, when=None, program_is_none_implies_all=False):
         """
+        Build a QuerySet of permissions that would grant a permission.
+
         Given a Q object on Permission, a permission type, and a program,
         return a QuerySet of permissions satisfying the Q object constraint
         that would grant the permission on the program.
@@ -2421,8 +2423,8 @@ class Permission(ExpirableModel):
         """
 
         qrole = Q(user=None, role__isnull=False)
-        return [permission.role.name for permission in
-                cls.q_permissions_on_program(qrole, name, program)]
+        return list(cls.q_permissions_on_program(
+                qrole, name, program).values_list('role__name', flat=True))
 
     #list of all the permission types which are deadlines
     deadline_types = [x for x in PERMISSION_CHOICES_FLAT if x.startswith("Teacher") or x.startswith("Student") or x.startswith("Volunteer")]

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -2314,6 +2314,37 @@ class Permission(ExpirableModel):
         app_label = 'users'
 
     @classmethod
+    def null_user_has_perm(cls, permission_type, program):
+        return cls.valid_objects().filter(permission_type=permission_type,
+                program=program, user__isnull=True).exists()
+
+    @classmethod
+    def q_permissions_on_program(cls, perm_q, name, program=None, when=None, program_is_none_implies_all=False):
+        """
+        Given a Q object on Permission, a permission type, and a program,
+        return a QuerySet of permissions satisfying the Q object constraint
+        that would grant the permission on the program.
+        """
+        # As explained above, some Permissions have no specified Program; for
+        # some types these are global across all programs, but for most they
+        # are not:
+        if name in cls.deadline_types:
+            program_is_none_implies_all = False
+
+        perms = [name]
+        for k,v in cls.implications.items():
+            # k implies v: it's a parent permission that includes v
+            if name in v: perms.append(k)
+        # perms is the list of all permission types that might imply the
+        # requested permission
+
+        qprogram = Q(program=program)
+        if program_is_none_implies_all:
+            qprogram |= Q(program=None)
+        initial_qset = cls.objects.filter(perm_q & qprogram).filter(permission_type__in=perms)
+        return initial_qset.filter(cls.is_valid_qobject(when=when))
+
+    @classmethod
     def user_has_perm(cls, user, name, program=None, when=None, program_is_none_implies_all=False):
         """Determine if the user has the specified permission on the program.
 
@@ -2364,18 +2395,34 @@ class Permission(ExpirableModel):
         """
         if user.isAdministrator(program=program):
             return True
-        if name in cls.deadline_types:
-            program_is_none_implies_all = False
-        perms=[name]
-        for k,v in cls.implications.items():
-            if name in v: perms.append(k)
 
         quser = Q(user=user) | Q(user=None, role__in=user.groups.all())
-        qprogram = Q(program=program)
-        if program_is_none_implies_all:
-            qprogram |= Q(program=None)
-        initial_qset = cls.objects.filter(quser & qprogram).filter(permission_type__in=perms)
-        return initial_qset.filter(cls.is_valid_qobject(when=when)).exists()
+        return cls.q_permissions_on_program(quser, name, program, when,
+                program_is_none_implies_all).exists()
+
+    @classmethod
+    def list_roles_with_perm(cls, name, program):
+        """Given a permission type on a program, list roles that would give the
+        permission on the program.
+
+        :param name:
+            The unique identifier of the permission identifier to check for.
+            Must be in PERMISSION_CHOICES_FLAT.
+        :type name:
+            `str`
+        :param program:
+            Check for permission for `name` on this program.
+        :type program:
+            `Program`
+        :return:
+            List of role names that would give the specified permission.
+        :rtype:
+            `list` of `str`
+        """
+
+        qrole = Q(user=None, role__isnull=False)
+        return [permission.role.name for permission in
+                cls.q_permissions_on_program(qrole, name, program)]
 
     #list of all the permission types which are deadlines
     deadline_types = [x for x in PERMISSION_CHOICES_FLAT if x.startswith("Teacher") or x.startswith("Student") or x.startswith("Volunteer")]


### PR DESCRIPTION
In the helper function for checking deadline satisfiability, if the user
is an administrator, annotate the request with information about which
permission or deadline was checked and what roles would have had
permission. Then display this information in the fruitsalad default
template.

To accommodate all this, also refactor deadline code to:

- add a new method for listing roles that have a particular permission,
  pulling out shared logic with user_has_perm
- eliminate duplication
- remove the unused meets_all_deadlines method.

Fixes #2324.