### PR TITLE
Fix for classrosters template

### DIFF
--- a/esp/templates/program/modules/programprintables/classrosters.html
+++ b/esp/templates/program/modules/programprintables/classrosters.html
@@ -25,11 +25,9 @@ body { font-family: georgia; }
 </head>
 <body>
 {% for item in scheditems %}
-{% if not forloop.first %}
-{% endif %}
-{% for section in item.cls.sections.all %}
+{% with section=item.cls %}
 {% include "program/modules/programprintables/classroster.html" %}
-{% endfor %}
+{% endwith %}
 {% endfor %}
 
 </body>


### PR DESCRIPTION
There was a view/template mismatch that resulted in a blank page, as reported by UCSD.
I fixed it, but I'm not sure this should even exist anymore for teachers with the implementation of rosters with `section_students` and `class_students` in `teacherclassregmodule` (although the /manage version of this is probably still useful).