### PR TITLE
Remove comment saying you can put HTML in the program name on nametags

### DIFF
--- a/esp/templates/program/modules/nametagmodule/selectoptions.html
+++ b/esp/templates/program/modules/nametagmodule/selectoptions.html
@@ -85,8 +85,6 @@ To have good quality IDs:<br />
 <br />
 <input type="text" id="programname" size="40" name="progname" value="{{ program.niceName }}" />
 <br />
-(You can put HTML in here if you want...)
-<br />
 <br />
 <input type="submit" value="Generate IDs!" />
 </fieldset>


### PR DESCRIPTION
You can't -- it will get escaped -- and it's probably better to use a template
override anyway.  Fixes #85.