### PR TITLE
Hidden resource types

### DIFF
--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -867,14 +867,17 @@ class Program(models.Model, CustomFormsLinkModel):
             return None
 
     @cache_function
-    def getResourceTypes(self, include_classroom=False, include_global=None):
-        #   Show all resources pertaining to the program that aren't these two hidden ones.
+    def getResourceTypes(self, include_classroom=False, include_global=None, include_hidden=False):
+        #   Show all resources pertaining to the program that aren't these hidden ones.
         from esp.resources.models import ResourceType
 
-        if include_classroom:
+        if include_hidden:
             exclude_types = []
         else:
-            exclude_types = [ResourceType.get_or_create('Classroom')]
+            exclude_types = list(ResourceType.objects.filter(hidden=True))
+
+        if not include_classroom:
+            exclude_types += [ResourceType.get_or_create('Classroom')]
 
         if include_global is None:
             include_global = Tag.getTag('allow_global_restypes')

--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -868,7 +868,7 @@ class Program(models.Model, CustomFormsLinkModel):
 
     @cache_function
     def getResourceTypes(self, include_classroom=False, include_global=None, include_hidden=True):
-        #   Show all resources pertaining to the program that aren't these hidden ones.
+        #   Show all resources pertaining to the program (except those of types that are excluded).
         from esp.resources.models import ResourceType
 
         if include_hidden:

--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -867,7 +867,7 @@ class Program(models.Model, CustomFormsLinkModel):
             return None
 
     @cache_function
-    def getResourceTypes(self, include_classroom=False, include_global=None, include_hidden=False):
+    def getResourceTypes(self, include_classroom=False, include_global=None, include_hidden=True):
         #   Show all resources pertaining to the program that aren't these hidden ones.
         from esp.resources.models import ResourceType
 

--- a/esp/esp/program/modules/forms/resources.py
+++ b/esp/esp/program/modules/forms/resources.py
@@ -44,12 +44,14 @@ class ResourceTypeForm(forms.Form):
     description = forms.CharField(required=False,widget=forms.Textarea)
     priority = forms.IntegerField(required=False, help_text='Assign this a unique number in relation to the priority of other resource types')
     is_global = forms.BooleanField(label='Global?', required=False)
+    hidden = forms.BooleanField(label='Hidden?', required=False, help_text='Should this resource type be hidden during teacher registration?')
 
     def load_restype(self, res_type):
         self.fields['name'].initial = res_type.name
         self.fields['description'].initial = res_type.description
         self.fields['priority'].initial = res_type.priority_default
         self.fields['is_global'].initial = (res_type.program == None)
+        self.fields['hidden'].initial = res_type.hidden
         self.fields['id'].initial = res_type.id
 
     def save_restype(self, program, res_type, choices = None):
@@ -59,6 +61,8 @@ class ResourceTypeForm(forms.Form):
             res_type.program = None
         else:
             res_type.program = program
+        if self.cleaned_data['hidden']:
+            res_type.hidden = self.cleaned_data['hidden']
         if self.cleaned_data['priority']:
             res_type.priority_default = self.cleaned_data['priority']
         if choices and filter(None, choices):

--- a/esp/esp/program/modules/forms/resources.py
+++ b/esp/esp/program/modules/forms/resources.py
@@ -82,7 +82,7 @@ class ResourceChoiceForm(forms.Form):
 
 def setup_furnishings(restype_list):
     #   Populate the available choices for furnishings based on a particular program.
-    return ((str(r.id), r.name) for r in restype_list)
+    return ((str(r.id), r.name + (" (Hidden)" if r.hidden else "")) for r in restype_list)
 
 def setup_timeslots(program):
     return ((str(e.id), e.short_description) for e in program.getTimeSlots())

--- a/esp/esp/program/modules/handlers/resourcemodule.py
+++ b/esp/esp/program/modules/handlers/resourcemodule.py
@@ -389,7 +389,9 @@ class ResourceModule(ProgramModuleObj):
         if 'timeslot_form' not in context:
             context['timeslot_form'] = TimeslotForm()
 
-        context['resource_types'] = self.program.getResourceTypes(include_global=Tag.getBooleanTag('allow_global_restypes', program = prog, default = False))
+        res_types = self.program.getResourceTypes(include_global=Tag.getBooleanTag('allow_global_restypes', program = prog, default = False),
+            include_classroom=True, include_hidden=True)
+        context['resource_types'] = sorted(res_types, key = lambda x: (not x.hidden, x.priority_default), reverse = True)
         for c in context['resource_types']:
             if c.program is None:
                 c.is_global = True

--- a/esp/esp/program/modules/handlers/resourcemodule.py
+++ b/esp/esp/program/modules/handlers/resourcemodule.py
@@ -389,8 +389,7 @@ class ResourceModule(ProgramModuleObj):
         if 'timeslot_form' not in context:
             context['timeslot_form'] = TimeslotForm()
 
