### PR TITLE
better admin bar to include user search

### DIFF
--- a/esp/esp/themes/theme_data/barebones/templates/sidebar/admin.html
+++ b/esp/esp/themes/theme_data/barebones/templates/sidebar/admin.html
@@ -1,0 +1,28 @@
+<li class="hidden nav-header admin">Admin</li>
+
+<li class="admin hidden"><a href="/admin/">
+  <i class="icon-cog"></i> Admin Home
+</a></li>
+<li class="admin hidden"><a href="/manage/programs/">
+  <i class="icon-time"></i> Programs
+</a></li>
+<li class="admin hidden"><a href="/admin/filebrowser/browse/">
+  <i class="icon-film"></i> Media Files
+</a></li>
+<li class="admin hidden"><a href="/themes/">
+  <i class="icon-eye-open"></i> Themes
+</a></li>
+<li class="unmorph hidden"><a href="/myesp/switchback/">
+  <i class="icon-user"></i> Unmorph to <script type="text/javascript">document.write(esp_user.cur_retTitle);</script>
+</a></li>
+<li class="onsite hidden"><a href="/myesp/onsite/">
+  <i class="icon-pencil"></i> On-site Registration
+</a></li>
+<li class="admin hidden">
+  <a>
+    <i class="icon-user"></i> Find User
+  </a>
+  <form id="user_search_form" name="user_search_form" method="get" action="/manage/usersearch">
+    <input type="text" id="user_search_field" name="userstr" style="width: 180px;">
+  </form>
+</li>


### PR DESCRIPTION
Currently the barebones nav doesn't have user search. This will add that search feature into barebones nav. It is possible it should just be in the main template instead, but I'll let someone else who cares more about theme standardization decide on the default...

<img width="972" alt="screen shot 2018-01-14 at 6 07 56 pm" src="https://user-images.githubusercontent.com/6059772/34924054-ec949fec-f955-11e7-80c4-7136acad4c8f.png">
