### PR TITLE
Add some logging to dbmail

### DIFF
--- a/esp/dbmail_cron.py
+++ b/esp/dbmail_cron.py
@@ -3,6 +3,8 @@
 import sys
 import os
 import fcntl
+import logging
+logger = logging.getLogger('esp.dbmail_cron')   # __name__ is not very useful
 os.environ['DJANGO_SETTINGS_MODULE'] = 'esp.settings'
 
 import os.path
@@ -28,6 +30,8 @@ from esp.dbmail.cronmail import process_messages, send_email_requests
 # esp.settings modifies tempfile to avoid collisions between sites.
 import tempfile
 
+logger.info('dbmail_cron: starting!')
+
 # lock to ensure only one cron instance runs at a time
 lock_file_path = os.path.join(tempfile.gettempdir(), 'espweb.dbmailcron.lock')
 lock_file_handle = open(lock_file_path, 'w')
@@ -35,12 +39,21 @@ try:
     fcntl.lockf(lock_file_handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
 except IOError:
     # another instance has the lock
+    logger.info('dbmail_cron: exiting because another instance has the lock.')
     sys.exit(0)
 
-process_messages()
-send_email_requests()
+try:
+    logger.info('dbmail_cron: beginning to process messages.')
+    process_messages()
+    logger.info('dbmail_cron: message processing complete; sending emails.')
+    send_email_requests()
+    logger.info('dbmail_cron: sent emails.')
+except Exception as e:
+    logger.info('dbmail_cron: fatal error!')
+    logger.exception(e)
+finally:
+    # Release the lock when message sending is complete.
+    fcntl.lockf(lock_file_handle, fcntl.LOCK_UN)
+    lock_file_handle.close()
 
-# Release the lock when message sending is complete.
-fcntl.lockf(lock_file_handle, fcntl.LOCK_UN)
-lock_file_handle.close()
-
+logger.info('dbmail_cron: done.')

--- a/esp/esp/dbmail/models.py
+++ b/esp/esp/dbmail/models.py
@@ -303,6 +303,7 @@ class MessageRequest(models.Model):
         It is the caller's responsibility to call this only on unprocessed
         MessageRequests.
         """
+        logger.info("Processing MessageRequest %d: %s", self.id, self.subject)
 
         # figure out who we're sending from...
         if self.sender is not None and len(self.sender.strip()) > 0:


### PR DESCRIPTION
If the script is working, it logs a bunch.  But if we crash, we were not
logging where we were before the crash.  Also, due to a logging
misconfiguration, the logs weren't going anywhere (because the logger
name didn't start with `esp.`).  Now it should all work!

Fixes #2624; slightly adapted from bd3c173 which is on yale-sr10.