### PR TITLE
don't upgrade libpq-dev because version 10 breaks our Travis tests, apparently

### DIFF
--- a/deploy/travis/install
+++ b/deploy/travis/install
@@ -2,7 +2,7 @@
 set -euf -o pipefail
 
 if [ "$TRAVIS_JOB" = "test" ]; then
-    sudo apt-get install -y $(cat esp/packages_base.txt | grep -v ^memcached | grep -v ^postgres)
+    sudo apt-get install -y $(cat esp/packages_base.txt | grep -v ^memcached | grep -v ^postgres | grep -v ^libpq-dev)
     esp/packages_base_manual_install.sh
     pip install -r esp/requirements.txt -q --log pip.log || (tail pip.log && exit 1)
 elif [ "$TRAVIS_JOB" = "lint" ]; then


### PR DESCRIPTION
All tests have been failing at the install step for about a week or so, and the culprit appears to be upgrading libpq-dev to version 10.  

Last good test: https://travis-ci.org/learning-unlimited/ESP-Website/jobs/283544097
First bad test: https://travis-ci.org/learning-unlimited/ESP-Website/jobs/283820126

Comparing the deploy/travis/install logs for both shows that the difference is the version number of libpq-dev and its dependency, libpq5.

Unfortunately, I cannot test this fix locally because on my dev box, apt-cache reports the latest version of libpq-dev as 9.3.9.