### PR TITLE
Simplify coteacher interface

### DIFF
--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -349,11 +349,14 @@ class TeacherClassRegModule(ProgramModuleObj):
         if 'op' in request.POST:
             op = request.POST['op']
 
-        conflictingusers = []
         error = False
 
-        if op == 'add':
+        old_coteachers_set = set(cls.get_teachers())
+        ccc = ClassCreationController(self.program)
+        
+        conflictinguser = ''
 
+        if op == 'add':
 
             if len(request.POST['teacher_selected'].strip()) == 0:
                 error = 'Error - Please click on the name when it drops down.'
@@ -369,16 +372,18 @@ class TeacherClassRegModule(ProgramModuleObj):
                                                                                      'txtTeachers': txtTeachers,
                                                                                      'coteachers':  coteachers,
                                                                                      'error': error,
-                                                                                     'conflicts': []})
+                                                                                     'conflict': []})
 
             # add schedule conflict checking here...
             teacher = ESPUser.objects.get(id = request.POST['teacher_selected'])
 
             if cls.conflicts(teacher):
-                conflictingusers.append(teacher.first_name+' '+teacher.last_name)
+                conflictinguser = (teacher.first_name+' '+teacher.last_name)
             else:
                 coteachers.append(teacher)
                 txtTeachers = ",".join([str(coteacher.id) for coteacher in coteachers ])
+                ccc.associate_teacher_with_class(cls, teacher)
+                ccc.send_class_mail_to_directors(cls)
 
         elif op == 'del':
             ids = request.POST.getlist('delete_coteachers')
@@ -390,39 +395,22 @@ class TeacherClassRegModule(ProgramModuleObj):
             coteachers = newcoteachers
             txtTeachers = ",".join([str(coteacher.id) for coteacher in coteachers ])
 
-
-        elif op == 'save':
-            old_coteachers_set = set(cls.get_teachers())
             new_coteachers_set = set(coteachers)
-
-            to_be_added = new_coteachers_set - old_coteachers_set
             to_be_deleted = old_coteachers_set - new_coteachers_set
 
-            # don't delete the current user
             if request.user in to_be_deleted:
                 to_be_deleted.remove(request.user)
 
-            for teacher in to_be_added:
-                if cls.conflicts(teacher):
-                    conflictingusers.append(teacher.first_name+' '+teacher.last_name)
+            for teacher in to_be_deleted:
+                cls.removeTeacher(teacher)
 
-            if len(conflictingusers) == 0:
-                # remove some old coteachers
-                for teacher in to_be_deleted:
-                    cls.removeTeacher(teacher)
-
-                # add bits for all new coteachers
-                ccc = ClassCreationController(self.program)
-                for teacher in to_be_added:
-                    ccc.associate_teacher_with_class(cls, teacher)
-                ccc.send_class_mail_to_directors(cls)
-                return self.goToCore(tl)
+            ccc.send_class_mail_to_directors(cls)
 
         return render_to_response(self.baseDir()+'coteachers.html', request, {'class':cls,
                                                                              'ajax':ajax,
                                                                              'txtTeachers': txtTeachers,
                                                                              'coteachers':  coteachers,
-                                                                             'conflicts':   conflictingusers})
+                                                                             'conflict':    conflictinguser})
 
     @aux_call
     @needs_teacher

--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -353,7 +353,7 @@ class TeacherClassRegModule(ProgramModuleObj):
 
         old_coteachers_set = set(cls.get_teachers())
         ccc = ClassCreationController(self.program)
-        
+
         conflictinguser = ''
 
         if op == 'add':

--- a/esp/templates/program/modules/teacherclassregmodule/coteachers.html
+++ b/esp/templates/program/modules/teacherclassregmodule/coteachers.html
@@ -71,7 +71,7 @@ You currently have no coteachers for this class.
 <form action="{{request.path}}" method="post" name="addteacher" onsubmit="cleanTeacherSubmit($j(this))">
 <table align="center" width="500">
     <tr>
-        <th colspan="2">Add A Coteacher</th>
+        <th colspan="2">Add a coteacher</th>
     </tr>
     <tr>
         <td colspan="2">Begin typing your coteacher's name in `Last, First' format to find them.</td>

--- a/esp/templates/program/modules/teacherclassregmodule/coteachers.html
+++ b/esp/templates/program/modules/teacherclassregmodule/coteachers.html
@@ -24,12 +24,9 @@
 
 <p>Please list all others that will be helping you teach this class.  They will need to create accounts and mark their available times through the teacher registration page (for scheduling purposes).</p>
 
-<p><b>Make sure you hit save!</b></p>
-
-{% if conflicts|length %}
-    <p style="color:red; font-weight: bold;">
-    The following teachers have conflicting schedules:<br />
-    {{ conflicts|join:"<br />" }}
+{% if conflict %}
+    <p>
+    <b><font color="red">{{ conflict }}</font> has a conflicting schedule.</b><br />
     </p>
 {% endif %}
 
@@ -74,7 +71,7 @@ You currently have no coteachers for this class.
 <form action="{{request.path}}" method="post" name="addteacher" onsubmit="cleanTeacherSubmit($j(this))">
 <table align="center" width="500">
     <tr>
-        <th colspan="2">Add More Coteachers</th>
+        <th colspan="2">Add A Coteacher</th>
     </tr>
     <tr>
         <td colspan="2">Begin typing your coteacher's name in `Last, First' format to find them.</td>
@@ -94,21 +91,7 @@ You currently have no coteachers for this class.
     </tr>
 </table>
 </form>
-<table align="center" width="500">
-    <tr>
-        <td align="center" colspan="2">When you are done, click the button below to return to teacher registration.</td>
-    </tr>
-    <tr>
-        <td align="center" colspan="2">
-            <form action="{{request.path}}" method="post" name="submit">
-            <input type="hidden" name="op" value="save" />
-            <input type="hidden" name="clsid" value="{{ class.id }}" />
-            <input type="hidden" name="coteachers" value="{{ txtTeachers }}" />
-            <input type="submit" class="button" value="Save and Continue" /><br />
-            </form>
-        </td>
-    </tr>
-</table>
+{% include "program/modules/teacherregcore/returnlink.html" %}
 </div>
 
 {% endblock %}


### PR DESCRIPTION
Removes need to "Save and continue" after deleting or adding teachers.
Now, adding or deleting a teacher is saved automatically.
This only causes one downside: an email is sent every time a teacher is added or deleted.
Fixes #729.