### PR TITLE
Text teachers for check-in reminder

### DIFF
--- a/esp/esp/program/modules/handlers/grouptextmodule.py
+++ b/esp/esp/program/modules/handlers/grouptextmodule.py
@@ -62,7 +62,8 @@ class GroupTextModule(ProgramModuleObj):
             "seq": 10
         }
 
-    def is_configured(self):
+    @staticmethod
+    def is_configured():
         """ Check if Twilio configuration settings are set.
             The text message module will not work without them. """
 
@@ -116,7 +117,8 @@ class GroupTextModule(ProgramModuleObj):
         context.update(usc.prepare_context(prog, target_path='/manage/%s/grouptextpanel' % prog.url))
         return render_to_response(self.baseDir()+'search.html', request, context)
 
-    def sendMessages(self, filterobj, body, override = False):
+    @staticmethod
+    def sendMessages(filterobj, body, override = False):
         """ Attempts to send a text message with body to users matching filterobj
             Returns a log of actions which can be displayed to user. """
 

--- a/esp/esp/program/modules/handlers/grouptextmodule.py
+++ b/esp/esp/program/modules/handlers/grouptextmodule.py
@@ -116,7 +116,7 @@ class GroupTextModule(ProgramModuleObj):
         context.update(usc.prepare_context(prog, target_path='/manage/%s/grouptextpanel' % prog.url))
         return render_to_response(self.baseDir()+'search.html', request, context)
 
-    def sendMessages(self, filterobj, body):
+    def sendMessages(self, filterobj, body, override = False):
         """ Attempts to send a text message with body to users matching filterobj
             Returns a log of actions which can be displayed to user. """
 
@@ -156,7 +156,8 @@ class GroupTextModule(ProgramModuleObj):
             send_log.append("Found contact info for "+str(user))
 
             # the user has elected to not receive text messages
-            if not contactInfo.receive_txt_message:
+            # unless override is true
+            if not contactInfo.receive_txt_message and not override:
                 send_log.append(str(user)+" does not want text messages, fine")
                 continue
             client = TwilioRestClient(account_sid, auth_token)

--- a/esp/esp/program/modules/handlers/teachercheckinmodule.py
+++ b/esp/esp/program/modules/handlers/teachercheckinmodule.py
@@ -365,6 +365,9 @@ class TeacherCheckinModule(ProgramModuleObj):
         elif 'date' in request.GET:
             date = datetime.strptime(request.GET['date'], "%m/%d/%Y").date()
         context = {}
+        group_text = GroupTextModule()
+        if not group_text.is_configured():
+            context['text_not_config'] = True
         form = TeacherCheckinForm(request.GET)
         if form.is_valid():
             when = form.cleaned_data['when']

--- a/esp/esp/program/modules/handlers/teachercheckinmodule.py
+++ b/esp/esp/program/modules/handlers/teachercheckinmodule.py
@@ -166,11 +166,9 @@ class TeacherCheckinModule(ProgramModuleObj):
         group_text = GroupTextModule()
         if group_text.is_configured():
             if 'username' in request.POST and 'section' in request.POST:
-                sec = ClassSection.objects.filter(id=request.POST['section'])
+                sec = ClassSection.objects.get(id=request.POST['section'])
                 teacher = PersistentQueryFilter.create_from_Q(ESPUser, Q(username=request.POST['username']))
-                # Concatenate message
-                message = "This is a test"
-                # Send message
+                message = "Don't forget to check-in for your " + one + " class that is scheduled for " + sec.start_time().pretty_time(True) + "!"
                 group_text.sendMessages(teacher, message, True)
                 json_data['message'] = "Texted teacher"
         else:

