### PR TITLE
Send emails to teachers re: cancelled classes

### DIFF
--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -1018,7 +1018,7 @@ class ClassSection(models.Model):
         from_email = '%s at %s <%s>' % (self.parent_program.program_type, settings.INSTITUTION_NAME, self.parent_program.director_email)
         if email_ssis:
             email_content += '\n' + render_to_string('email/class_cancellation_body.txt', context)
-        teachers = self.get_teachers()
+        teachers = self.parent_class.get_teachers()
         for t in teachers:
             to_email = ['%s <%s>' % (t.name(), t.email)]
             send_mail(email_title, email_content, from_email, to_email)

--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -1012,6 +1012,17 @@ class ClassSection(models.Model):
         from_email = '%s Web Site <%s>' % (self.parent_program.program_type, self.parent_program.director_email)
         send_mail(email_title, email_content, from_email, to_email)
 
+        #   Send e-mail to teachers
+        context['director_email'] = self.parent_program.director_email
+        email_content = render_to_string('email/class_cancellation_teacher.txt', context)
+        from_email = '%s at %s <%s>' % (self.parent_program.program_type, settings.INSTITUTION_NAME, self.parent_program.director_email)
+        if email_ssis:
+            email_content += '\n' + render_to_string('email/class_cancellation_body.txt', context)
+        teachers = self.get_teachers()
+        for t in teachers:
+            to_email = ['%s <%s>' % (t.name(), t.email)]
+            send_mail(email_title, email_content, from_email, to_email)
+
         self.clearStudents()
 
         #   If specified, remove the class's time and room assignment.

--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -961,7 +961,7 @@ class ClassSection(models.Model):
 
     enrolled_students = DerivedField(models.IntegerField, count_enrolled_students)(null=False, default=0)
 
-    def cancel(self, email_students=True, include_lottery_students=False, explanation=None, unschedule=True):
+    def cancel(self, email_students=True, email_teachers=True, include_lottery_students=False, explanation=None, unschedule=True):
         if include_lottery_students:
             student_verbs = ['Enrolled', 'Interested', 'Priority/1']
         else:
@@ -1013,15 +1013,16 @@ class ClassSection(models.Model):
         send_mail(email_title, email_content, from_email, to_email)
 
         #   Send e-mail to teachers
-        context['director_email'] = self.parent_program.director_email
-        email_content = render_to_string('email/class_cancellation_teacher.txt', context)
-        from_email = '%s at %s <%s>' % (self.parent_program.program_type, settings.INSTITUTION_NAME, self.parent_program.director_email)
-        if email_ssis:
-            email_content += '\n' + render_to_string('email/class_cancellation_body.txt', context)
-        teachers = self.parent_class.get_teachers()
-        for t in teachers:
-            to_email = ['%s <%s>' % (t.name(), t.email)]
-            send_mail(email_title, email_content, from_email, to_email)
+        if email_teachers:
+            context['director_email'] = self.parent_program.director_email
+            email_content = render_to_string('email/class_cancellation_teacher.txt', context)
+            from_email = '%s at %s <%s>' % (self.parent_program.program_type, settings.INSTITUTION_NAME, self.parent_program.director_email)
+            if email_ssis:
+                email_content += '\n' + render_to_string('email/class_cancellation_body.txt', context)
+            teachers = self.parent_class.get_teachers()
+            for t in teachers:
+                to_email = ['%s <%s>' % (t.name(), t.email)]
+                send_mail(email_title, email_content, from_email, to_email)
 
         self.clearStudents()
 
@@ -1771,10 +1772,10 @@ was approved! Please go to http://esp.mit.edu/teach/%s/class_status/%s to view y
         self.clearStudents()
         self.set_all_sections_to_status(REJECTED)
 
-    def cancel(self, email_students=True, include_lottery_students=False, explanation=None, unschedule=False):
+    def cancel(self, email_students=True, email_teachers=True, include_lottery_students=False, explanation=None, unschedule=False):
         """ Cancel this class by cancelling all of its sections. """
         for sec in self.sections.all():
-            sec.cancel(email_students, include_lottery_students, explanation, unschedule)
+            sec.cancel(email_students, email_teachers, include_lottery_students, explanation, unschedule)
         self.status = CANCELLED
         self.save()
 

--- a/esp/esp/program/modules/forms/management.py
+++ b/esp/esp/program/modules/forms/management.py
@@ -144,7 +144,8 @@ class ClassCancellationForm(forms.Form):
     target = forms.ModelChoiceField(queryset=ClassSubject.objects.all(), widget=forms.HiddenInput)
     explanation = forms.CharField(widget=forms.Textarea(attrs={'rows': 4, 'cols': 60}), required=False, help_text='Optional but recommended')
     unschedule = forms.BooleanField(help_text='Check this box to unschedule all sections of this class, in order to free up space for others.  This will delete the original time and location and you won\'t be able to recover them.', required=False)
