### PR TITLE
Printable of classes sorted by teachers

### DIFF
--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -1602,8 +1602,7 @@ class ClassSubject(models.Model, CustomFormsLinkModel):
     def getTeacherNames(self):
         teachers = []
         for teacher in self.get_teachers():
-            name = '%s %s' % (teacher.first_name,
-                              teacher.last_name)
+            name = teacher.name()
             if name.strip() == '':
                 name = teacher.username
             teachers.append(name)
@@ -1612,8 +1611,7 @@ class ClassSubject(models.Model, CustomFormsLinkModel):
     def getTeacherNamesLast(self):
         teachers = []
         for teacher in self.get_teachers():
-            name = '%s, %s' % (teacher.last_name,
-                              teacher.first_name)
+            name = teacher.name_last_first()
             if name.strip() == '':
                 name = teacher.username
             teachers.append(name)

--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -1481,7 +1481,7 @@ class ClassSubject(models.Model, CustomFormsLinkModel):
         if hasattr(self, "_teachers"):
             return self._teachers
 
-        return self.teachers.all()
+        return self.teachers.all().order_by('last_name')
     get_teachers.depend_on_m2m('program.ClassSubject', 'teachers', lambda subj, event: {'self': subj})
 
     def students_dict(self):

--- a/esp/esp/program/modules/handlers/programprintables.py
+++ b/esp/esp/program/modules/handlers/programprintables.py
@@ -400,6 +400,22 @@ class ProgramPrintables(ProgramModuleObj):
 
     @aux_call
     @needs_admin
+    def classesbyteacher(self, request, tl, one, two, module, extra, prog):
+        def cmp_teacher(one, other):
+            cmp0 = cmp(one.get_teachers()[0].last_name.lstrip(), other.get_teachers()[0].last_name.lstrip())
+
+            if cmp0 != 0:
+                return cmp0
+
+            return cmp(one, other)
+
+        def filt_teacher(cls):
+            return len(cls.get_teachers()) > 0
+
+        return self.classesbyFOO(request, tl, one, two, module, extra, prog, cmp_teacher, filt_teacher)
+
+    @aux_call
+    @needs_admin
     def classesbyroom(self, request, tl, one, two, module, extra, prog):
         def cmp_room(one, other):
             qs_one = one.initial_rooms()

--- a/esp/esp/program/modules/handlers/programprintables.py
+++ b/esp/esp/program/modules/handlers/programprintables.py
@@ -313,9 +313,9 @@ class ProgramPrintables(ProgramModuleObj):
     @needs_admin
     def classesbyFOO(self, request, tl, one, two, module, extra, prog, sort_exp = lambda x,y: cmp(x,y), filt_exp = lambda x: True, split_teachers = False):
         classes_raw = ClassSubject.objects.filter(parent_program = self.program)
-        
+
         classes_filt = [cls for cls in classes_raw if cls.isAccepted()]
-        
+
         if split_teachers:
             classes = []
             for cls in classes_filt:

--- a/esp/esp/program/modules/handlers/programprintables.py
+++ b/esp/esp/program/modules/handlers/programprintables.py
@@ -343,7 +343,7 @@ class ProgramPrintables(ProgramModuleObj):
 
         classes.sort(sort_exp)
 
-        context = {'classes': classes, 'program': self.program, 'split_teachers': split_teachers}
+        context = {'classes': classes, 'program': self.program}
 
         return render_to_response(self.baseDir()+'classes_list.html', request, context)
 
@@ -411,12 +411,8 @@ class ProgramPrintables(ProgramModuleObj):
     @aux_call
     @needs_admin
     def classesbyteacher(self, request, tl, one, two, module, extra, prog):
-        split_teachers = ('split_teachers' in request.GET)
         def cmp_teacher(one, other):
-            if split_teachers:
-                cmp0 = cmp(one.split_teacher.last_name.lower(), other.split_teacher.last_name.lower())
-            else:
-                cmp0 = cmp(str(one.getTeacherNamesLast()[0].lower()), str(other.getTeacherNamesLast()[0]).lower())
+            cmp0 = cmp(one.split_teacher.last_name.lower(), other.split_teacher.last_name.lower())
 
             if cmp0 != 0:
                 return cmp0
@@ -426,7 +422,7 @@ class ProgramPrintables(ProgramModuleObj):
         def filt_teacher(cls):
             return len(cls.get_teachers()) > 0
 
-        return self.classesbyFOO(request, tl, one, two, module, extra, prog, cmp_teacher, filt_teacher, split_teachers)
+        return self.classesbyFOO(request, tl, one, two, module, extra, prog, cmp_teacher, filt_teacher, True)
 
     @aux_call
     @needs_admin

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -214,6 +214,9 @@ class BaseESPUser(object):
     def name(self):
         return u'%s %s' % (self.first_name, self.last_name)
 
