### PR TITLE
Intelligently class search by ID in admin toolbar

### DIFF
--- a/esp/esp/program/modules/handlers/classsearchmodule.py
+++ b/esp/esp/program/modules/handlers/classsearchmodule.py
@@ -1,5 +1,6 @@
 import json
 import random
+import re
 
 from django.http import HttpResponseRedirect
 from django.db.models.query import Q
@@ -108,6 +109,16 @@ class ClassSearchModule(ProgramModuleObj):
         if data is not None:
             decoded = json.loads(data)
         elif namequery: # only search if not None and not ""
+            # if this looks like a class ID then just go to its manage page
+            id_match = re.match('^[a-zA-Z]?(\\d+)$', namequery)
+            if id_match:
+                id_query = int(id_match.group(1))
+                try:
+                    subj = ClassSubject.objects.get(id=id_query)
+                    return HttpResponseRedirect(subj.get_absolute_url())
+                except ClassSubject.DoesNotExist:
+                    context['failed_id_search'] = True
+                    context['id_query'] = id_query
             decoded = {'filter': 'title', 'negated': False, 'values': [namequery]}
 
         if decoded is not None:
@@ -119,7 +130,11 @@ class ClassSearchModule(ProgramModuleObj):
                 queryset = list(queryset)
                 random.shuffle(queryset)
             if request.GET.get('lucky'):
-                return HttpResponseRedirect(queryset[0].get_absolute_url())
+                if queryset:
+                    return HttpResponseRedirect(queryset[0].get_absolute_url())
+                # if you're not lucky enough and no classes satisfying your
+                # search exist, fall through and send you to the class search
+                # page as usual
             context['query'] = decoded
             context['queryset'] = queryset
             context['flag_types'] = self.program.flag_types.all()

--- a/esp/templates/program/modules/classsearchmodule/class_search.html
+++ b/esp/templates/program/modules/classsearchmodule/class_search.html
@@ -19,6 +19,10 @@
 
 <h1>Search Classes for {{ program.niceName }}</h1>
 
+{% if failed_id_search %}
+<p><strong>No class with ID {{ id_query }} found. Attempting as title search:</strong></p>
+{% endif %}
+
 {% load query_builder %}
 {% render_query_builder query_builder query %}
 


### PR DESCRIPTION
Search directly by ID, bypassing the program check, if the query looks
like a class ID. If not, fall back to searching by name as usual with a
message.

Also fail in "I'm Feeling Lucky" gracefully.