### PR TITLE
Updated admin coteacher page

### DIFF
--- a/esp/esp/program/modules/handlers/adminclass.py
+++ b/esp/esp/program/modules/handlers/adminclass.py
@@ -351,9 +351,6 @@ class AdminClass(ProgramModuleObj):
         # set txtTeachers and coteachers....
         if not 'coteachers' in request.POST:
             coteachers = cls.get_teachers()
-            coteachers = [ user for user in coteachers
-                           if user.id != request.user.id           ]
-
             txtTeachers = ",".join([str(user.id) for user in coteachers ])
 
         else:
@@ -367,8 +364,12 @@ class AdminClass(ProgramModuleObj):
         if 'op' in request.POST:
             op = request.POST['op']
 
-        conflictingusers = []
         error = False
+
+        old_coteachers_set = set(cls.get_teachers())
+        ccc = ClassCreationController(self.program)
+
+        conflictinguser = ''
 
         if op == 'add':
 
@@ -384,16 +385,19 @@ class AdminClass(ProgramModuleObj):
                                            'ajax': ajax,
                                            'txtTeachers': txtTeachers,
                                            'coteachers': coteachers,
-                                           'error': error})
+                                           'error': error,
+                                           'conflict': []})
 
             # add schedule conflict checking here...
             teacher = ESPUser.objects.get(id = request.POST['teacher_selected'])
 
             if cls.conflicts(teacher):
-                conflictingusers.append(teacher.first_name+' '+teacher.last_name)
+                conflictinguser = (teacher.first_name+' '+teacher.last_name)
             else:
                 coteachers.append(teacher)
                 txtTeachers = ",".join([str(coteacher.id) for coteacher in coteachers ])
+                ccc.associate_teacher_with_class(cls, teacher)
+                ccc.send_class_mail_to_directors(cls)
 
         elif op == 'del':
             ids = request.POST.getlist('delete_coteachers')
@@ -405,31 +409,18 @@ class AdminClass(ProgramModuleObj):
             coteachers = newcoteachers
             txtTeachers = ",".join([str(coteacher.id) for coteacher in coteachers ])
 
-
-        elif op == 'save':
-            #            if
-            for teacher in coteachers:
-                if cls.conflicts(teacher):
-                    conflictingusers.append(teacher.first_name+' '+teacher.last_name)
-            if len(conflictingusers) == 0:
-                for teacher in cls.get_teachers():
-                    cls.removeTeacher(teacher)
-
-                # add bits for all new (and old) coteachers
-                ccc = ClassCreationController(self.program)
-                for teacher in coteachers:
-                    ccc.associate_teacher_with_class(cls, teacher)
-                ccc.send_class_mail_to_directors(cls)
-                return self.goToCore(tl)
-
-
+            new_coteachers_set = set(coteachers)
+            to_be_deleted = old_coteachers_set - new_coteachers_set
+            for teacher in to_be_deleted:
+                cls.removeTeacher(teacher)
+            ccc.send_class_mail_to_directors(cls)
 
         return render_to_response(self.baseDir()+'coteachers.html', request,
                                   {'class': cls,
                                    'ajax': ajax,
                                    'txtTeachers': txtTeachers,
                                    'coteachers': coteachers,
-                                   'conflicts': conflictingusers})
+                                   'conflict': conflictinguser})
 
     @aux_call
     @needs_admin

--- a/esp/templates/program/modules/adminclass/coteachers.html
+++ b/esp/templates/program/modules/adminclass/coteachers.html
@@ -24,10 +24,9 @@
 
 <p>Please list all teachers that will be helping teach this class.  They will need to create accounts and mark their available times through the teacher registration page (for scheduling purposes).</p>
 
-{% if conflicts|length %}
-    <p style="color:red; font-weight: bold;">
-    The following teachers have conflicting schedules:<br />
-    {{ conflicts|join:"<br />" }}
+{% if conflict %}
+    <p>
+    <b><font color="red">{{ conflict }}</font> has a conflicting schedule.</b><br />
     </p>
 {% endif %}
 
@@ -72,7 +71,7 @@ There are currently no teachers associated with this class.
 <form action="{{request.path}}" method="post" name="addteacher" onsubmit="cleanTeacherSubmit($j(this))">
 <table align="center" width="400">
     <tr>
-        <th colspan="2">Add More Teachers</th>
+        <th colspan="2">Add a coteacher</th>
     </tr>
     <tr>
         <td colspan="2">Begin typing the teacher's name in `Last, First' format to find them.</td>
@@ -92,21 +91,6 @@ There are currently no teachers associated with this class.
     </tr>
 </table>
 </form>
-<table align="center" width="400">
-    <tr>
-        <td align="center" colspan="2">When you are done, click the button below to return to the program management page.</td>
-    </tr>
-    <tr>
-        <td align="center" colspan="2">
-            <form action="{{request.path}}" method="post" name="submit">
-            <input type="hidden" name="op" value="save" />
-            <input type="hidden" name="clsid" value="{{ class.id }}" />
-            <input type="hidden" name="coteachers" value="{{ txtTeachers }}" />
-            <input type="submit" class="button" value="Save and Continue" /><br />
-            </form>
-        </td>
-    </tr>
-</table>
 </div>
 
 {% endblock %}


### PR DESCRIPTION
This makes the admin coteacher page work just like how the normal coteacher page works since #2421, except for two differences:
1. I fixed a bug where a coteacher wouldn't be listed if they were the admin looking at the page and the class ID was supplied via GET.
2. All teachers can be deleted, including the admin looking at the page if they are a coteacher or the last teacher of the class.

Fixes #2444.