### PR TITLE
Check in student immediately upon scanning

### DIFF
--- a/docs/admin/releases/11/README.rst
+++ b/docs/admin/releases/11/README.rst
@@ -13,4 +13,5 @@ Minor new features and fixes
 - Can now modify resource choices from the resources management module
 - There is now a default login help page /myesp/loginhelp.html that admins can modify.
 - For chapters that use barcodes for student check-in, the barcodes can now be scanned
-  in using your device's camera, so a physical barcode scanner is no longer needed.
+  in using your device's camera, so a physical barcode scanner is no longer needed. The
+  default behavior is to check-in the student automatically upon each successful scan.

--- a/esp/esp/program/modules/handlers/onsitecheckinmodule.py
+++ b/esp/esp/program/modules/handlers/onsitecheckinmodule.py
@@ -210,7 +210,34 @@ class OnSiteCheckinModule(ProgramModuleObj):
         context['results'] = results
         return render_to_response(self.baseDir()+'barcodecheckin.html', request, context)
 
-
+    @aux_call
+    @needs_onsite
+    def ajaxbarcodecheckin(self, request, tl, one, two, module, extra, prog):
+        """
+        POST to this view to check-in a student with a user ID.
+        POST data:
+          'code':          The student's ID.
+        """
+        json_data = {}
+        if request.method == 'POST' and 'code' in request.POST:
+            code = request.POST['code']
+            students = ESPUser.objects.filter(id=code)
+            if not students.exists():
+                json_data['message'] = '%s is not a user!' % code
+            else:
+                student = students[0]
+                info_string = student.name() + " (" + str(code) + ")"
+                if student.isStudent():
+                    existing = Record.user_completed(student, 'attended', prog)
+                    if existing:
+                        json_data['message'] = '%s is already checked in!' % info_string
+                    else:
+                        new = Record(user=student, program=prog, event='attended')
+                        new.save()
+                        json_data['message'] = '%s is now checked in!' % info_string
+                else:
+                    json_data['message'] = '%s is not a student!' % info_string
+        return HttpResponse(json.dumps(json_data), content_type='text/json')
 
     @aux_call
     @needs_onsite

--- a/esp/templates/program/modules/onsitecheckinmodule/barcodecheckin.html
+++ b/esp/templates/program/modules/onsitecheckinmodule/barcodecheckin.html
@@ -10,8 +10,6 @@
 
 {% block content %}
 <style type="text/css">
-.nocheckmark { border: 1px solid black; }
-
 /* Controls */
 
 .overlay__close {
@@ -30,9 +28,30 @@
     border-radius: 2rem;
     z-index: 100;
     box-sizing: content-box;
+    font-family: sans-serif !important;
 }
 
-/* Scan! Button */
+.scan_popup {
+    font-size: large;
+    line-height: 1.5;
+    position: absolute;
+    z-index: 100;
+    background-color: #555;
+    color: #fff;
+    text-align: center;
+    border-radius: 6px;
+    padding: 8px 8px;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    -webkit-transform: translate(-50%, -50%);
+    -moz-transform: translate(-50%, -50%);
+    -o-transform: translate(-50%, -50%);
+    display: none;
+    font-family: sans-serif !important;
+}
+
+/* Scan Button */
 
 .scan {
     font-size: large;
@@ -43,10 +62,11 @@
 
 /* Reader Dropdown */
 
-.controls select {
+.controls, .controls select {
     font-size: large !important;
     margin: auto;
     height: auto !important;
+    font-family: sans-serif !important;
 }
 
 .controls.hide {
@@ -120,16 +140,19 @@
 
     <div class="controls">
         <button type="button" class="scan"><i class="fas fa-barcode"></i>&ensp;Scan barcodes with your device</button>
-        &emsp;
+        <br><br>
         <select>
             <option selected value="code_39_reader">Code 39</option>
             <option value="codabar_reader">Codabar</option>
             <option value="code_128_reader">Code 128</option>
             <option value="i2of5_reader">Interleaved 2 of 5</option>
         </select>
+        <br><br>
+        <input type="checkbox" id="autocheckinbox" value="autocheckin" checked> Auto-checkin scanned barcodes<br>
     </div>
     <div class="overlay overlay--inline">
         <div class="overlay__content viewport" id="interactive">
+            <div id="scaninfo" class="scan_popup"></div>
             <div class="overlay__close">X</div>
         </div>
     </div>
@@ -218,12 +241,24 @@ $j(function() {
 
     Quagga.onDetected(function(result) {
         var code = result.codeResult.code;
+        var autocheckin = document.getElementById("autocheckinbox");
 
         if (App.lastResult !== code) {
             App.lastResult = code;
-
-            var results = document.querySelector('#checkinform > p > textarea')
-            results.value += "\n" + code
+            if (autocheckin.checked){
+                var data = {code: code, csrfmiddlewaretoken: csrf_token()};
+                $j.post('ajaxbarcodecheckin', data, function(result) {
+                    if (result.hasOwnProperty('message')) {
+                        var message = result.message;
+                        $j('#scaninfo').show();
+                        $j('#scaninfo').html(message);
+                        setTimeout("$j('#scaninfo').fadeOut(); ", 2000);
+                    }
+                }, "json");
+            } else {
+                var results = document.querySelector('#checkinform > p > textarea')
+                results.value += "\n" + code
+            }
         }
     });
 


### PR DESCRIPTION
If using your device's camera to check in students with barcodes (#2539), the default is now to instantly check the student in via a POST request. A temporary popup tells the user the result of the checkin attempt (whether the ID is not valid, whether the user is not a student, whether the student is already checked in, or whether the student has been checked in successfully). This behavior can be disabled with a checkbox, which will cause any further scanned barcodes to be added to the `textarea`, which can then be submitted in bulk as normal. Fixes #2561.