### PR TITLE
Category fixes in catalog

### DIFF
--- a/esp/esp/program/modules/handlers/studentclassregmodule.py
+++ b/esp/esp/program/modules/handlers/studentclassregmodule.py
@@ -453,12 +453,25 @@ class StudentClassRegModule(ProgramModuleObj):
 
         categories = {}
         for cls in classes:
-            categories[cls.category_id] = {'id':cls.category_id, 'category':cls.category_txt if hasattr(cls, 'category_txt') else cls.category.category}
+            categories[cls.category_id] = {'id':cls.category_id, 'category':cls.category_txt if hasattr(cls, 'category_txt') else cls.category.category, 'symbol':cls.category.symbol}
+
+        # Is the catalog sorted by category? If so, by which aspect of category?
+        # Default is to sort by category symbol
+        cat_sort = 'category__symbol'
+        program_sort_fields = Tag.getProgramTag('catalog_sort_fields', prog)
+        if program_sort_fields:
+            cat_sort = program_sort_fields.split(',')[0]
+
+        cat_sort_split = cat_sort.split('__')
+        if cat_sort_split[0] == 'category' and cat_sort_split[1] in ['id', 'category', 'symbol']:
+            categories_sort = sorted(categories.values(), key = lambda cat: cat[cat_sort_split[1]])
+        else:
+            categories_sort = None
 
         # Allow tag configuration of whether class descriptions get collapsed
         # when the class is full (default: yes)
         collapse_full = Tag.getBooleanTag('collapse_full_classes', prog, True)
-        context = {'classes': classes, 'one': one, 'two': two, 'categories': categories.values(), 'collapse_full': collapse_full}
+        context = {'classes': classes, 'one': one, 'two': two, 'categories': categories_sort, 'collapse_full': collapse_full}
 
         scrmi = prog.studentclassregmoduleinfo
         context['register_from_catalog'] = scrmi.register_from_catalog
@@ -479,7 +492,7 @@ class StudentClassRegModule(ProgramModuleObj):
 
         class_category_id = None
         for cls in classes:
-            if cls.category.id != class_category_id:
+            if cls.category.id != class_category_id and categories_sort:
                 class_category_id = cls.category.id
                 class_blobs.append(category_header_str % (class_category_id, cls.category.category))
             class_blobs.append(render_class_direct(cls))

--- a/esp/templates/program/modules/studentclassregmodule/catalog.html
+++ b/esp/templates/program/modules/studentclassregmodule/catalog.html
@@ -47,6 +47,7 @@ Viewing classes for: {{ timeslot.friendly_name }}
 </div>
 <br>
 
+{% if categories %}
 <table align="center" style="text-align: center; margin: auto;" width="60%" border="0">
  <tr>
   <th colspan="2">
@@ -70,6 +71,7 @@ Viewing classes for: {{ timeslot.friendly_name }}
 </tr>
 {% endif %}
 </table>
+{% endif %}
 
 {% load render_qsd %}
 {% render_inline_program_qsd program "learn:catalog" %}


### PR DESCRIPTION
This makes sure that the categories at the top of the catalog are sorted properly (matching the sorting in the catalog). It also removes the category headings within the catalog if the catalog is not primarily sorted by category.

Fixes #2567.