### PR TITLE
add default loginhelp page

### DIFF
--- a/esp/esp/users/urls.py
+++ b/esp/esp/users/urls.py
@@ -5,6 +5,7 @@ from esp.users.views.registration import GradeChangeRequestView
 from esp.web.views import bio
 from esp.web.views import main
 from esp.web.views import myesp
+from django.views.generic import TemplateView
 
 urlpatterns = [
     url(r'^register/?$', views.user_registration_phase1,
@@ -25,6 +26,7 @@ urlpatterns = [
     url(r'^disableaccount/?$', views.disable_account),
     url(r'^grade_change_request/?$', GradeChangeRequestView.as_view(), name = 'grade_change_request'),
     url(r'^makeadmin/?$', views.make_admin),
+    url(r'^loginhelp', TemplateView.as_view(template_name='users/loginhelp.html'), name='Login Help'),
     url(r'^morph/?$', views.morph_into_user),
 ]
 

--- a/esp/templates/users/loginhelp.html
+++ b/esp/templates/users/loginhelp.html
@@ -34,7 +34,7 @@ If you do not have access to that email account anymore, [send us an email][3].
 password recovery), then chances our your browser doesn't support [cookies][1].
 Please visit [Google's guide to cookies][1].
 
-- If you've gone to the password reset page but you haven't received the rese
+- If you've gone to the password reset page but you haven't received the reset
 email, it's likely that the automatic message sent by our website with a link
 to creating a new password may have been marked as spam by your email client.
 Please check your spam folder.

--- a/esp/templates/users/loginhelp.html
+++ b/esp/templates/users/loginhelp.html
@@ -1,0 +1,50 @@
+{% extends "main.html" %}
+
+{% block title %}Login Help{% endblock %}
+{% block content_title %}Login Help{% endblock %}
+
+{% block content %}
+
+{% load render_qsd %}
+
+{% inline_qsd_block ''loginhelp'' %}
+
+
+Login Help
+===============
+
+##Welcome!##
+
+In order to join {{ settings.INSTITUTION_NAME }}
+{{ settings.ORGANIZATION_SHORT_NAME }}, you first need to log on to this web
+site.
+If you have not already done so, please
+[create an account](/myesp/register/ "Join {{ settings.ORGANIZATION_SHORT_NAME }}!") now.
+Note: Creating an account does *not* register you for any programs.
+
+
+
+- If you've forgotten my username/password, you can use our
+[password reset page][2] as long as you still have access to the email you
+used to register.
+The reset will remind you of your username and ask you to reset your password.
+If you do not have access to that email account anymore, [send us an email][3].
+
+- If you tried logging in and it says my password is invalid (even after
+password recovery), then chances our your browser doesn't support [cookies][1].
+Please visit [Google's guide to cookies][1].
+
+- If you've gone to the password reset page but you haven't received the rese
+email, it's likely that the automatic message sent by our website with a link
+to creating a new password may have been marked as spam by your email client.
+Please check your spam folder.
+
+
+
+
+[1]: http://www.google.com/cookies.html "Enabling cookies in your browser."
+[2]: /myesp/passwdrecover/
+[3]: mailto:{{ DEFAULT_EMAIL_ADDRESSES.support }}
+
+{% end_inline_qsd_block %}
+{% endblock %}

--- a/esp/templates/users/loginhelp.html
+++ b/esp/templates/users/loginhelp.html
@@ -24,13 +24,13 @@ Note: Creating an account does *not* register you for any programs.
 
 
 
-- If you've forgotten my username/password, you can use our
+- If you've forgotten your username/password, you can use our
 [password reset page][2] as long as you still have access to the email you
 used to register.
 The reset will remind you of your username and ask you to reset your password.
 If you do not have access to that email account anymore, [send us an email][3].
 
-- If you tried logging in and it says my password is invalid (even after
+- If you tried logging in and it says your password is invalid (even after
 password recovery), then chances our your browser doesn't support [cookies][1].
 Please visit [Google's guide to cookies][1].
 


### PR DESCRIPTION
There are a few spots (such as "need help?" or "login help" link under the log / sign up buttons) that links to this page /myesp/loginhelp.html, but that page does not exist by default. This creates a default page that admins can modify.