### PR TITLE
Sort fillslot like catalog

### DIFF
--- a/esp/esp/program/modules/handlers/studentclassregmodule.py
+++ b/esp/esp/program/modules/handlers/studentclassregmodule.py
@@ -398,6 +398,26 @@ class StudentClassRegModule(ProgramModuleObj):
             # TODO(benkraft): we shouldn't need to do this.  find a better way.
             raise AjaxError(inst)
 
+    @staticmethod
+    def sort_categories(classes, prog):
+        categories = {}
+        for cls in classes:
+            categories[cls.category_id] = {'id':cls.category_id, 'category':cls.category_txt if hasattr(cls, 'category_txt') else cls.category.category, 'symbol':cls.category.symbol}
+
+        # Is the catalog sorted by category? If so, by which aspect of category?
+        # Default is to sort by category symbol
+        catalog_sort = 'category__symbol'
+        program_sort_fields = Tag.getProgramTag('catalog_sort_fields', prog)
+        if program_sort_fields:
+            catalog_sort = program_sort_fields.split(',')[0]
+
+        catalog_sort_split = catalog_sort.split('__')
+        if catalog_sort_split[0] == 'category' and catalog_sort_split[1] in ['id', 'category', 'symbol']:
+            categories_sort = sorted(categories.values(), key = lambda cat: cat[catalog_sort_split[1]])
+        else:
+            categories_sort = None
+        return categories_sort
+
     @aux_call
     @needs_student
     @meets_deadline('/Classes')
@@ -431,23 +451,7 @@ class StudentClassRegModule(ProgramModuleObj):
                 classes = filter(lambda c: c.grade_min <=user_grade and c.grade_max >= user_grade, classes)
             classes = filter(lambda c: not c.isRegClosed(), classes)
 
-        categories = {}
-
-        for cls in classes:
-            categories[cls.category_id] = {'id':cls.category_id, 'category':cls.category_txt if hasattr(cls, 'category_txt') else cls.category.category, 'symbol':cls.category.symbol}
-
-        # Are the classes sorted by category? If so, by which aspect of category?
-        # Default is to sort by category symbol
-        catalog_sort = 'category__symbol'
-        program_sort_fields = Tag.getProgramTag('catalog_sort_fields', prog)
-        if program_sort_fields:
-            catalog_sort = program_sort_fields.split(',')[0]
-
-        catalog_sort_split = catalog_sort.split('__')
-        if catalog_sort_split[0] == 'category' and catalog_sort_split[1] in ['id', 'category', 'symbol']:
-            categories_sort = sorted(categories.values(), key = lambda cat: cat[catalog_sort_split[1]])
-        else:
-            categories_sort = None
+        categories_sort = self.sort_categories(classes, self.program)
 
         return render_to_response(self.baseDir()+'fillslot.html', request, {'classes':    classes,
                                                                             'one':        one,
@@ -461,22 +465,7 @@ class StudentClassRegModule(ProgramModuleObj):
         # using .extra() to select all the category text simultaneously
         classes = ClassSubject.objects.catalog(self.program)
 
-        categories = {}
-        for cls in classes:
-            categories[cls.category_id] = {'id':cls.category_id, 'category':cls.category_txt if hasattr(cls, 'category_txt') else cls.category.category, 'symbol':cls.category.symbol}
-
-        # Is the catalog sorted by category? If so, by which aspect of category?
-        # Default is to sort by category symbol
-        catalog_sort = 'category__symbol'
-        program_sort_fields = Tag.getProgramTag('catalog_sort_fields', prog)
-        if program_sort_fields:
-            catalog_sort = program_sort_fields.split(',')[0]
-
-        catalog_sort_split = catalog_sort.split('__')
-        if catalog_sort_split[0] == 'category' and catalog_sort_split[1] in ['id', 'category', 'symbol']:
-            categories_sort = sorted(categories.values(), key = lambda cat: cat[catalog_sort_split[1]])
-        else:
-            categories_sort = None
+        categories_sort = self.sort_categories(classes, self.program)
 
         # Allow tag configuration of whether class descriptions get collapsed
         # when the class is full (default: yes)

--- a/esp/templates/program/modules/studentclassregmodule/fillslot.html
+++ b/esp/templates/program/modules/studentclassregmodule/fillslot.html
@@ -46,6 +46,7 @@ input.addbutton {
 {% endif %}
 {% endif %}
 
+{% if categories %}
 <div class="row-fluid">
 <table class="table table-bordered table-condensed span6">
 <tbody>
@@ -73,6 +74,7 @@ input.addbutton {
 </tbody>
 </table>
 </div>
+{% endif %}
 
 {% load render_qsd %}
 {% render_inline_program_qsd program "learn:fillslot" %}
@@ -90,6 +92,7 @@ There are no available classes during this time block for students of your grade
 {# If the line below gives you a TemplateSyntaxError, try replacing it with a 'with' tag. #}
 {% for class in classes %}
 
+{% if categories %}
 {% ifchanged class.category_id %}<hr size="1"/>
 
     <a name="cat{{class.category_id}}"></a>
@@ -110,6 +113,7 @@ There are no available classes during this time block for students of your grade
       <p class="linktop">
          <a href="#top">[ Return to Category List ]</a>
       </p> {% endifchanged %}
+{% endif %}
 
 {% render_class class request.user request.GET.filter timeslot %}
 


### PR DESCRIPTION
This takes the fixes for category sorting and display from #2597 and implements them in the `fillslot` logic. I also removed the old class sorting logic from the fillslot code, since we want to be consistent and sort the classes as they are sorted in the normal catalog (which is already done via `ClassSubject.objects.catalog()`).

Fixes #2645.