### PR TITLE
Functionality to scan barcodes with device's camera

### DIFF
--- a/esp/templates/program/modules/onsitecheckinmodule/barcodecheckin.html
+++ b/esp/templates/program/modules/onsitecheckinmodule/barcodecheckin.html
@@ -73,73 +73,66 @@
 <h1>Barcode Checkin &mdash; For {{ program.niceName }}</h1>
 
 <div id='program_form'>
+    <p>
+    Welcome to barcode check-in for {{ program.niceName }}.  Please enter a list of user IDs.
+    </p>
 
-<p>
-Welcome to barcode check-in for {{ program.niceName }}.  Please enter a list of user IDs.
-</p>
+    {% if results %}
+    <p>
+    Checked in {{ results.new|length }} students.  {{ results.not_found|length }} students were not found, {{ results.existing|length }} students were already checked in, and {{ results.not_student|length }} IDs did not correspond to students.
+    </p>
+    {% if results.not_found %}
+    <p>
+    Students not found:
+    {% for id in results.not_found %}
+    {{ id }}{% if not forloop.last %},{% endif %}
+    {% endfor %}
+    </p>
+    {% endif %}
+    {% if results.not_student %}
+    <p>
+    IDs not corresponding to students:
+    {% for id in results.not_student %}
+    {{ id }}{% if not forloop.last %},{% endif %}
+    {% endfor %}
+    </p>
+    {% endif %}
+    {% comment %}
+    {% if results.existing %}
+    <p>
+    IDs already checked in:
+    {% for id in results.existing %}
+    {{ id }}{% if not forloop.last %},{% endif %}
+    {% endfor %}
+    </p>
+    {% endif %}
+    {% endcomment %}
+    {% endif %}
 
-{% if results %}
-<p>
-Checked in {{ results.new|length }} students.  {{ results.not_found|length }} students were not found, {{ results.existing|length }} students were already checked in, and {{ results.not_student|length }} IDs did not correspond to students.
-</p>
-{% if results.not_found %}
-<p>
-Students not found:
-{% for id in results.not_found %}
-{{ id }}{% if not forloop.last %},{% endif %}
-{% endfor %}
-</p>
-{% endif %}
-{% if results.not_student %}
-<p>
-IDs not corresponding to students:
-{% for id in results.not_student %}
-{{ id }}{% if not forloop.last %},{% endif %}
-{% endfor %}
-</p>
-{% endif %}
-{% comment %}
-{% if results.existing %}
-<p>
-IDs already checked in:
-{% for id in results.existing %}
-{{ id }}{% if not forloop.last %},{% endif %}
-{% endfor %}
-</p>
-{% endif %}
-{% endcomment %}
-{% endif %}
+    <form id="checkinform" name="checkinform" method="POST" action="{{ request.path }}">
+                        {{ form.as_p }}
+                        <p class="ids">
+                    <input type="submit" value="Submit" />
+                    </p>
+    </form>
 
-<form id="checkinform" name="checkinform" method="POST" action="{{ request.path }}">
-                    {{ form.as_p }}
-                    <p class="ids">
-                <input type="submit" value="Submit" />
-                </p>
-</form>
+    <br><br>
 
-<br><br>
-
-<div class="controls">
-    <button type="button" class="scan"><i class="fas fa-barcode"></i>&ensp;Scan barcodes with your device</button>
-    &emsp;
-    <select>
-        <option selected value="code_39_reader">Code 39</option>
-        <option value="codabar_reader">Codabar</option>
-        <option value="code_128_reader">Code 128</option>
-        <option value="i2of5_reader">Interleaved 2 of 5</option>
-    </select>
-</div>
-<div class="overlay overlay--inline">
-    <div class="overlay__content viewport" id="interactive">
-        <div class="overlay__close">X</div>
+    <div class="controls">
+        <button type="button" class="scan"><i class="fas fa-barcode"></i>&ensp;Scan barcodes with your device</button>
+        &emsp;
+        <select>
+            <option selected value="code_39_reader">Code 39</option>
+            <option value="codabar_reader">Codabar</option>
+            <option value="code_128_reader">Code 128</option>
+            <option value="i2of5_reader">Interleaved 2 of 5</option>
+        </select>
     </div>
