### PR TITLE
Automatic nametags for any user group or volunteers

### DIFF
--- a/esp/esp/program/modules/handlers/nametagmodule.py
+++ b/esp/esp/program/modules/handlers/nametagmodule.py
@@ -131,9 +131,25 @@ class NameTagModule(ProgramModuleObj):
                               'username': user.username})
 
         elif idtype == 'volunteers':
+            volunteers = []
+            volunteer_dict = self.program.volunteers(QObjects=True)
+            volunteers = ESPUser.objects.filter(volunteer_dict['volunteer_all']).distinct()
+
+            volunteers = [ volunteer for volunteer in volunteers ]
+            volunteers = filter(lambda x: len(x.first_name+x.last_name), volunteers)
+            volunteers.sort()
+
+            user_title = "Volunteer"
+            for volunteer in volunteers:
+                users.append({'title': user_title,
+                              'name' : '%s %s' % (volunteer.first_name, volunteer.last_name),
+                              'id'   : volunteer.id,
+                              'username': volunteer.username})
+
+        elif idtype == 'misc':
             users = []
-            volunteers = request.POST['volunteers']
-            for user in volunteers.split("\n"):
+            misc = request.POST['misc_info']
+            for user in misc.split("\n"):
                 arruser = user.split(",", 1)
 
                 if len(arruser) >= 2:

--- a/esp/templates/program/modules/nametagmodule/selectoptions.html
+++ b/esp/templates/program/modules/nametagmodule/selectoptions.html
@@ -47,19 +47,29 @@ To have good quality IDs:<br />
 <strong>ID Type</strong>
 <ul>
   <li><input type="radio" name="type" value="students" id="students"
-       onclick="document.getElementById('volunteers').disabled = true;" checked="checked" />
+       onclick="document.getElementById('volunteers').disabled = true; document.getElementById('group').disabled = true;" checked="checked" />
       <label for="students">Students</label>
   </li>
   <li><input type="radio" name="type" value="teacher" id="teachers"
-       onclick="document.getElementById('volunteers').disabled = true;" />
+       onclick="document.getElementById('volunteers').disabled = true; document.getElementById('group').disabled = true;" />
       <label for="teachers">Teachers</label>
   </li>
+  <li><input type="radio" name="type" value="other" id="other"
+       onclick="document.getElementById('volunteers').disabled = true; document.getElementById('group').disabled = false;" />
+      <label for="teachers">Other Group</label>
+  </li>
+<select name="group" id="group" disabled>
+    {% for group in groups %}
+    <option value="{{ group.id }}">{{ group.name }}</option>
+    {% endfor %}
+    <option value="" selected hidden></option>
+</select>
   <li><input type="radio" name="type" value="volunteers" id="volunt"
-       onclick="document.getElementById('volunteers').disabled = false;" />
+       onclick="document.getElementById('volunteers').disabled = false; document.getElementById('group').disabled = true;" />
       <label for="volunt">Volunteers</label>
   </li>
   <li><input type="radio" name="type" value="blank" id="blank"
-       onclick="document.getElementById('volunteers').disabled = true;" />
+       onclick="document.getElementById('volunteers').disabled = true; document.getElementById('group').disabled = true;" />
       <label for="blank">Blank</label>
   </li>
 </ul>
@@ -76,7 +86,7 @@ To have good quality IDs:<br />
 <br />
 <input type="text" id="number" name="number" value="20" size="5" />
 <br />
-<label for="blanktitle"><strong>Title (if blank chosen) of IDs:</strong></label>
+<label for="blanktitle"><strong>Title (if "Blank" or "Other Group" chosen) of IDs:</strong></label>
 <br />
 <input type="text" id="blanktitle" name="blanktitle" value="Student" size="15" />
 <br />

--- a/esp/templates/program/modules/nametagmodule/selectoptions.html
+++ b/esp/templates/program/modules/nametagmodule/selectoptions.html
@@ -47,15 +47,15 @@ To have good quality IDs:<br />
 <strong>ID Type</strong>
 <ul>
   <li><input type="radio" name="type" value="students" id="students"
