### PR TITLE
Lunch constraint form removes old lunches

### DIFF
--- a/esp/esp/program/controllers/lunch_constraints.py
+++ b/esp/esp/program/controllers/lunch_constraints.py
@@ -66,6 +66,8 @@ class LunchConstraintGenerator(object):
                     self.days[day]['before'].append(timeslot)
 
     def clear_existing_constraints(self):
+        for lunch in ClassSubject.objects.filter(parent_program__id=self.program.id, category=self.get_lunch_category()):
+            lunch.delete()
         for constraint in ScheduleConstraint.objects.filter(program=self.program):
             for boolexp in [constraint.condition, constraint.requirement]:
                 boolexp.delete()

--- a/esp/esp/program/modules/forms/admincore.py
+++ b/esp/esp/program/modules/forms/admincore.py
@@ -38,7 +38,7 @@ class LunchConstraintsForm(forms.Form):
         cg = LunchConstraintGenerator(self.program, timeslots, generate_constraints=(self.cleaned_data['generate_constraints'] is True), autocorrect=(self.cleaned_data['autocorrect'] is True), include_conditions=(self.cleaned_data['include_conditions'] is True))
         cg.generate_all_constraints()
 
-    timeslots = forms.MultipleChoiceField(choices=[], widget=forms.CheckboxSelectMultiple)
+    timeslots = forms.MultipleChoiceField(choices=[], required=False, widget=forms.CheckboxSelectMultiple)
 
     generate_constraints=forms.BooleanField(initial=True, required=False, help_text="Check this box to generate lunch scheduling constraints. If unchecked, only lunch sections will be generated, and the other two check boxes will have no effect.")
     autocorrect = forms.BooleanField(initial=True, required=False, help_text="Check this box to attempt automatically adding lunch to a student's schedule so that they are less likely to violate the schedule constraint.")


### PR DESCRIPTION
Allows for resetting lunch blocks or removing lunch blocks through the lunch constraint form.
Fixes #1798.