-</div>
-
-<!--<br />
-{% load render_qsd %}
-{% render_inline_program_qsd program "onsite:status" %}-->
-
-
+    <div class="overlay overlay--inline">
+        <div class="overlay__content viewport" id="interactive">
+            <div class="overlay__close">X</div>
+        </div>
+    </div>
 </div>
 
 <script type="text/javascript">
@@ -165,13 +158,11 @@ $j(function() {
                 }.bind(this),
                 stop = function() {
                     Quagga.stop();
-                    console.log("Scanner stopped")
                     this.hideOverlay();
                     this.attachListeners();
                 }.bind(this);
 
             this.showOverlay(stop);
-            console.log("Activating Scanner");
             var video = document.querySelector('.overlay__content > video');
             video.setAttribute("autoplay", true);
             video.setAttribute('muted', true);
@@ -197,7 +188,6 @@ $j(function() {
                       return
                   }
                   Quagga.start();
-                  console.log("Initialization finished. Ready to start");
               });
             return scanner;
         },

--- a/esp/templates/program/modules/onsitecheckinmodule/barcodecheckin.html
+++ b/esp/templates/program/modules/onsitecheckinmodule/barcodecheckin.html
@@ -5,16 +5,66 @@
 {% block stylesheets %}
     {{ block.super }}
     <link rel='stylesheet' type='text/css' href='/media/styles/forms.css' />
+    <link rel="stylesheet" type='text/css' href="https://use.fontawesome.com/releases/v5.0.9/css/all.css">
 {% endblock %}
 
 {% block content %}
 <style type="text/css">
 .nocheckmark { border: 1px solid black; }
-</style>
-<br />
-<br />
 
-<br /><br />
+/* Controls */
+
+.overlay__close {
+    position: absolute;
+    right: 0;
+    padding: 0.5rem;
+    width: 2rem;
+    height: 2rem;
+    line-height: 2rem;
+    text-align: center;
+    background-color: white;
+    cursor: pointer;
+    border: 3px solid black;
+    font-size: 1.5rem;
+    margin: -1rem;
+    border-radius: 2rem;
+    z-index: 100;
+    box-sizing: content-box;
+}
+
+/* Scan! Button */
+
+.scan {
+    font-size: large;
+    padding: 0.5rem;
+    text-align: center;
+    display: inline;
+}
+
+/* Reader Dropdown */
+
+.controls select {
+    font-size: large !important;
+    margin: auto;
+    height: auto !important;
+}
+
+.controls.hide {
+    display: none;
+}
+
+.overlay--inline {
+    position: absolute;
+    display: none;
+}
+
+.overlay--inline.show {
+    display: block;
+}
+</style>
+
+<script src="https://cdn.rawgit.com/serratus/quaggaJS/1.0/dist/quagga.min.js"></script>
+
 <h1>Barcode Checkin &mdash; For {{ program.niceName }}</h1>
 
 <div id='program_form'>
@@ -57,17 +107,137 @@ IDs already checked in:
 
 <form id="checkinform" name="checkinform" method="POST" action="{{ request.path }}">
                     {{ form.as_p }}
-                    <p>
+                    <p class="ids">
                 <input type="submit" value="Submit" />
                 </p>
 </form>
 
-<br />
+<br><br>
+
+<div class="controls">
+    <button type="button" class="scan"><i class="fas fa-barcode"></i>&ensp;Scan barcodes with your device</button>
+    &emsp;
+    <select>
+        <option selected value="code_39_reader">Code 39</option>
+        <option value="codabar_reader">Codabar</option>
+        <option value="code_128_reader">Code 128</option>
+        <option value="i2of5_reader">Interleaved 2 of 5</option>
+    </select>
+</div>
+<div class="overlay overlay--inline">
+    <div class="overlay__content">
+        <div class="overlay__close">X</div>
+    </div>
+</div>
+
+<!--<br />
 {% load render_qsd %}
