### PR TITLE
Fix userview formatting

### DIFF
--- a/esp/public/media/default_styles/userview.css
+++ b/esp/public/media/default_styles/userview.css
@@ -1,5 +1,6 @@
 #user-sidebar {
   float: right;
+  width: 44%;
 }
 
 #user-sidebar .change-program {
@@ -17,7 +18,6 @@
   
   display: block;
   border: 1px solid #3366cc;
-  border-right: none;
   
   padding: 7px;
   margin-right: -20px;
@@ -39,6 +39,7 @@
 table.dottedtable {
   border-spacing: 0;
   border-collapse: collapse;
+  width: 55%;
 }
 
 table.dottedtable tr {
@@ -53,14 +54,24 @@ table.dottedtable td {
 table.dottedtable .key {
   font-size: 90%;
   color: #444;
-  width: 150px;
+  width: 40%;
   padding-right: 20px;
   
   vertical-align: top;
 }
 
-table.dottedtable.long td:nth-child(even) {
-  min-width: 210px;
+select {
+  width: auto !important;
+}
+
+.biophoto {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.change-program {
+  text-align: center;
 }
 
 .yes {

--- a/esp/templates/users/userview.html
+++ b/esp/templates/users/userview.html
@@ -132,7 +132,7 @@
 
 {% if profile.student_info %}
 <h2>Student Info</h2>
-<table class="dottedtable long">
+<table class="dottedtable">
 <tr><td class="key">School</td><td>{{ profile.student_info.school }}</td></tr>
 <tr><td class="key">Graduation Year</td><td>{{ profile.student_info.graduation_year }} ({{ user.getGrade }}th Grade)<br />
 <form action="/manage/userview/" method="get" name="change_grade">
@@ -148,7 +148,7 @@
 
 {% if profile.teacher_info %}
 <h2>Teacher Info</h2>
-<table class="dottedtable long">
+<table class="dottedtable">
     <tr><td class="key">Affiliation</td><td>{{ profile.teacher_info.affiliation }}</td></tr>
     <tr><td class="key">Graduation Year</td><td>{{ profile.teacher_info.graduation_year }}</td></tr>
 <tr><td class="key">College/Employer</td><td>{{ profile.teacher_info.college }}</td></tr>
@@ -158,14 +158,14 @@
 {% endif %}
 
 {% if profile.guardian_info %}
-<table class="dottedtable long">
+<table class="dottedtable">
 <tr><td class="key">Year Finished School</td><td>{{ profile.guardian_info.year_finished }}</td></tr>
 <tr><td class="key">Number of Children in ESP</td><td>{{ profile.guardian_info.num_kids }}</td></tr>
 </table>
 {% endif %}
 
 {% if profile.educator_info %}
-<table class="dottedtable long">
+<table class="dottedtable">
 <tr><td class="key">Subjects Taught</td><td>{{ profile.educator_info.subject_taught }}</td></tr>
 <tr><td class="key">Grades Taught</td><td>{{ profile.educator_info.grades_taught }}</td></tr>
 <tr><td class="key">School</td><td>{{ profile.educator_info.school }}</td></tr>
@@ -177,7 +177,7 @@
 
 <h2>Emergency Contact Info</h2>
 {% if profile.contact_emergency %}{# We want to explicitly say "no contact info here!" if we don't have any, so that, in an emergency, folks don't start burning admin power digging through the database for contact info that we don't have #}
-<table class="dottedtable long">
+<table class="dottedtable">
 <tr><td class="key">Name</td><td>{{ profile.contact_emergency.first_name }} {{ profile.contact_emergency.last_name }}</td></tr>
 <tr><td class="key">E-mail</td><td>{{ profile.contact_emergency.e_mail }}</td></tr>
 <tr><td class="key">Day Phone</td><td>{{ profile.contact_emergency.phone_day }}</td></tr>
@@ -191,7 +191,7 @@
 
 {% if profile.contact_guardian %}
 <h2>Parent/Guardian Contact Info</h2>
-<table class="dottedtable long">
+<table class="dottedtable">
 <tr><td class="key">Name</td><td>{{ profile.contact_guardian.first_name }} {{ profile.contact_guardian.last_name }}</td></tr>
 <tr><td class="key">E-mail</td><td>{{ profile.contact_guardian.e_mail }}</td></tr>
 <tr><td class="key">Day Phone</td><td>{{ profile.contact_guardian.phone_day }}</td></tr>


### PR DESCRIPTION
I fixed the percentage width of the two sides (55% for the left side, 45% for the right side). I also fixed how some of the info tables were wider than others. I changed the widths of the `<select>`s to auto, so now the grade field isn't super wide. And then I centered the image and program `<select>` to better fill the empty space at the top of the right sidebar.

![image](https://user-images.githubusercontent.com/7232514/52971812-b4d7bc80-336d-11e9-805a-6f24aa04777f.png)

Fixes #2559.