### PR TITLE
Selective resource import

### DIFF
--- a/esp/esp/program/modules/handlers/resourcemodule.py
+++ b/esp/esp/program/modules/handlers/resourcemodule.py
@@ -245,8 +245,10 @@ class ResourceModule(ProgramModuleObj):
                     end   = orig_timeslot.end + time_delta,
                 )
                 #   Save the new timeslot only if it doesn't duplicate an existing one
-                if import_mode == 'save' and not Event.objects.filter(program=new_timeslot.program, start=new_timeslot.start, end=new_timeslot.end).exists() and new_timeslot.short_description + "_" + str(new_timeslot.start) in to_import:
+                if import_mode == 'save' and not Event.objects.filter(program=new_timeslot.program, start=new_timeslot.start, end=new_timeslot.end).exists() and str(orig_timeslot.id) in to_import:
                     new_timeslot.save()
+                else:
+                    new_timeslot.old_id = orig_timeslot.id
                 new_timeslots.append(new_timeslot)
 
             #   Render a preview page showing the resources for the previous program if desired
@@ -291,8 +293,10 @@ class ResourceModule(ProgramModuleObj):
                     autocreated = res_type.autocreated,
                     hidden = res_type.hidden
                 )
-                if import_mode == 'save' and not ResourceType.objects.filter(name=new_res_type.name, description = new_res_type.description, program = self.program).exists() and new_res_type.name in to_import:
+                if import_mode == 'save' and not ResourceType.objects.filter(name=new_res_type.name, description = new_res_type.description, program = self.program).exists() and str(res_type.id) in to_import:
                     new_res_type.save()
+                else:
+                    new_res_type.old_id = res_type.id
                 res_type_list.append(new_res_type)
             context['past_program'] = past_program
             if import_mode == 'preview':
@@ -337,8 +341,10 @@ class ResourceModule(ProgramModuleObj):
                             user = resource.user,
                             event = timeslot
                         )
-                        if import_mode == 'save' and not Resource.objects.filter(name=new_res.name, event=new_res.event).exists() and new_res.name in to_import:
+                        if import_mode == 'save' and not Resource.objects.filter(name=new_res.name, event=new_res.event).exists() and str(resource.id) in to_import:
                             new_res.save()
+                        else:
+                            new_res.old_id = resource.id
                         if import_furnishings:
                             new_furns = self.furnishings_import(resource, new_res, self.program, import_mode, to_import)
                             furnishing_dict[resource.name].update(new_furn.res_type.name + (" (Hidden)" if new_furn.res_type.hidden else "") + ((": " + new_furn.attribute_value) if new_furn.attribute_value else "") for new_furn in new_furns)
@@ -365,8 +371,10 @@ class ResourceModule(ProgramModuleObj):
                             event = ts_map[res.event.id]
                         )
                         #   Check to avoid duplicating rooms (so the process is idempotent)
-                        if import_mode == 'save' and not Resource.objects.filter(name=new_res.name, event=new_res.event).exists() and new_res.name in to_import:
+                        if import_mode == 'save' and not Resource.objects.filter(name=new_res.name, event=new_res.event).exists() and str(res.id) in to_import:
                             new_res.save()
+                        else:
+                            new_res.old_id = res.id
                         if import_furnishings:
                             new_furns = self.furnishings_import(res, new_res, self.program, import_mode, to_import)
                             furnishing_dict[res.name].update(new_furn.res_type.name + (" (Hidden)" if new_furn.res_type.hidden else "") + ((": " + new_furn.attribute_value) if new_furn.attribute_value else "") for new_furn in new_furns)
@@ -426,7 +434,7 @@ class ResourceModule(ProgramModuleObj):
                 res_group = new_res.res_group,
                 attribute_value = f.attribute_value
             )
-            if import_mode == 'save' and not Resource.objects.filter(name=new_furnishing.name, event=new_res.event).exists() and new_res.name in to_import:
+            if import_mode == 'save' and not Resource.objects.filter(name=new_furnishing.name, event=new_res.event).exists() and str(old_res.id) in to_import:
                 new_furnishing.save()
             new_furnishings.append(new_furnishing)
         return new_furnishings
@@ -512,8 +520,10 @@ class ResourceModule(ProgramModuleObj):
                             user = equipment.user,
                             event = timeslot
                         )
-                        if import_mode == 'save' and not Resource.objects.filter(name=new_equip.name, event=new_equip.event).exists() and new_equip.name in to_import:
+                        if import_mode == 'save' and not Resource.objects.filter(name=new_equip.name, event=new_equip.event).exists() and str(equipment.id) in to_import:
                             new_equip.save()
