### PR TITLE
Add option to override texting preferences in group texting module

### DIFF
--- a/esp/esp/program/modules/handlers/grouptextmodule.py
+++ b/esp/esp/program/modules/handlers/grouptextmodule.py
@@ -88,10 +88,13 @@ class GroupTextModule(ProgramModuleObj):
         # get the filter to use and text message to send from the request; this is set in grouptextpanel form
         filterObj = PersistentQueryFilter.objects.get(id=request.GET['filterid'])
         message = request.POST['message']
+        override = False
+        if 'text-override' in request.POST:
+            override = request.POST['text-override']
 
-        log = self.sendMessages(filterObj, message)
+        log = self.sendMessages(filterObj, message, override = override)
 
-        return render_to_response(self.baseDir()+'finished.html', request, {'log': log})
+        return render_to_response(self.baseDir()+'finished.html', request, {'log': log, 'override': override})
 
     @main_call
     @needs_admin

--- a/esp/templates/program/modules/grouptextmodule/finished.html
+++ b/esp/templates/program/modules/grouptextmodule/finished.html
@@ -25,6 +25,9 @@
 <p>The texts have been submitted to our SMS provider.</p>
 
 <h2>Send log</h2>
+{% if override %}
+<p><i>(Texting preferences were overriden)</i></p>
+{% endif %}
 
 <pre>{{ log }}</pre>
 

--- a/esp/templates/program/modules/grouptextmodule/options.html
+++ b/esp/templates/program/modules/grouptextmodule/options.html
@@ -5,6 +5,15 @@
 {% block xtrajs %}
 {{block.super}}
 <script type="text/javascript">
+function confirmOverride(checkbox) {
+    if (checkbox.checked) {
+        var r = confirm("Are you sure you'd like to override the texting preferences of all of the recipients?");
+        if (!r) {
+            checkbox.checked = false;
+        }
+    }
+}
+
 <!--
 
 var lists = [
@@ -50,6 +59,7 @@ var TextMessage = {
 <form action="/manage/{{ program.getUrlBase }}/grouptextfinal?filterid={{ filterid }}" method="post" name="grouptext">
 <textarea name="message" id="message_input" cols="40" rows="4" oninput="TextMessage.onMessageChange();"></textarea>
 <p id="length_remaining">160 characters remaining.</p>
+<input type="checkbox" name="text-override" onchange='confirmOverride(this);'> Override texting preferences.<br><br>
 <input type="submit" value="Send your message!" />
 </form>
 

--- a/esp/templates/program/modules/grouptextmodule/options.html
+++ b/esp/templates/program/modules/grouptextmodule/options.html
@@ -7,7 +7,7 @@
 <script type="text/javascript">
 function confirmOverride(checkbox) {
     if (checkbox.checked) {
-        var r = confirm("Are you sure you'd like to override the texting preferences of all of the recipients?");
+        var r = confirm("Are you sure you'd like to override the texting preferences of all of the recipients? This will cause the text to be sent to every selected recipient.");
         if (!r) {
             checkbox.checked = false;
         }
@@ -59,7 +59,7 @@ var TextMessage = {
 <form action="/manage/{{ program.getUrlBase }}/grouptextfinal?filterid={{ filterid }}" method="post" name="grouptext">
 <textarea name="message" id="message_input" cols="40" rows="4" oninput="TextMessage.onMessageChange();"></textarea>
 <p id="length_remaining">160 characters remaining.</p>
-<input type="checkbox" name="text-override" onchange='confirmOverride(this);'> Override texting preferences.<br><br>
+<input type="checkbox" name="text-override" onchange='confirmOverride(this);'> Override texting preferences<br><br>
 <input type="submit" value="Send your message!" />
 </form>
 


### PR DESCRIPTION
This adds a checkbox that allows admins to override the texting preferences for the recipients of the text message. This provides a way to text volunteers and teachers, since there is no way for them to set texting preferences (under the assumption that it's fine to text them and they won't incur some outrageous fee). I've also added a little popup to double check that people know what they are doing.

Fixes #2589.