### PR TITLE
Fix theme tests

### DIFF
--- a/esp/esp/themes/tests.py
+++ b/esp/esp/themes/tests.py
@@ -2,9 +2,10 @@
 Tests for the theme editor.
 """
 
-import re
 import os
 import random
+import re
+import shutil
 
 from django.conf import settings
 
@@ -77,54 +78,88 @@ class ThemesTest(TestCase):
         response = self.client.get('/themes/select/')
         self.assertEqual(response.status_code, 200)
 
-        #   Test each theme that is available.
-        for theme_name in tc.get_theme_names():
-            #   Delete the theme_compiled.css file so we force a new one to be generated.
-            css_filename = os.path.join(settings.MEDIA_ROOT, 'styles', themes_settings.COMPILED_CSS_FILE)
-            if os.path.exists(css_filename):
-                os.remove(css_filename)
+        # Move the existing images dir out of the way, so we don't conflict
+        # with it (either what the user has there, or between themes).
+        # TODO(benkraft): Do the same for styles, although in practice
+        # conflicts there are less likely.
+        # TODO(benkraft): This is a super hacky way to do things!  Instead we
+        # should be doing all these tests in some sort of tmpdir to avoid
+        # touching anything of the user's.
+        images_dir = os.path.join(settings.MEDIA_ROOT, 'images', 'theme')
+        # Really we should use a tempdir, but on vagrant it may be on a
+        # different file system, which causes problems, so we do a hackier
+        # thing instead.
+        images_backup_dir = os.path.join(settings.MEDIA_ROOT, 'images',
+                                         'theme_backup_for_tests')
+        if os.path.exists(images_dir):
+            os.rename(images_dir, images_backup_dir)
 
-            #   POST to the theme selector with our choice of theme
-            response = self.client.post('/themes/select/', {'action': 'select', 'theme': theme_name})
-            self.assertEqual(response.status_code, 200)
+        try:
+            #   Test each theme that is available.
+            for theme_name in tc.get_theme_names():
+                #   Delete the theme_compiled.css file so we force a new one to be generated.
+                css_filename = os.path.join(settings.MEDIA_ROOT, 'styles', themes_settings.COMPILED_CSS_FILE)
+                if os.path.exists(css_filename):
+                    os.remove(css_filename)
+                # Clobber any stray theme images dir, to avoid conflicts.
+                # Note that we've already backed up any one the user had
+                # created, above.
+                if os.path.exists(images_dir):
+                    shutil.rmtree(images_dir)
 
-            #   Supply more settings if the theme asks for them.
-            if '<form id="theme_setup_form"' in response.content:
-                field_matches = re.findall(r'<(input id="\S+"|textarea).*?name="(\S+)".*?>', response.content, flags=re.DOTALL)
-                #   This is the union of all the theme configuration settings that
-                #   have a non-trivial form (e.g. key = value fails validation).
-                settings_dict = {
-                    'theme': theme_name,
-                    'just_selected': 'True',
-                    'front_page_style': 'bubblesfront.html',
-                    'facebook_link': 'http://somehost.net',
-                    'nav_structure': '[{"header": "header", "header_link": "/header_link/", "links": [{"link": "link1", "text": "text1"}]}]',
-                }
-                for entry in field_matches:
-                    if entry[1] not in settings_dict:
-                        #   Supply value = key if we do not already know what to say
-                        settings_dict[entry[1]] = entry[1]
+                # Make sure there won't be any conflicts between this theme and
+                # existing files -- since they would cause harder-to-understand
+                # errors later on.
+                self.assertFalse(tc.check_local_modifications(theme_name))
 
-                #   If theme setup succeeded, we will be redirected to the landing page.
-                response = self.client.post('/themes/setup/', settings_dict, follow=True)
-                self.assertTrue(('http://testserver/themes/', 302) in response.redirect_chain)
+                #   POST to the theme selector with our choice of theme
+                response = self.client.post('/themes/select/', {'action': 'select', 'theme': theme_name})
+                self.assertEqual(response.status_code, 200)
 
-            #   Check that the CSS stylesheet has been included in the page.
-            self.assertTrue('/media/styles/theme_compiled.css' in response.content)
+                #   Supply more settings if the theme asks for them.
+                if '<form id="theme_setup_form"' in response.content:
+                    field_matches = re.findall(r'<(input id="\S+"|textarea).*?name="(\S+)".*?>', response.content, flags=re.DOTALL)
+                    #   This is the union of all the theme configuration settings that
+                    #   have a non-trivial form (e.g. key = value fails validation).
+                    settings_dict = {
+                        'theme': theme_name,
+                        'just_selected': 'True',
+                        'front_page_style': 'bubblesfront.html',
+                        'facebook_link': 'http://somehost.net',
+                        'nav_structure': '[{"header": "header", "header_link": "/header_link/", "links": [{"link": "link1", "text": "text1"}]}]',
+                    }
+                    for entry in field_matches:
+                        if entry[1] not in settings_dict:
+                            #   Supply value = key if we do not already know what to say
+                            settings_dict[entry[1]] = entry[1]
 
-            #   Check that the CSS stylesheet has been compiled.
-            self.assertTrue(os.path.exists(css_filename))
-            self.assertTrue(len(open(css_filename).read()) > 1000)  #   Hacky way to check that content is substantial
+                    #   If theme setup succeeded, we will be redirected to the landing page.
+                    response = self.client.post('/themes/setup/', settings_dict, follow=True)
+                    self.assertTrue(('http://testserver/themes/', 302) in response.redirect_chain)
 
-            #   Check that the template override is marked with the theme name.
-            self.assertTrue(('<!-- Theme: %s -->' % theme_name) in response.content)
+                #   Check that the CSS stylesheet has been included in the page.
+                self.assertTrue('/media/styles/theme_compiled.css' in response.content)
 
-        #   Test that the theme can be cleared and the home page reverts.
-        response = self.client.post('/themes/select/', {'action': 'clear'})
-        response = self.client.get('/')
-        self.assertTrue(len(re.findall(r'<a href="/themes.*?Configure site appearance.*?</a>', response.content, flags=re.DOTALL)) == 1)
+                #   Check that the CSS stylesheet has been compiled.
+                self.assertTrue(os.path.exists(css_filename))
+                self.assertTrue(len(open(css_filename).read()) > 1000)  #   Hacky way to check that content is substantial
 
-        self.client.logout()
+                #   Check that the template override is marked with the theme name.
+                self.assertTrue(('<!-- Theme: %s -->' % theme_name) in response.content)
+
+            #   Test that the theme can be cleared and the home page reverts.
+            response = self.client.post('/themes/select/', {'action': 'clear'})
+            response = self.client.get('/')
+            self.assertTrue(len(re.findall(r'<a href="/themes.*?Configure site appearance.*?</a>', response.content, flags=re.DOTALL)) == 1)
+
+            self.client.logout()
+
+        finally:
+            # Restore the backed up images dir.
+            if os.path.exists(images_dir):
+                shutil.rmtree(images_dir)
+            if os.path.exists(images_backup_dir):
+                os.rename(images_backup_dir, images_dir)
 
     def testEditor(self):
         """ Check that the theme editor backend functionality is working. """

--- a/esp/esp/themes/tests.py
+++ b/esp/esp/themes/tests.py
@@ -80,8 +80,8 @@ class ThemesTest(TestCase):
 
         # Move the existing images dir out of the way, so we don't conflict
         # with it (either what the user has there, or between themes).
-        # TODO(benkraft): Do the same for styles, although in practice
-        # conflicts there are less likely.
+        # TODO(benkraft): Do the same for styles and scripts, although in
+        # practice conflicts there are less likely.
         # TODO(benkraft): This is a super hacky way to do things!  Instead we
         # should be doing all these tests in some sort of tmpdir to avoid
         # touching anything of the user's.


### PR DESCRIPTION
Adding the bigpicture theme caused a conflict between the tests for it and for
fruitsalad -- the two both set the same default files, which causes us to hit a
confirm page to clobber them in the test, and we don't know to click that, so
things don't work right.  This could also happen even before bigpicture, if
running tests locally on a dev server that had such a conflicting file.

One way to fix it would be to click past the confirm page. But that's a problem
since it may be clobbering real files, if someone is running locally!  So
instead, we now back up the offending files, and restore them at the end.  This
is super hacky -- we really shouldn't be modifying the user's files at all ever
if we can avoid it -- but it at least fixes the problem for now.

Fixes #2388.