### PR TITLE
Progress bars for starred classes

### DIFF
--- a/esp/esp/program/modules/handlers/studentregtwophase.py
+++ b/esp/esp/program/modules/handlers/studentregtwophase.py
@@ -46,6 +46,7 @@ from esp.middleware.threadlocalrequest import get_current_request
 from esp.program.models import ClassCategories, ClassSection, ClassSubject, RegistrationType, StudentRegistration, StudentSubjectInterest
 from esp.program.modules.base import ProgramModuleObj, main_call, aux_call, meets_deadline, needs_student, meets_grade, meets_cap, no_auth
 from esp.users.models import Record, ESPUser
+from esp.tagdict.models import Tag
 from esp.utils.web import render_to_response
 from esp.utils.query_utils import nest_Q
 
@@ -92,6 +93,7 @@ class StudentRegTwoPhase(ProgramModuleObj):
         for registration, and links to the phase1/phase2 sub-pages.
         """
 
+        context = {}
         timeslot_dict = {}
         # Populate the timeslot dictionary with the priority to class title
         # mappings for each timeslot.
@@ -134,6 +136,10 @@ class StudentRegTwoPhase(ProgramModuleObj):
         blockCount = 0
         schedule = []
         timeslots = prog.getTimeSlots(types=['Class Time Block', 'Compulsory'])
+
+        context['num_priority'] = prog.priorityLimit()
+        context['num_star'] = Tag.getProgramTag("num_stars", program = prog, default = 10)
+
         for i in range(len(timeslots)):
             timeslot = timeslots[i]
             if prevTimeSlot != None:
@@ -146,14 +152,13 @@ class StudentRegTwoPhase(ProgramModuleObj):
                 priority_list = sorted(priority_dict.items(), key=lambda item: item[0].name)
             else:
                 priority_list = []
+            star_count = 0
             if timeslot.id in star_counts:
-                priority_list.append((
-                    'Starred', "(%d classes)" % star_counts[timeslot.id]))
-            schedule.append((timeslot, priority_list, blockCount + 1))
+                star_count = star_counts[timeslot.id]
+            schedule.append((timeslot, priority_list, blockCount + 1, star_count))
 
             prevTimeSlot = timeslot
 
-        context = {}
         context['timeslots'] = schedule
 
         return render_to_response(

--- a/esp/esp/program/modules/handlers/studentregtwophase.py
+++ b/esp/esp/program/modules/handlers/studentregtwophase.py
@@ -152,10 +152,17 @@ class StudentRegTwoPhase(ProgramModuleObj):
                 priority_list = sorted(priority_dict.items(), key=lambda item: item[0].name)
             else:
                 priority_list = []
+            temp_list = []
+            for i in range(0, context['num_priority']):
+                if i < len(priority_list):
+                    temp_list.append(("Priority " + str(i + 1), priority_list[i][1]))
+                else:
+                    temp_list.append(("Priority " + str(i + 1), ""))
+            priority_list = temp_list
             star_count = 0
             if timeslot.id in star_counts:
                 star_count = star_counts[timeslot.id]
-            schedule.append((timeslot, priority_list, blockCount + 1, star_count))
+            schedule.append((timeslot, priority_list, blockCount + 1, star_count, float(star_count)/context['num_star']*100))
 
             prevTimeSlot = timeslot
 

--- a/esp/esp/tagdict/__init__.py
+++ b/esp/esp/tagdict/__init__.py
@@ -54,7 +54,7 @@ all_global_tags = {
     'automatic_registration_redirect': (True, "If student/teacher registration is open for exactly one program, redirect to student registration after student account creation (enabled by default)"),
     'text_messages_to_students': (True, ""),
     'local_state': (False, ""),
-    'grade_ranges': (False, "Replaces min and max grade options in teacher class reg with grade ranges, as specified by tag")
+    'grade_ranges': (False, "Replaces min and max grade options in teacher class reg with grade ranges, as specified by tag"),
 }
 
 # Any tag used with Tag.getProgramTag(),
@@ -102,4 +102,5 @@ all_program_tags = {
     'student_lottery_run': (False, ""),
     'formstack_id': (False, ""),
     'formstack_viewkey': (False, ""),
+    'num_stars': (False, "The preferred number of starred classes per timeslot for student two-phase registration"),
 }

--- a/esp/templates/program/modules/studentregtwophase/studentregtwophase.html
+++ b/esp/templates/program/modules/studentregtwophase/studentregtwophase.html
@@ -26,7 +26,7 @@ Welcome to the registration lottery for {{program.niceName}}. Please complete al
 
 <hr>
 
-<h1>Step 1 &ndash; Mark all classes you are interested in taking</h1>
+<h1>Step 1 &ndash; Star all classes you are interested in taking</h1>
 {% inline_program_qsd_block program "learn:studentregtwophase/step1" %}
 <p>
 Follow the link below to star classes you would consider taking for {{program.niceName}}.
@@ -45,7 +45,7 @@ View the classes >>
 {% inline_program_qsd_block program "learn:studentregtwophase/step2" %}
 <p>
 Rank your preferences for each time block during {{program.niceName}}. We highly
-recommend you mark a class for every priority slot to ensure a full schedule.
+recommend you have at least {{num_star}} classes starred for every priority slot to ensure a full schedule.
 </p>
 {% end_inline_program_qsd_block %}
 <div id="program_form">
@@ -55,7 +55,7 @@ recommend you mark a class for every priority slot to ensure a full schedule.
     Classes for {{request.user.first_name}} {{request.user.last_name}} - ID: {{request.user.id}}
     </th>
 </tr>
-{% for timeslot, priority_list, blockCount in timeslots %}
+{% for timeslot, priority_list, blockCount, star_count in timeslots %}
     {% ifchanged timeslot.start.day %}
         <tr><th class="small" colspan="3" height="3" style="text-align: center;">Classes beginning on {{ timeslot.pretty_date }}</th></tr>
     {% endifchanged %}
@@ -72,15 +72,12 @@ recommend you mark a class for every priority slot to ensure a full schedule.
         <td width="25%" valign="top" align="center">{{ timeslot.short_description }}</td>
 
         <td style="vertical-align: top !important;">
+            <progress value="{{star_count}}" max="{{num_star}}"></progress> ({{star_count}}/{{num_star}} starred classes)
             <i>
             {% for verb,title in priority_list %}
-	        <span>{{verb}}</span>: {{title}}
-                {% if not forloop.last %}<br />{% endif %}
+	        <br><span>{{verb}}</span>: {{title}}
             {% endfor %}
             </i>
-            {% if priority_list|length_is:0 %}
-                No classes
-            {% endif %}
         </td>
 
         {%comment%}{% if module.deadline_met %}{%endcomment%}

--- a/esp/templates/program/modules/studentregtwophase/studentregtwophase.html
+++ b/esp/templates/program/modules/studentregtwophase/studentregtwophase.html
@@ -88,7 +88,7 @@ recommend you have at least {{num_star}} classes starred for every priority slot
     {% else %}
     <tr>
     <tr>
-        <td width="20%" valign="top" align="center">{{ timeslot.short_description }}</td>
+        <td width="20%"align="center">{{ timeslot.short_description }}</td>
 
         <td style="vertical-align: top !important;">
             <div class="progress-custom">
@@ -110,7 +110,7 @@ recommend you have at least {{num_star}} classes starred for every priority slot
         </td>
 
         {%comment%}{% if module.deadline_met %}{%endcomment%}
-        <td width='20%' align='center' style="vertical-align: top !important;">
+        <td width='20%' align='center'>
             <a href="/learn/{{program.getUrlBase}}/rank_classes/{{timeslot.id}}">[edit rankings]</a>
         </td>
         {%comment%}{% endif %}{%endcomment%}

--- a/esp/templates/program/modules/studentregtwophase/studentregtwophase.html
+++ b/esp/templates/program/modules/studentregtwophase/studentregtwophase.html
@@ -15,6 +15,25 @@
   padding: 2px 5px;
   text-decoration: none;
 }
+
+.progress-custom {
+    display: table;
+    width: 100%;
+    margin-bottom: 4px;
+}
+
+.progress-custom .progress{
+    margin-bottom: 0;
+    display: table-cell;
+    vertical-align: middle;
+}
+
+.progress-custom .progress-value{
+    display: table-cell;
+    vertical-align: middle;
+    width: 40%; 
+    padding-left: 1em;
+}
 </style>
 {% endblock %}
 
@@ -49,13 +68,13 @@ recommend you have at least {{num_star}} classes starred for every priority slot
 </p>
 {% end_inline_program_qsd_block %}
 <div id="program_form">
-<table cellpadding="3" class="fullwidth">
+<table cellpadding="3" style="width:100%;" class="fullwidth">
 <tr>
     <th colspan="3">
     Classes for {{request.user.first_name}} {{request.user.last_name}} - ID: {{request.user.id}}
     </th>
 </tr>
-{% for timeslot, priority_list, blockCount, star_count in timeslots %}
+{% for timeslot, priority_list, blockCount, star_count, perc_star in timeslots %}
     {% ifchanged timeslot.start.day %}
         <tr><th class="small" colspan="3" height="3" style="text-align: center;">Classes beginning on {{ timeslot.pretty_date }}</th></tr>
     {% endifchanged %}
@@ -69,19 +88,29 @@ recommend you have at least {{num_star}} classes starred for every priority slot
     {% else %}
     <tr>
     <tr>
-        <td width="25%" valign="top" align="center">{{ timeslot.short_description }}</td>
+        <td width="20%" valign="top" align="center">{{ timeslot.short_description }}</td>
 
         <td style="vertical-align: top !important;">
-            <progress value="{{star_count}}" max="{{num_star}}"></progress> ({{star_count}}/{{num_star}} starred classes)
+            <div class="progress-custom">
+                <div class="progress">
+                    <div class="bar" role="progressbar" aria-valuenow="{{star_count}}" aria-valuemin="0" aria-valuemax="{{num_star}}" style="width: {{perc_star}}%;"></div>
+                </div>
+                <div class="progress-value">
+                    ({{star_count}}/{{num_star}} starred classes)
+                </div>
+            </div>
             <i>
             {% for verb,title in priority_list %}
-	        <br><span>{{verb}}</span>: {{title}}
+                <span><font color={% if not title %}"red"{% else %}"green"{% endif %}>{{verb}}: {{title}}</font></span>
+                {% if not forloop.last %}
+                    <br>
+                {% endif %}
             {% endfor %}
             </i>
         </td>
 
         {%comment%}{% if module.deadline_met %}{%endcomment%}
-        <td width='25%' align='center' style="vertical-align: top !important;">
+        <td width='20%' align='center' style="vertical-align: top !important;">
             <a href="/learn/{{program.getUrlBase}}/rank_classes/{{timeslot.id}}">[edit rankings]</a>
         </td>
         {%comment%}{% endif %}{%endcomment%}


### PR DESCRIPTION
Adds a progress bar for each timeslot in two phase registration that reports the number of starred classes for that time slot out of the desired number of starred classes (use tag `num_stars`, default = 10).

Fixes #382.
Also maybe fixes #1437, although I'm in favor of also implementing #1166.

![image](https://user-images.githubusercontent.com/7232514/29696178-269f49dc-8915-11e7-90a9-ab8e3bb13a9e.png)