+    def name_last_first(self):
+        return u'%s, %s' % (self.last_name, self.first_name)
+
     def nonblank_name(self):
         name = self.name()
         if name.strip() == '': name = self.username

--- a/esp/templates/program/modules/programprintables/classes_list.html
+++ b/esp/templates/program/modules/programprintables/classes_list.html
@@ -56,13 +56,8 @@ table.sortable thead {
  <td sorttable_customkey="{{ cls.id }}">{{ cls.emailcode }}</td>
  <td>{{ cls.title }}</td>
  <td>{{ cls.class_info|truncatewords_html:10 }}
- {% if split_teachers %}
- <td>{{ cls.split_teacher.name }}</td>
- <td>{{ cls.split_teacher.getLastProfile.contact_user.phone_cell }}</td>
- {% else %}
- <td>{{ cls.getTeacherNamesLast|join:"; " }}</td>
- <td>{% for teacher in cls.teachers.all %}{{ teacher.getLastProfile.contact_user.phone_cell }}{% if not forloop.last %}, {% endif %}{% endfor %}</td>
- {% endif %}
+ <td>{% for teacher in cls.teachers.all %}{% if teacher.id == cls.split_teacher.id %}<b>{% endif %}{{ teacher.name_last_first }}{% if teacher.id == cls.split_teacher.id %}</b>{% endif %}{% if not forloop.last %}; {% endif %}{% endfor %}</td>
+ <td>{% for teacher in cls.teachers.all %}{% if teacher.id == cls.split_teacher.id %}<b>{% endif %}{{ teacher.getLastProfile.contact_user.phone_cell }}{% if teacher.id == cls.split_teacher.id %}</b>{% endif %}{% if not forloop.last %}; {% endif %}{% endfor %}</td>
  <td width="170">{% for sec in cls.sections.all %}Section {{ sec.index }}: {% if not sec.prettyrooms|length_is:0 %}{{ sec.prettyrooms|join:", "}}{% else %} Unassigned{% endif %}<br />{% endfor %}</td>
  <td width="260">{% for sec in cls.sections.all %}Section {{ sec.index }}: {% if not sec.prettyrooms|length_is:0 %}{{ sec.friendly_times|join:", "}}{% else %} Unassigned{% endif %}<br />{% endfor %}</td>
  <td>{% if cls.allow_lateness %} Y {% else %} N {% endif %}</td>

--- a/esp/templates/program/modules/programprintables/classes_list.html
+++ b/esp/templates/program/modules/programprintables/classes_list.html
@@ -44,8 +44,8 @@ table.sortable thead {
  <th>Class Code</th>
  <th>Class Title</th>
  <th>Description (short)</th>
- <th>Teachers</th>
- <th>Teacher Phone #s</th>
+ <th>Teacher{% if not split_teachers %}s{% endif %}</th>
+ <th>Teacher Phone #{% if not split_teachers %}s{% endif %}</th>
  <th>Room(s)</th>
  <th>Time(s)</th>
  <th>Allow Late?</th>
@@ -56,8 +56,13 @@ table.sortable thead {
  <td sorttable_customkey="{{ cls.id }}">{{ cls.emailcode }}</td>
  <td>{{ cls.title }}</td>
  <td>{{ cls.class_info|truncatewords_html:10 }}
+ {% if split_teachers %}
+ <td>{{ cls.split_teacher.name }}</td>
+ <td>{{ cls.split_teacher.getLastProfile.contact_user.phone_cell }}</td>
+ {% else %}
  <td>{{ cls.getTeacherNamesLast|join:"; " }}</td>
  <td>{% for teacher in cls.teachers.all %}{{ teacher.getLastProfile.contact_user.phone_cell }}{% if not forloop.last %}, {% endif %}{% endfor %}</td>
+ {% endif %}
  <td width="170">{% for sec in cls.sections.all %}Section {{ sec.index }}: {% if not sec.prettyrooms|length_is:0 %}{{ sec.prettyrooms|join:", "}}{% else %} Unassigned{% endif %}<br />{% endfor %}</td>
  <td width="260">{% for sec in cls.sections.all %}Section {{ sec.index }}: {% if not sec.prettyrooms|length_is:0 %}{{ sec.friendly_times|join:", "}}{% else %} Unassigned{% endif %}<br />{% endfor %}</td>
  <td>{% if cls.allow_lateness %} Y {% else %} N {% endif %}</td>

--- a/esp/templates/program/modules/programprintables/classes_list.html
+++ b/esp/templates/program/modules/programprintables/classes_list.html
@@ -44,8 +44,8 @@ table.sortable thead {
  <th>Class Code</th>
  <th>Class Title</th>
  <th>Description (short)</th>
- <th>Teacher{% if not split_teachers %}s{% endif %}</th>
- <th>Teacher Phone #{% if not split_teachers %}s{% endif %}</th>
+ <th>Teachers</th>
+ <th>Teacher Phone #s</th>
  <th>Room(s)</th>
  <th>Time(s)</th>
  <th>Allow Late?</th>

--- a/esp/templates/program/modules/programprintables/options.html
+++ b/esp/templates/program/modules/programprintables/options.html
@@ -68,6 +68,7 @@ Please select from options below.
 </li>
 {% endif %}
 <li><a href="./classesbytitle" title="Classes by Name">Class Subjects</a></li>
+<li><a href="./classesbyteacher" title="Classes by Teacher">Classes Sorted by Teacher</a></li>
 <li><a href="./teachersbyname" title="Teacher List">Teacher List</a> (can be sorted by name, class, or start time); <a href="./teachersbyname/secondday">teachers for second day of classes only</a></li>
 <li><a href="./roomsbytime" title="Room List">Open Rooms by Time</a></li>
 <li><a href="./studentsbyname" title="Student List">Students by Name</a> (by students)</li>

--- a/esp/templates/program/modules/programprintables/options.html
+++ b/esp/templates/program/modules/programprintables/options.html
@@ -69,7 +69,6 @@ Please select from options below.
 {% endif %}
 <li><a href="./classesbytitle" title="Classes by Name">Class Subjects</a></li>
 <li><a href="./classesbyteacher" title="Classes by Teacher">Classes Sorted by Teacher</a></li>
-<li><a href="./classesbyteacher?split_teachers" title="Classes by Teacher">Classes Sorted by Teacher (and split by teacher)</a></li>
 <li><a href="./teachersbyname" title="Teacher List">Teacher List</a> (can be sorted by name, class, or start time); <a href="./teachersbyname/secondday">teachers for second day of classes only</a></li>
 <li><a href="./roomsbytime" title="Room List">Open Rooms by Time</a></li>
 <li><a href="./studentsbyname" title="Student List">Students by Name</a> (by students)</li>

--- a/esp/templates/program/modules/programprintables/options.html
+++ b/esp/templates/program/modules/programprintables/options.html
@@ -69,6 +69,7 @@ Please select from options below.
 {% endif %}
 <li><a href="./classesbytitle" title="Classes by Name">Class Subjects</a></li>
 <li><a href="./classesbyteacher" title="Classes by Teacher">Classes Sorted by Teacher</a></li>
+<li><a href="./classesbyteacher?split_teachers" title="Classes by Teacher">Classes Sorted by Teacher (and split by teacher)</a></li>
 <li><a href="./teachersbyname" title="Teacher List">Teacher List</a> (can be sorted by name, class, or start time); <a href="./teachersbyname/secondday">teachers for second day of classes only</a></li>
 <li><a href="./roomsbytime" title="Room List">Open Rooms by Time</a></li>
 <li><a href="./studentsbyname" title="Student List">Students by Name</a> (by students)</li>

--- a/esp/templates/program/modules/programprintables/sections_list.html
+++ b/esp/templates/program/modules/programprintables/sections_list.html
@@ -58,14 +58,7 @@ table.sortable thead {
  <td>{{ cls.title }}</td>
  <td>{{ cls.parent_class.class_info|truncatewords_html:10 }}
  <td>{{ cls.parent_class.getTeacherNamesLast|join:"; " }}</td>
- <td>{% for teacher in cls.teachers %}
-   {% if teacher.getLastProfile.contact_user.phone_cell %}
-   {{ teacher.getLastProfile.contact_user.phone_cell }}
-   {% else %}
-   {{ teacher.getLastProfile.contact_user.phone_day }}
-   {% endif %}
-   {% if not forloop.last %}, {% endif %}{% endfor %}
- </td>
+ <td>{% for teacher in cls.teachers %}{% if teacher.getLastProfile.contact_user.phone_cell %}{{ teacher.getLastProfile.contact_user.phone_cell }}{% else %}{{ teacher.getLastProfile.contact_user.phone_day }}{% endif %}{% if not forloop.last %}; {% endif %}{% endfor %}</td>
  <td>{% if cls.prettyrooms|length_is:0 %}Unassigned{% else %}{{ cls.prettyrooms|join:"<br />"}}{% endif %}</td>
  <td>{% if cls.friendly_times|length_is:0 %}Unassigned{% else %}{{ cls.friendly_times|join:"<br />"}}{% endif %}</td>
  <td>{% if cls.parent_class.allow_lateness %} Y {% else %} N {% endif %}</td>


### PR DESCRIPTION
Uses the last name of the first teacher of each class to sort classes. If a class has no teacher(s) (e.g. Lunch), it is excluded.

Fixes #1220.