### PR TITLE
WYSIWYG GUI for Comm Panel

### DIFF
--- a/esp/esp/program/modules/handlers/commmodule.py
+++ b/esp/esp/program/modules/handlers/commmodule.py
@@ -100,16 +100,14 @@ class CommModule(ProgramModuleObj):
 
         MessageRequest.assert_is_valid_sendto_fn_or_ESPError(sendto_fn_name)
 
-        #   If they were trying to use HTML, don't sanitize the content.
+        # If they used the rich-text editor, we'll need to add <html> tags
         if '<html>' not in body:
-            htmlbody = body.replace('<', '&lt;').replace('>', '&gt;').replace('\n', '<br />')
-        else:
-            htmlbody = body
+            body = '<html>' + body + '</html>'
 
         contextdict = {'user'   : ActionHandler(firstuser, firstuser),
                        'program': ActionHandler(self.program, firstuser) }
 
-        renderedtext = Template(htmlbody).render(DjangoContext(contextdict))
+        renderedtext = Template(body).render(DjangoContext(contextdict))
 
         return render_to_response(self.baseDir()+'preview.html', request,
                                               {'filterid': filterid,

--- a/esp/public/media/default_images/template_tag.svg
+++ b/esp/public/media/default_images/template_tag.svg
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 4.2333332 4.2333335"
+   height="16"
+   width="16">
+  <defs
+     id="defs2" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <text
+     id="text3717"
+     y="1.0583333"
+     x="0.52916664"
+     style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+     xml:space="preserve"><tspan
+       style="stroke-width:0.26458332"
+       y="10.713829"
+       x="0.52916664"
+       id="tspan3715"></tspan></text>
+  <text
+     id="text3721"
+     y="2.8470268"
+     x="0.00068908097"
+     style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+     xml:space="preserve"><tspan
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:condensed;font-size:2.82222223px;font-family:Arial;-inkscape-font-specification:'Arial, Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+       y="2.8470268"
+       x="0.00068908097"
+       id="tspan3719">{{ }}</tspan></text>
+</svg>

--- a/esp/templates/program/modules/commmodule/step2.html
+++ b/esp/templates/program/modules/commmodule/step2.html
@@ -4,14 +4,23 @@
 
 {% block xtrajs %}
 {{block.super}}
+<script src="//cdnjs.cloudflare.com/ajax/libs/jodit/3.2.36/jodit.min.js"></script>
 <script type="text/javascript">
-<!--
-
-//-->
+function insertText(newText) {
+  var sl = document.getSelection()
+  var node = sl.baseNode
+  if ($j(node).closest("div").hasClass("jodit_wysiwyg")) {
+    var range = sl.getRangeAt(0);
+    var nnode = document.createElement("span");
+    range.surroundContents(nnode);
+    nnode.innerHTML = newText;
+  }
+}
 </script>
 {% endblock %}
 {% block stylesheets %}
 {{block.super}}
+<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/jodit/3.2.36/jodit.min.css">
 <style type="text/css">
 .listtable, .listtable th, .listtable td{ border: 1px solid #999; border-collapse: collapse;}
 #divmaintext .unchosen { background-color: #CCC; }
@@ -64,124 +73,26 @@ into the text of the message&mdash;the parameters are listed below.
   </label> <br />
   <textarea cols="80" rows="20" name="body" id="emailbody">{{body}}</textarea>
   <br />
-
+  <select id="tag_insert" style="width:auto">
+    <option value="" disabled selected>Insert a template tag at cursor</option>
+    <option value="{% templatetag openvariable %}user.name{% templatetag closevariable %}">User's Full Name</option>
+    <option value="{% templatetag openvariable %}user.username{% templatetag closevariable %}">User's ESP Web Site Username</option>
+    <option value="{% templatetag openvariable %}user.first_name{% templatetag closevariable %}">User's First Name</option>
+    <option value="{% templatetag openvariable %}user.last_name{% templatetag closevariable %}">User's Last Name</option>
+    <option value="{% templatetag openvariable %}program.student_schedule{% templatetag closevariable %}">Student's schedule for Program</option>
+    <option value="{% templatetag openvariable %}program.student_schedule_norooms{% templatetag closevariable %}">Student's schedule without room numbers</option>
+    <option value="{% templatetag openvariable %}program.teacher_schedule{% templatetag closevariable %}">Teacher's schedule for Program</option>
+    <option value="{% templatetag openvariable %}program.teacher_schedule_dates{% templatetag closevariable %}">Teacher's schedule with dates</option>
+    <option value="{% templatetag openvariable %}program.volunteer_schedule{% templatetag closevariable %}">Volunteer's schedule for Program</option>
+    <option value="{% templatetag openvariable %}program.volunteer_schedule_dates{% templatetag closevariable %}">Volunteer's schedule with dates</option>
+    <option value="{% templatetag openvariable %}program.optionanscript{% templatetag closevariable %}">optionanscript (classes and descriptions) for Program</option>
+    <option value="{% templatetag openvariable %}program.receipt{% templatetag closevariable %}">Confirmation receipt for Program</option>
+    <option value="{% templatetag openvariable %}program.full_classes{% templatetag closevariable %}">Newline-separated list of user's classes that have full or nearly-full sections</option>
+    <option value="{% templatetag openvariable %}program.diag_sat_scores{% templatetag closevariable %}">User's Diagnostic SAT Scores</option>
+    <option value="{% templatetag openvariable %}program.prac_sat_scores{% templatetag closevariable %}">User's Practice SAT Scores</option>
+  </select>
+  <br />
   </td>
-
-  <td width="200">
-   <table class="listtable" cellspacing="0">
-    <tr>
-      <th>Invocation</th>
-      <th>Description</th>
-    </tr>
-    <tr>
-      <th><span style="white-space: nowrap;">
-     {% templatetag openvariable %}user.name{% templatetag closevariable %}
-          </span>
-      </th>
-      <td>User's Full Name</td>
-    </tr>
-    <tr>
-      <th><span style="white-space: nowrap;">
-     {% templatetag openvariable %}user.username{% templatetag closevariable %}
-          </span>
-      </th>
-      <td>User's ESP Web Site Username</td>
-    </tr>
-    <tr>
-      <th><span style="white-space: nowrap;">
-     {% templatetag openvariable %}user.first_name{% templatetag closevariable %}
-          </span>
-      </th>
-      <td>User's First Name</td>
-    </tr>
-    <tr>
-      <th><span style="white-space: nowrap;">
-     {% templatetag openvariable %}user.last_name{% templatetag closevariable %}
-          </span>
-      </th>
-      <td>User's Last Name</td>
-    </tr>
-    <tr>
-      <th><span style="white-space: nowrap;">
-     {% templatetag openvariable %}program.student_schedule{% templatetag closevariable %}
-          </span>
-      </th>
-      <td>Student's schedule for Program</td>
-    </tr>
-    <tr>
-      <th><span style="white-space: nowrap;">
-     {% templatetag openvariable %}program.student_schedule_norooms{% templatetag closevariable %}
-          </span>
-      </th>
-      <td>Student's schedule without room numbers</td>
-    </tr>
-    <tr>
-      <th><span style="white-space: nowrap;">
-     {% templatetag openvariable %}program.teacher_schedule{% templatetag closevariable %}
-          </span>
-      </th>
-      <td>Teacher's schedule for Program</td>
-    </tr>
-    <tr>
-      <th><span style="white-space: nowrap;">
-     {% templatetag openvariable %}program.teacher_schedule_dates{% templatetag closevariable %}
-          </span>
-      </th>
-      <td>Teacher's schedule with dates</td>
-    </tr>
-    <tr>
-      <th><span style="white-space: nowrap;">
-     {% templatetag openvariable %}program.volunteer_schedule{% templatetag closevariable %}
-          </span>
-      </th>
-      <td>Volunteer's schedule for Program</td>
-    </tr>
-    <tr>
-      <th><span style="white-space: nowrap;">
-     {% templatetag openvariable %}program.volunteer_schedule_dates{% templatetag closevariable %}
-          </span>
-      </th>
-      <td>Volunteer's schedule with dates</td>
-    </tr>
-    <tr>
-      <th><span style="white-space: nowrap;">
-     {% templatetag openvariable %}program.transcript{% templatetag closevariable %}
-          </span>
-      </th>
-      <td>Transcript (classes and descriptions) for Program</td>
-    </tr>
-    <tr>
-      <th><span style="white-space: nowrap;">
-     {% templatetag openvariable %}program.receipt{% templatetag closevariable %}
-          </span>
-      </th>
-      <td>Confirmation receipt for Program</td>
-    </tr>
-    <tr>
-      <th><span style="white-space: nowrap;">
-     {% templatetag openvariable %}program.full_classes{% templatetag closevariable %}
-          </span>
-      </th>
-      <td>Newline-separated list of user's classes that have full or nearly-full sections</td>
-    </tr>
-    <tr>
-      <th><span style="white-space: nowrap;">
-     {% templatetag openvariable %}program.diag_sat_scores{% templatetag closevariable %}
-          </span>
-      </th>
-      <td>User's Diagnostic SAT Scores</td>
-    </tr>
-    <tr>
-      <th><span style="white-space: nowrap;">
-     {% templatetag openvariable %}program.prac_sat_scores{% templatetag closevariable %}
-          </span>
-      </th>
-      <td>User's Practice SAT Scores</td>
-    </tr>
-    </table>
-  </td>
-
-
 </tr>
 </table>
 
@@ -191,4 +102,18 @@ into the text of the message&mdash;the parameters are listed below.
 <input type="hidden" name="filterid" value="{{filterid}}" />
 <input type="hidden" name="sendto_fn_name" value="{{sendto_fn_name}}" />
 </form>
+
+<script type="text/javascript">
+var editor = new Jodit("#emailbody", {
+  "enter": "BR",
+  "buttons": "source,|,bold,strikethrough,underline,italic,|,superscript,subscript,|,ul,ol,|,outdent,indent,|,font,fontsize,brush,paragraph,|,image,file,video,table,link,|,align,undo,redo,\n,cut,hr,eraser,copyformat,|,symbol,fullsize,selectall",
+  "toolbarAdaptive": false,
+  "saveModeInStorage": true
+});
+
+$j('#tag_insert').on('change', function() {
+  insertText($j(this).val())
+  $j(this).val("");
+});
+</script>
 {% endblock %}

--- a/esp/templates/program/modules/commmodule/step2.html
+++ b/esp/templates/program/modules/commmodule/step2.html
@@ -96,7 +96,7 @@ var editor = new Jodit("#emailbody", {
         '{% templatetag openvariable %}program.teacher_schedule_dates{% templatetag closevariable %}': 'Teacher\'s schedule with dates',
         '{% templatetag openvariable %}program.volunteer_schedule{% templatetag closevariable %}': 'Volunteer\'s schedule for Program',
         '{% templatetag openvariable %}program.volunteer_schedule_dates{% templatetag closevariable %}': 'Volunteer\'s schedule with dates',
-        '{% templatetag openvariable %}program.optionanscript{% templatetag closevariable %}': 'optionanscript (classes and descriptions) for Program',
+        '{% templatetag openvariable %}program.transcript{% templatetag closevariable %}': 'Transcript (classes and descriptions) for Program',
         '{% templatetag openvariable %}program.receipt{% templatetag closevariable %}': 'Confirmation receipt for Program',
         '{% templatetag openvariable %}program.full_classes{% templatetag closevariable %}': 'Newline-separated list of user\'s classes that have full or nearly-full sections',
         '{% templatetag openvariable %}program.diag_sat_scores{% templatetag closevariable %}': 'User\'s Diagnostic SAT Scores',

--- a/esp/templates/program/modules/commmodule/step2.html
+++ b/esp/templates/program/modules/commmodule/step2.html
@@ -5,18 +5,6 @@
 {% block xtrajs %}
 {{block.super}}
 <script src="//cdnjs.cloudflare.com/ajax/libs/jodit/3.2.36/jodit.min.js"></script>
-<script type="text/javascript">
-function insertText(newText) {
-  var sl = document.getSelection()
-  var node = sl.baseNode
-  if ($j(node).closest("div").hasClass("jodit_wysiwyg")) {
-    var range = sl.getRangeAt(0);
-    var nnode = document.createElement("span");
-    range.surroundContents(nnode);
-    nnode.innerHTML = newText;
-  }
-}
-</script>
 {% endblock %}
 {% block stylesheets %}
 {{block.super}}
@@ -27,6 +15,8 @@ function insertText(newText) {
 #divmaintext .chosen { background-color: #FFF; }
 #divmaintext td.notchooser { cursor: pointer }
 #finalsentence { border: 1px solid black; width: 550px; }
+/*Fix css for template tag button*/
+.jodit_icon_insertDate { width: 16px; height: 16px}
 </style>
 {% endblock %}
 
@@ -73,25 +63,6 @@ into the text of the message&mdash;the parameters are listed below.
   </label> <br />
   <textarea cols="80" rows="20" name="body" id="emailbody">{{body}}</textarea>
   <br />
-  <select id="tag_insert" style="width:auto">
-    <option value="" disabled selected>Insert a template tag at cursor</option>
-    <option value="{% templatetag openvariable %}user.name{% templatetag closevariable %}">User's Full Name</option>
-    <option value="{% templatetag openvariable %}user.username{% templatetag closevariable %}">User's ESP Web Site Username</option>
-    <option value="{% templatetag openvariable %}user.first_name{% templatetag closevariable %}">User's First Name</option>
-    <option value="{% templatetag openvariable %}user.last_name{% templatetag closevariable %}">User's Last Name</option>
-    <option value="{% templatetag openvariable %}program.student_schedule{% templatetag closevariable %}">Student's schedule for Program</option>
-    <option value="{% templatetag openvariable %}program.student_schedule_norooms{% templatetag closevariable %}">Student's schedule without room numbers</option>
-    <option value="{% templatetag openvariable %}program.teacher_schedule{% templatetag closevariable %}">Teacher's schedule for Program</option>
-    <option value="{% templatetag openvariable %}program.teacher_schedule_dates{% templatetag closevariable %}">Teacher's schedule with dates</option>
-    <option value="{% templatetag openvariable %}program.volunteer_schedule{% templatetag closevariable %}">Volunteer's schedule for Program</option>
-    <option value="{% templatetag openvariable %}program.volunteer_schedule_dates{% templatetag closevariable %}">Volunteer's schedule with dates</option>
-    <option value="{% templatetag openvariable %}program.optionanscript{% templatetag closevariable %}">optionanscript (classes and descriptions) for Program</option>
-    <option value="{% templatetag openvariable %}program.receipt{% templatetag closevariable %}">Confirmation receipt for Program</option>
-    <option value="{% templatetag openvariable %}program.full_classes{% templatetag closevariable %}">Newline-separated list of user's classes that have full or nearly-full sections</option>
-    <option value="{% templatetag openvariable %}program.diag_sat_scores{% templatetag closevariable %}">User's Diagnostic SAT Scores</option>
-    <option value="{% templatetag openvariable %}program.prac_sat_scores{% templatetag closevariable %}">User's Practice SAT Scores</option>
-  </select>
-  <br />
   </td>
 </tr>
 </table>
@@ -106,14 +77,38 @@ into the text of the message&mdash;the parameters are listed below.
 <script type="text/javascript">
 var editor = new Jodit("#emailbody", {
   "enter": "BR",
-  "buttons": "source,|,bold,strikethrough,underline,italic,|,superscript,subscript,|,ul,ol,|,outdent,indent,|,font,fontsize,brush,paragraph,|,image,file,video,table,link,|,align,undo,redo,\n,cut,hr,eraser,copyformat,|,symbol,fullsize,selectall",
+  "buttons": "source,|,bold,strikethrough,underline,italic,|,superscript,subscript,|,ul,ol,outdent,indent,align,|,font,fontsize,brush,paragraph,|,image,video,table,link,hr,|,undo,redo,cut,eraser,copyformat,|,symbol,fullsize,selectall,|",
   "toolbarAdaptive": false,
-  "saveModeInStorage": true
-});
-
-$j('#tag_insert').on('change', function() {
-  insertText($j(this).val())
-  $j(this).val("");
+  "saveModeInStorage": true,
+  extraButtons: [
+    {
+      name: 'insertDate',
+      iconURL: '/media/images/template_tag.svg',
+      mode: 3,
+      list: {
+        '{% templatetag openvariable %}user.name{% templatetag closevariable %}': 'User\'s Full Name',
+        '{% templatetag openvariable %}user.username{% templatetag closevariable %}': 'User\'s ESP Web Site Username',
+        '{% templatetag openvariable %}user.first_name{% templatetag closevariable %}': 'User\'s First Name',
+        '{% templatetag openvariable %}user.last_name{% templatetag closevariable %}': 'User\'s Last Name',
+        '{% templatetag openvariable %}program.student_schedule{% templatetag closevariable %}': 'Student\'s schedule for Program',
+        '{% templatetag openvariable %}program.student_schedule_norooms{% templatetag closevariable %}': 'Student\'s schedule without room numbers',
+        '{% templatetag openvariable %}program.teacher_schedule{% templatetag closevariable %}': 'Teacher\'s schedule for Program',
+        '{% templatetag openvariable %}program.teacher_schedule_dates{% templatetag closevariable %}': 'Teacher\'s schedule with dates',
+        '{% templatetag openvariable %}program.volunteer_schedule{% templatetag closevariable %}': 'Volunteer\'s schedule for Program',
+        '{% templatetag openvariable %}program.volunteer_schedule_dates{% templatetag closevariable %}': 'Volunteer\'s schedule with dates',
+        '{% templatetag openvariable %}program.optionanscript{% templatetag closevariable %}': 'optionanscript (classes and descriptions) for Program',
+        '{% templatetag openvariable %}program.receipt{% templatetag closevariable %}': 'Confirmation receipt for Program',
+        '{% templatetag openvariable %}program.full_classes{% templatetag closevariable %}': 'Newline-separated list of user\'s classes that have full or nearly-full sections',
+        '{% templatetag openvariable %}program.diag_sat_scores{% templatetag closevariable %}': 'User\'s Diagnostic SAT Scores',
+        '{% templatetag openvariable %}program.prac_sat_scores{% templatetag closevariable %}': 'User\'s Practice SAT Scores',
+      },
+      exec: function(editor, current, control) {
+        var key = control['name'];
+        editor.selection.insertHTML(key);
+    },
+      tooltip: "Insert a template tag",
+    }
+  ],
 });
 </script>
 {% endblock %}

--- a/esp/templates/program/modules/commmodule/step2.html
+++ b/esp/templates/program/modules/commmodule/step2.html
@@ -32,10 +32,8 @@
 There are <strong>{{listcount}}</strong> distinct users in your query{% if selected %} of <strong>{{ selected }}</strong>{% endif %}. If you feel this to be off, please
 <a href="javascript:history.go(-1);">go back</a> now.<br />
 <br />
-Please write your email/message now. Note that you can use <tt>{{ parameter }}</tt> to enter a parameter
-into the text of the message&mdash;the parameters are listed below.
-
-<p><b>Tip:</b> If you would like to send your message in HTML format, wrap your entire message body in &lt;html&gt; and &lt;/html&gt; tags.</p>
+Please write your email/message now. Note that you can use <tt>{% templatetag openvariable %} parameter {% templatetag closevariable %}</tt> to enter a parameter
+into the text of the message. You can use the {% templatetag openvariable %}{% templatetag closevariable %} button to choose from the possible parameters.
 
 <form action="/manage/{{program.getUrlBase}}/commprev" method="post" name="comm2">
 <table border="0" cellspacing="0" width="100%">


### PR DESCRIPTION
I added a GUI similar to that of #2665. In order for the GUI to have enough space, I converted the table of template tags into a dropdown menu. By selecting an option from the menu, it inserts the corresponding template tag into the email at the current cursor location. However, I ran into a couple problems. I'd appreciate any feedback and/or suggestions on the following:

- I had to insert the template tags within a `<span>` because createElement() requires a tag and `<span>` seemed the least intrusive. I think this should be fine, but please let me know if it won't be.
- The template tag insertion only works when the user is using the WYSIWYG panel, not the source code panel, of the GUI. I tried to make it work for both, but it was VERY messy.
- The only way to make the HTML actually work for the email is to include `<html>` tags, of course. However, these tags need to be manually added in the source code panel. AND, if you go back to the WYSIWYG panel, those tags disappear.

Example:

![image](https://user-images.githubusercontent.com/7232514/52249280-19434800-28a7-11e9-8323-3e9fb3ff8c7b.png)