-    email_lottery_students = forms.BooleanField(help_text='Check this box to e-mail students who applied for this class in a lottery, in addition to those that are actually enrolled.', required=False)
+    email_lottery_students = forms.BooleanField(help_text='Check this box to e-mail all students who applied for this class in a lottery, in addition to those that are actually enrolled.', required=False)
+    email_teachers = forms.BooleanField(initial=True, help_text='Check this box to notify all teachers of this class that this class has been cancelled.', required=False)
     acknowledgement = forms.BooleanField(help_text='By checking this box, I acknowledge that all students in the class will be e-mailed and then removed from the class.  This operation cannot be undone.')
 
     def __init__(self, *args, **kwargs):
@@ -157,7 +158,8 @@ class SectionCancellationForm(forms.Form):
     target = forms.ModelChoiceField(queryset=ClassSection.objects.all(), widget=forms.HiddenInput)
     explanation = forms.CharField(widget=forms.Textarea(attrs={'rows': 4, 'cols': 60}), required=False, help_text='Optional but recommended')
     unschedule = forms.BooleanField(help_text='Check this box to unschedule this section in order to free up space for others.  This will delete the original time and location and you won\'t be able to recover them.', required=False)
-    email_lottery_students = forms.BooleanField(help_text='Check this box to e-mail students who applied for this class in a lottery, in addition to those that are actually enrolled.', required=False)
+    email_lottery_students = forms.BooleanField(help_text='Check this box to e-mail students who applied for this section in a lottery, in addition to those that are actually enrolled.', required=False)
+    email_teachers = forms.BooleanField(initial=True, help_text='Check this box to notify all teachers of this class that this section has been cancelled.', required=False)
     acknowledgement = forms.BooleanField(help_text='By checking this box, I acknowledge that all students in the section will be e-mailed and then removed from the class.  This operation cannot be undone.')
 
     def __init__(self, *args, **kwargs):

--- a/esp/esp/program/modules/handlers/adminclass.py
+++ b/esp/esp/program/modules/handlers/adminclass.py
@@ -217,7 +217,7 @@ class AdminClass(ProgramModuleObj):
                 cls_cancel_form.is_bound = True
                 if cls_cancel_form.is_valid():
                     #   Call the Class{Subject,Section}.cancel() method to e-mail and remove students, etc.
-                    cls_cancel_form.cleaned_data['target'].cancel(email_students=True, include_lottery_students=cls_cancel_form.cleaned_data['email_lottery_students'], explanation=cls_cancel_form.cleaned_data['explanation'], unschedule=cls_cancel_form.cleaned_data['unschedule'])
+                    cls_cancel_form.cleaned_data['target'].cancel(email_students=True, email_teachers = cls_cancel_form.cleaned_data['email_teachers'], include_lottery_students=cls_cancel_form.cleaned_data['email_lottery_students'], explanation=cls_cancel_form.cleaned_data['explanation'], unschedule=cls_cancel_form.cleaned_data['unschedule'])
                     cls_cancel_form = None
             else:
                 j = 0
@@ -226,7 +226,7 @@ class AdminClass(ProgramModuleObj):
                         sec_cancel_forms[j].data = request.POST
                         sec_cancel_forms[j].is_bound = True
                         if sec_cancel_forms[j].is_valid():
-                            sec_cancel_forms[j].cleaned_data['target'].cancel(email_students=True, include_lottery_students=sec_cancel_forms[j].cleaned_data['email_lottery_students'], explanation=sec_cancel_forms[j].cleaned_data['explanation'], unschedule=sec_cancel_forms[j].cleaned_data['unschedule'])
+                            sec_cancel_forms[j].cleaned_data['target'].cancel(email_students=True, email_teachers = sec_cancel_forms[j].cleaned_data['email_teachers'], include_lottery_students=sec_cancel_forms[j].cleaned_data['email_lottery_students'], explanation=sec_cancel_forms[j].cleaned_data['explanation'], unschedule=sec_cancel_forms[j].cleaned_data['unschedule'])
                             sec_cancel_forms[j] = None
                     j += 1
 

--- a/esp/templates/email/class_cancellation_teacher.txt
+++ b/esp/templates/email/class_cancellation_teacher.txt
@@ -1,0 +1,12 @@
+-- Notice to teachers --
+Class Section {{ sec.emailcode }} has been cancelled.  {% if email_students %}{{ num_students }} students have been sent the following email.{% else %}Students were not emailed.{% endif %} All students have been removed from the class.
+If you did not request this class cancellation, please contact us at {{ director_email }} immediately.
+-------------------------
+
+{% include "email/class_cancellation_body.txt" %}
+{% if email_ssis %}
+
+Additionally, all students that selected this class in the class lottery were emailed the email below.
+-------------------------
+
+{% endif %}


### PR DESCRIPTION
When a class/section is cancelled, the website now sends an email to each of the teachers of the class.
Fixes #2360.