### PR TITLE
Fix class import error when using grade ranges with new minimum grade for program

### DIFF
--- a/esp/esp/program/controllers/classreg.py
+++ b/esp/esp/program/controllers/classreg.py
@@ -1,7 +1,7 @@
 from esp.mailman import add_list_member
 from esp.program.models import Program, ClassSubject, ClassSection, ClassCategories, ClassSizeRange
 from esp.middleware import ESPError
-from esp.program.modules.forms.teacherreg import TeacherClassRegForm
+from esp.program.modules.forms.teacherreg import TeacherClassRegForm, TeacherOpenClassRegForm
 from esp.resources.forms import ResourceRequestFormSet
 from esp.resources.models import ResourceType, ResourceRequest
 from esp.tagdict.models import Tag
@@ -44,6 +44,10 @@ class ClassCreationController(object):
     def makeaclass(self, user, reg_data, form_class=TeacherClassRegForm):
 
         reg_form, resource_formset = self.get_forms(reg_data, form_class=form_class)
+        
+        if form_class == TeacherOpenClassRegForm:
+            reg_form.cleaned_data['grade_min'] = self.program.grade_min
+            reg_form.cleaned_data['grade_max'] = self.program.grade_max
 
         self.require_teacher_has_time(user, user, reg_form._get_total_time_requested())
 

--- a/esp/esp/program/controllers/classreg.py
+++ b/esp/esp/program/controllers/classreg.py
@@ -44,7 +44,7 @@ class ClassCreationController(object):
     def makeaclass(self, user, reg_data, form_class=TeacherClassRegForm):
 
         reg_form, resource_formset = self.get_forms(reg_data, form_class=form_class)
-        
+
         if form_class == TeacherOpenClassRegForm:
             reg_form.cleaned_data['grade_min'] = self.program.grade_min
             reg_form.cleaned_data['grade_max'] = self.program.grade_max

--- a/esp/esp/program/modules/forms/teacherreg.py
+++ b/esp/esp/program/modules/forms/teacherreg.py
@@ -82,7 +82,7 @@ class TeacherClassRegForm(FormWithRequiredCss):
 
     # To enable grade ranges, admins should set the Tag grade_ranges.
     # e.g. [[7,9],[9,10],[9,12],[10,12],[11,12]] gives five grade ranges: 7-9, 9-10, 9-12, 10-12, and 11-12
