### PR TITLE
Make duration field not required when disabled

### DIFF
--- a/esp/esp/program/modules/forms/management.py
+++ b/esp/esp/program/modules/forms/management.py
@@ -49,6 +49,7 @@ class ClassManageForm(ManagementForm):
             if self.cls.hasScheduledSections():
                 self.fields['duration'].widget.attrs['disabled'] = True
                 self.fields['duration'].widget.attrs['title'] = "At least one section of this class has already been scheduled"
+                self.fields['duration'].required = False
         else:
             super(ClassManageForm, self).__init__(*args, **kwargs)
 


### PR DESCRIPTION
Fixes #2639, which caused a bug that prevented making any changes on a class manage page after any sections were scheduled.