### PR TITLE
Resize nametag names

### DIFF
--- a/esp/templates/program/modules/nametagmodule/ids.html
+++ b/esp/templates/program/modules/nametagmodule/ids.html
@@ -45,6 +45,7 @@ body { font-family: georgia;
 .indicator { border: 1px solid black; border-width: 0 1px 0 1px; height: 0.85in;}
 </style>
 
+<script src="http://rawgit.com/STRML/textFit/master/textFit.min.js"></script>
 
 </head>
 <body>
@@ -96,5 +97,9 @@ body { font-family: georgia;
         {% endif %}
     {% endif %}
 {% endfor %}
+
+<script>
+textFit(document.getElementsByClassName('name'));
+</script>
 </body>
 </html>

--- a/esp/templates/program/modules/nametagmodule/singleid.html
+++ b/esp/templates/program/modules/nametagmodule/singleid.html
@@ -28,7 +28,9 @@
     <span class="programtitle">{{ programname }}</span>
     <div class="title">{{ user.title }}</div>
     <hr />
-    <div class="name">{{ user.name }}</div>
+    {% if user.name %}
+        <div class="name">{{ user.name }}</div>
+    {% endif %}
   </div>
 </div>
 </div>


### PR DESCRIPTION
Resizes the name on a nametag to fit comfortably using the function [here](https://github.com/STRML/textFit).
Fixes #1645.