### PR TITLE
Round program durations to match class durations

### DIFF
--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -967,7 +967,7 @@ class Program(models.Model, CustomFormsLinkModel):
                     else:
                         rounded_seconds = durationSeconds
                     if (max_seconds is None) or (durationSeconds <= max_seconds):
-                        durationDict[Decimal(durationSeconds) / 3600] = \
+                        durationDict[(Decimal(durationSeconds) / 3600).quantize(Decimal('.01'))] = \
                                         str(rounded_seconds / 3600) + ':' + \
                                         str((rounded_seconds / 60) % 60).rjust(2,'0')
 

--- a/esp/esp/program/modules/forms/management.py
+++ b/esp/esp/program/modules/forms/management.py
@@ -58,7 +58,7 @@ class ClassManageForm(ManagementForm):
             csm = cls.class_size_max
         else:  csm = 0
         if cls.duration:
-            dur = Decimal(float(str(cls.duration)))
+            dur = cls.duration
         else:  dur = Decimal(0)
         self.initial = {
             prefix+'status': cls.status,
@@ -76,7 +76,7 @@ class ClassManageForm(ManagementForm):
         cls.grade_min = self.cleaned_data['min_grade']
         cls.grade_max = self.cleaned_data['max_grade']
         if not cls.hasScheduledSections():
-            cls.duration = Decimal(str(self.cleaned_data['duration']))
+            cls.duration = Decimal(self.cleaned_data['duration'])
         cls.class_size_max = self.cleaned_data['class_size']
         cls.directors_notes = self.cleaned_data['notes']
 


### PR DESCRIPTION
Class durations are rounded to two decimal places, but the program durations were not rounded at all. This caused mismatches in the new duration field (#2612) on the manage class field whenever the duration caused a value with more than two decimal places (e.g. 55 minutes).

I tested classes with durations of 45 minutes, 1 hour 45 minutes, 1 hour, 55 minutes, and 1 hour 55 minutes.