### PR TITLE
Fix ordering of two-phase priorities

### DIFF
--- a/esp/esp/program/modules/handlers/studentregtwophase.py
+++ b/esp/esp/program/modules/handlers/studentregtwophase.py
@@ -102,7 +102,7 @@ class StudentRegTwoPhase(ProgramModuleObj):
         priority_regs = priority_regs.select_related(
             'relationship', 'section', 'section__parent_class')
         for student_reg in priority_regs:
-            rel = student_reg.relationship
+            rel = student_reg.relationship.name
             title = student_reg.section.parent_class.title
             sec = student_reg.section
             times = sec.meeting_times.all().order_by('start')
@@ -148,14 +148,12 @@ class StudentRegTwoPhase(ProgramModuleObj):
 
             if timeslot.id in timeslot_dict:
                 priority_dict = timeslot_dict[timeslot.id]
-                # (relationship, class_title) -> relationship.name
-                priority_list = sorted(priority_dict.items(), key=lambda item: item[0].name)
             else:
-                priority_list = []
+                priority_dict = {}
             temp_list = []
             for i in range(0, context['num_priority']):
-                if i < len(priority_list):
-                    temp_list.append(("Priority " + str(i + 1), priority_list[i][1]))
+                if "Priority/" + str(i + 1) in priority_dict:
+                    temp_list.append(("Priority " + str(i + 1), priority_dict["Priority/" + str(i + 1)]))
                 else:
                     temp_list.append(("Priority " + str(i + 1), ""))
             priority_list = temp_list

--- a/esp/esp/program/modules/handlers/studentregtwophase.py
+++ b/esp/esp/program/modules/handlers/studentregtwophase.py
@@ -151,11 +151,13 @@ class StudentRegTwoPhase(ProgramModuleObj):
             else:
                 priority_dict = {}
             temp_list = []
-            for i in range(0, context['num_priority']):
-                if "Priority/" + str(i + 1) in priority_dict:
-                    temp_list.append(("Priority " + str(i + 1), priority_dict["Priority/" + str(i + 1)]))
+            for i in range(1, context['num_priority'] + 1):
+                priority_name = 'Priority/%s' % i
+                reg_type = RegistrationType.objects.get(name = priority_name, category = "student")
+                if priority_name in priority_dict:
+                    temp_list.append((reg_type, priority_dict[priority_name]))
                 else:
-                    temp_list.append(("Priority " + str(i + 1), ""))
+                    temp_list.append((reg_type, ""))
             priority_list = temp_list
             star_count = 0
             if timeslot.id in star_counts:


### PR DESCRIPTION
Fixes #2552.

I wasn't able to replicate the odd behavior reported in #2552 on my dev server, but I replaced the old sorting behavior with a much better way of parsing through the priorities (using dictionary keys), which seems to be better nonetheless. It also fixed another bug that was introduced with #2425 where the priorities would shift upwards (in priority number) if there were skipped priority levels (in other words, if a student had set Priority/1 and Priority/3, they would be displayed as Priority/1 and Priority/2). This is also fixed by the new implementation.

![image](https://user-images.githubusercontent.com/7232514/38887041-886de62a-422c-11e8-9128-c28f25a95669.png)