### PR TITLE
Aligned Log in and Sign up buttons

### DIFF
--- a/esp/esp/themes/theme_data/fruitsalad/less/main.less
+++ b/esp/esp/themes/theme_data/fruitsalad/less/main.less
@@ -487,12 +487,13 @@ position: absolute;
 top: 9px; right: 48px;
 height: 21px; width: 45px;
 font-size: 10.5px;
-padding-right: 15px;
 border-radius: 0px;
 color: white;
 border: none;
 cursor: pointer;
 z-index: 0;
+padding: 0px;
+text-align: left;
 }
 
 #login_arrow1 {

--- a/esp/esp/themes/theme_data/fruitsalad/templates/bubblesfront.html
+++ b/esp/esp/themes/theme_data/fruitsalad/templates/bubblesfront.html
@@ -19,7 +19,6 @@
 {{ block.super }}
 <script type="text/javascript">
 window.onload = function(){
-
 // create behavior wrapper
 var wrap = function(target, label) {
   var flag = false;
@@ -37,13 +36,10 @@ var wrap = function(target, label) {
   };
   target.onblur();
 };
-
 // set behavior on Username, Password, and Search fields
 wrap(document.getElementById('login_user_index'),'Username');
 wrap(document.getElementById('login_pswd_index'),'Password');
-
 };
-
 function set_teachlearn(tl) {
 if (document.getElementById('remember').checked) {
 document.cookie = 'teachlearn=' + tl + '; expires=' + new Date("January 1, 2025").toGMTString() + '; path=/';
@@ -81,7 +77,7 @@ document.cookie = 'teachlearn=' + tl + '; expires=' + new Date("January 1, 2025"
   <input type="text" id="login_user_index" name="username"/>
   <input type="password" id="login_pswd_index" name="password" />
   <span id="login_arrow1"></span>
-  <input type="submit" id="login_submit" name="login_submit" value="Log in" />
+  <input type="submit" style="padding:0px;text-align:left;" id="login_submit" name="login_submit" value=" Log in" />
   <span id="login_arrow2"></span>
   <a href="/myesp/register" id="login_signup">Sign up</a>
   <a href="/myesp/loginhelp.html" id="login_help_index">need help?</a>

--- a/esp/esp/themes/theme_data/fruitsalad/templates/bubblesfront.html
+++ b/esp/esp/themes/theme_data/fruitsalad/templates/bubblesfront.html
@@ -19,6 +19,7 @@
 {{ block.super }}
 <script type="text/javascript">
 window.onload = function(){
+
 // create behavior wrapper
 var wrap = function(target, label) {
   var flag = false;
@@ -36,10 +37,13 @@ var wrap = function(target, label) {
   };
   target.onblur();
 };
+
 // set behavior on Username, Password, and Search fields
 wrap(document.getElementById('login_user_index'),'Username');
 wrap(document.getElementById('login_pswd_index'),'Password');
+
 };
+
 function set_teachlearn(tl) {
 if (document.getElementById('remember').checked) {
 document.cookie = 'teachlearn=' + tl + '; expires=' + new Date("January 1, 2025").toGMTString() + '; path=/';
@@ -77,7 +81,7 @@ document.cookie = 'teachlearn=' + tl + '; expires=' + new Date("January 1, 2025"
   <input type="text" id="login_user_index" name="username"/>
   <input type="password" id="login_pswd_index" name="password" />
   <span id="login_arrow1"></span>
-  <input type="submit" style="padding:0px;text-align:left;" id="login_submit" name="login_submit" value=" Log in" />
+  <input type="submit" id="login_submit" name="login_submit" value="Log in" />
   <span id="login_arrow2"></span>
   <a href="/myesp/register" id="login_signup">Sign up</a>
   <a href="/myesp/loginhelp.html" id="login_help_index">need help?</a>

--- a/esp/esp/themes/theme_data/fruitsalad/templates/main.html
+++ b/esp/esp/themes/theme_data/fruitsalad/templates/main.html
@@ -139,7 +139,7 @@ var currentProgram = undefined;
   <input type="text" id="login_user" name="username" />
   <input type="password" id="login_pswd" name="password" />
   <span id="login_arrow1"></span>
-  <input type="submit" style="padding:0px;text-align:left;" id="login_submit" name="login_submit" value=" Log in" />
+  <input type="submit" id="login_submit" name="login_submit" value="Log in" />
   <span id="login_arrow2"></span>
   <a href="/myesp/register" id="login_signup">Sign up</a>
   <a href="/myesp/loginhelp.html" id="login_help">need help?</a>

--- a/esp/esp/themes/theme_data/fruitsalad/templates/main.html
+++ b/esp/esp/themes/theme_data/fruitsalad/templates/main.html
@@ -35,7 +35,6 @@
 }
 #submenu {
   width: 600px;
-
 }
 #submenu li {
   display: inline;
@@ -140,7 +139,7 @@ var currentProgram = undefined;
   <input type="text" id="login_user" name="username" />
   <input type="password" id="login_pswd" name="password" />
   <span id="login_arrow1"></span>
-  <input type="submit" id="login_submit" name="login_submit" value="Log in" />
+  <input type="submit" style="padding:0px;text-align:left;" id="login_submit" name="login_submit" value=" Log in" />
   <span id="login_arrow2"></span>
   <a href="/myesp/register" id="login_signup">Sign up</a>
   <a href="/myesp/loginhelp.html" id="login_help">need help?</a>


### PR DESCRIPTION
Fixes issue #2479. Just added a style tag to the log in button removing the padding and thus align it with the sign up button.

Note that it seems template overrides are automatically created when the theme is set, so anyone who actually wants this change will have to fix this in their own template overrides on their sites (I think).