-        res_types = self.program.getResourceTypes(include_global=Tag.getBooleanTag('allow_global_restypes', program = prog, default = False),
-            include_classroom=True, include_hidden=True)
+        res_types = self.program.getResourceTypes(include_global=Tag.getBooleanTag('allow_global_restypes', program = prog, default = False))
         context['resource_types'] = sorted(res_types, key = lambda x: (not x.hidden, x.priority_default), reverse = True)
         for c in context['resource_types']:
             if c.program is None:

--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -590,9 +590,11 @@ class TeacherClassRegModule(ProgramModuleObj):
             # potentially relevant
             if Tag.getTag('allow_global_restypes'):
                 resource_types = prog.getResourceTypes(include_classroom=True,
-                                                       include_global=True)
+                                                       include_global=True,
+                                                       include_hidden=False)
             else:
-                resource_types = prog.getResourceTypes(include_classroom=True)
+                resource_types = prog.getResourceTypes(include_classroom=True,
+                                                       include_hidden=False)
             resource_types = list(resource_types)
             resource_types.reverse()
 

--- a/esp/esp/resources/admin.py
+++ b/esp/esp/resources/admin.py
@@ -42,7 +42,7 @@ class ResourceTypeAdmin(admin.ModelAdmin):
         return "%s" % str(obj.choices)
     rt_choices.short_description = 'Choices'
 
-    list_display = ('name', 'description', 'only_one', 'consumable', 'autocreated', 'priority_default', 'rt_choices', 'program')
+    list_display = ('name', 'description', 'only_one', 'consumable', 'autocreated', 'hidden', 'priority_default', 'rt_choices', 'program')
     search_fields = ['name', 'description', 'consumable', 'priority_default',
             'attributes_pickled', 'program__name']
 

--- a/esp/esp/resources/migrations/0005_resourcetype_hidden.py
+++ b/esp/esp/resources/migrations/0005_resourcetype_hidden.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('resources', '0004_resource_attribute_value'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='resourcetype',
+            name='hidden',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/esp/esp/resources/models.py
+++ b/esp/esp/resources/models.py
@@ -81,6 +81,8 @@ class ResourceType(models.Model):
     choices = ListField('attributes_pickled')
     program = models.ForeignKey('program.Program', null=True, blank=True)                 #   If null, this resource type is global.  Otherwise it's specific to one program.
     autocreated = models.BooleanField(default=False)
+    #   Whether to offer this resource type as an option in the class creation/editing form
+    hidden = models.BooleanField(default=False)
 
     def _get_attributes(self):
         if hasattr(self, '_attributes_cached'):

--- a/esp/templates/program/modules/resourcemodule/classrooms.html
+++ b/esp/templates/program/modules/resourcemodule/classrooms.html
@@ -53,7 +53,7 @@
         </td>
         <td class="underline">{{ c.num_students }}</td>
         <td class="underline">{% for t in c.timegroup %}{{ t }}<br />{% endfor %}</td>
-        <td class="underline">{% for f in c.furnishings %}{{ f.res_type.name }}<br />{% endfor %}</td>
+        <td class="underline">{% for f in c.furnishings %}{{ f.res_type.name }}{% if f.res_type.hidden %} (Hidden){% endif %}<br />{% endfor %}</td>
     </tr>
     {% endfor %}
     </table></td></tr>

--- a/esp/templates/program/modules/resourcemodule/equipment.html
+++ b/esp/templates/program/modules/resourcemodule/equipment.html
@@ -35,7 +35,7 @@
                 <a href="/manage/{{ prog.url }}/resources/equipment?op=edit&id={{ r.id }}">[Edit]</a>
                 <a href="/manage/{{ prog.url }}/resources/equipment?op=delete&id={{ r.id }}">[Delete]</a>
             </td>
-            <td class="underline">{{ r.res_type.name }}</td>
+            <td class="underline">{{ r.res_type.name }}{% if r.res_type.hidden %} (Hidden){% endif %}</td>
             <td class="underline">{% for t in r.timegroup %}{{ t }}<br />{% endfor %}</td>
         </tr>
     {% endfor %}

--- a/esp/templates/program/modules/resourcemodule/resource_types.html
+++ b/esp/templates/program/modules/resourcemodule/resource_types.html
@@ -44,6 +44,9 @@
         <td width="10%"></td>
     </tr>
     {% for h in resource_types %}
+    {% ifchanged h.hidden %}{% if h.hidden %}
+    <tr><th colspan="5">Resource Types Hidden During Teacher Registration</th></tr>
+    {% endif %}{% endifchanged %}
         <tr>
             <td><div id="restype-{{ h.id }}">{{ h.name }}</div> {% if h.is_global %}(global){% endif %}</td>
             <td>{{ h.description }}</td>


### PR DESCRIPTION
This adds an option to resource types to have them hidden during teacher registration, which allows for associating resources with classrooms that admins may not want teachers to see when creating or editing classes (for scheduling purposes, etc.). These resources are still shown on the resources page under a separate heading, and I've added annotations in the classrooms and floating resources forms so that it is obvious which resources are hidden.

Fixes #2593 and maybe #1394.