### PR TITLE
Add coteacher deadline

### DIFF
--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -349,7 +349,7 @@ class TeacherClassRegModule(ProgramModuleObj):
 
     @aux_call
     @needs_teacher
-    @meets_deadline('/MainPage')
+    @meets_deadline('/Classes/Coteachers')
     def coteachers(self, request, tl, one, two, module, extra, prog):
         if not 'clsid' in request.POST:
             return self.goToCore(tl) # just fails.

--- a/esp/esp/users/migrations/0015_auto_20180709_1328.py
+++ b/esp/esp/users/migrations/0015_auto_20180709_1328.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0014_auto_20180217_1243'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='permission',
+            name='permission_type',
+            field=models.CharField(max_length=80, choices=[(b'Administer', b'Full administrative permissions'), (b'View', b'Able to view a program'), (b'Onsite', b'Access to onsite interfaces'), (b'GradeOverride', b'Ignore grade ranges for studentreg'), (b'OverrideFull', b'Register for a full program'), (b'OverridePhaseZero', b'Bypass Phase Zero to proceed to other student reg modules'), (b'Student Deadlines', ((b'Student', b'Basic student access'), (b'Student/All', b'All student deadlines'), (b'Student/Applications', b'Apply for classes'), (b'Student/Catalog', b'View the catalog'), (b'Student/Classes', b'Register for classes'), (b'Student/Classes/Lottery', b'Enter the lottery'), (b'Student/Classes/PhaseZero', b'Enter Phase Zero'), (b'Student/Classes/Lottery/View', b'View lottery results'), (b'Student/ExtraCosts', b'Extra costs page'), (b'Student/MainPage', b'Registration mainpage'), (b'Student/Confirm', b'Confirm registration'), (b'Student/Cancel', b'Cancel registration'), (b'Student/Removal', b'Remove class registrations after registration closes'), (b'Student/Payment', b'Pay for a program'), (b'Student/Profile', b'Set profile info'), (b'Student/Survey', b'Access to survey'), (b'Student/FormstackMedliab', b'Access to Formstack medical and liability form'), (b'Student/Finaid', b'Access to financial aid application'))), (b'Teacher Deadlines', ((b'Teacher', b'Basic teacher access'), (b'Teacher/All', b'All teacher deadlines'), (b'Teacher/Acknowledgement', b'Teacher acknowledgement'), (b'Teacher/AppReview', b"Review students' apps"), (b'Teacher/Availability', b'Set availability'), (b'Teacher/Catalog', b'Catalog'), (b'Teacher/Classes', b'Classes'), (b'Teacher/Classes/All', b'Classes/All'), (b'Teacher/Classes/View', b'Classes/View'), (b'Teacher/Classes/Edit', b'Classes/Edit'), (b'Teacher/Classes/CancelReq', b'Request class cancellation'), (b'Teacher/Classes/Coteachers', b'Add or remove coteachers'), (b'Teacher/Classes/Create', b'Create classes of all types'), (b'Teacher/Classes/Create/Class', b'Create standard classes'), (b'Teacher/Classes/Create/OpenClass', b'Create open classes'), (b'Teacher/Events', b'Teacher training signup'), (b'Teacher/Quiz', b'Teacher quiz'), (b'Teacher/MainPage', b'Registration mainpage'), (b'Teacher/Survey', b'Teacher Survey'), (b'Teacher/Profile', b'Set profile info'), (b'Teacher/Survey', b'Access to survey'))), (b'Volunteer Deadlines', ((b'Volunteer', b'Basic volunteer access'), (b'Volunteer/Signup', b'Volunteer signup')))]),
+        ),
+    ]

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -2280,6 +2280,7 @@ class Permission(ExpirableModel):
             ("Teacher/Classes/View", "Classes/View"),
             ("Teacher/Classes/Edit", "Classes/Edit"),
             ("Teacher/Classes/CancelReq", "Request class cancellation"),
+            ("Teacher/Classes/Coteachers", "Add or remove coteachers"),
             ("Teacher/Classes/Create", "Create classes of all types"),
             ("Teacher/Classes/Create/Class", "Create standard classes"),
             ("Teacher/Classes/Create/OpenClass", "Create open classes"),


### PR DESCRIPTION
Changes the deadline dependency of the coteachers page from `/Teacher/MainPage` to `/Teacher/Classes/Coteachers` so the coteachers page can be closed independently.

Fixes #2371.