### PR TITLE
Fixes to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ pre:
 	@echo "Backing things up and fixing permissions."
 	@# get credentials, if we lack them, before we try to do anything fancy with pipes
 	sudo -v
-        @# We might not have write permissions on the homedir, but www-data should.
-        sudo -u postgres pg_dump $(SITE)_django | gzip | sudo -u www-data tee $(SITE)_$(shell date +"%Y%m%d").sql.gz >/dev/null
+	@# We might not have write permissions on the homedir, but www-data should.
+	set -o pipefail; sudo -u postgres pg_dump $(SITE)_django | gzip | sudo -u www-data tee $(SITE)_$(shell date +"%Y%m%d").sql.gz >/dev/null
 	-sudo chown -RL "www-data:www-data" .
 
 src:


### PR DESCRIPTION
The main fix here, to #2508, is to `set -o pipefail` where we have a
nontrivial pipeline, so that if the first command (the `pg_dump`) fails,
at least we'll obviously crash.  In the past it would just silently fail
and continue working, which is bad since then we have no db dump.

While I was in the area I also converted some tabs to spaces, because
`make` is really just happier with tabs.