--- a/esp/public/media/scripts/onsite/teacher_checkin.js
+++ b/esp/public/media/scripts/onsite/teacher_checkin.js
@@ -113,7 +113,6 @@ $j(function(){
     });
 
     function textTeacher(user, sec, callback, errorCallback){
-        refresh_csrf_cookie();
         var data = {username: user, section: sec, csrfmiddlewaretoken: csrf_token()};
         $j.post('ajaxteachertext', data, "json").success(callback)
         .error(function(){
@@ -125,8 +124,8 @@ $j(function(){
     }
 
     $j(".text").click(function(){
-        var username = this.id.replace("text_", "");
-        var section = this.name;
+        var username = $j(this).data("username");
+        var section = $j(this).data("section");
         var $td = $j(this.parentNode);
         var $msg = $td.children('.message');
         textTeacher(username, section, function(response) {

--- a/esp/public/media/scripts/onsite/teacher_checkin.js
+++ b/esp/public/media/scripts/onsite/teacher_checkin.js
@@ -131,10 +131,8 @@ $j(function(){
         var $td = $j(this.parentNode);
         var $msg = $td.children('.message');
         textTeacher(username, section, function(response) {
-            // alert('Hello');
-            alert(response.message);
+            $msg.text(response.message);
         });
-        // $msg.text('Texted teacher');
     });
 
     $j(".uncheckin:enabled").click(function(){

--- a/esp/public/media/scripts/onsite/teacher_checkin.js
+++ b/esp/public/media/scripts/onsite/teacher_checkin.js
@@ -127,12 +127,13 @@ $j(function(){
     $j(".text").click(function(){
         var username = this.id.replace("text_", "");
         var section = this.name;
-        var $me = $j(this);
         var $td = $j(this.parentNode);
         var $msg = $td.children('.message');
         textTeacher(username, section, function(response) {
             $msg.text(response.message);
         });
+        $j(this).attr("disabled",true);
+        $msg.text('Texting teacher...');
     });
 
     $j(".uncheckin:enabled").click(function(){

--- a/esp/public/media/scripts/onsite/teacher_checkin.js
+++ b/esp/public/media/scripts/onsite/teacher_checkin.js
@@ -112,6 +112,31 @@ $j(function(){
         $msg.text('Checking in...');
     });
 
+    function textTeacher(user, sec, callback, errorCallback){
+        refresh_csrf_cookie();
+        var data = {username: user, section: sec, csrfmiddlewaretoken: csrf_token()};
+        $j.post('ajaxteachertext', data, "json").success(callback)
+        .error(function(){
+            alert("An error occurred while atempting to text " + user + ".");
+            if (errorCallback) {
+                errorCallback();
+            }
+        });
+    }
+
+    $j(".text").click(function(){
+        var username = this.id.replace("text_", "");
+        var section = this.name;
+        var $me = $j(this);
+        var $td = $j(this.parentNode);
+        var $msg = $td.children('.message');
+        textTeacher(username, section, function(response) {
+            // alert('Hello');
+            alert(response.message);
+        });
+        // $msg.text('Texted teacher');
+    });
+
     $j(".uncheckin:enabled").click(function(){
         var username = this.id.replace("uncheckin_", "");
         undoCheckIn(username, function(response) {

--- a/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
+++ b/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
@@ -168,7 +168,8 @@
         <td class="text-teacher">
             <span class="message"></span>
             <input id="text_{{ teacher.username }}" name="{{ section.id }}"
-                   class="button text" type="button" value="Text Teacher" />
+                   class="button text" type="button" value="Text Teacher"
+                   {% if text_not_config %} disabled{% endif %}/>
         </tr>
         <tr>
     {% endfor %}

--- a/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
+++ b/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
@@ -44,7 +44,7 @@
             content: "◀"; font-weight: bold;
         }
 
-        .selected .not-checked-in, .selected .checkin-column, .selected .phone {
+        .selected .not-checked-in, .selected .checkin-column, .selected .phone, .selected .text-teacher {
             background-color: #FFFF00;
         }
 
@@ -116,7 +116,7 @@
 
 <table>
 <tr>
-    <th colspan="5">
+    <th colspan="6">
         {% if start_time %}
             Missing teachers for classes starting at {{ start_time.pretty_start_time }}
         {% else %}
@@ -127,7 +127,7 @@
 </tr>
 {% if sections|length_is:0 %}
 <tr>
-    <td colspan="5">
+    <td colspan="6">
         There are no class sections
         {% if start_time %} starting in this timeslot
         {% else %} scheduled for the program{% if date %} on {{ date|date:"D m/d/Y" }}{% endif %}
@@ -158,17 +158,21 @@
         <td class="checkin-column">
             {% if teacher.id not in arrived %}
             <span class="message"></span>
-            <input id="checkin_{{ teacher.username }}" name="{{ teacher.last_name }}"
+            <input id="checkin_{{ teacher.username }}" name="{{ section.parent_class.emailcode }}: {{ section.name }}"
                    class="button checkin" type="button" value="Check In" {% if when %}disabled="disabled"{% endif %} /><span />
             {% else %}
             Already checked-in
             {% endif %}
         </td>
         <td class="phone"> {{ teacher.phone }} </td>
+        <td class="text-teacher">
+            <span class="message"></span>
+            <input id="text_{{ teacher.username }}" name="{{ section.id }}"
+                   class="button text" type="button" value="Text Teacher" />
         </tr>
         <tr>
     {% endfor %}
-    <td colspan="5" class="section-detail-td">
+    <td colspan="6" class="section-detail-td">
         <div class="section-detail fqr-class">
             <div class="section-detail-header">
                 {{section.title}}

--- a/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
+++ b/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
@@ -167,9 +167,9 @@
         <td class="phone"> {{ teacher.phone }} </td>
         <td class="text-teacher">
             <span class="message"></span>
-            <input id="text_{{ teacher.username }}" name="{{ section.id }}"
+            <input data-username="{{ teacher.username }}" data-section="{{ section.id }}"
                    class="button text" type="button" value="Text Teacher"
-                   {% if text_not_config %} disabled{% endif %}/>
+                   {% if not text_configured %} disabled title="Twilio texting settings are not configured"{% endif %}/>
         </tr>
         <tr>
     {% endfor %}


### PR DESCRIPTION
Adds a button for each teacher on the check-in page that allows you to text them a reminder (using Twilio) to check-in before their class.
Fixes #2412.

![image](https://user-images.githubusercontent.com/7232514/28401937-eea71654-6cd1-11e7-8af3-68befbc940a1.png)

Some notes:

- If Twilio settings are not configured, buttons are disabled.
- If there are any problems sending the message, the on-site user will receive a popup.
- Buttons are disabled after texting a teacher to prevent spam (but are re-enabled after refreshing the page).
- Message is as follows:
`"Don't forget to check-in for your " + one + " class that is scheduled for " + sec.start_time().pretty_time(True) + "!"`