### PR TITLE
Fix layout and JS for missingteachers

### DIFF
--- a/esp/public/media/scripts/onsite/teacher_checkin.js
+++ b/esp/public/media/scripts/onsite/teacher_checkin.js
@@ -210,23 +210,13 @@ $j(function(){
         });
     }
 
-    $j(document).keypress(function(e){
-        if(e.which==13 && e.shiftKey){
-            $j(".selected .checkin").click();
-            e.preventDefault();
-            input.val("");
-        }
-        else if((e.which==122 || e.which==26) && e.ctrlKey){
-            undoLiveCheckIn();
-            e.preventDefault();
-        }
-        else if(e.which==63){
-            window.open($j(".selected a")[0].href);
-            e.preventDefault();
-        }
-    }).keydown(function(e){
-        if(e.target.nodeName !== "TEXTAREA" && e.target.nodeName !== "INPUT") {
+    $j(document).keydown(function(e){
+        if(/^[a-z]$/i.test(e.key) && !e.ctrlKey) {
+            if(e.target.nodeName !== "TEXTAREA" && e.target.nodeName !== "INPUT")
+                input.val("");
             input.focus();
+        }
+        else if([38, 40, 33, 34].includes(e.which)) {
             if(e.which==38)
                 selected--;
             else if(e.which==40)
@@ -235,9 +225,20 @@ $j(function(){
                 selected-=5;
             else if(e.which==34)
                 selected+=5;
-            else
-                return;
+            e.preventDefault();
             updateSelected(true);
+        }
+        else if(e.which==90 && e.ctrlKey){
+            undoLiveCheckIn();
+            e.preventDefault();
+        }
+        else if(e.which==13 && e.shiftKey){
+            $j(".selected .checkin").click();
+            e.preventDefault();
+            input.val("");
+        }
+        else if(e.which==191 && e.shiftKey){
+            window.open($j(".selected a")[0].href);
             e.preventDefault();
         }
     }).keyup(function(e){

--- a/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
+++ b/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
@@ -9,8 +9,8 @@
     <style type="text/css">
         #shortcuts-box {
             position: fixed;
-            left: 10px;
-            top: 150px;
+            right: 10px;
+            top: 10px;
             width: 200px;
             border: 1px solid gray;
             padding: 5px;
@@ -21,6 +21,9 @@
         }
         #shortcuts-box:hover {
             opacity: 1;
+        }
+        #shortcuts-box input{
+            width: 190px;
         }
 
         .section-first-row {


### PR DESCRIPTION
I moved the hovering box over to the top right, so it doesn't conflict with the admin toolbar in some themes. I also noticed some problems with the JS (e.g. could only use arrow keys if you werent't focused on the input but the input would focus after each arrow keys press, Ctrl-Z would undo the input text before undo-ing the check-in). I've fixed it all up so it now works as described in the hovering box. I also added a small change that the input text will reset if the user clicks outside of the input and then starts typing again. If the input is focused, then the user will need to use backspace, Ctrl-A, etc. to edit the value like normal.

Fixes #2605.