### PR TITLE
add ndmin parameter for corner case in import_assignments in lottery.py

### DIFF
--- a/esp/esp/program/controllers/lottery.py
+++ b/esp/esp/program/controllers/lottery.py
@@ -767,9 +767,12 @@ class LotteryAssignmentController(object):
         if len(data_parts) != 3:
             raise ValueError('provided lottery_data is corrupted (doesn\'t contain three parts)')
 
-        self.student_sections = numpy.loadtxt(StringIO(data_parts[0]))
-        self.student_ids = numpy.loadtxt(StringIO(data_parts[1]))
-        self.section_ids = numpy.loadtxt(StringIO(data_parts[2]))
+        # ndmin is for corner cases where one of the array dimensions is 1.  If you don't include the ndmin parameter,
+        # then "mono-dimensional axes will be squeezed" (see the numpy documentation), and the resulting array
+        # would not have the right shape.
+        self.student_sections = numpy.loadtxt(StringIO(data_parts[0]), ndmin=2)
+        self.student_ids = numpy.loadtxt(StringIO(data_parts[1]), ndmin=1)
+        self.section_ids = numpy.loadtxt(StringIO(data_parts[2]), ndmin=1)
 
     def clear_mailman_list(self, list_name):
         contents = list_contents(list_name)


### PR DESCRIPTION
If there is only one student or section, then the import_assignements lottery.py fails because numpy.loadtxt generates an array with the wrong number of dimensions (one fewer than expected).  

This likely wouldn't occur in a real program, but I discovered it while testing the lottery module on stanford-sr8 with a small amount of data.

This is fixed by specifying the parameter ndmin to force numpy.loadtxt to produce an array with the right number of dimensions (see documentation here: https://docs.scipy.org/doc/numpy-1.14.0/reference/generated/numpy.loadtxt.html )

 