### PR TITLE
Update the SSL cert when adding a site

### DIFF
--- a/deploy/server_setup/new_site.sh
+++ b/deploy/server_setup/new_site.sh
@@ -425,10 +425,13 @@ WSGIDaemonProcess $SITENAME processes=2 threads=1 maximum-requests=500 display-n
 
 EOF
     service apache2 graceful
+    # TODO(benkraft): put the renewal script in git too.
+    /lu/certbot/renew_lu.py
     echo "Added VirtualHost to Apache configuration $APACHE_CONF_FILE"
 
-    echo "Apache has been set up.  Please check them by looking over the"
-    echo -n "output above, then press enter to continue or Ctrl-C to quit."
+    echo "Apache has been set up, and a new SSL cert has been requested."
+    echo "Please check them by looking over the output above, then press"
+    echo -n "enter to continue or Ctrl-C to quit."
     read THROWAWAY
 fi
 


### PR DESCRIPTION
Now that we don't have a wildcard cert (since Let's Encrypt doesn't
support it), we need to update it when adding a site.  This just
requires running the script we already have.