### PR TITLE
Bump django version

### DIFF
--- a/esp/requirements.txt
+++ b/esp/requirements.txt
@@ -1,5 +1,5 @@
 # Django
-Django==1.8.15
+Django==1.8.19
 
 # Django-specific packages
 git+https://github.com/luac/django-argcache.git@0.1 # Handles caching


### PR DESCRIPTION
This contains some minor security fixes; nothing that looks particularly interesting but always a good idea to have.  The main change is actually on dev servers; I think our default settings should continue to work
fine.  See https://docs.djangoproject.com/en/1.11/releases/1.8.16/#dns-rebinding-vulnerability-when-debug-true for details.

Fixes #2513.