### PR TITLE
Add class style to main catalog

### DIFF
--- a/esp/templates/inclusion/program/class_catalog_core.html
+++ b/esp/templates/inclusion/program/class_catalog_core.html
@@ -32,6 +32,13 @@
         {% autoescape off %}
          {{ class.class_info|escape|linebreaksbr }}<br />
         {% endautoescape %}
+       {% if class.class_style %}
+       <br /><br />
+       <b>Class Style</b><br />
+       <span style="font-style:italic;">
+         {{ class.class_style }}
+       </span>
+       {% endif %}
        {% if class.prereqs %}
        <br /><br />
        <b>Prerequisites</b><br />


### PR DESCRIPTION
Adds the class style implemented in #2302 to classes in the main catalog and FCFS phase.
(Only shown if a class has a class style, just like prereqs)
![image](https://user-images.githubusercontent.com/7232514/28284336-79a6c6a8-6ae5-11e7-87f4-ca597288dbe7.png)

Fixes #2407.