-    grade_range    = forms.ChoiceField( label='Grade Range', choices=[], required=False, widget=BlankSelectWidget() )
+    grade_range    = forms.ChoiceField( label='Grade Range', choices=[], widget=BlankSelectWidget() )
     grade_min      = forms.ChoiceField( label='Minimum Grade Level', choices=[(7, 7)], widget=BlankSelectWidget() )
     grade_max      = forms.ChoiceField( label='Maximum Grade Level', choices=[(12, 12)], widget=BlankSelectWidget() )
     class_size_max = forms.ChoiceField( label='Maximum Number of Students',
@@ -151,13 +151,10 @@ class TeacherClassRegForm(FormWithRequiredCss):
         if Tag.getProgramTag('grade_ranges', prog):
             grade_ranges = json.loads(Tag.getProgramTag('grade_ranges', prog))
             self.fields['grade_range'].choices = [(range,str(range[0]) + " - " + str(range[1])) for range in grade_ranges]
-            self.fields['grade_range'].required = True
-            hide_field( self.fields['grade_min'] )
-            self.fields['grade_min'].required = False
-            hide_field( self.fields['grade_max'] )
-            self.fields['grade_max'].required = False
+            del self.fields['grade_min']
+            del self.fields['grade_max']
         else:
-            hide_field( self.fields['grade_range'] )
+            del self.fields['grade_range']
         if crmi.use_class_size_max:
             # class_size_max: crmi.getClassSizes
             self.fields['class_size_max'].choices = class_sizes

--- a/esp/esp/program/modules/forms/teacherreg.py
+++ b/esp/esp/program/modules/forms/teacherreg.py
@@ -148,7 +148,7 @@ class TeacherClassRegForm(FormWithRequiredCss):
         # grade_min, grade_max: crmi.getClassGrades
         self.fields['grade_min'].choices = class_grades
         self.fields['grade_max'].choices = class_grades
-        if Tag.getProgramTag('grade_ranges', prog):
+        if not isinstance(self, TeacherOpenClassRegForm) and Tag.getProgramTag('grade_ranges', prog):
             grade_ranges = json.loads(Tag.getProgramTag('grade_ranges', prog))
             self.fields['grade_range'].choices = [(range,str(range[0]) + " - " + str(range[1])) for range in grade_ranges]
             del self.fields['grade_min']
@@ -321,10 +321,8 @@ class TeacherOpenClassRegForm(TeacherClassRegForm):
         # Modify some help texts to be form-specific.
         self.fields['duration'].help_text = "For how long are you willing to teach this class?"
 
-        del self.fields['grade_range']
-
         fields = [('category', open_class_category.id),
-                  ('prereqs', ''), ('session_count', 1), ('grade_min', program.grade_min), ('grade_max', program.grade_max),
+                  ('prereqs', ''), ('session_count', 1), ('grade_min', program.grade_min), ('grade_max', program.grade_max), ('grade_min', program.grade_min),
                   ('class_size_max', 200), ('class_size_optimal', ''), ('optimal_class_size_range', ''),
                   ('allowable_class_size_ranges', ''), ('hardness_rating', '**'), ('allow_lateness', True),
                   ('requested_room', '')]

--- a/esp/esp/program/modules/forms/teacherreg.py
+++ b/esp/esp/program/modules/forms/teacherreg.py
@@ -148,7 +148,7 @@ class TeacherClassRegForm(FormWithRequiredCss):
         # grade_min, grade_max: crmi.getClassGrades
         self.fields['grade_min'].choices = class_grades
         self.fields['grade_max'].choices = class_grades
-        if not isinstance(self, TeacherOpenClassRegForm) and Tag.getProgramTag('grade_ranges', prog):
+        if Tag.getProgramTag('grade_ranges', prog):
             grade_ranges = json.loads(Tag.getProgramTag('grade_ranges', prog))
             self.fields['grade_range'].choices = [(range,str(range[0]) + " - " + str(range[1])) for range in grade_ranges]
             del self.fields['grade_min']
@@ -321,8 +321,14 @@ class TeacherOpenClassRegForm(TeacherClassRegForm):
         # Modify some help texts to be form-specific.
         self.fields['duration'].help_text = "For how long are you willing to teach this class?"
 
+        if self.fields.get('grade_min') and self.fields.get('grade_min'):
+            del self.fields['grade_min']
+            del self.fields['grade_max']
+        else:
+            del self.fields['grade_range']
+
         fields = [('category', open_class_category.id),
-                  ('prereqs', ''), ('session_count', 1), ('grade_min', program.grade_min), ('grade_max', program.grade_max), ('grade_min', program.grade_min),
+                  ('prereqs', ''), ('session_count', 1),
                   ('class_size_max', 200), ('class_size_optimal', ''), ('optimal_class_size_range', ''),
                   ('allowable_class_size_ranges', ''), ('hardness_rating', '**'), ('allow_lateness', True),
                   ('requested_room', '')]

--- a/esp/esp/program/modules/forms/teacherreg.py
+++ b/esp/esp/program/modules/forms/teacherreg.py
@@ -321,7 +321,7 @@ class TeacherOpenClassRegForm(TeacherClassRegForm):
         # Modify some help texts to be form-specific.
         self.fields['duration'].help_text = "For how long are you willing to teach this class?"
 
-        if self.fields.get('grade_min') and self.fields.get('grade_min'):
+        if self.fields.get('grade_min') and self.fields.get('grade_max'):
             del self.fields['grade_min']
             del self.fields['grade_max']
         else:


### PR DESCRIPTION
Stanford ran into an error that only arises when you try to import an old class (that included the old minimum grade) while using the grade ranges option and a new, higher minimum grade for the new program. I originally had the other grade fields hidden in the form, but when the minimum grade for the program is changed and the old imported class included the old minimum grade, that old minimum grade is then hidden in the `grade_min` field, which then causes an error each time the form is submitted. So here I went all the way and deleted the unnecessary grade fields instead of just hiding them (`grade_ranges` when using minimum and maximum grades, `grade_min` and `grade_max` when using grade ranges).