### PR TITLE
Adds a button to text all teachers on missingteachers

### DIFF
--- a/esp/public/media/scripts/onsite/teacher_checkin.js
+++ b/esp/public/media/scripts/onsite/teacher_checkin.js
@@ -139,7 +139,8 @@ $j(function(){
     });
 
     $j(".text-all").click(function(){
-        var r = confirm("Are you sure you'd like to text ALL unchecked-in teachers?");
+        var num_teachers = $j(".checkin:visible").length
+        var r = confirm("Are you sure you'd like to text " + num_teachers + " unchecked-in teachers?");
         if (r) {
             $j(".checkin:visible").closest('tr').find('.text').each(function() {
                 textTeacher($j(this))

--- a/esp/public/media/scripts/onsite/teacher_checkin.js
+++ b/esp/public/media/scripts/onsite/teacher_checkin.js
@@ -141,7 +141,7 @@ $j(function(){
     $j(".text-all").click(function(){
         var r = confirm("Are you sure you'd like to text ALL unchecked-in teachers?");
         if (r) {
-            $j(".checkin").closest('tr').find('.text').each(function() {
+            $j(".checkin:visible").closest('tr').find('.text').each(function() {
                 textTeacher($j(this))
             });
             $j(this).attr("disabled",true);

--- a/esp/public/media/scripts/onsite/teacher_checkin.js
+++ b/esp/public/media/scripts/onsite/teacher_checkin.js
@@ -112,7 +112,7 @@ $j(function(){
         $msg.text('Checking in...');
     });
 
-    function textTeacher(user, sec, callback, errorCallback){
+    function sendText(user, sec, callback, errorCallback){
         var data = {username: user, section: sec, csrfmiddlewaretoken: csrf_token()};
         $j.post('ajaxteachertext', data, "json").success(callback)
         .error(function(){
@@ -123,22 +123,30 @@ $j(function(){
         });
     }
 
-    $j(".text").click(function(){
-        var username = $j(this).data("username");
-        var section = $j(this).data("section");
-        var $td = $j(this.parentNode);
-        var $msg = $td.children('.message');
-        textTeacher(username, section, function(response) {
-            $msg.text(response.message);
+    function textTeacher(btn) {
+        var username = $j(btn).data("username");
+        var section = $j(btn).data("section");
+        var msg = $j(btn).closest('td').find('.message');
+        sendText(username, section, function(response) {
+            $j(msg).text(response.message);
         });
-        $j(this).attr("disabled",true);
-        $msg.text('Texting teacher...');
+        $j(btn).attr("disabled",true);
+        $j(msg).text('Texting teacher...');
+    }
+
+    $j(".text").click(function(){
+        textTeacher($j(this))
     });
 
     $j(".text-all").click(function(){
-        $j(".text").click()
-        $j(this).attr("disabled",true);
-        $j(this).attr("title","Teachers already texted");
+        var r = confirm("Are you sure you'd like to text ALL unchecked-in teachers?");
+        if (r) {
+            $j(".checkin").closest('tr').find('.text').each(function() {
+                textTeacher($j(this))
+            });
+            $j(this).attr("disabled",true);
+            $j(this).attr("title","Teachers already texted");
+        }
     });
 
     $j(".uncheckin:enabled").click(function(){

--- a/esp/public/media/scripts/onsite/teacher_checkin.js
+++ b/esp/public/media/scripts/onsite/teacher_checkin.js
@@ -135,6 +135,12 @@ $j(function(){
         $msg.text('Texting teacher...');
     });
 
+    $j(".text-all").click(function(){
+        $j(".text").click()
+        $j(this).attr("disabled",true);
+        $j(this).attr("title","Teachers already texted");
+    });
+
     $j(".uncheckin:enabled").click(function(){
         var username = this.id.replace("uncheckin_", "");
         undoCheckIn(username, function(response) {

--- a/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
+++ b/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
@@ -113,7 +113,7 @@
 <br/><a href="teachercheckin{% if when %}?when={{ url_when }}{% endif %}">&lt;&lt;Back</a>
 
 <p style="text-align:right">
-<input class="button text-all" type="button" value="Text All Teachers"
+<input class="button text-all" type="button" value="Text All Unchecked-In Teachers"
     {% if not text_configured %} disabled title="Twilio texting settings are not configured"{% endif %}/>
 </p>
 

--- a/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
+++ b/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
@@ -112,6 +112,11 @@
 
 <br/><a href="teachercheckin{% if when %}?when={{ url_when }}{% endif %}">&lt;&lt;Back</a>
 
+<p style="text-align:right">
+<input class="button text-all" type="button" value="Text All Teachers"
+    {% if not text_configured %} disabled title="Twilio texting settings are not configured"{% endif %}/>
+</p>
+
 <p style="text-align: center">
 
 <table>


### PR DESCRIPTION
Adds a button that clicks all the individual buttons to text teachers on the `missingteachers` page. Button is disabled after clicking to prevent multiple clicks. Button is also disabled (as the individual buttons are) if Twilio is not configured.

Fixes #2569.