-       onclick="document.getElementById('volunteers').disabled = true; document.getElementById('group').disabled = true;" checked="checked" />
+       onclick="document.getElementById('misc_info').disabled = true; document.getElementById('group').disabled = true;" checked="checked" />
       <label for="students">Students</label>
   </li>
   <li><input type="radio" name="type" value="teacher" id="teachers"
-       onclick="document.getElementById('volunteers').disabled = true; document.getElementById('group').disabled = true;" />
+       onclick="document.getElementById('misc_info').disabled = true; document.getElementById('group').disabled = true;" />
       <label for="teachers">Teachers</label>
   </li>
   <li><input type="radio" name="type" value="other" id="other"
-       onclick="document.getElementById('volunteers').disabled = true; document.getElementById('group').disabled = false;" />
+       onclick="document.getElementById('misc_info').disabled = true; document.getElementById('group').disabled = false;" />
       <label for="teachers">Other Group</label>
   </li>
 <select name="group" id="group" disabled>
@@ -65,21 +65,25 @@ To have good quality IDs:<br />
     <option value="" selected hidden></option>
 </select>
   <li><input type="radio" name="type" value="volunteers" id="volunt"
-       onclick="document.getElementById('volunteers').disabled = false; document.getElementById('group').disabled = true;" />
+       onclick="document.getElementById('misc_info').disabled = true; document.getElementById('group').disabled = true;" />
       <label for="volunt">Volunteers</label>
   </li>
+  <li><input type="radio" name="type" value="misc" id="misc"
+       onclick="document.getElementById('misc_info').disabled = false; document.getElementById('group').disabled = true;" />
+      <label for="volunt">Miscellaneous (enter info below)</label>
+  </li>
   <li><input type="radio" name="type" value="blank" id="blank"
-       onclick="document.getElementById('volunteers').disabled = true; document.getElementById('group').disabled = true;" />
+       onclick="document.getElementById('misc_info').disabled = true; document.getElementById('group').disabled = true;" />
       <label for="blank">Blank</label>
   </li>
 </ul>
 
 <br />
 <br />
-<label for="volunteers"><strong>Volunteers:</strong></label>
+<label for="misc_info"><strong>Miscellaneous:</strong></label>
 <br />
 (&quot;Name, Title&quot; on each line, without quotes.)<br />
-<textarea name="volunteers" id="volunteers" rows="25" cols="40" disabled></textarea>
+<textarea name="misc_info" id="misc_info" rows="25" cols="40" disabled></textarea>
 <br />
 <br />
 <label for="number"><strong>Number (if blank chosen) of IDs:</strong></label>

--- a/esp/templates/program/modules/nametagmodule/selectoptions.html
+++ b/esp/templates/program/modules/nametagmodule/selectoptions.html
@@ -56,14 +56,15 @@ To have good quality IDs:<br />
   </li>
   <li><input type="radio" name="type" value="other" id="other"
        onclick="document.getElementById('misc_info').disabled = true; document.getElementById('group').disabled = false;" />
-      <label for="teachers">Other Group</label>
+      <label for="teachers">Other Group</label>&nbsp;&nbsp;&nbsp;
+      <select name="group" id="group" disabled>
+        {% for group in groups %}
+        <option value="{{ group.id }}">{{ group.name }}</option>
+        {% endfor %}
+        <option value="" selected hidden></option>
+      </select>
   </li>
-<select name="group" id="group" disabled>
-    {% for group in groups %}
-    <option value="{{ group.id }}">{{ group.name }}</option>
-    {% endfor %}
-    <option value="" selected hidden></option>
-</select>
+
   <li><input type="radio" name="type" value="volunteers" id="volunt"
        onclick="document.getElementById('misc_info').disabled = true; document.getElementById('group').disabled = true;" />
       <label for="volunt">Volunteers</label>


### PR DESCRIPTION
Adds a new option and dropdown menu to select any user group for nametag creation.

Requested by Stanford for use with custom student reg groups (so the nametags still have usernames on them).