### PR TITLE
Small changes to text message profile form field

### DIFF
--- a/esp/esp/users/forms/user_profile.py
+++ b/esp/esp/users/forms/user_profile.py
@@ -61,8 +61,6 @@ class UserContactForm(FormUnrestrictedOtherUser, FormWithTagInitialValues):
             del self.fields['phone_day']
         if not Tag.getBooleanTag('text_messages_to_students') or not self.user.isStudent():
             del self.fields['receive_txt_message']
-        if self.user.getLastProfile().contact_user and not self.user.getLastProfile().contact_user.receive_txt_message:
-            self.fields['receive_txt_message'].initial = 'False'
 
     def clean(self):
         super(UserContactForm, self).clean()

--- a/esp/esp/users/forms/user_profile.py
+++ b/esp/esp/users/forms/user_profile.py
@@ -61,7 +61,7 @@ class UserContactForm(FormUnrestrictedOtherUser, FormWithTagInitialValues):
             del self.fields['phone_day']
         if not Tag.getBooleanTag('text_messages_to_students') or not self.user.isStudent():
             del self.fields['receive_txt_message']
-        if self.user.getLastProfile() and not self.user.getLastProfile().contact_user.receive_txt_message:
+        if self.user.getLastProfile().contact_user and not self.user.getLastProfile().contact_user.receive_txt_message:
             self.fields['receive_txt_message'].initial = 'False'
 
     def clean(self):

--- a/esp/esp/users/forms/user_profile.py
+++ b/esp/esp/users/forms/user_profile.py
@@ -48,7 +48,7 @@ class UserContactForm(FormUnrestrictedOtherUser, FormWithTagInitialValues):
     e_mail = forms.EmailField()
     phone_day = USPhoneNumberField(required=False)
     phone_cell = USPhoneNumberField(required=False)
-    receive_txt_message = forms.BooleanField(required=False)
+    receive_txt_message = forms.TypedChoiceField(coerce=lambda x: x =='True', choices=((True, 'Yes'),(False, 'No')), widget=forms.RadioSelect)
     address_street = StrippedCharField(length=40, max_length=100)
     address_city = StrippedCharField(length=20, max_length=50)
     address_state = forms.ChoiceField(choices=zip(_states,_states), widget=forms.Select(attrs={'class': 'input-mini'}))
@@ -59,8 +59,10 @@ class UserContactForm(FormUnrestrictedOtherUser, FormWithTagInitialValues):
         super(UserContactForm, self).__init__(*args, **kwargs)
         if not Tag.getBooleanTag('request_student_phonenum', default=True):
             del self.fields['phone_day']
-        if not Tag.getBooleanTag('text_messages_to_students'):
+        if not Tag.getBooleanTag('text_messages_to_students') or not self.user.isStudent():
             del self.fields['receive_txt_message']
+        if self.user.registrationprofile_set.count() > 0 and not self.user.getLastProfile().contact_user.receive_txt_message:
+            self.fields['receive_txt_message'].initial = 'False'
 
     def clean(self):
         super(UserContactForm, self).clean()

--- a/esp/esp/users/forms/user_profile.py
+++ b/esp/esp/users/forms/user_profile.py
@@ -61,7 +61,7 @@ class UserContactForm(FormUnrestrictedOtherUser, FormWithTagInitialValues):
             del self.fields['phone_day']
         if not Tag.getBooleanTag('text_messages_to_students') or not self.user.isStudent():
             del self.fields['receive_txt_message']
-        if self.user.registrationprofile_set.count() > 0 and not self.user.getLastProfile().contact_user.receive_txt_message:
+        if self.user.getLastProfile() and not self.user.getLastProfile().contact_user.receive_txt_message:
             self.fields['receive_txt_message'].initial = 'False'
 
     def clean(self):

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -1791,7 +1791,7 @@ class ContactInfo(models.Model, CustomFormsLinkModel):
     def updateForm(self, form_data, prepend=''):
         newkey = self.__dict__
         for key, val in newkey.items():
-            if val and key != 'id':
+            if val not in [None, ''] and key != 'id':
                 form_data[prepend+key] = val
         return form_data
 

--- a/esp/public/media/default_styles/forms.css
+++ b/esp/public/media/default_styles/forms.css
@@ -3,6 +3,11 @@
     border-collapse: collapse;
 }
 
+/* Profile editor */
+#id_receive_txt_message {
+    list-style:none
+}
+
 /*  Default formatting */
 #divmaintext form table tbody td, #divmaintext form table tbody th {
     vertical-align: top;

--- a/esp/templates/users/profiles/usercontact.html
+++ b/esp/templates/users/profiles/usercontact.html
@@ -1,5 +1,11 @@
 <!-- User ContactInfo -->
 
+<style>
+#id_receive_txt_message {
+    list-style:none
+}
+</style>
+
 <h3>Contact Information</h3>
 
  <div class="control-group">

--- a/esp/templates/users/profiles/usercontact.html
+++ b/esp/templates/users/profiles/usercontact.html
@@ -1,11 +1,5 @@
 <!-- User ContactInfo -->
 
-<style>
-#id_receive_txt_message {
-    list-style:none
-}
-</style>
-
 <h3>Contact Information</h3>
 
  <div class="control-group">


### PR DESCRIPTION
This changes the form field from a boolean field to a radio select field, allowing to have both `True` and `False` options, with one of the two options required to submit the form.
This fixes the potential problem of students submitting the form without reading/thinking about the field in the form (since the field was previously not required).
This also removes the field from the form if you are not a student or if it is not enabled by the `text_messages_to_students` tag.
Finally, I also added a little CSS to remove the bullet points that would otherwise be next to the radio buttons.

![image](https://user-images.githubusercontent.com/7232514/29956090-80d86508-8e99-11e7-8e85-6d54da715f1b.png)

N.B. Since the option values are converted to strings, it required some coercing to save the value as a boolean when the form is submitted and some setup in the `__init__` of the form in case the user previously selected "No" (otherwise, we could get some very grumpy students who complain about having to select "No" over and over every time they have to update their profile).