### PR TITLE
Add buttons to change status of all classes on class search page

### DIFF
--- a/esp/esp/program/modules/handlers/classsearchmodule.py
+++ b/esp/esp/program/modules/handlers/classsearchmodule.py
@@ -137,6 +137,7 @@ class ClassSearchModule(ProgramModuleObj):
                 # page as usual
             context['query'] = decoded
             context['queryset'] = queryset
+            context['IDs'] = [cls.id for cls in queryset]
             context['flag_types'] = self.program.flag_types.all()
         return render_to_response(self.baseDir()+'class_search.html',
                                   request, context)

--- a/esp/public/media/scripts/program/modules/flag-results-page.js
+++ b/esp/public/media/scripts/program/modules/flag-results-page.js
@@ -59,6 +59,18 @@ function hideAll () {
     $j(".flag-detail").hide();
 }
 
+function approveAll () {
+    $j("#program_form .btn-approve").click();
+}
+
+function unreviewAll () {
+    $j("#program_form .btn-unreview").click();
+}
+
+function rejectAll () {
+    $j("#program_form .btn-reject").click();
+}
+
 $j(document).ready(function () {
     $j(".flag-detail").hide();
     $j(".manage-approve-link").hide();

--- a/esp/public/media/scripts/program/modules/flag-results-page.js
+++ b/esp/public/media/scripts/program/modules/flag-results-page.js
@@ -60,15 +60,24 @@ function hideAll () {
 }
 
 function approveAll () {
-    $j("#program_form .btn-approve").click();
+    var r = confirm("Are you sure you'd like to approve all of these classes?");
+    if (r) {
+        $j("#program_form .btn-approve").click();
+    }
 }
 
 function unreviewAll () {
-    $j("#program_form .btn-unreview").click();
+    var r = confirm("Are you sure you'd like to unreview all of these classes?");
+    if (r) {
+        $j("#program_form .btn-unreview").click();
+    }
 }
 
 function rejectAll () {
-    $j("#program_form .btn-reject").click();
+    var r = confirm("Are you sure you'd like to reject all of these classes?");
+    if (r) {
+        $j("#program_form .btn-reject").click();
+    }
 }
 
 $j(document).ready(function () {

--- a/esp/public/media/scripts/program/modules/flag-results-page.js
+++ b/esp/public/media/scripts/program/modules/flag-results-page.js
@@ -59,24 +59,30 @@ function hideAll () {
     $j(".flag-detail").hide();
 }
 
-function approveAll () {
-    var r = confirm("Are you sure you'd like to approve all of these classes?");
+function approveAll (IDs) {
+    var r = confirm("Are you sure you'd like to approve ALL of these classes?");
     if (r) {
-        $j("#program_form .btn-approve").click();
+        IDs.forEach(function(element) {
+            approve(element);
+        });
     }
 }
 
-function unreviewAll () {
-    var r = confirm("Are you sure you'd like to unreview all of these classes?");
+function unreviewAll (IDs) {
+    var r = confirm("Are you sure you'd like to unreview ALL of these classes?");
     if (r) {
-        $j("#program_form .btn-unreview").click();
+        IDs.forEach(function(element) {
+            unreview(element);
+        });
     }
 }
 
-function rejectAll () {
-    var r = confirm("Are you sure you'd like to reject all of these classes?");
+function rejectAll (IDs) {
+    var r = confirm("Are you sure you'd like to reject ALL of these classes?");
     if (r) {
-        $j("#program_form .btn-reject").click();
+        IDs.forEach(function(element) {
+            reject(element);
+        });
     }
 }
 

--- a/esp/templates/program/modules/classsearchmodule/class_search.html
+++ b/esp/templates/program/modules/classsearchmodule/class_search.html
@@ -32,9 +32,9 @@ Your query returned {{queryset|length}} of {{program.classsubject_set.count}} cl
 </p>
 
 <div class="btn-group">
-    <button class="btn btn-approve" onclick="approveAll({{ IDs }});">approve all</button>
-    <button class="btn btn-unreview" onclick="unreviewAll({{ IDs }});">unreview all</button>
-    <button class="btn btn-reject" onclick="rejectAll({{ IDs }});">reject all</button>
+    <button class="btn btn-approve" onclick="approveAll({{ IDs|escapejs }});">approve all</button>
+    <button class="btn btn-unreview" onclick="unreviewAll({{ IDs|escapejs }});">unreview all</button>
+    <button class="btn btn-reject" onclick="rejectAll({{ IDs|escapejs }});">reject all</button>
 </div>
 
 <div class="flag-query-results" id="program_form">

--- a/esp/templates/program/modules/classsearchmodule/class_search.html
+++ b/esp/templates/program/modules/classsearchmodule/class_search.html
@@ -31,6 +31,12 @@
 Your query returned {{queryset|length}} of {{program.classsubject_set.count}} classes in {{program.niceName}}.  Click on a class or flag to see more detail (<a href="#" onclick="showAll()">show all</a> <a href="#" onclick="showWithComments()">show comments</a> <a href="#" onclick="hideAll()">hide all</a>).  Or <a href="?">search again</a>.
 </p>
 
+<div class="btn-group">
+    <button class="btn btn-approve" onclick="approveAll();">approve all</button>
+    <button class="btn btn-unreview" onclick="unreviewAll();">unreview all</button>
+    <button class="btn btn-reject" onclick="rejectAll();">reject all</button>
+</div>
+
 <div class="flag-query-results" id="program_form">
     {% for class in queryset %}
         <div class="fqr-class" id="fqr-class-{{class.id}}">

--- a/esp/templates/program/modules/classsearchmodule/class_search.html
+++ b/esp/templates/program/modules/classsearchmodule/class_search.html
@@ -32,9 +32,9 @@ Your query returned {{queryset|length}} of {{program.classsubject_set.count}} cl
 </p>
 
 <div class="btn-group">
-    <button class="btn btn-approve" onclick="approveAll();">approve all</button>
-    <button class="btn btn-unreview" onclick="unreviewAll();">unreview all</button>
-    <button class="btn btn-reject" onclick="rejectAll();">reject all</button>
+    <button class="btn btn-approve" onclick="approveAll({{ IDs }});">approve all</button>
+    <button class="btn btn-unreview" onclick="unreviewAll({{ IDs }});">unreview all</button>
+    <button class="btn btn-reject" onclick="rejectAll({{ IDs }});">reject all</button>
 </div>
 
 <div class="flag-query-results" id="program_form">


### PR DESCRIPTION
Adds 3 buttons (analogous to the three buttons that are listed for each class on the search page) which allows the user to change the status of all of the classes that are currently being shown on the class search page. Works by clicking all of the individual buttons via jQuery.

![image](https://user-images.githubusercontent.com/7232514/41671968-8dc81ca8-746d-11e8-965b-4e1d41b081b8.png)

Fixes #2537.
