### PR TITLE
Handle Twilio exceptions gracefully

### DIFF
--- a/esp/esp/program/modules/handlers/grouptextmodule.py
+++ b/esp/esp/program/modules/handlers/grouptextmodule.py
@@ -45,6 +45,7 @@ from esp.middleware import ESPError
 
 from django.conf import settings
 
+from twilio import TwilioRestException
 from twilio.rest import TwilioRestClient
 
 class GroupTextModule(ProgramModuleObj):
@@ -175,9 +176,12 @@ class GroupTextModule(ProgramModuleObj):
                     formattedNumber = '+1' + formattedNumber
 
                 send_log.append("Sending text message to "+formattedNumber)
-                client.sms.messages.create(body=body,
+                try:
+                    client.sms.messages.create(body=body,
                                            to=formattedNumber,
                                            from_=ourNumbers[numberIndex])
+                except TwilioRestException as error:
+                    send_log.append(error.msg)
                 numberIndex = (numberIndex + 1) % len(ourNumbers)
 
         return "\n".join(send_log)

--- a/esp/esp/program/modules/handlers/teachercheckinmodule.py
+++ b/esp/esp/program/modules/handlers/teachercheckinmodule.py
@@ -51,7 +51,6 @@ from django.template.loader import render_to_string, select_template
 from django.db.models.aggregates import Min
 from django.db.models.query   import Q
 from datetime import datetime, timedelta
-from twilio.rest import TwilioRestClient
 
 import collections
 import json
@@ -169,8 +168,11 @@ class TeacherCheckinModule(ProgramModuleObj):
                 sec = ClassSection.objects.get(id=request.POST['section'])
                 teacher = PersistentQueryFilter.create_from_Q(ESPUser, Q(username=request.POST['username']))
                 message = "Don't forget to check-in for your " + one + " class that is scheduled for " + sec.friendly_times(include_date = True)[0] + "!"
-                GroupTextModule.sendMessages(teacher, message, True)
-                return {'message': "Texted teacher"}
+                log = GroupTextModule.sendMessages(teacher, message, True)
+                if "error" in log:
+                    return {'message': "Error texting teacher"}
+                else:
+                    return {'message': "Texted teacher"}
             else:
                 return {'message': "Username and/or section not provided"}
         else:


### PR DESCRIPTION
This handles Twilio exceptions and includes them in the logs when sending text messages. This also then catches whether there is an error when texting teachers for teacher checkin. To save space, the text on the teacher checkin page only says whether there was an error or not.

I tested this successfully with the phone number 000-000-0000.

Fixes #2573.