### PR TITLE
Credit card charge name

### DIFF
--- a/esp/esp/program/modules/handlers/creditcardmodule_stripe.py
+++ b/esp/esp/program/modules/handlers/creditcardmodule_stripe.py
@@ -297,6 +297,7 @@ class CreditCardModule_Stripe(ProgramModuleObj):
 
         #   Render the success page, which doesn't do much except direct back to studentreg.
         context['amount_paid'] = totalcost_dollars
+        context['group_name'] = group_name
         context['can_confirm'] = self.deadline_met('/Confirm')
         return render_to_response(self.baseDir() + 'success.html', request, context)
 

--- a/esp/esp/program/modules/handlers/creditcardmodule_stripe.py
+++ b/esp/esp/program/modules/handlers/creditcardmodule_stripe.py
@@ -297,7 +297,7 @@ class CreditCardModule_Stripe(ProgramModuleObj):
 
         #   Render the success page, which doesn't do much except direct back to studentreg.
         context['amount_paid'] = totalcost_dollars
-        context['group_name'] = group_name
+        context['statement_descriptor'] = group_name[0:22]
         context['can_confirm'] = self.deadline_met('/Confirm')
         return render_to_response(self.baseDir() + 'success.html', request, context)
 

--- a/esp/templates/program/modules/creditcardmodule_stripe/success.html
+++ b/esp/templates/program/modules/creditcardmodule_stripe/success.html
@@ -19,7 +19,7 @@
 
 <h3>Success!</h3>
 
-<p>We have received your credit card payment of ${{ amount_paid|floatformat:2 }}.{% if can_confirm %} <a href="/learn/{{ program.getUrlBase }}/confirmreg" target="_blank">Click here</a> to print your registration receipt.{% endif %}</p>
+<p>We have received your credit card payment of ${{ amount_paid|floatformat:2 }}. The charge may show up on your statement as {{ group_name }} or "Learning Unlimited." {% if can_confirm %} <a href="/learn/{{ program.getUrlBase }}/confirmreg" target="_blank">Click here</a> to print your registration receipt.{% endif %}</p>
 
 <p><a href="/learn/{{ program.getUrlBase }}/studentreg">Click here</a> to return to the main student registration page.</p>
 

--- a/esp/templates/program/modules/creditcardmodule_stripe/success.html
+++ b/esp/templates/program/modules/creditcardmodule_stripe/success.html
@@ -19,7 +19,7 @@
 
 <h3>Success!</h3>
 
-<p>We have received your credit card payment of ${{ amount_paid|floatformat:2 }}. The charge may show up on your statement as {{ group_name }} or "Learning Unlimited." {% if can_confirm %} <a href="/learn/{{ program.getUrlBase }}/confirmreg" target="_blank">Click here</a> to print your registration receipt.{% endif %}</p>
+<p>We have received your credit card payment of ${{ amount_paid|floatformat:2 }}. The charge may show up on your statement as "{{ statement_descriptor }}" or "Learning Unlimited." {% if can_confirm %} <a href="/learn/{{ program.getUrlBase }}/confirmreg" target="_blank">Click here</a> to print your registration receipt.{% endif %}</p>
 
 <p><a href="/learn/{{ program.getUrlBase }}/studentreg">Click here</a> to return to the main student registration page.</p>
 


### PR DESCRIPTION
Fixes issue #2203, adding a line after the payment goes through about how it might appear as either the statement descriptor or "learning unlimited." 

I tested this using [Stripe](https://stripe.com/docs/testing)'s testing API and credit card numbers.