### PR TITLE
Request Cancellation Button Deadline and Logic

### DIFF
--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -82,6 +82,7 @@ class TeacherClassRegModule(ProgramModuleObj):
         context['can_create'] = self.any_reg_is_open()
         context['can_create_class'] = self.class_reg_is_open()
         context['can_create_open_class'] = self.open_class_reg_is_open()
+        context['can_req_cancel'] = self.deadline_met('/Classes/CancelReq')
         context['crmi'] = self.crmi
         context['clslist'] = self.clslist(get_current_request().user)
         context['friendly_times_with_date'] = Tag.getBooleanTag('friendly_times_with_date', self.program, False)

--- a/esp/esp/program/templatetags/class_render_row.py
+++ b/esp/esp/program/templatetags/class_render_row.py
@@ -10,11 +10,12 @@ register = template.Library()
 
 
 @cache_inclusion_tag(register, 'inclusion/program/class_teacher_list_row.html')
-def render_class_teacher_list_row(cls):
+def render_class_teacher_list_row(cls, can_req_cancel):
     """Render a class for the teacher list of classes in teacherreg."""
     return {'cls': cls,
             'program': cls.parent_program,
             'crmi': cls.parent_program.classregmoduleinfo,
+            'can_req_cancel': can_req_cancel,
             'friendly_times_with_date': Tag.getBooleanTag(
                 'friendly_times_with_date', cls.parent_program, False),
             'email_host_sender': settings.EMAIL_HOST_SENDER

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -2279,7 +2279,7 @@ class Permission(ExpirableModel):
             ("Teacher/Classes/All", "Classes/All"),
             ("Teacher/Classes/View", "Classes/View"),
             ("Teacher/Classes/Edit", "Classes/Edit"),
-            ("Teacher/Classes/CancelReq", "Classes/CancelReq"),
+            ("Teacher/Classes/CancelReq", "Request class cancellation"),
             ("Teacher/Classes/Create", "Create classes of all types"),
             ("Teacher/Classes/Create/Class", "Create standard classes"),
             ("Teacher/Classes/Create/OpenClass", "Create open classes"),

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -2279,6 +2279,7 @@ class Permission(ExpirableModel):
             ("Teacher/Classes/All", "Classes/All"),
             ("Teacher/Classes/View", "Classes/View"),
             ("Teacher/Classes/Edit", "Classes/Edit"),
+            ("Teacher/Classes/CancelReq", "Classes/CancelReq"),
             ("Teacher/Classes/Create", "Create classes of all types"),
             ("Teacher/Classes/Create/Class", "Create standard classes"),
             ("Teacher/Classes/Create/OpenClass", "Create open classes"),

--- a/esp/public/media/default_styles/battlescreen.css
+++ b/esp/public/media/default_styles/battlescreen.css
@@ -204,3 +204,29 @@ color: #006600;
   margin-top: 0px;
   margin-bottom: 0px;
 }
+
+.clsmiddle {
+    vertical-align: middle;
+}
+
+.cancelbutton {
+    color: #000000;
+    font-family: Arial,helvetica,sans-serif;
+    font-size: 11px;
+    font-weight: bold;
+    border: #cccccc 1px solid;
+    background-color: #cccccc;
+    cursor: default;
+    padding: 2px 5px 2px 5px;
+    text-decoration: none;
+    margin: 0px;
+    line-height: normal;
+    cursor: pointer;
+    box-shadow: none;
+    transition: border linear 0.2s, box-shadow linear 0.2s;
+    border-radius: 0;
+}
+
+.teachbutton {
+    margin: 0 !important;
+}

