### PR TITLE
Fill in possible resource type choices in classsearch

### DIFF
--- a/esp/public/media/scripts/program/modules/classsearch.js
+++ b/esp/public/media/scripts/program/modules/classsearch.js
@@ -1,0 +1,55 @@
+var prog_url = $j('#classsearchscript').data('prog_url');
+
+//Get choices (if there are any) for a resource via POST
+function getChoices(resource_type, callback){
+    var data = {furnishing: resource_type, csrfmiddlewaretoken: csrf_token()};
+    $j.post('/manage/' + prog_url + '/ajaxfurnishingchoices', data, "json").success(callback);
+}
+
+//Update the option field to reflect whether there are specific choices (dropdown) or not (open response). If a value is supplied, set that value as selected afterwards.
+function update_choices(resource_type_obj, choice_obj) {
+    var resource_type = $j(resource_type_obj).val()
+    var value = $j(choice_obj).val()
+    var reactid = $j(choice_obj).data("reactid")
+    getChoices(resource_type, function(response) {
+        var choices = response.choices;
+        if(choices[0] != "Don't care" || choices.length > 1){
+            $j(choice_obj).replaceWith($j('<select data-reactid="'+reactid+'">').addClass("qb-input").attr('type', 'text'));
+            var new_obj = $j('[data-reactid="'+reactid+'"]')
+            $j(new_obj).data("reactid",reactid)
+            $j(new_obj).append($j('<option>').text('(option)'));
+            for (i in choices) {
+                $j(new_obj).append($j('<option>').val(choices[i]).text(choices[i]));
+            }
+            if (value) {
+                $j(new_obj).val(value);
+            }
+        } else if ($j(choice_obj).is("select")) {
+            $j(choice_obj).replaceWith($j('<input data-reactid="'+reactid+'">').addClass("qb-input"));
+        }
+    });
+}
+
+function checkSelect(sel){
+    var span = $j(sel).parent();
+    if($j(span).parent().prev().children(".qb-input:not(.qb-negate)").val() == "resource"){
+        var choice_obj = $j(span).next().find("input, select");
+        if(choice_obj.length > 0){
+            update_choices(sel, choice_obj);
+        }
+    }
+}
+
+function checkInput(inp){
+    checkSelect($j(inp).parent().parent().prev().find("select.qb-input"));
+}
+
+//Set up choices if resource type already chosen on page load
+$j.initialize("input.qb-input", function() {
+    checkInput(this);
+}, { target: document.getElementsByClassName('query-builder')[0] });
+
+//Update choices when resource type is changed
+$j(document).on('change', 'select.qb-input', function() {
+    checkSelect(this);
+});

--- a/esp/templates/program/modules/classsearchmodule/class_search.html
+++ b/esp/templates/program/modules/classsearchmodule/class_search.html
@@ -13,6 +13,9 @@
     <script type="text/jsx" src="/media/scripts/query-builder.jsx"></script>
     <script type="text/javascript" src="/media/scripts/program/modules/flag-results-page.js"></script>
     <script type="text/javascript" src="/media/scripts/program/modules/flag-edit.js"></script>
+    <!--jQuery.initialize plugin is created to help maintain dynamically created elements on the page-->
+    <script src="https://rawgit.com/pie6k/jquery.initialize/eb28c24e2eef256344777b45a455173cba36e850/jquery.initialize.js"></script>
+    <script id="classsearchscript" src="/media/scripts/program/modules/classsearch.js" data-prog_url="{{ program.url }}"></script>
 {% endblock %}
 
 {% block content %}

--- a/esp/templates/program/modules/classsearchmodule/class_search.html
+++ b/esp/templates/program/modules/classsearchmodule/class_search.html
@@ -14,7 +14,7 @@
     <script type="text/javascript" src="/media/scripts/program/modules/flag-results-page.js"></script>
     <script type="text/javascript" src="/media/scripts/program/modules/flag-edit.js"></script>
     <!--jQuery.initialize plugin is created to help maintain dynamically created elements on the page-->
-    <script src="https://rawgit.com/pie6k/jquery.initialize/eb28c24e2eef256344777b45a455173cba36e850/jquery.initialize.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/pie6k/jquery.initialize@eb28c24e2eef256344777b45a455173cba36e850/jquery.initialize.js"></script>
     <script id="classsearchscript" src="/media/scripts/program/modules/classsearch.js" data-prog_url="{{ program.url }}"></script>
 {% endblock %}
 


### PR DESCRIPTION
In #2594 I made it possible to filter classes on /classsearch by the resources that were requested. It was also possible to filter by the desired_value of the requested resource, but the filter was just a text entry field. This expands that functionality by replacing the `input` with a `select` with the options that have been set for the resource type (if options have been set) (using the code added in #2547).

Fixes #2634.