+                        else:
+                            new_equip.old_id = equipment.id
                         new_equipment_list.append(new_equip)
             else:
                 #   Attempt to match timeslots for the programs
@@ -551,8 +561,10 @@ class ResourceModule(ProgramModuleObj):
                             user = equipment.user,
                             event = ts_map[equipment.event.id]
                         )
-                        if import_mode == 'save' and not Resource.objects.filter(name=new_equip.name, event=new_equip.event).exists() and new_equip.name in to_import:
+                        if import_mode == 'save' and not Resource.objects.filter(name=new_equip.name, event=new_equip.event).exists() and str(equipment.id) in to_import:
                             new_equip.save()
+                        else:
+                            new_equip.old_id = equipment.id
                         new_equipment_list.append(new_equip)
 
             context['past_program'] = past_program

--- a/esp/templates/program/modules/resourcemodule/classroom_import.html
+++ b/esp/templates/program/modules/resourcemodule/classroom_import.html
@@ -7,6 +7,14 @@
     <link rel="stylesheet" href="/media/styles/forms.css" type="text/css" />
 {% endblock %}
 
+{% block xtrajs %}
+<script>
+function toggle(source) {
+  $j('input[name=to_import]').prop('checked', source.checked);
+}
+</script>
+{% endblock %}
+
 {% block content %}
 
 <h1>Manage Resources for {{ prog.niceName }}</h1>
