### PR TITLE
Update pip before using it to install anything else

### DIFF
--- a/esp/update_deps.sh
+++ b/esp/update_deps.sh
@@ -49,5 +49,6 @@ then
 fi
 
 # Upgrade/install pip, setuptools, wheel, and application dependencies.
-pip install -U pip setuptools wheel
+pip install -U pip
+pip install -U setuptools wheel
 pip install -U -r "$BASEDIR/esp/requirements.txt"


### PR DESCRIPTION
setuptools needs a new version of pip, but virtualenv packages a
very old version of pip. If we don't do this, we get strange errors.