### PR TITLE
Teacher reg option of grade ranges instead of mins and maxes

### DIFF
--- a/esp/esp/program/modules/forms/teacherreg.py
+++ b/esp/esp/program/modules/forms/teacherreg.py
@@ -151,9 +151,9 @@ class TeacherClassRegForm(FormWithRequiredCss):
         # grade_min, grade_max: crmi.getClassGrades
         self.fields['grade_min'].choices = class_grades
         self.fields['grade_max'].choices = class_grades
-        grade_ranges = json.loads(Tag.getTag('grade_ranges'))
-        if grade_ranges:
-            self.fields['grade_range'].choices = [(range,`range[0]` + " - " + `range[1]`) for range in grade_ranges]
+        if Tag.getTag('grade_ranges'):
+            grade_ranges = json.loads(Tag.getTag('grade_ranges'))
+            self.fields['grade_range'].choices = [(range,str(range[0]) + " - " + str(range[1])) for range in grade_ranges]
             hide_field( self.fields['grade_min'] )
             hide_field( self.fields['grade_max'] )
         else:

--- a/esp/esp/program/modules/forms/teacherreg.py
+++ b/esp/esp/program/modules/forms/teacherreg.py
@@ -287,7 +287,8 @@ class TeacherClassRegForm(FormWithRequiredCss):
             cleaned_data['class_size_optimal'] = None
 
         # If using grade ranges instead of min and max, extract min and max from grade range.
-        cleaned_data['grade_min'], cleaned_data['grade_max'] = json.loads(cleaned_data.get('grade_range'))
+        if cleaned_data.get('grade_range'):
+            cleaned_data['grade_min'], cleaned_data['grade_max'] = json.loads(cleaned_data.get('grade_range'))
 
         # Return cleaned data
         return cleaned_data

--- a/esp/esp/program/modules/forms/teacherreg.py
+++ b/esp/esp/program/modules/forms/teacherreg.py
@@ -67,7 +67,7 @@ class TeacherClassRegForm(FormWithRequiredCss):
     style_choices = []
 
     # To enable class styles, admins should set the Tag grade_ranges.
-    # e.g. [[7,9],[9,10],[9,12],[10,12],[11,12]] gives five grade ranges: 7-9, 9-10, 9-12, 10-12, and 11-12)
+    # e.g. [[7,9],[9,10],[9,12],[10,12],[11,12]] gives five grade ranges: 7-9, 9-10, 9-12, 10-12, and 11-12
     grade_range_choices = []
 
     # Grr, TypedChoiceField doesn't seem to exist yet

--- a/esp/esp/program/modules/forms/teacherreg.py
+++ b/esp/esp/program/modules/forms/teacherreg.py
@@ -66,10 +66,6 @@ class TeacherClassRegForm(FormWithRequiredCss):
     #     [["Lecture", "Lecture Style Class"], ["Seminar", "Seminar Style Class"]]
     style_choices = []
 
-    # To enable class styles, admins should set the Tag grade_ranges.
-    # e.g. [[7,9],[9,10],[9,12],[10,12],[11,12]] gives five grade ranges: 7-9, 9-10, 9-12, 10-12, and 11-12
-    grade_range_choices = []
-
     # Grr, TypedChoiceField doesn't seem to exist yet
     title          = StrippedCharField(    label='Course Title', length=50, max_length=200 )
     category       = forms.ChoiceField( label='Course Category', choices=[], widget=BlankSelectWidget() )
@@ -84,8 +80,9 @@ class TeacherClassRegForm(FormWithRequiredCss):
     session_count  = forms.ChoiceField( label='Number of Days of Class', choices=[(1,1)], widget=BlankSelectWidget(),
                                         help_text='(How many days will your class take to complete?)' )
 
-
-    grade_range    = forms.ChoiceField( label='Grade Range', choices=grade_range_choices, required=False)
+    # To enable grade ranges, admins should set the Tag grade_ranges.
+    # e.g. [[7,9],[9,10],[9,12],[10,12],[11,12]] gives five grade ranges: 7-9, 9-10, 9-12, 10-12, and 11-12
+    grade_range    = forms.ChoiceField( label='Grade Range', choices=[], required=False)
     grade_min      = forms.ChoiceField( label='Minimum Grade Level', choices=[(7, 7)], widget=BlankSelectWidget() )
     grade_max      = forms.ChoiceField( label='Maximum Grade Level', choices=[(12, 12)], widget=BlankSelectWidget() )
     class_size_max = forms.ChoiceField( label='Maximum Number of Students',
@@ -290,10 +287,7 @@ class TeacherClassRegForm(FormWithRequiredCss):
             cleaned_data['class_size_optimal'] = None
 
         # If using grade ranges instead of min and max, extract min and max from grade range.
-        if cleaned_data.get('grade_range'):
-            grade_range = json.loads(cleaned_data.get('grade_range'))
-            cleaned_data['grade_min'] = grade_range[0]
-            cleaned_data['grade_max'] = grade_range[1]
+        cleaned_data['grade_min'], cleaned_data['grade_max'] = json.loads(cleaned_data.get('grade_range'))
 
         # Return cleaned data
         return cleaned_data

--- a/esp/esp/program/modules/forms/teacherreg.py
+++ b/esp/esp/program/modules/forms/teacherreg.py
@@ -290,8 +290,8 @@ class TeacherClassRegForm(FormWithRequiredCss):
             cleaned_data['class_size_optimal'] = None
 
         # If using grade ranges instead of min and max, extract min and max from grade range.
-        grade_range = json.loads(cleaned_data.get('grade_range'))
-        if grade_range:
+        if cleaned_data.get('grade_range'):
+            grade_range = json.loads(cleaned_data.get('grade_range'))
             cleaned_data['grade_min'] = grade_range[0]
             cleaned_data['grade_max'] = grade_range[1]
 

--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -592,6 +592,10 @@ class TeacherClassRegModule(ProgramModuleObj):
                 current_data['allow_lateness'] = newclass.allow_lateness
                 current_data['title'] = newclass.title
                 current_data['url']   = newclass.emailcode()
+                min_grade = newclass.grade_min
+                max_grade = newclass.grade_max
+                if Tag.getTag('grade_ranges'):
+                    current_data['grade_range'] = [min_grade,max_grade]
                 for field_name in get_custom_fields():
                     if field_name in newclass.custom_form_data:
                         current_data[field_name] = newclass.custom_form_data[field_name]

--- a/esp/esp/tagdict/__init__.py
+++ b/esp/esp/tagdict/__init__.py
@@ -54,6 +54,7 @@ all_global_tags = {
     'automatic_registration_redirect': (True, "If student/teacher registration is open for exactly one program, redirect to student registration after student account creation (enabled by default)"),
     'text_messages_to_students': (True, ""),
     'local_state': (False, ""),
+    'grade_ranges': (False, "Replaces min and max grade options in teacher class reg with grade ranges, as specified by tag")
 }
 
 # Any tag used with Tag.getProgramTag(),


### PR DESCRIPTION
This adds the option to provide teachers with grade ranges to choose from when registering a class instead of requiring the teacher to specify a minimum and maximum grade level for their class.
Grade range options are set with the grade_ranges tag.
e.g. `[[7,9],[9,10],[9,12],[10,12],[11,12]]` gives five grade ranges: 7-9, 9-10, 9-12, 10-12, and 11-12)
When the form is submitted, the form parses the grade range and sets the minimum and maximum grade levels for the class.
Fixes #51.

![image](https://user-images.githubusercontent.com/7232514/28450865-e2186370-6d9e-11e7-92d2-e7a0b44e03dc.png)
