### PR TITLE
Fix error when an invalid barcode is submitted

### DIFF
--- a/esp/esp/program/modules/handlers/onsitecheckinmodule.py
+++ b/esp/esp/program/modules/handlers/onsitecheckinmodule.py
@@ -190,6 +190,7 @@ class OnSiteCheckinModule(ProgramModuleObj):
                         student = ESPUser.objects.get(id=code)
                     except (ValueError, ESPUser.DoesNotExist):
                         results['not_found'].append(code)
+                        continue
 
                     if student.isStudent():
                         existing = Record.user_completed(student, 'attended', prog)


### PR DESCRIPTION
In the case where a submitted ID is nonzero or invalid, we were catching the
error but handling it incorrectly.  In the case where this was not the first
ID, we'd re-use the previous one, thereby processing it twice and perhaps
causing a number in the results to be off by one.  In the case where this was
the first ID, we'd crash with an undefined name error.  Now we'll correctly
just continue to the next ID in all cases.