### PR TITLE
WYSIWYG GUI for QSD Editing

### DIFF
--- a/esp/public/media/default_styles/qsd.css
+++ b/esp/public/media/default_styles/qsd.css
@@ -2,19 +2,9 @@
 .hidden {
   display: none;
 }
-.hidden {
-  display: none;
-}
-.hidden {
-  display: none;
-}
-.hidden {
-  display: none;
-}
 
 textarea.qsd_editor {
     width: 550px;
-    overflow: auto;
     border: 1px dashed #cccccc;
     border-top: none;
     margin: 8px 0 0;
@@ -36,33 +26,22 @@ div.qsd_header
     border: 1px dashed #cccccc;
     margin: 0px;
     height: 16px;
-    overflow: hidden;
     text-align: center;
 }
 
-div.hidden, div.qsd_edit_hidden
+div.hidden, div.qsd_edit_hidden, div.qsd_view_hidden
 {
     height: 0px;
     visibility: hidden;
+}
+
+div.qsd_buttons {
+    text-align: center;
 }
 
 div.qsd_edit_visible
 {
-    font-family: Arial, Helvetica, sans-serif;
-    font-size: 12px;
-    color: #cccccc;
-    padding: 0px;
-    border: 1px dashed #cccccc;
-    margin: 0px;
-    overflow: hidden;
-    text-align: center;
     visibility: visible;
-}
-
-div.qsd_view_hidden
-{
-    height: 0px;
-    visibility: hidden;
 }
 
 div.qsd_view_visible

