### PR TITLE
Update automatic printing text for new Firefox version.

### DIFF
--- a/esp/templates/program/modules/onsiteprintschedules/instructions.html
+++ b/esp/templates/program/modules/onsiteprintschedules/instructions.html
@@ -24,7 +24,7 @@ To use this tool as intended you must:<br />
 <li>Use firefox :-D</li>
 <li>Set up the printer as default:<br />
 <ol>
-<li>Goto <tt>about:config</tt> and type `<tt>print.print_printer</tt>'. Enter the string title (exactly) for the ESP Printer.</li>
+<li>Goto <tt>about:config</tt> and type `<tt>print_printer</tt>'. Enter the string title (exactly) for the ESP Printer.</li>
 <li>Rightclick on some whitespace and click on "New --> Boolean". Add <tt>print.always_print_silent</tt> and make it TRUE.</li>
 <li>While you're at it, you might as well make <tt>print.print_color</tt> false.</li>
 </ol>


### PR DESCRIPTION
print_printer is now used instead of print.print_printer.