### PR TITLE
CSS fix for student lottery progress bars

### DIFF
--- a/esp/templates/program/modules/studentregtwophase/studentregtwophase.html
+++ b/esp/templates/program/modules/studentregtwophase/studentregtwophase.html
@@ -34,6 +34,33 @@
     width: 40%; 
     padding-left: 1em;
 }
+
+/*from Bootstrap 3.3.7*/
+.progress {
+  overflow: hidden;
+  height: 20px;
+  margin-bottom: 20px;
+  background-color: #f5f5f5;
+  border-radius: 4px;
+  -webkit-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+
+.progress-bar {
+  float: left;
+  width: 0%;
+  height: 100%;
+  font-size: 12px;
+  line-height: 20px;
+  color: #fff;
+  text-align: center;
+  background-color: #337ab7;
+  -webkit-box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15);
+  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15);
+  -webkit-transition: width 0.6s ease;
+  -o-transition: width 0.6s ease;
+  transition: width 0.6s ease;
+}
 </style>
 {% endblock %}
 
@@ -68,8 +95,6 @@ recommend you have at least {{num_star}} classes starred for every priority slot
 </p>
 {% end_inline_program_qsd_block %}
 <div id="program_form">
-<!--I prefer the progress bars from this version, rather than those from v. 4 -willgearty-->
-<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
 <table cellpadding="3" style="width:100%;" class="fullwidth">
 <tr>
     <th colspan="3">

--- a/esp/templates/program/modules/studentregtwophase/studentregtwophase.html
+++ b/esp/templates/program/modules/studentregtwophase/studentregtwophase.html
@@ -5,8 +5,6 @@
 
 {% block stylesheets %}
 {{ block.super }}
-<!--I prefer the progress bars from this version, rather than those from v. 4 -willgearty-->
-<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
 <link rel="stylesheet" type="text/css" href="/media/styles/forms.css" />
 <style>
 .button {
@@ -70,6 +68,8 @@ recommend you have at least {{num_star}} classes starred for every priority slot
 </p>
 {% end_inline_program_qsd_block %}
 <div id="program_form">
+<!--I prefer the progress bars from this version, rather than those from v. 4 -willgearty-->
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
 <table cellpadding="3" style="width:100%;" class="fullwidth">
 <tr>
     <th colspan="3">

--- a/esp/templates/program/modules/studentregtwophase/studentregtwophase.html
+++ b/esp/templates/program/modules/studentregtwophase/studentregtwophase.html
@@ -5,6 +5,8 @@
 
 {% block stylesheets %}
 {{ block.super }}
+<!--I prefer the progress bars from this version, rather than those from v. 4 -willgearty-->
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
 <link rel="stylesheet" type="text/css" href="/media/styles/forms.css" />
 <style>
 .button {
@@ -93,7 +95,7 @@ recommend you have at least {{num_star}} classes starred for every priority slot
         <td style="vertical-align: top !important;">
             <div class="progress-custom">
                 <div class="progress">
-                    <div class="bar" role="progressbar" aria-valuenow="{{star_count}}" aria-valuemin="0" aria-valuemax="{{num_star}}" style="width: {{perc_star}}%;"></div>
+                    <div class="progress-bar" role="progressbar" aria-valuenow="{{star_count}}" aria-valuemin="0" aria-valuemax="{{num_star}}" style="width: {{perc_star}}%;"></div>
                 </div>
                 <div class="progress-value">
                     ({{star_count}}/{{num_star}} starred classes)


### PR DESCRIPTION
I realized that the original class (`bar`) I was using was theme specific, so I've fixed it to use the up-to-date bootstrap class (`progress-bar`).