### PR TITLE
Add dates to volunteer offers

### DIFF
--- a/esp/esp/cal/admin.py
+++ b/esp/esp/cal/admin.py
@@ -39,7 +39,7 @@ from esp.cal.models import EventType, Event
 admin_site.register(EventType)
 
 class EventAdmin(admin.ModelAdmin):
-    list_display = ('id', 'program', 'name', 'pretty_time', 'event_type', 'short_description')
+    list_display = ('id', 'program', 'name', 'short_time', 'pretty_date', 'event_type', 'short_description')
     list_filter = ('program', 'start', 'end', 'event_type')
     date_hierarchy = 'start'
     search_fields = ('=id', 'name', 'short_description', 'description')

--- a/esp/esp/program/admin.py
+++ b/esp/esp/program/admin.py
@@ -174,7 +174,9 @@ admin_site.register(VolunteerRequest, VolunteerRequestAdmin)
 class VolunteerOfferAdmin(admin.ModelAdmin):
     def program(obj):
         return obj.request.program
-    list_display = ('id', 'user', 'email', 'name', 'request', program, 'confirmed')
+    def date(obj):
+        return obj.request.timeslot.pretty_date()
+    list_display = ('id', 'user', 'email', 'name', 'request', date, program, 'confirmed')
     list_filter = ('request__program',)
     search_fields = default_user_search() + ['email', 'name']
 admin_site.register(VolunteerOffer, VolunteerOfferAdmin)

--- a/esp/esp/program/admin.py
+++ b/esp/esp/program/admin.py
@@ -166,7 +166,11 @@ class VolunteerOfferInline(admin.StackedInline):
 class VolunteerRequestAdmin(admin.ModelAdmin):
     def description(obj):
         return obj.timeslot.description
-    list_display = ('id', 'program', description, 'timeslot', 'num_volunteers')
+    def time(obj):
+        return obj.timeslot.short_time()
+    def date(obj):
+        return obj.timeslot.pretty_date()
+    list_display = ('id', 'program', description, time, date, 'num_volunteers')
     list_filter = ('program',)
     inlines = [VolunteerOfferInline,]
 admin_site.register(VolunteerRequest, VolunteerRequestAdmin)
@@ -174,9 +178,13 @@ admin_site.register(VolunteerRequest, VolunteerRequestAdmin)
 class VolunteerOfferAdmin(admin.ModelAdmin):
     def program(obj):
         return obj.request.program
+    def description(obj):
+        return obj.request.timeslot.description
+    def time(obj):
+        return obj.request.timeslot.short_time()
     def date(obj):
         return obj.request.timeslot.pretty_date()
-    list_display = ('id', 'user', 'email', 'name', 'request', date, program, 'confirmed')
+    list_display = ('id', 'user', 'email', 'name', description, time, date, program, 'confirmed')
     list_filter = ('request__program',)
     search_fields = default_user_search() + ['email', 'name']
 admin_site.register(VolunteerOffer, VolunteerOfferAdmin)

--- a/esp/templates/program/modules/volunteermanage/main.html
+++ b/esp/templates/program/modules/volunteermanage/main.html
@@ -32,8 +32,11 @@ You may request groups of volunteers for your program here.  At the <a href="/vo
     <tr><td colspan="3">No requests at this time.  Please add some using one of the forms below.</td></tr>
 {% else %}
     {% for vr in requests %}
+    {% ifchanged vr.timeslot.start.date %}
+    <th colspan="3" align="center">{{ vr.timeslot.pretty_date }}</th>
+    {% endifchanged %}
     <tr>
-    <td>{{ vr.timeslot.pretty_time }}</td>
+    <td>{{ vr.timeslot.short_time }}</td>
     <td>{{ vr.timeslot.description }}: {{ vr.num_offers }} / {{ vr.num_volunteers }} volunteers <br />
         <div id="offers" style="color: blue; font-size: 0.9em;">{% for offer in vr.get_offers %}
         {{ offer.name }}, {{ offer.email }}, {{ offer.phone }} <br />


### PR DESCRIPTION
Volunteer requests are now separated by date on `/volunteering`. I changed the displayed time in the first column so that it wasn't redundant with the new headers. While I was at it, I fixed up some of the admin page displays so that they now include the dates of the events.

Fixes #2465.

![image](https://user-images.githubusercontent.com/7232514/41791140-b6f59e3c-7609-11e8-8451-3764dee6289a.png)