### PR TITLE
Add duration-from-now labels next to deadline datepickers

### DIFF
--- a/esp/esp/utils/widgets.py
+++ b/esp/esp/utils/widgets.py
@@ -17,14 +17,9 @@ import time
 
 # DATETIMEWIDGET
 calEnable = u"""
+<span id="{id}-info"><span id="{id}-gi"></span> <span id="{id}-duration"></span></span>
 <script type="text/javascript">
-    $j("#%s").%s({
-        showOn: 'button',
-        buttonImage: '%simages/calbutton_tight.png',
-        buttonImageOnly: true,
-        dateFormat: '%s',
-        timeFormat: '%s'
-    });
+    setupDatepickerDurationLabel('{widget}', '{id}', '{media_url}', '{date_format}', '{time_format}');
 </script>"""
 
 class DateTimeWidget(forms.widgets.TextInput):
@@ -61,7 +56,12 @@ class DateTimeWidget(forms.widgets.TextInput):
     def render(self, name, value, attrs=None):
         final_attrs = self.prepare_render_attrs(name, value, attrs)
         id = final_attrs['id']
-        cal = calEnable % (id, 'datetimepicker', settings.MEDIA_URL, self.dformat, self.tformat)
+        cal = calEnable.format(
+                widget='datetimepicker',
+                id=id,
+                media_url=settings.MEDIA_URL,
+                date_format=self.dformat,
+                time_format=self.tformat)
         return u'<input%s />%s' % (forms.utils.flatatt(final_attrs), cal)
 
     def value_from_datadict(self, data, files, name):
@@ -89,7 +89,12 @@ class DateWidget(DateTimeWidget):
     def render(self, name, value, attrs=None):
         final_attrs = self.prepare_render_attrs(name, value, attrs)
         id = final_attrs['id']
-        cal = calEnable % (id, 'datepicker', settings.MEDIA_URL, self.dformat, self.tformat)
+        cal = calEnable.format(
+                widget='datepicker',
+                id=id,
+                media_url=settings.MEDIA_URL,
+                date_format=self.dformat,
+                time_format=self.tformat)
         return u'<input%s />%s' % (forms.utils.flatatt(final_attrs), cal)
 
 class ClassAttrMergingSelect(forms.Select):

--- a/esp/public/media/scripts/datepicker-duration.js
+++ b/esp/public/media/scripts/datepicker-duration.js
@@ -1,0 +1,41 @@
+function setupDatepickerDurationLabel(widget, id, mediaUrl, dateFormat, timeFormat){
+  var $picker = $j("#" + id);
+  var $info = $j("#" + id + "-info");
+  var $gi = $j("#" + id + "-gi");
+  var $duration = $j("#" + id + "-duration");
+  function refresh() {
+    var date = $picker[widget]('getDate');
+    if (date) {
+      var hours = (date - Date.now()) / (60*60*1000);
+      var abshours = Math.abs(hours);
+      var duration = (abshours < 24) ? (
+        abshours.toFixed(1) + " hours"
+      ) : (
+        (abshours / 24).toFixed(1) + " days"
+      );
+      if (abshours > 24 * 120) {
+        $info.prop('class', 'label label-important');
+        $gi.prop('class', 'glyphicon glyphicon-alert');
+      } else {
+        $info.prop('class', 'label label-info');
+        if (hours < 0) {
+          $gi.prop('class', 'glyphicon glyphicon-backward');
+        } else {
+          $gi.prop('class', 'glyphicon glyphicon-forward');
+        }
+      }
+      $duration.text(hours < 0 ? (duration + " ago") : ("in " + duration));
+      $info.show();
+    } else {
+      $info.hide();
+    }
+  }
+  $picker[widget]({
+    showOn: 'button',
+      buttonImage: mediaUrl + 'images/calbutton_tight.png',
+      buttonImageOnly: true,
+      dateFormat: dateFormat,
+      timeFormat: timeFormat,
+  }).on("change", refresh);
+  refresh();
+}

--- a/esp/public/media/theme_editor/less/forms.less
+++ b/esp/public/media/theme_editor/less/forms.less
@@ -594,3 +594,8 @@ legend + .control-group {
 .error_background {
     background-color:#D3D3D3;
 }
+
+// datepicker
+input.hasDatepicker {
+    max-width: 10em;
+}

--- a/esp/templates/elements/html
+++ b/esp/templates/elements/html
@@ -39,6 +39,7 @@
     {% block jquery_ui_version %}
     <script type="text/javascript" src="/media/scripts/jquery-ui.js"></script>
     <script type="text/javascript" src="/media/scripts/jquery-ui.timepicker.js"></script>
+    <script type="text/javascript" src="/media/scripts/datepicker-duration.js"></script>
     {% endblock %}
     <script type="text/javascript" src="/media/scripts/common.js"></script>
     {% endblock jquery %}

--- a/esp/templates/program/modules/admincore/deadlines.html
+++ b/esp/templates/program/modules/admincore/deadlines.html
@@ -77,6 +77,10 @@
         vertical-align: middle;
     }
 
+    #userbitforms table th.halfwidth
+    {
+        width: 50%;
+    }
     #userbitforms table th.small
     {
         font-size: 12px;
@@ -162,11 +166,15 @@
     {{ perm.form.id }}
     <table border="0" width="550px" cellspacing="0" cellpadding="3px">
     <tr>
-        <th width="400px"><p class="bitname"><span style="color: #000066">{% if perm.open_now %}Open:{% else %}Closed:{% endif %}</span> {{ perm.name }}</p>
+        <th class="halfwidth"><p class="bitname"><span style="color: #000066">{% if perm.open_now %}Open:{% else %}Closed:{% endif %}</span> {{ perm.name }}</p>
 <p class="bitname"><span style="color: #000066">To:</span> {{ perm.role }}s</p>
             <span class="bituri">{{ perm.permission_type }}</span>
         </th>
-        <th class="small" width="145px">Available from: <br />{{ perm.form.start_date }} to <br /> {{ perm.form.end_date }}</th>
+        <th class="halfwidth small">
+            Available from:<br />{{ perm.form.start_date }}
+            <br />
+            to<br />{{ perm.form.end_date }}
+        </th>
     </tr>
     <tr>
         <td valign="top">


### PR DESCRIPTION
On datepickers on the deadline page, add a little colorful Bootstrap
label with a glyphicon that indicates how far away the selected time is
from now, which will alert users about dates more than 120 days in the
past or future and otherwise indicate whether the date is in the past or
future.

Fixes #1700.

<img width="564" alt="screen shot 2017-11-05 at 3 53 50 pm" src="https://user-images.githubusercontent.com/3482833/32419096-af6695b6-c242-11e7-8895-d3be4717c2dd.png">
