### PR TITLE
Explicitly order sections to make sure index() is stable

### DIFF
--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -1320,7 +1320,9 @@ class ClassSubject(models.Model, CustomFormsLinkModel):
 
     def get_sections(self):
         if not hasattr(self, "_sections") or self._sections is None:
-            self._sections = self.sections.all()
+            # We explicitly order by ID to make sure we get reproducible
+            # ordering for e.g. index().
+            self._sections = self.sections.order_by('id')
 
         return self._sections
 


### PR DESCRIPTION
I'm amazed this has ever worked right, but I guess in the past postgres
has mostly ordered consistently; apparently in whatever version MIT ESP
is using (9.6, I think) it doesn't.  Anyway, this is definitely safer.

Hopefully fixes #2505.