### PR TITLE
Fix usersearch width

### DIFF
--- a/esp/esp/themes/theme_data/circles/less/main.less
+++ b/esp/esp/themes/theme_data/circles/less/main.less
@@ -340,7 +340,7 @@ div .error
 #usersearchform .usersearchbox
 {
     font-size: 0.8em;
-    width: 150px;
+    width: ~"calc(100% - 10px)";
     background-color: #333333;
     border: 1px solid #666666;
     color: white;


### PR DESCRIPTION
This fixes the width of the user search box on the circles theme. The css is a little hacky because LESS does some funky compilation stuff with `calc()` (although this has been [fixed](https://github.com/less/less.js/blob/master/CHANGELOG.md#300) since v. 3.0).

Note: you'll need to update the theme and hard refresh the page for the change to take effect.

Fixes #2542.