### PR TITLE
Allow .ico uploads on filebrowser

### DIFF
--- a/esp/esp/django_settings.py
+++ b/esp/esp/django_settings.py
@@ -366,6 +366,21 @@ CYBERSOURCE_CONFIG = {
 #   (not just '/media/uploads/' which is the default)
 FILEBROWSER_DIRECTORY = ''
 
+FILEBROWSER_EXTENSIONS = {
+    'Image': ['.jpg','.jpeg','.gif','.png','.tif','.tiff','.ico'],
+    'Document': ['.pdf','.doc','.rtf','.txt','.xls','.csv','.css'],
+    'Video': ['.mov','.wmv','.mpeg','.mpg','.avi','.rm'],
+    'Audio': ['.mp3','.mp4','.wav','.aiff','.midi','.m4p'],
+    'Script': ['.js'],
+}
+
+FILEBROWSER_SELECT_FORMATS = {
+    'file': ['Image','Document','Video','Audio','Script'],
+    'image': ['Image'],
+    'document': ['Document'],
+    'media': ['Video','Audio'],
+}
+
 #   Default imports for shell_plus, for convenience.
 SHELL_PLUS_POST_IMPORTS = (
         ('esp.utils.shell_utils', '*'),

--- a/esp/esp/django_settings.py
+++ b/esp/esp/django_settings.py
@@ -368,14 +368,13 @@ FILEBROWSER_DIRECTORY = ''
 
 FILEBROWSER_EXTENSIONS = {
     'Image': ['.jpg','.jpeg','.gif','.png','.tif','.tiff','.ico'],
-    'Document': ['.pdf','.doc','.rtf','.txt','.xls','.csv','.css'],
+    'Document': ['.pdf','.doc','.rtf','.txt','.xls','.csv'],
     'Video': ['.mov','.wmv','.mpeg','.mpg','.avi','.rm'],
     'Audio': ['.mp3','.mp4','.wav','.aiff','.midi','.m4p'],
-    'Script': ['.js'],
 }
 
 FILEBROWSER_SELECT_FORMATS = {
-    'file': ['Image','Document','Video','Audio','Script'],
+    'file': ['Image','Document','Video','Audio'],
     'image': ['Image'],
     'document': ['Document'],
     'media': ['Video','Audio'],


### PR DESCRIPTION
This extends the default allowed filetypes for filebrowser uploads to include .ico, .css, and .js, since these are all common filetypes that chapters might want to upload to change or supplement default files (including theming, scripting, and favicons).

Fixes #2608.