### PR TITLE
Fix error in lunch constraint generation

### DIFF
--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -1633,7 +1633,13 @@ class BooleanExpression(models.Model):
     @cache_function
     def get_stack(self):
         return [s.subclass_instance() for s in self.booleantoken_set.all().order_by('seq')]
+    # Sadly, the way django signals work, we have to depend on every subclass
+    # of BooleanToken, not just BooleanToken itself.
     get_stack.depend_on_row('program.BooleanToken', lambda token: {'self': token.exp})
+    get_stack.depend_on_row('program.ScheduleTestTimeblock', lambda token: {'self': token.exp})
+    get_stack.depend_on_row('program.ScheduleTestOccupied', lambda token: {'self': token.exp})
+    get_stack.depend_on_row('program.ScheduleTestCategory', lambda token: {'self': token.exp})
+    get_stack.depend_on_row('program.ScheduleTestSectionList', lambda token: {'self': token.exp})
 
     def reset(self):
         self.booleantoken_set.all().delete()

--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -674,7 +674,13 @@ class Program(models.Model, CustomFormsLinkModel):
     def getScheduleConstraints(self):
         return ScheduleConstraint.objects.filter(program=self).select_related()
     getScheduleConstraints.depend_on_model('program.ScheduleConstraint')
+    # Sadly, the way django signals work, we have to depend on every subclass
+    # of BooleanToken, not just BooleanToken itself.
     getScheduleConstraints.depend_on_model('program.BooleanToken')
+    getScheduleConstraints.depend_on_model('program.ScheduleTestTimeblock')
+    getScheduleConstraints.depend_on_model('program.ScheduleTestOccupied')
+    getScheduleConstraints.depend_on_model('program.ScheduleTestCategory')
+    getScheduleConstraints.depend_on_model('program.ScheduleTestSectionList')
 
     def lock_schedule(self, lock_level=1):
         """ Locks all schedule assignments for the program, for convenience
@@ -1569,7 +1575,13 @@ class BooleanToken(models.Model):
     @cache_function
     def subclass_instance(self):
         return get_subclass_instance(BooleanToken, self)
+    # Sadly, the way django signals work, we have to depend on every subclass
+    # of BooleanToken, not just BooleanToken itself.
     subclass_instance.depend_on_row('program.BooleanToken', lambda bt: {'self': bt})
+    subclass_instance.depend_on_row('program.ScheduleTestTimeblock', lambda bt: {'self': bt})
+    subclass_instance.depend_on_row('program.ScheduleTestOccupied', lambda bt: {'self': bt})
+    subclass_instance.depend_on_row('program.ScheduleTestCategory', lambda bt: {'self': bt})
+    subclass_instance.depend_on_row('program.ScheduleTestSectionList', lambda bt: {'self': bt})
 
     @staticmethod
     def evaluate(stack, *args, **kwargs):


### PR DESCRIPTION
This fixes #2510, a nasty bug in lunch constraint generation, which has
been around forever but formerly was masked by postgres being fairly
stable about ordering in practice.  In particular, the constraints were
generated with several duplicate `seq` values rather than each token
having a distinct `seq`.

The underlying issue was that `BooleanExpression.get_stack()` is cached,
and the cache wasn't being expired when new tokens were added, because
apparently `depend_on_row` doesn't work correctly for subclasses --
django only sends the signal for the exact model class being written,
not the subclasses, it seems.  This meant that sometimes when tokens
were added, they wouldn't see the preceding token, because they would
get a cached value of `get_stack()` generated before the previous token
was added.

The fix -- not the nicest but it should work -- is to just explicitly
depend on every subclass.  Luckily this seems to be the only cache that
depends on `BooleanToken`, so I didn't have to change it anywhere else.

I tested this by regenerating some lunch constraints on my dev server;
they now have distinct `seq`s for every token within each expression,
and the ordering looks correct to me.