-{% render_inline_program_qsd program "onsite:status" %}
+{% render_inline_program_qsd program "onsite:status" %}-->
 
 
 </div>
+
+<script type="text/javascript">
+var Quagga = window.Quagga;
+var App = {
+    _lastResult: null,
+    init: function() {
+        this.attachListeners();
+    },
+    activateScanner: function() {
+        var scanner = this.configureScanner('.overlay__content'),
+            onDetected = function (result) {
+                this.addToResults(result);
+            }.bind(this),
+            stop = function() {
+                scanner.stop();  // should also clear all event-listeners?
+                scanner.removeEventListener('detected', onDetected);
+                this.hideOverlay();
+                this.attachListeners();
+            }.bind(this);
+
+        this.showOverlay(stop);
+        console.log("activateScanner");
+        scanner.addEventListener('detected', onDetected).start();
+        var video = document.querySelector('.overlay__content > video');
+        // this supposedly makes this work for iOS 11
+        video.setAttribute("autoplay", true);
+        video.setAttribute('muted', true);
+        video.setAttribute('playsinline', true);
+    },
+    addToResults: function(result) {
+        if (this._lastResult === result.codeResult.code) {
+            return;
+        }
+        this._lastResult = result.codeResult.code;
+        var results = document.querySelector('#checkinform > p > textarea')
+        
+        results.value += "\n" + result.codeResult.code
+        
+        // var results = document.querySelector('ul.results'),
+        //    li = document.createElement('li'),
+        //    format = document.createElement('span'),
+        //    code = document.createElement('span');
+
+        // li.className = "result";
+        // format.className = "format";
+        // code.className = "code";
+
+        // li.appendChild(format);
+        // li.appendChild(code);
+
+        // format.appendChild(document.createTextNode(result.codeResult.format));
+        // code.appendChild(document.createTextNode(result.codeResult.code));
+
+        // results.insertBefore(li, results.firstChild);
+    },
+    attachListeners: function() {
+        var button = document.querySelector('button.scan'),
+            self = this;
+
+        button.addEventListener("click", function clickListener (e) {
+            e.preventDefault();
+            button.removeEventListener("click", clickListener);
+            self.activateScanner();
+        });
+    },
+    showOverlay: function(cancelCb) {
+        document.querySelector('.controls')
+            .classList.add('hide');
+        document.querySelector('.overlay--inline')
+            .classList.add('show');
+        var closeButton = document.querySelector('.overlay__close');
+        closeButton.addEventListener('click', function closeHandler() {
+            closeButton.removeEventListener("click", closeHandler);
+            cancelCb();
+        });
+    },
+    hideOverlay: function() {
+        document.querySelector('.controls')
+            .classList.remove('hide');
+        document.querySelector('.overlay--inline')
+            .classList.remove('show');
+    },
+    querySelectedReaders: function() {
+        return Array(document.querySelector('.controls select').value);
+    },
+    configureScanner: function(selector) {
+        var scanner = Quagga
+            .decoder({readers: this.querySelectedReaders()})
+            .locator({patchSize: 'medium'})
+            .fromSource({
+                target: selector,
+                constraints: {
+                    width: 600,
+                    height: 600,
+                    facingMode: "environment"
+                }
+            });
+        return scanner;
+    }
+};
+App.init();
+</script>
 
 
 {% endblock %}

--- a/esp/templates/program/modules/onsitecheckinmodule/barcodecheckin.html
+++ b/esp/templates/program/modules/onsitecheckinmodule/barcodecheckin.html
@@ -61,9 +61,14 @@
 .overlay--inline.show {
     display: block;
 }
+
+#interactive.viewport canvas.drawingBuffer, video.drawingBuffer {
+  margin-left: -640px;
+}
 </style>
 
