### PR TITLE
Buttons to next and previous teacher checkin pages

### DIFF
--- a/esp/esp/program/modules/handlers/teachercheckinmodule.py
+++ b/esp/esp/program/modules/handlers/teachercheckinmodule.py
@@ -357,12 +357,24 @@ class TeacherCheckinModule(ProgramModuleObj):
                               getMissingTeachers(). Should be given in the
                               format "%m/%d/%Y %H:%M".
         """
-        starttime = date = None
+        starttime = date = next = previous = None
         if 'start' in request.GET:
             starttime = Event.objects.get(id=request.GET['start'])
             date = starttime.start.date()
+            times = prog.getTimeSlotList()
+            i = times.index(starttime)
+            if i > 0:
+                previous = times[i - 1]
+            if i < len(times) - 1:
+                next = times[i + 1]
         elif 'date' in request.GET:
             date = datetime.strptime(request.GET['date'], "%m/%d/%Y").date()
+            dates = prog.dates()
+            i = dates.index(date)
+            if i > 0:
+                previous = dates[i - 1].strftime('%m/%d/%Y')
+            if i < len(dates) - 1:
+                next = dates[i + 1].strftime('%m/%d/%Y')
         context = {}
         context['text_configured'] = GroupTextModule.is_configured()
         form = TeacherCheckinForm(request.GET)
@@ -381,6 +393,8 @@ class TeacherCheckinModule(ProgramModuleObj):
             context['show_flags'] = True
             context['flag_types'] = ClassFlagType.get_flag_types(self.program)
         context['start_time'] = starttime
+        context['next'] = next
+        context['previous'] = previous
         return render_to_response(self.baseDir()+'missingteachers.html',
                                   request, context)
 

--- a/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
+++ b/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
@@ -110,7 +110,20 @@
 
 <div id='program_form'>
 
-<br/><a href="teachercheckin{% if when %}?when={{ url_when }}{% endif %}">&lt;&lt;Back</a>
+<br/>
+<a class="btn" style="float: left" href="teachercheckin{% if when %}?when={{ url_when }}{% endif %}">&lt;&lt;Back</a>
+{% if previous or next %}
+<div style="text-align:right">
+{% if date %}
+{% if previous %}<a class="btn" href="missingteachers?date={{ previous }}{% if when %}when={{ url_when }}{% endif %}">&lt;&lt;Previous day</a>{% endif %}
+{% if next %}<a class="btn" href="missingteachers?date={{ next }}{% if when %}when={{ url_when }}{% endif %}">Next day&gt;&gt;</a>{% endif %}
+{% else %}
+{% if previous %}<a class="btn" href="missingteachers?start={{ previous.id }}{% if when %}when={{ url_when }}{% endif %}">&lt;&lt;Previous time slot</a>{% endif %}
+{% if next %}<a class="btn" href="missingteachers?start={{ next.id }}{% if when %}when={{ url_when }}{% endif %}">Next time slot&gt;&gt;</a>{% endif %}
+{% endif %}
+</div>
+<br>
+{% endif %}
 
 <p style="text-align:right">
 <input class="button text-all" type="button" value="Text All Unchecked-In Teachers"

--- a/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
+++ b/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
@@ -115,11 +115,11 @@
 {% if previous or next %}
 <div style="text-align:right">
 {% if start_time %}
-{% if previous %}<a class="btn" href="missingteachers?start={{ previous.id }}{% if when %}when={{ url_when }}{% endif %}">&lt;&lt;Previous time slot</a>{% endif %}
-{% if next %}<a class="btn" href="missingteachers?start={{ next.id }}{% if when %}when={{ url_when }}{% endif %}">Next time slot&gt;&gt;</a>{% endif %}
+{% if previous %}<a class="btn" href="missingteachers?start={{ previous.id }}{% if when %}&when={{ url_when }}{% endif %}">&lt;&lt;Previous time slot</a>{% endif %}
+{% if next %}<a class="btn" href="missingteachers?start={{ next.id }}{% if when %}&when={{ url_when }}{% endif %}">Next time slot&gt;&gt;</a>{% endif %}
 {% elif date %}
-{% if previous %}<a class="btn" href="missingteachers?date={{ previous }}{% if when %}when={{ url_when }}{% endif %}">&lt;&lt;Previous day</a>{% endif %}
-{% if next %}<a class="btn" href="missingteachers?date={{ next }}{% if when %}when={{ url_when }}{% endif %}">Next day&gt;&gt;</a>{% endif %}
+{% if previous %}<a class="btn" href="missingteachers?date={{ previous }}{% if when %}&when={{ url_when }}{% endif %}">&lt;&lt;Previous day</a>{% endif %}
+{% if next %}<a class="btn" href="missingteachers?date={{ next }}{% if when %}&when={{ url_when }}{% endif %}">Next day&gt;&gt;</a>{% endif %}
 {% endif %}
 </div>
 <br>

--- a/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
+++ b/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
@@ -114,12 +114,12 @@
 <a class="btn" style="float: left" href="teachercheckin{% if when %}?when={{ url_when }}{% endif %}">&lt;&lt;Back</a>
 {% if previous or next %}
 <div style="text-align:right">
-{% if date %}
-{% if previous %}<a class="btn" href="missingteachers?date={{ previous }}{% if when %}when={{ url_when }}{% endif %}">&lt;&lt;Previous day</a>{% endif %}
-{% if next %}<a class="btn" href="missingteachers?date={{ next }}{% if when %}when={{ url_when }}{% endif %}">Next day&gt;&gt;</a>{% endif %}
-{% else %}
+{% if start_time %}
 {% if previous %}<a class="btn" href="missingteachers?start={{ previous.id }}{% if when %}when={{ url_when }}{% endif %}">&lt;&lt;Previous time slot</a>{% endif %}
 {% if next %}<a class="btn" href="missingteachers?start={{ next.id }}{% if when %}when={{ url_when }}{% endif %}">Next time slot&gt;&gt;</a>{% endif %}
+{% else %}
+{% if previous %}<a class="btn" href="missingteachers?date={{ previous }}{% if when %}when={{ url_when }}{% endif %}">&lt;&lt;Previous day</a>{% endif %}
+{% if next %}<a class="btn" href="missingteachers?date={{ next }}{% if when %}when={{ url_when }}{% endif %}">Next day&gt;&gt;</a>{% endif %}
 {% endif %}
 </div>
 <br>

--- a/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
+++ b/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
@@ -117,7 +117,7 @@
 {% if start_time %}
 {% if previous %}<a class="btn" href="missingteachers?start={{ previous.id }}{% if when %}when={{ url_when }}{% endif %}">&lt;&lt;Previous time slot</a>{% endif %}
 {% if next %}<a class="btn" href="missingteachers?start={{ next.id }}{% if when %}when={{ url_when }}{% endif %}">Next time slot&gt;&gt;</a>{% endif %}
-{% else %}
+{% elif date %}
 {% if previous %}<a class="btn" href="missingteachers?date={{ previous }}{% if when %}when={{ url_when }}{% endif %}">&lt;&lt;Previous day</a>{% endif %}
 {% if next %}<a class="btn" href="missingteachers?date={{ next }}{% if when %}when={{ url_when }}{% endif %}">Next day&gt;&gt;</a>{% endif %}
 {% endif %}

--- a/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
+++ b/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
@@ -244,7 +244,7 @@
 {% endfor %}
 </table>
 
-<br/><a href="teachercheckin{% if when %}?when={{ url_when }}{% endif %}">&lt;&lt;Back</a><br/>
+<br/><a class="btn" style="float: left" href="teachercheckin{% if when %}?when={{ url_when }}{% endif %}">&lt;&lt;Back</a><br/>
 
 <br />
 {% load render_qsd %}


### PR DESCRIPTION
I added buttons that go to the next and previous teacher checkin pages (hours or days, depending on what is being used) if they exist. For example, the first hour looks like this:

![image](https://user-images.githubusercontent.com/7232514/43412215-5b86fdfc-93e1-11e8-8258-8d3d4e139f91.png)

And the second hour looks like this:

![image](https://user-images.githubusercontent.com/7232514/43412227-665704f2-93e1-11e8-98d1-220bec47d084.png)

Fixes #2293.