### PR TITLE
AJAX scheduler: make teachers with no availability always available

### DIFF
--- a/esp/public/media/default_styles/scheduling.css
+++ b/esp/public/media/default_styles/scheduling.css
@@ -42,6 +42,14 @@ table,th,td
     opacity: .9;
 }
 
+.teacher-available-with-fallback-cell {
+    background: repeating-linear-gradient(
+                45deg,
+                #3c3, #3c3 10px, #ac3 10px, #ac3 20px
+    );
+    opacity: .9;
+}
+
 .teacher-available-not-first-cell {
     background: repeating-linear-gradient(
                 45deg,
@@ -49,6 +57,14 @@ table,th,td
                 #32cd32 15px,
                 #555555 15px,
                 #555555 20px
+    );
+    opacity: .9;
+}
+
+.teacher-available-with-fallback-cell.teacher-available-not-first-cell {
+    background: repeating-linear-gradient(
+                45deg,
+                #3c3, #3c3 5px, #ac3 5px, #ac3 15px, #555 15px, #555 20px
     );
     opacity: .9;
 }

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Matrix.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Matrix.js
@@ -72,7 +72,7 @@ function Matrix(
          * Adds a class to all non-disabled cells corresponding to each
          * timeslot in timeslots.
          *
-         * @param timeslots: A 1-d array of tiemslot IDs
+         * @param timeslots: An object of arrays from getAvailableTimeslots
          * @param className: The class to add to the cells
          */
         addClassToTimeslots = function(timeslots, className) {
@@ -86,9 +86,12 @@ function Matrix(
                 }.bind(this));
             }.bind(this));
         }.bind(this);
-        var available_timeslots = timeslots[0];
-        var teaching_timeslots = timeslots[1];
+        var available_timeslots = timeslots.available;
+        var teaching_timeslots = timeslots.teaching;
         addClassToTimeslots(available_timeslots, "teacher-available-cell");
+        if (timeslots.usedEmptyFallback) {
+            addClassToTimeslots(available_timeslots, "teacher-available-with-fallback-cell");
+        }
         addClassToTimeslots(teaching_timeslots, "teacher-teaching-cell");
         if(section.length<=1) {
             return;
@@ -121,17 +124,19 @@ function Matrix(
     /**
      * Unhighlight the cells that are currently highlighted
      *
-     * @param timeslots: A 2-d array. The first element is an array of
-     *                   timeslots where all teachers are completely available.
-     *                   The second is an array of timeslots where one or more
-     *                   teachers are teaching, but would be available otherwise.
+     * @param timeslots: An object of arrays from getAvailableTimeslots.
+     *                   Under the key "available" is an array of timeslots
+     *                   where all teachers are completely available.
+     *                   Under the key "teaching" is an array of timeslots
+     *                   where one or more teachers are teaching, but would be
+     *                   available otherwise.
      */
     this.unhighlightTimeslots = function(timeslots) {
         /**
          * Removes a class from all non-disabled cells corresponding to each
          * timeslot in timeslots.
          *
-         * @param timeslots: A 1-d array of tiemslot IDs
+         * @param timeslots: A 1-d array of timeslot IDs
          * @param className: The class to remove from the cells
          */
         removeClassFromTimeslots = function(timeslots, className) {
@@ -144,9 +149,9 @@ function Matrix(
             }.bind(this));
         }.bind(this);
 
-        var available_timeslots = timeslots[0];
-        var teaching_timeslots = timeslots[1];
-        removeClassFromTimeslots(available_timeslots, "teacher-available-cell teacher-available-not-first-cell");
+        var available_timeslots = timeslots.available;
+        var teaching_timeslots = timeslots.teaching;
+        removeClassFromTimeslots(available_timeslots, "teacher-available-cell teacher-available-with-fallback-cell teacher-available-not-first-cell");
         removeClassFromTimeslots(teaching_timeslots, "teacher-teaching-cell");
     };
 
@@ -225,7 +230,7 @@ function Matrix(
             return result;
         }
 
-        var availableTimeslots = this.sections.getAvailableTimeslots(section)[0];
+        var availableTimeslots = this.sections.getAvailableTimeslots(section).available;
         var validateIndividualCell = function(index, cell) {
             return !(cell.disabled || (cell.section && cell.section !== section) ||
                     availableTimeslots.indexOf(schedule_timeslots[index]) == -1);

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Timeslots.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Timeslots.js
@@ -7,6 +7,9 @@ function Timeslots(timeslots_data, lunch_timeslots){
     // TODO: move helper to add timeslot order here
     this.timeslots_sorted = helpers_add_timeslots_order(timeslots_data);
     this.timeslots = timeslots_data;
+    this.timeslots_sorted_ids = this.timeslots_sorted.map(function(timeslot) {
+      return timeslot.id;
+    });
     this.lunch_timeslots = {};
 
     if(lunch_timeslots) {


### PR DESCRIPTION
If a teacher is not available for any timeslots, consider them available
for all timeslots, with a different striped yellow-green style to warn
about the fact that this was used. Fixes #1005 probably?

(If the availability module is enabled, scheduling classes onto such
fallback timeslots will fail on the server side and be reported to the
client. But I think this is fine since it moves us closer to #1401?)