### PR TITLE
Made log in button not use custom font

### DIFF
--- a/esp/esp/themes/theme_data/fruitsalad/less/main.less
+++ b/esp/esp/themes/theme_data/fruitsalad/less/main.less
@@ -487,13 +487,15 @@ position: absolute;
 top: 9px; right: 48px;
 height: 21px; width: 45px;
 font-size: 10.5px;
+text-decoration: none;
 border-radius: 0px;
 color: white;
 border: none;
 cursor: pointer;
 z-index: 0;
 padding: 0px;
-text-align: left;
+padding-right: 10px;
+font-family: Arial, Lucida, Helvetica, sans-serif;
 }
 
 #login_arrow1 {


### PR DESCRIPTION
Fixes #2543.  Made the log in button not use the the custom font, mostly because I don't know how to make the sign in link use the custom font. Plus some of the sites have weird custom fonts that don't seem appropriate for log in/ sign up buttons anyhow.

Exacerbates issue #1342 though. But worth it for now until that gets fixed (probably never?).