-<script src="https://cdn.rawgit.com/serratus/quaggaJS/1.0/dist/quagga.min.js"></script>
+<script src="https://webrtc.github.io/adapter/adapter-latest.js" type="text/javascript"></script>
+<script src="https://cdn.rawgit.com/serratus/quaggaJS/master/dist/quagga.min.js"></script>
 
 <h1>Barcode Checkin &mdash; For {{ program.niceName }}</h1>
 
@@ -125,7 +130,7 @@ IDs already checked in:
     </select>
 </div>
 <div class="overlay overlay--inline">
-    <div class="overlay__content">
+    <div class="overlay__content viewport" id="interactive">
         <div class="overlay__close">X</div>
     </div>
 </div>
@@ -138,88 +143,101 @@ IDs already checked in:
 </div>
 
 <script type="text/javascript">
-var Quagga = window.Quagga;
-var App = {
-    _lastResult: null,
-    init: function() {
-        this.attachListeners();
-    },
-    activateScanner: function() {
-        var scanner = this.configureScanner('.overlay__content'),
-            onDetected = function (result) {
-                this.addToResults(result);
-            }.bind(this),
-            stop = function() {
-                scanner.stop();  // should also clear all event-listeners?
-                scanner.removeEventListener('detected', onDetected);
-                this.hideOverlay();
-                this.attachListeners();
-            }.bind(this);
+$j(function() {
+    var App = {
+        init: function() {
+            this.attachListeners();
+        },
+        attachListeners: function() {
+            var button = document.querySelector('button.scan'),
+                self = this;
 
-        this.showOverlay(stop);
-        console.log("activateScanner");
-        scanner.addEventListener('detected', onDetected).start();
-        var video = document.querySelector('.overlay__content > video');
-        // this supposedly makes this work for iOS 11
-        video.setAttribute("autoplay", true);
-        video.setAttribute('muted', true);
-        video.setAttribute('playsinline', true);
-    },
-    addToResults: function(result) {
-        if (this._lastResult === result.codeResult.code) {
-            return;
-        }
-        this._lastResult = result.codeResult.code;
-        var results = document.querySelector('#checkinform > p > textarea')
-        
-        results.value += "\n" + result.codeResult.code
-    },
-    attachListeners: function() {
-        var button = document.querySelector('button.scan'),
-            self = this;
-
-        button.addEventListener("click", function clickListener (e) {
-            e.preventDefault();
-            button.removeEventListener("click", clickListener);
-            self.activateScanner();
-        });
-    },
-    showOverlay: function(cancelCb) {
-        document.querySelector('.controls')
-            .classList.add('hide');
-        document.querySelector('.overlay--inline')
-            .classList.add('show');
-        var closeButton = document.querySelector('.overlay__close');
-        closeButton.addEventListener('click', function closeHandler() {
-            closeButton.removeEventListener("click", closeHandler);
-            cancelCb();
-        });
-    },
-    hideOverlay: function() {
-        document.querySelector('.controls')
-            .classList.remove('hide');
-        document.querySelector('.overlay--inline')
-            .classList.remove('show');
-    },
-    querySelectedReaders: function() {
-        return Array(document.querySelector('.controls select').value);
-    },
-    configureScanner: function(selector) {
-        var scanner = Quagga
-            .decoder({readers: this.querySelectedReaders()})
-            .locator({patchSize: 'medium'})
-            .fromSource({
-                target: selector,
-                constraints: {
-                    width: 600,
-                    height: 600,
-                    facingMode: "environment"
-                }
+            button.addEventListener("click", function clickListener (e) {
+                e.preventDefault();
+                button.removeEventListener("click", clickListener);
+                self.activateScanner();
             });
-        return scanner;
-    }
-};
-App.init();
+        },
+        activateScanner: function() {
+            var scanner = this.configureScanner('.overlay__content'),
+                onDetected = function (result) {
+                    this.addToResults(result);
+                }.bind(this),
+                stop = function() {
+                    Quagga.stop();
+                    console.log("Scanner stopped")
+                    this.hideOverlay();
+                    this.attachListeners();
+                }.bind(this);
+
+            this.showOverlay(stop);
+            console.log("Activating Scanner");
+            var video = document.querySelector('.overlay__content > video');
+            video.setAttribute("autoplay", true);
+            video.setAttribute('muted', true);
+            video.setAttribute('playsinline', true);
+        },
+        configureScanner: function(selector) {
+            var scanner = Quagga.init({
+                decoder: {
+                    readers: this.querySelectedReaders()
+                },
+                inputStream: {
+                    type : "LiveStream",
+                    constraints: {
+                        width: {min: 640},
+                        height: {min: 480},
+                        facingMode: "environment",
+                        aspectRatio: {min: 1, max: 2}
+                    }
+                },
+            }, function(err) {
+                  if (err) {
+                      console.log(err);
+                      return
+                  }
+                  Quagga.start();
+                  console.log("Initialization finished. Ready to start");
+              });
+            return scanner;
+        },
+        querySelectedReaders: function() {
+            return Array(document.querySelector('.controls select').value);
+        },
+        showOverlay: function(cancelCb) {
+            document.querySelector('.controls')
+                .classList.add('hide');
+            document.querySelector('.overlay--inline')
+                .classList.add('show');
+            var closeButton = document.querySelector('.overlay__close');
+            closeButton.addEventListener('click', function closeHandler() {
+                closeButton.removeEventListener("click", closeHandler);
+                cancelCb();
+            });
+        },
+        hideOverlay: function() {
+            document.querySelector('.controls')
+                .classList.remove('hide');
+            document.querySelector('.overlay--inline')
+                .classList.remove('show');
+        },
+        lastResult : null
+    };
+
+    App.init();
+
+    Quagga.onDetected(function(result) {
+        var code = result.codeResult.code;
+
+        if (App.lastResult !== code) {
+            App.lastResult = code;
+
+            var results = document.querySelector('#checkinform > p > textarea')
+            results.value += "\n" + code
+        }
+    });
+
+});
 </script>
 
 

--- a/esp/templates/program/modules/onsitecheckinmodule/barcodecheckin.html
+++ b/esp/templates/program/modules/onsitecheckinmodule/barcodecheckin.html
@@ -173,23 +173,6 @@ var App = {
         var results = document.querySelector('#checkinform > p > textarea')
         
         results.value += "\n" + result.codeResult.code
-        
-        // var results = document.querySelector('ul.results'),
-        //    li = document.createElement('li'),
-        //    format = document.createElement('span'),
-        //    code = document.createElement('span');
-
-        // li.className = "result";
-        // format.className = "format";
-        // code.className = "code";
-
-        // li.appendChild(format);
-        // li.appendChild(code);
-
-        // format.appendChild(document.createTextNode(result.codeResult.format));
-        // code.appendChild(document.createTextNode(result.codeResult.code));
-
-        // results.insertBefore(li, results.firstChild);
     },
     attachListeners: function() {
         var button = document.querySelector('button.scan'),


### PR DESCRIPTION
Fixes #2506.

Adds functionality to the barcode checkin page to allow a user to scan barcodes with their device's camera (specifically the rear-facing camera if there are two), which adds the user IDs to the text box as an external scanner would. The user can then submit these user IDs just as they normally would.

The javascript library ([quaggaJS](https://serratus.github.io/quaggaJS/)) has the potential to work with various types of barcodes, although I have found the most reliability with Code 39, Code 128, and other linear codes, hence these are the only implemented options at the moment. Furthermore, this library, as opposed to other libraries, is invariant to scale and rotation, allowing for more flexibility and efficiency.

This works on computers (PC, Mac, and presumably Linux), (recent) Android devices, and iOS 11. Full compatibility [here](https://caniuse.com/#feat=stream).