### PR TITLE
Display program name in some error pages

### DIFF
--- a/esp/esp/program/modules/base.py
+++ b/esp/esp/program/modules/base.py
@@ -538,7 +538,10 @@ def meets_grade(method):
         cur_grade = request.user.getGrade(moduleObj.program)
         if cur_grade != 0 and (cur_grade < moduleObj.program.grade_min or \
                                cur_grade > moduleObj.program.grade_max):
-            return render_to_response(errorpage, request, {'yog': request.user.getYOG(moduleObj.program)})
+            return render_to_response(errorpage, request, {
+                    'program': moduleObj.program,
+                    'yog': request.user.getYOG(moduleObj.program),
+                })
 
         return method(moduleObj, request, tl, *args, **kwargs)
 

--- a/esp/templates/errors/program/deadline-learn.html
+++ b/esp/templates/errors/program/deadline-learn.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 
-<h1>Student Registration Closed</h1>
+<h1>{{ moduleObj.program.niceName }} Student Registration Closed</h1>
 
 <strong>
 <p>

--- a/esp/templates/errors/program/deadline-teach.html
+++ b/esp/templates/errors/program/deadline-teach.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 
-<h1>Teacher Registration Closed</h1>
+<h1>{{ moduleObj.program.niceName }} Teacher Registration Closed</h1>
 
 <strong>
 <p>

--- a/esp/templates/errors/program/deadline-volunteer.html
+++ b/esp/templates/errors/program/deadline-volunteer.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 
-<h1>Volunteer Registration Closed</h1>
+<h1>{{ moduleObj.program.niceName }} Volunteer Registration Closed</h1>
 
 <strong>
 <p>

--- a/esp/templates/errors/program/wronggrade.html
+++ b/esp/templates/errors/program/wronggrade.html
@@ -1,10 +1,10 @@
 {% extends "main.html" %}
 
-{% block title %}{{prog.niceName }} Student Registration{% endblock %}
+{% block title %}{{ program.niceName }} Student Registration{% endblock %}
 
 {% block content %}
 
-<h1>{{prog.niceName }} Student Registration&mdash; Error</h1>
+<h1>{{ program.niceName }} Student Registration&mdash; Error</h1>
 
 <p>
 Not in the correct grade for this program.


### PR DESCRIPTION
Display the program name in Deadline Closed and Wrong Grade error pages.
This makes it easier for users (or us) to notice when they accidentally
visit last year's program instead of this year's.

Tangentially related to #2455?