### PR TITLE
Makes address optionally not required for teachers

### DIFF
--- a/esp/esp/tagdict/__init__.py
+++ b/esp/esp/tagdict/__init__.py
@@ -54,7 +54,8 @@ all_global_tags = {
     'automatic_registration_redirect': (True, "If student/teacher registration is open for exactly one program, redirect to student registration after student account creation (enabled by default)"),
     'text_messages_to_students': (True, ""),
     'local_state': (False, ""),
-    'grade_ranges': (False, "Replaces min and max grade options in teacher class reg with grade ranges, as specified by tag")
+    'grade_ranges': (False, "Replaces min and max grade options in teacher class reg with grade ranges, as specified by tag"),
+    'teacher_address_required': (True, "Is an address required for a teacher profile? (enabled by default, set to 'False' to disable)")
 }
 
 # Any tag used with Tag.getProgramTag(),

--- a/esp/esp/users/forms/user_profile.py
+++ b/esp/esp/users/forms/user_profile.py
@@ -10,7 +10,7 @@ from django.conf import settings
 import json
 from localflavor.us.forms import USPhoneNumberField
 
-_states = ['AL' , 'AK' , 'AR', 'AZ' , 'CA' , 'CO' , 'CT' , 'DC' , 'DE' , 'FL' , 'GA' , 'GU' , 'HI' , 'IA' , 'ID'  ,'IL','IN'  ,'KS'  ,'KY'  ,'LA'  ,'MA' ,'MD'  ,'ME'  ,'MI'  ,'MN'  ,'MO' ,'MS'  ,'MT'  ,'NC'  ,'ND' ,'NE'  ,'NH'  ,'NJ'  ,'NM' ,'NV'  ,'NY' ,'OH'  , 'OK' ,'OR'  ,'PA'  ,'PR' ,'RI'  ,'SC'  ,'SD'  ,'TN' ,'TX'  ,'UT'  ,'VA'  ,'VI'  ,'VT'  ,'WA'  ,'WI'  ,'WV' ,'WY' ,'Canada', 'UK']
+_states = ['' , 'AL' , 'AK' , 'AR', 'AZ' , 'CA' , 'CO' , 'CT' , 'DC' , 'DE' , 'FL' , 'GA' , 'GU' , 'HI' , 'IA' , 'ID'  ,'IL','IN'  ,'KS'  ,'KY'  ,'LA'  ,'MA' ,'MD'  ,'ME'  ,'MI'  ,'MN'  ,'MO' ,'MS'  ,'MT'  ,'NC'  ,'ND' ,'NE'  ,'NH'  ,'NJ'  ,'NM' ,'NV'  ,'NY' ,'OH'  , 'OK' ,'OR'  ,'PA'  ,'PR' ,'RI'  ,'SC'  ,'SD'  ,'TN' ,'TX'  ,'UT'  ,'VA'  ,'VI'  ,'VT'  ,'WA'  ,'WI'  ,'WV' ,'WY' ,'Canada', 'UK']
 
 class DropdownOtherWidget(forms.MultiWidget):
     """

--- a/esp/esp/users/forms/user_profile.py
+++ b/esp/esp/users/forms/user_profile.py
@@ -49,10 +49,10 @@ class UserContactForm(FormUnrestrictedOtherUser, FormWithTagInitialValues):
     phone_day = USPhoneNumberField(required=False)
     phone_cell = USPhoneNumberField(required=False)
     receive_txt_message = forms.BooleanField(required=False)
-    address_street = StrippedCharField(length=40, max_length=100)
-    address_city = StrippedCharField(length=20, max_length=50)
-    address_state = forms.ChoiceField(choices=zip(_states,_states), widget=forms.Select(attrs={'class': 'input-mini'}))
-    address_zip = StrippedCharField(length=5, max_length=5, widget=forms.TextInput(attrs={'class': 'input-small'}))
+    address_street = StrippedCharField(required=False, length=40, max_length=100)
+    address_city = StrippedCharField(required=False, length=20, max_length=50)
+    address_state = forms.ChoiceField(required=False, choices=zip(_states,_states), widget=forms.Select(attrs={'class': 'input-mini'}))
+    address_zip = StrippedCharField(required=False, length=5, max_length=5, widget=forms.TextInput(attrs={'class': 'input-small'}))
     address_postal = forms.CharField(required=False, widget=forms.HiddenInput())
 
     def __init__(self, *args, **kwargs):
@@ -61,6 +61,11 @@ class UserContactForm(FormUnrestrictedOtherUser, FormWithTagInitialValues):
             del self.fields['phone_day']
         if not Tag.getBooleanTag('text_messages_to_students'):
             del self.fields['receive_txt_message']
+        if not self.user.isTeacher() or Tag.getBooleanTag('teacher_address_required', default = True):
+            self.fields['address_street'].required = True
+            self.fields['address_city'].required = True
+            self.fields['address_state'].required = True
+            self.fields['address_zip'].required = True
 
     def clean(self):
         super(UserContactForm, self).clean()


### PR DESCRIPTION
If the tag `teacher_address_required` is set to `False`, this makes the address fields not required for teachers.
Fixes #1503.

N.B. I tried the opposite logic (start with fields required and make them not required), but for some reason it wouldn't work, so I stuck with this implementation.