### PR TITLE
Fix userview table width in case of long email addresses

### DIFF
--- a/esp/public/media/default_styles/userview.css
+++ b/esp/public/media/default_styles/userview.css
@@ -40,6 +40,8 @@ table.dottedtable {
   border-spacing: 0;
   border-collapse: collapse;
   width: 55%;
+  table-layout: fixed;
+  word-wrap: break-word;
 }
 
 table.dottedtable tr {


### PR DESCRIPTION
Yale (@kkbrum) reported that the formatting changes in #2674 weren't working if a user had a really long email address (for example). Apparently, by default tables will expand to avoid breaking words. This fixes the tables to be 55% of the width of the content no matter what and then breaks any words that would otherwise overflow.