### PR TITLE
Print classes from class search

### DIFF
--- a/esp/templates/program/modules/classsearchmodule/class_search.html
+++ b/esp/templates/program/modules/classsearchmodule/class_search.html
@@ -36,6 +36,16 @@ Your query returned {{queryset|length}} of {{program.classsubject_set.count}} cl
     <button class="btn btn-unreview" onclick="unreviewAll({{ IDs|escapejs }});">unreview all</button>
     <button class="btn btn-reject" onclick="rejectAll({{ IDs|escapejs }});">reject all</button>
 </div>
+</br>
+<div class="btn-group" style="z-index: 99; margin-right: 5px; float: left;">
+    <a class="btn btn-approve" href="./coursecatalog?clsids={{ IDs|join:',' }}" target="_blank" title="Change sorting with the 'catalog_sort_fields' tag">course catalog</a>
+</div>
+<div class="btn-group">
+    <a class="btn btn-approve" href="./classesbyid?clsids={{ IDs|join:',' }}" target="_blank">spreadsheet (by ID)</a>
+    <a class="btn btn-unreview" href="./classesbytitle?clsids={{ IDs|join:',' }}" target="_blank">spreadsheet (by title)</a>
+    <a class="btn btn-reject" href="./classesbytime?clsids={{ IDs|join:',' }}" target="_blank">spreadsheet (by time)</a>
+</div>
+</br>
 
 <div class="flag-query-results" id="program_form">
     {% for class in queryset %}


### PR DESCRIPTION
Adds buttons that link to printables that are subset by the classes displayed in the /classsearch query, including the course catalog and spreadsheet layouts sorted by ID, title, and time.

![image](https://user-images.githubusercontent.com/7232514/51494705-6f27d400-1d6e-11e9-9633-0071e9d4cb70.png)

Fixes #2635.