--- a/esp/templates/inclusion/program/class_teacher_list_row.html
+++ b/esp/templates/inclusion/program/class_teacher_list_row.html
@@ -1,5 +1,33 @@
 {# expects program, class, can_req_cancel, and crmi (ClassRegModuleInfo) #}
 
+<style>
+.clsmiddle {
+    vertical-align: middle;
+}
+
+.cancelbutton {
+    color: #000000;
+    font-family: Arial,helvetica,sans-serif;
+    font-size: 11px;
+    font-weight: bold;
+    border: #cccccc 1px solid;
+    background-color: #cccccc;
+    cursor: default;
+    padding: 2px 5px 2px 5px;
+    text-decoration: none;
+    margin: 0px;
+    line-height: normal;
+    cursor: pointer;
+    box-shadow: none;
+    transition: border linear 0.2s, box-shadow linear 0.2s;
+    border-radius: 0;
+}
+
+.teachbutton {
+    margin: 0 !important;
+}
+</style>
+
 <tr{% if not cls.isReviewed %} style="color: gray"{% endif %}{% if cls.isRejected or cls.isCancelled %} style="color: red"{% endif %}>
   <td class="clsleft classname bordertop2" colspan="3">
   {% block cls_title %}
@@ -11,22 +39,18 @@
   </td>
   {% block cls_row_1_buttons %}
   <td class="clsmiddle bordertop2">
-    {% if not cls.num_students and not cls.hasScheduledSections %}
-        <form method="post" action="/teach/{{program.getUrlBase}}/deleteclass/{{cls.id }}" onsubmit="return deleteClass();">
-          <input class="button" type="submit" value="Delete"/>
-        </form>
-    {% elif can_req_cancel %}
-        <button class="button" onclick="requestCancel({{cls.id}})">Request Cancellation</button>
+    {% if can_req_cancel %}
+        <button class="cancelbutton" onclick="requestCancel({{cls.id}})">Request Cancellation</button>
     {% endif %}
   </td>
   <td class="clsmiddle bordertop2">
-    <form method="post" action="/teach/{{program.getUrlBase}}/editclass/{{cls.id }}">
+    <form class="teachbutton" method="post" action="/teach/{{program.getUrlBase}}/editclass/{{cls.id }}">
       <input type="hidden" name="command" value="edit_class_{{cls.id}}">
       <input class="button" type="submit" value="View/Edit">
     </form>
   </td>
   <td class="clsmiddle bordertop2">
-    <form method="get" action="/teach/{{program.getUrlBase}}/class_status/{{cls.id}}">
+    <form class="teachbutton" method="get" action="/teach/{{program.getUrlBase}}/class_status/{{cls.id}}">
       <input class="button" type="submit" value="Detailed Status" />
     </form>
   </td>

--- a/esp/templates/inclusion/program/class_teacher_list_row.html
+++ b/esp/templates/inclusion/program/class_teacher_list_row.html
@@ -1,4 +1,4 @@
-{# expects program, class, and crmi (ClassRegModuleInfo) #}
+{# expects program, class, can_req_cancel, and crmi (ClassRegModuleInfo) #}
 
 <tr{% if not cls.isReviewed %} style="color: gray"{% endif %}{% if cls.isRejected or cls.isCancelled %} style="color: red"{% endif %}>
   <td class="clsleft classname bordertop2" colspan="3">
@@ -11,12 +11,12 @@
   </td>
   {% block cls_row_1_buttons %}
   <td class="clsmiddle bordertop2">
-    {% if cls.num_students or not module.deadline_met %}
-        <button class="button" onclick="requestCancel({{cls.id}})">Request Cancellation</button>
-    {% else %}
+    {% if not cls.num_students and not cls.hasScheduledSections %}
         <form method="post" action="/teach/{{program.getUrlBase}}/deleteclass/{{cls.id }}" onsubmit="return deleteClass();">
           <input class="button" type="submit" value="Delete"/>
         </form>
+    {% elif can_req_cancel %}
+        <button class="button" onclick="requestCancel({{cls.id}})">Request Cancellation</button>
     {% endif %}
   </td>
   <td class="clsmiddle bordertop2">

--- a/esp/templates/inclusion/program/class_teacher_list_row.html
+++ b/esp/templates/inclusion/program/class_teacher_list_row.html
@@ -1,33 +1,5 @@
 {# expects program, class, can_req_cancel, and crmi (ClassRegModuleInfo) #}
 
-<style>
-.clsmiddle {
-    vertical-align: middle;
-}
-
-.cancelbutton {
-    color: #000000;
-    font-family: Arial,helvetica,sans-serif;
-    font-size: 11px;
-    font-weight: bold;
-    border: #cccccc 1px solid;
-    background-color: #cccccc;
-    cursor: default;
-    padding: 2px 5px 2px 5px;
-    text-decoration: none;
-    margin: 0px;
-    line-height: normal;
-    cursor: pointer;
-    box-shadow: none;
-    transition: border linear 0.2s, box-shadow linear 0.2s;
-    border-radius: 0;
-}
-
-.teachbutton {
-    margin: 0 !important;
-}
-</style>
-
 <tr{% if not cls.isReviewed %} style="color: gray"{% endif %}{% if cls.isRejected or cls.isCancelled %} style="color: red"{% endif %}>
   <td class="clsleft classname bordertop2" colspan="3">
   {% block cls_title %}

--- a/esp/templates/program/modules/teacherclassregmodule/listclasses.html
+++ b/esp/templates/program/modules/teacherclassregmodule/listclasses.html
@@ -98,7 +98,7 @@ If you have any questions regarding the program, <br /> please email the
   {% endif %}
   {% load class_render_row %}
   {% for cls in clslist %}
-    {% render_class_teacher_list_row cls %}
+    {% render_class_teacher_list_row cls can_req_cancel %}
   {% endfor %}
 
    {% if can_create %}


### PR DESCRIPTION
This was originally to fix #2447, but then I realized a larger problem.
It appears there was once a working "Delete" button for classes but it doesn't seem to work anymore.
`<input class="button" type="submit" value="Delete" {% if cls.num_students or not module.deadline_met %}disabled {% endif %} />`
Since this was within the `class_teacher_list_row` inclusion template, rather than the `list_classes` template, the `module` variable was not passed, and so the logic always disabled the button.

Perhaps this originally worked for some reason or I'm interpreting all of this incorrectly. (N.B. Stanford uses a pretty different template for `list_classes.html`, so some of my knowledge/understanding may be a little off.)

Either way, I had originally kept this logic for #2418, thinking that whenever the Delete button was disabled, I would hide it and show the Request Cancellation button instead.
Of course, since the Delete button was always disabled, this new logic made it so that the Request Cancellation button was always shown instead of the delete button.


Anywho, as I was trying to implement a deadline for the Request Cancellation button as per #2447, I realized all of this, so I implemented new logic, thinking that people might want the delete button to actually work, but this probably doesn't actually fix #2447.
The current logic is this:

- If a class has not been scheduled and has no students enrolled, the Delete button is shown.
- If a class is scheduled or has students enrolled AND the deadline for requesting a cancellation is still open, the Request Cancellation button is shown.
- If a class is scheduled or has students enrolled AND the deadline is closed, neither button is shown.

The deadline is included within the normal Teacher deadlines, so it will always be open if "All teacher deadlines" is open. However, once that deadline is closed, a chapter can open "Classes/CancelReq" as  a separate deadline if they'd like to allow cancellation requests after teacher registration closes.

@mariolsen0112358, does this fix #2447? Would it be better if there was no delete button and the request cancellation is shown until reg closes, at which point it can be controlled by a deadline? Can you envision any reason why you would want to make the Cancellation Request button disappear _before_ teacher reg closes?