--- a/esp/templates/inclusion/qsd/render_qsd.html
+++ b/esp/templates/inclusion/qsd/render_qsd.html
@@ -46,7 +46,7 @@ $j(document).ready(function() {
 
 var editor = new Jodit("#qsd_content_{{ qsdrec.edit_id }}", {
   "enter": "BR",
-  "buttons": "source,|,bold,strikethrough,underline,italic,|,superscript,subscript,|,ul,ol,|,outdent,indent,|,font,fontsize,brush,paragraph,|,image,video,table,link,|,align,undo,redo,\n,cut,hr,eraser,copyformat,|,symbol,fullsize,selectall",
+  "buttons": "source,|,bold,strikethrough,underline,italic,|,superscript,subscript,|,ul,ol,outdent,indent,align,|,font,fontsize,brush,paragraph,|,image,video,table,link,hr,|,undo,redo,cut,eraser,copyformat,|,symbol,fullsize,selectall",
   "toolbarAdaptive": false,
   "saveModeInStorage": true,
   "uploader": {

--- a/esp/templates/inclusion/qsd/render_qsd.html
+++ b/esp/templates/inclusion/qsd/render_qsd.html
@@ -1,5 +1,7 @@
 <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/jodit/3.2.36/jodit.min.css">
 <script src="//cdnjs.cloudflare.com/ajax/libs/jodit/3.2.36/jodit.min.js"></script>
+<!--jQuery.initialize plugin is created to help maintain dynamically created elements on the page-->
+<script src="https://cdn.jsdelivr.net/gh/pie6k/jquery.initialize@eb28c24e2eef256344777b45a455173cba36e850/jquery.initialize.js"></script>
 
 {% load markup %}
 
@@ -42,6 +44,10 @@ $j(document).ready(function() {
   if (esp_user.cur_admin != "1") {
     $j(".qsd_view_visible").removeClass("qsd_view_visible");
   }
+  
+  $j.initialize(".jodit_toolbar_btn-image input[name=url]", function() {
+    $j(this).after("Upload files <a href='/admin/filebrowser/browse/' target='_blank'>here");
+  });
 });
 
 var editor = new Jodit("#qsd_content_{{ qsdrec.edit_id }}", {
@@ -49,9 +55,6 @@ var editor = new Jodit("#qsd_content_{{ qsdrec.edit_id }}", {
   "buttons": "source,|,bold,strikethrough,underline,italic,|,superscript,subscript,|,ul,ol,outdent,indent,align,|,font,fontsize,brush,paragraph,|,image,video,table,link,hr,|,undo,redo,cut,eraser,copyformat,|,symbol,fullsize,selectall",
   "toolbarAdaptive": false,
   "saveModeInStorage": true,
-  "uploader": {
-    "insertImageAsBase64URI": true
-  },
 });
 </script>
 <br />

--- a/esp/templates/inclusion/qsd/render_qsd.html
+++ b/esp/templates/inclusion/qsd/render_qsd.html
@@ -46,9 +46,12 @@ $j(document).ready(function() {
 
 var editor = new Jodit("#qsd_content_{{ qsdrec.edit_id }}", {
   "enter": "BR",
-  "buttons": "source,|,bold,strikethrough,underline,italic,|,superscript,subscript,|,ul,ol,|,outdent,indent,|,font,fontsize,brush,paragraph,|,image,file,video,table,link,|,align,undo,redo,\n,cut,hr,eraser,copyformat,|,symbol,fullsize,selectall",
+  "buttons": "source,|,bold,strikethrough,underline,italic,|,superscript,subscript,|,ul,ol,|,outdent,indent,|,font,fontsize,brush,paragraph,|,image,video,table,link,|,align,undo,redo,\n,cut,hr,eraser,copyformat,|,symbol,fullsize,selectall",
   "toolbarAdaptive": false,
-  "saveModeInStorage": true
+  "saveModeInStorage": true,
+  "uploader": {
+    "insertImageAsBase64URI": true
+  },
 });
 </script>
 <br />

--- a/esp/templates/inclusion/qsd/render_qsd.html
+++ b/esp/templates/inclusion/qsd/render_qsd.html
@@ -1,3 +1,6 @@
+<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/jodit/3.2.36/jodit.min.css">
+<script src="//cdnjs.cloudflare.com/ajax/libs/jodit/3.2.36/jodit.min.js"></script>
+
 {% load markup %}
 
 <div class="qsd_bits hidden">
@@ -14,22 +17,20 @@
         <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
     </div>
     <div class="hidden" id="inline_edit_{{ qsdrec.edit_id }}">
-        <button type="button" onclick="qsd_inline_finish('{{ qsdrec.url }}', '{{ qsdrec.edit_id }}', 'save');"
-            class="btn btn-success"><span class="glyphicon glyphicon-floppy-saved" aria-hidden="true"></span>
-            Save changes</button>
-        <button type="button" onclick="qsd_inline_finish('{{ qsdrec.url }}', '{{ qsdrec.edit_id }}', 'preview');"
-            class="btn btn-info"><span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span>
-            Preview</button>
-        <button type="button" onclick="qsd_inline_finish('{{ qsdrec.url }}', '{{ qsdrec.edit_id }}', false);"
-            class="btn btn-danger"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
-            Cancel</button>
+        <div class="qsd_buttons">
+            <button type="button" onclick="qsd_inline_finish('{{ qsdrec.url }}', '{{ qsdrec.edit_id }}', 'save');"
+                class="btn btn-success"><span class="glyphicon glyphicon-floppy-saved" aria-hidden="true"></span>
+                Save changes</button>
+            <button type="button" onclick="qsd_inline_finish('{{ qsdrec.url }}', '{{ qsdrec.edit_id }}', 'preview');"
+                class="btn btn-info"><span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span>
+                Preview</button>
+            <button type="button" onclick="qsd_inline_finish('{{ qsdrec.url }}', '{{ qsdrec.edit_id }}', false);"
+                class="btn btn-danger"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
+                Cancel</button>
+        </div>
         <textarea rows="8" cols="80" id="qsd_content_{{ qsdrec.edit_id }}"
                   class="qsd_editor {% if not inline %}qsd_fullsize{% endif %} qsd_bits hidden {% if inline and not qsdrec.id %}qsd_halfsize{% endif %}"
                   name="qsd_content">{% autoescape on %}{{ qsdrec.content }}{% endautoescape %}</textarea>
-        {% comment %}
-        Avoid extra whitespace between <textarea> and </textarea>, or it'll
-        get accidentally added to the content with each edit!
-        {% endcomment %}
     </div>
 </div>
 <div class="qsd_view_visible prettify" id="inline_qsd_{{ qsdrec.edit_id }}">
@@ -41,6 +42,13 @@ $j(document).ready(function() {
   if (esp_user.cur_admin != "1") {
     $j(".qsd_view_visible").removeClass("qsd_view_visible");
   }
+});
+
+var editor = new Jodit("#qsd_content_{{ qsdrec.edit_id }}", {
+  "enter": "BR",
+  "buttons": "source,|,bold,strikethrough,underline,italic,|,superscript,subscript,|,ul,ol,|,outdent,indent,|,font,fontsize,brush,paragraph,|,image,file,video,table,link,|,align,undo,redo,\n,cut,hr,eraser,copyformat,|,symbol,fullsize,selectall",
+  "toolbarAdaptive": false,
+  "saveModeInStorage": true
 });
 </script>
 <br />

--- a/esp/templates/qsd/qsd_edit.html
+++ b/esp/templates/qsd/qsd_edit.html
@@ -70,9 +70,12 @@
 <script type="text/javascript">
 var editor = new Jodit("#qsd_content", {
   "enter": "BR",
-  "buttons": "source,|,bold,strikethrough,underline,italic,|,superscript,subscript,|,ul,ol,|,outdent,indent,|,font,fontsize,brush,paragraph,|,image,file,video,table,link,|,align,undo,redo,\n,cut,hr,eraser,copyformat,|,symbol,fullsize,selectall",
+  "buttons": "source,|,bold,strikethrough,underline,italic,|,superscript,subscript,|,ul,ol,|,outdent,indent,|,font,fontsize,brush,paragraph,|,image,video,table,link,|,align,undo,redo,\n,cut,hr,eraser,copyformat,|,symbol,fullsize,selectall",
   "toolbarAdaptive": false,
-  "saveModeInStorage": true
+  "saveModeInStorage": true,
+  "uploader": {
+    "insertImageAsBase64URI": true
+  },
 });
 </script>
 {% endblock %}

--- a/esp/templates/qsd/qsd_edit.html
+++ b/esp/templates/qsd/qsd_edit.html
@@ -4,6 +4,7 @@
 
 {% block stylesheets %}
 {{ block.super }}
+<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/jodit/3.2.36/jodit.min.css">
 <style type="text/css">
 .wikitoolbar {
    min-width: 233px;
@@ -30,7 +31,7 @@
 {% block xtrajs %}
 {{ block.super }}
 <script type="text/javascript" src="/media/scripts/jquery.js"></script>
-<script type="text/javascript" src="/media/scripts/markdown.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/jodit/3.2.36/jodit.min.js"></script>
 {% endblock %}
 
 
@@ -59,13 +60,19 @@
   </p>
 
   <h2>Content</h2>
-  <p>Please use <a href="http://daringfireball.net/projects/markdown/syntax">
-     Markdown</a> whenever possible. (Although HTML will work.)
-  </p>
-  <p><textarea class="wide markdown" name="content" rows="50" style="font-family: monospace;">{{ content|escape }}</textarea></p>
+  <p><textarea id="qsd_content" class="wide" name="content" rows="50" style="font-family: monospace;">{{ content|escape }}</textarea></p>
   <p><input type="submit" name="post_edit" value="Save Changes!" class="btn btn-primary" /> &nbsp;| <a href="{{ target_url }}">Cancel</a> | <a href="{{ return_to_view }}">Back to Page View</a></p>
 </form>
 <div id="divmainqsddatetimestamp">
   <p>Last modified by {{ qsdrec.author }} on {{ qsdrec.create_date }}</p>
 </div>
+
+<script type="text/javascript">
+var editor = new Jodit("#qsd_content", {
+  "enter": "BR",
+  "buttons": "source,|,bold,strikethrough,underline,italic,|,superscript,subscript,|,ul,ol,|,outdent,indent,|,font,fontsize,brush,paragraph,|,image,file,video,table,link,|,align,undo,redo,\n,cut,hr,eraser,copyformat,|,symbol,fullsize,selectall",
+  "toolbarAdaptive": false,
+  "saveModeInStorage": true
+});
+</script>
 {% endblock %}

--- a/esp/templates/qsd/qsd_edit.html
+++ b/esp/templates/qsd/qsd_edit.html
@@ -5,33 +5,13 @@
 {% block stylesheets %}
 {{ block.super }}
 <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/jodit/3.2.36/jodit.min.css">
-<style type="text/css">
-.wikitoolbar {
-   min-width: 233px;
-   border: 1px solid #333;
-   float: left;
-}
-
-.wikitoolbar a {
-   padding: 0;
-   margin: 0;
-}
-
-.wikitoolbar a img {
-   border: 2px solid #ccc;
-}
-
-.wikitoolbar a:hover img {
-   border: 2px solid #cc9;
-}
-
-</style>
 {% endblock %}
 
 {% block xtrajs %}
 {{ block.super }}
-<script type="text/javascript" src="/media/scripts/jquery.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/jodit/3.2.36/jodit.min.js"></script>
+<!--jQuery.initialize plugin is created to help maintain dynamically created elements on the page-->
+<script src="https://cdn.jsdelivr.net/gh/pie6k/jquery.initialize@eb28c24e2eef256344777b45a455173cba36e850/jquery.initialize.js"></script>
 {% endblock %}
 
 
@@ -73,9 +53,12 @@ var editor = new Jodit("#qsd_content", {
   "buttons": "source,|,bold,strikethrough,underline,italic,|,superscript,subscript,|,ul,ol,outdent,indent,align,|,font,fontsize,brush,paragraph,|,image,video,table,link,hr,|,undo,redo,cut,eraser,copyformat,|,symbol,fullsize,selectall",
   "toolbarAdaptive": false,
   "saveModeInStorage": true,
-  "uploader": {
-    "insertImageAsBase64URI": true
-  },
+});
+
+$j(document).ready(function() {
+  $j.initialize(".jodit_toolbar_btn-image input[name=url]", function() {
+    $j(this).after("Upload files <a href='/admin/filebrowser/browse/' target='_blank'>here");
+  });
 });
 </script>
 {% endblock %}

--- a/esp/templates/qsd/qsd_edit.html
+++ b/esp/templates/qsd/qsd_edit.html
@@ -70,7 +70,7 @@
 <script type="text/javascript">
 var editor = new Jodit("#qsd_content", {
   "enter": "BR",
-  "buttons": "source,|,bold,strikethrough,underline,italic,|,superscript,subscript,|,ul,ol,|,outdent,indent,|,font,fontsize,brush,paragraph,|,image,video,table,link,|,align,undo,redo,\n,cut,hr,eraser,copyformat,|,symbol,fullsize,selectall",
+  "buttons": "source,|,bold,strikethrough,underline,italic,|,superscript,subscript,|,ul,ol,outdent,indent,align,|,font,fontsize,brush,paragraph,|,image,video,table,link,hr,|,undo,redo,cut,eraser,copyformat,|,symbol,fullsize,selectall",
   "toolbarAdaptive": false,
   "saveModeInStorage": true,
   "uploader": {


### PR DESCRIPTION
This adds a very nice GUI to the QSD editing components of the website (including editable text on template pages and the .edit.html pages for static pages). I made sure that there is still a way to edit the source code directly for those that are familiar with HTML/markdown. Information about the GUI is [here](https://xdsoft.net/jodit/). I included almost all of the buttons that were offered, but let me know if any should be removed.

Fixes #2652.

Examples:

![image](https://user-images.githubusercontent.com/7232514/52248798-f9128980-28a4-11e9-955e-4348353788d6.png)

![image](https://user-images.githubusercontent.com/7232514/52248792-f021b800-28a4-11e9-9386-83340a546d24.png)

![image](https://user-images.githubusercontent.com/7232514/52248674-64a82700-28a4-11e9-9610-41661b550edb.png)