@@ -27,8 +35,8 @@ You have chosen to import the classrooms from {{ past_program.niceName }} to {{ 
 <input type="hidden" name="complete_availability" value="{{ complete_availability }}" />
 <input type="hidden" name="import_furnishings" value="{{ import_furnishings }}" />
 <table align="center" cellpadding="0" cellspacing="0" width="550">
-    <tr><th colspan="2">Proposed classrooms for {{ prog.niceName }}</th></tr>
-    <tr><td colspan="2"><table cellpadding="0" cellspacing="0" width="100%">
+    <tr><th colspan="5">Proposed classrooms for {{ prog.niceName }}</th></tr>
+    <tr><td colspan="5"><table cellpadding="0" cellspacing="0" width="100%">
     <tr>
         <td class="underline"><b>Room</b></td>
         <td class="underline"><b>Capacity</b></td>
@@ -36,6 +44,7 @@ You have chosen to import the classrooms from {{ past_program.niceName }} to {{ 
         {% if import_furnishings %}
         <td class="underline"><b>Furnishings</b></td>
         {% endif %}
+        <td class="underline"><b>Import? <input type="checkbox" onclick=toggle(this) checked></b></td>
     </tr>
     {% for c in new_rooms %}
     <tr>
@@ -53,10 +62,11 @@ You have chosen to import the classrooms from {{ past_program.niceName }} to {{ 
             </ol>
         </td>
         {% endif %}
+        <td class="underline"><input type="checkbox" name="to_import" value="{{c.name}}" checked></td>
     </tr>
     {% endfor %}
     </table></td></tr>
-    <tr><td colspan="2" align="center"><input class="fancybutton" type="submit" value="Complete Import" /></td></tr>
+    <tr><td colspan="5" align="center"><input class="fancybutton" type="submit" value="Complete Import" /></td></tr>
 </table>
 </form>
 </div>

--- a/esp/templates/program/modules/resourcemodule/classroom_import.html
+++ b/esp/templates/program/modules/resourcemodule/classroom_import.html
@@ -62,7 +62,7 @@ You have chosen to import the classrooms from {{ past_program.niceName }} to {{ 
             </ol>
         </td>
         {% endif %}
-        <td class="underline"><input type="checkbox" name="to_import" value="{{c.name}}" checked></td>
+        <td class="underline"><input type="checkbox" name="to_import" value="{{c.old_id}}" checked></td>
     </tr>
     {% endfor %}
     </table></td></tr>

--- a/esp/templates/program/modules/resourcemodule/equipment_import.html
+++ b/esp/templates/program/modules/resourcemodule/equipment_import.html
@@ -47,7 +47,7 @@ You have chosen to import the floating resources from {{ past_program.niceName }
         <td class="underline">{{ r.name }}</td>
         <td class="underline">{{ r.res_type.name }}{% if r.res_type.hidden %} (Hidden){% endif %}</td>
         <td class="underline">{% for t in r.timegroup %}{{ t }}<br />{% endfor %}</td>
-        <td class="underline"><input type="checkbox" name="to_import" value="{{r.name}}" checked></td>
+        <td class="underline"><input type="checkbox" name="to_import" value="{{r.old_id}}" checked></td>
     </tr>
     {% endfor %}
     </table></td></tr>

--- a/esp/templates/program/modules/resourcemodule/equipment_import.html
+++ b/esp/templates/program/modules/resourcemodule/equipment_import.html
@@ -7,6 +7,14 @@
     <link rel="stylesheet" href="/media/styles/forms.css" type="text/css" />
 {% endblock %}
 
+{% block xtrajs %}
+<script>
+function toggle(source) {
+  $j('input[name=to_import]').prop('checked', source.checked);
+}
+</script>
+{% endblock %}
+
 {% block content %}
 
 <h1>Manage Resources for {{ prog.niceName }}</h1>
@@ -26,22 +34,24 @@ You have chosen to import the floating resources from {{ past_program.niceName }
 <input type="hidden" name="program" value="{{ past_program.id }}" />
 <input type="hidden" name="complete_availability" value="{{ complete_availability }}" />
 <table align="center" cellpadding="0" cellspacing="0" width="550">
-    <tr><th colspan="2">Proposed floating resources for {{ prog.niceName }}</th></tr>
-    <tr><td colspan="2"><table cellpadding="0" cellspacing="0" width="100%">
+    <tr><th colspan="4">Proposed floating resources for {{ prog.niceName }}</th></tr>
+    <tr><td colspan="4"><table cellpadding="0" cellspacing="0" width="100%">
     <tr>
         <td class="underline"><b>Name</b></td>
         <td class="underline"><b>Type</b></td>
         <td class="underline"><b>Available Times</b></td>
+        <td class="underline"><b>Import? <input type="checkbox" onclick=toggle(this) checked></b></td>
     </tr>
     {% for r in new_equipment %}
     <tr>
         <td class="underline">{{ r.name }}</td>
         <td class="underline">{{ r.res_type.name }}{% if r.res_type.hidden %} (Hidden){% endif %}</td>
         <td class="underline">{% for t in r.timegroup %}{{ t }}<br />{% endfor %}</td>
+        <td class="underline"><input type="checkbox" name="to_import" value="{{r.name}}" checked></td>
     </tr>
     {% endfor %}
     </table></td></tr>
-    <tr><td colspan="2" align="center"><input class="fancybutton" type="submit" value="Complete Import" /></td></tr>
+    <tr><td colspan="4" align="center"><input class="fancybutton" type="submit" value="Complete Import" /></td></tr>
 </table>
 </form>
 </div>

--- a/esp/templates/program/modules/resourcemodule/resource_types.html
+++ b/esp/templates/program/modules/resourcemodule/resource_types.html
@@ -47,30 +47,30 @@
     <tr><th colspan="2">Resource Types for {{ prog.niceName }}</th></tr>
     <tr><td colspan="2"><table width="100%" cellpadding="0" cellspacing="0">
     <tr>
-        <td width="15%"><b>Type</b></td>
-        <td width="30%"><b>Description</b></td>
-        <td width="10%"><b>Priority</b></td>
-        <td width="5%"><b>Only<br/>One</b></td>
-        <td width="30%"><b>Choices</b></td>
-        <td width="10%"></td>
+        <td width="15%" class="underline"><b>Type</b></td>
+        <td width="30%" class="underline"><b>Description</b></td>
+        <td width="10%" class="underline"><b>Priority</b></td>
+        <td width="5%" class="underline"><b>Only<br/>One</b></td>
+        <td width="30%" class="underline"><b>Choices</b></td>
+        <td width="10%" class="underline"></td>
     </tr>
     {% for h in resource_types %}
     {% ifchanged h.hidden %}{% if h.hidden %}
     <tr><th colspan="6">Resource Types Hidden During Teacher Registration</th></tr>
     {% endif %}{% endifchanged %}
         <tr>
-            <td><div id="restype-{{ h.id }}">{{ h.name }}</div>{% if h.is_global %} (global){% endif %}</td>
-            <td>{{ h.description }}</td>
-            <td>{{ h.priority_default }}</td>
-            <td>{% if h.only_one %}&#10003;{% endif %}</td>
-            <td>
+            <td class="underline"><div id="restype-{{ h.id }}">{{ h.name }}</div>{% if h.is_global %} (global){% endif %}</td>
+            <td class="underline">{{ h.description }}</td>
+            <td class="underline">{{ h.priority_default }}</td>
+            <td class="underline">{% if h.only_one %}&#10003;{% endif %}</td>
+            <td class="underline">
                 <ol>
                 {% for choice in h.choices %}
                 <li>{{ choice }}</li>
                 {% endfor %}
                 </ol>
             </td>
-            <td>
+            <td class="underline">
             <a href="/manage/{{ prog.url }}/resources/restype?op=edit&id={{ h.id }}">[Edit]</a>
             <a href="/manage/{{ prog.url }}/resources/restype?op=delete&id={{ h.id }}">[Delete]</a>
             </td>

--- a/esp/templates/program/modules/resourcemodule/restype_import.html
+++ b/esp/templates/program/modules/resourcemodule/restype_import.html
@@ -59,7 +59,7 @@ You have chosen to import the resource types from {{ past_program.niceName }} to
             {{ forloop.counter }}. {{ choice }}{% if not forloop.last %}<br>{% endif %}
         {% endfor %}
         </td>
-        <td class="underline"><input type="checkbox" name="to_import" value="{{r.name}}" checked></td>
+        <td class="underline"><input type="checkbox" name="to_import" value="{{r.old_id}}" checked></td>
     </tr>
     {% endfor %}
     </table></td></tr>

--- a/esp/templates/program/modules/resourcemodule/restype_import.html
+++ b/esp/templates/program/modules/resourcemodule/restype_import.html
@@ -7,6 +7,14 @@
     <link rel="stylesheet" href="/media/styles/forms.css" type="text/css" />
 {% endblock %}
 
+{% block xtrajs %}
+<script>
+function toggle(source) {
+  $j('input[name=to_import]').prop('checked', source.checked);
+}
+</script>
+{% endblock %}
+
 {% block content %}
 
 <h1>Manage Resources for {{ prog.niceName }}</h1>
@@ -28,28 +36,30 @@ You have chosen to import the resource types from {{ past_program.niceName }} to
     <tr><th colspan="6">Proposed resource types for {{ prog.niceName }}</th></tr>
     <tr><td colspan="6"><table cellpadding="0" cellspacing="0" width="100%">
     <tr>
-        <td width="20%"><b>Type</b></td>
-        <td width="32.5%"><b>Description</b></td>
-        <td width="10%"><b>Priority</b></td>
-        <td width="5%"><b>Only<br/>One</b></td>
-        <td width="32.5%"><b>Choices</b></td>
+        <td width="20%" class="underline"><b>Type</b></td>
+        <td width="32.5%" class="underline"><b>Description</b></td>
+        <td width="10%" class="underline"><b>Priority</b></td>
+        <td width="5%" class="underline"><b>Only<br/>One</b></td>
+        <td width="32.5%" class="underline"><b>Choices</b></td>
+        <td class="underline"><b>Import? <input type="checkbox" onclick=toggle(this) checked></b></td>
     </tr>
     {% for r in new_restypes %}
     {% ifchanged r.hidden %}{% if r.hidden %}
     <tr><th colspan="6">Resource Types Hidden During Teacher Registration</th></tr>
     {% endif %}{% endifchanged %}
     <tr>
-        <td>
+        <td class="underline">
             {{ r.name }}</div>{% if r.is_global %} (global){% endif %}
         </td>
-        <td>{{ r.description }}</td>
-        <td>{{ r.priority_default }}</td>
-        <td>{% if r.only_one %}&#10003;{% endif %}</td>
-        <td>
+        <td class="underline">{{ r.description }}</td>
+        <td class="underline">{{ r.priority_default }}</td>
+        <td class="underline">{% if r.only_one %}&#10003;{% endif %}</td>
+        <td class="underline">
         {% for choice in r.choices %}
             {{ forloop.counter }}. {{ choice }}{% if not forloop.last %}<br>{% endif %}
         {% endfor %}
         </td>
+        <td class="underline"><input type="checkbox" name="to_import" value="{{r.name}}" checked></td>
     </tr>
     {% endfor %}
     </table></td></tr>

--- a/esp/templates/program/modules/resourcemodule/timeslot_import.html
+++ b/esp/templates/program/modules/resourcemodule/timeslot_import.html
@@ -47,7 +47,7 @@ You have chosen to import the timeslots from {{ past_program.niceName }} to {{ p
         <td class="underline">{{ t.start.date }}</td>
         <td class="underline">{{ t.start.time }}</td>
         <td class="underline">{{ t.end.time }}</td>
-        <td class="underline"><input type="checkbox" name="to_import" value="{{ t.short_description }}_{{ t.start|safe }}" checked></td>
+        <td class="underline"><input type="checkbox" name="to_import" value="{{ t.old_id }}" checked></td>
     </tr>
     {% endfor %}
     </table></td></tr>

--- a/esp/templates/program/modules/resourcemodule/timeslot_import.html
+++ b/esp/templates/program/modules/resourcemodule/timeslot_import.html
@@ -7,6 +7,14 @@
     <link rel="stylesheet" href="/media/styles/forms.css" type="text/css" />
 {% endblock %}
 
+{% block xtrajs %}
+<script>
+function toggle(source) {
+  $j('input[name=to_import]').prop('checked', source.checked);
+}
+</script>
+{% endblock %}
+
 {% block content %}
 
 <h1>Manage Resources for {{ prog.niceName }}</h1>
@@ -26,22 +34,24 @@ You have chosen to import the timeslots from {{ past_program.niceName }} to {{ p
 <input type="hidden" name="program" value="{{ past_program.id }}" />
 <input type="hidden" name="start_date" value="{{ start_date }}" />
 <table align="center" cellpadding="0" cellspacing="0" width="550">
-    <tr><th colspan="2">Proposed timeslots for {{ prog.niceName }}</th></tr>
-    <tr><td colspan="2"><table cellpadding="0" cellspacing="0" width="100%">
+    <tr><th colspan="4">Proposed timeslots for {{ prog.niceName }}</th></tr>
+    <tr><td colspan="4"><table cellpadding="0" cellspacing="0" width="100%">
     <tr>
         <td class="underline"><b>Date</b></td>
         <td class="underline"><b>Start</b></td>
         <td class="underline"><b>End</b></td>
+        <td class="underline"><b>Import? <input type="checkbox" onclick=toggle(this) checked></b></td>
     </tr>
     {% for t in new_timeslots %}
     <tr>
         <td class="underline">{{ t.start.date }}</td>
         <td class="underline">{{ t.start.time }}</td>
         <td class="underline">{{ t.end.time }}</td>
+        <td class="underline"><input type="checkbox" name="to_import" value="{{ t.short_description }}_{{ t.start|safe }}" checked></td>
     </tr>
     {% endfor %}
     </table></td></tr>
-    <tr><td colspan="2" align="center"><input class="fancybutton" type="submit" value="Complete Import" /></td></tr>
+    <tr><td colspan="4" align="center"><input class="fancybutton" type="submit" value="Complete Import" /></td></tr>
 </table>
 </form>
 </div>

--- a/esp/templates/program/modules/resourcemodule/timeslots.html
+++ b/esp/templates/program/modules/resourcemodule/timeslots.html
@@ -33,18 +33,27 @@
 </form>
 
 <table align="center" cellpadding="0" cellspacing="0" width="100%">
-    <tr><th colspan="2">Timeslots for {{ prog.niceName }}</th></tr>
+    <tr><th colspan="5">Timeslots for {{ prog.niceName }}</th></tr>
     <tr>
-        <td><b>Timeslot Name (Length)</b></td>
+        <td><b>Name</b></td>
+        <td><b>Type</b></td>
+        <td><b>Start Time</b></td>
+        <td><b>Duration</b></td>
         <td><b>Options</b></td>
     </tr>
     {% for h in timeslots %}
+    {% ifchanged h.selections.0.start.date %}
+    <th colspan="5" align="center">{{ h.selections.0.pretty_date }}</th>
+    {% endifchanged %}
     <tr>
-        <th class="small" colspan="2" align="center"><b>Block {{ forloop.counter }}</b></th>
+        <th class="small" colspan="5" align="center"><b>Block {{ forloop.counter }}</b></th>
     </tr>
         {% for t in h.selections %}
         <tr>
-            <td>{{ t.short_description }} <small>({{ t.event_type }}: {{ t.duration_str }})</small></td>
+            <td>{{ t.short_description }}</td>
+            <td>{{ t.event_type }}</td>
+            <td>{{ t.start.time }}</td>
+            <td>{{ t.duration_str }}</td>
             <td>
                 <a href="/manage/{{ prog.url }}/resources/timeslot?op=edit&id={{ t.id }}">[Edit]</a>
                 <a href="/manage/{{ prog.url }}/resources/timeslot?op=delete&id={{ t.id }}">[Delete]</a>


### PR DESCRIPTION
This allows for selectively importing resources from a previous program (timeslots, resource types, classrooms, and floating resources). Instead of always importing an entire program's-worth of resources, admins can now select which of the old resources they'd like to import.

I've successfully tested importing all resources, some resources (where they aren't already imported), some resources (where they are already imported), and no resources.

Fixes #2457.