### PR TITLE
Remove unused HttpResponse in set_donation_amount

### DIFF
--- a/esp/esp/program/modules/handlers/jsondatamodule.py
+++ b/esp/esp/program/modules/handlers/jsondatamodule.py
@@ -908,9 +908,6 @@ teachers[key].filter(is_active = True).distinct().count()))
             #   Specify quantity 1 and the desired amount
             iac.set_preference('Donation to Learning Unlimited', 1, amount=amount_donation)
 
-        data = {'amount_donation': amount_donation, 'amount_due': iac.amount_due()}
-        return HttpResponse(json.dumps(data), content_type='application/json')
-
     @aux_call
     @json_response()
     @needs_admin


### PR DESCRIPTION
We are seeing exceptions like:
   Decimal('20.00') is not JSON serializable
when forming the HttpResponse. But the response is not actually used.
set_donation_amount is only called as an Ajax call from these places:
  templates/program/modules/creditcardmodule_stripe/cardpay.html
  templates/program/modules/donationmodule/donation.html
and both of them discard the result.