### PR TITLE
Fix handling of finaid form tag

### DIFF
--- a/esp/esp/program/modules/handlers/financialaidappmodule.py
+++ b/esp/esp/program/modules/handlers/financialaidappmodule.py
@@ -104,7 +104,7 @@ class FinancialAidAppModule(ProgramModuleObj):
                 model = FinancialAidRequest
                 tag_data = Tag.getTag('finaid_form_fields')
                 if tag_data:
-                    fields = tuple(tag_data.split(','))
+                    fields = tuple(field.strip() for field in tag_data.split(',') if hasattr(FinancialAidRequest(), field.strip()))
                 else:
                     fields = '__all__'
 

--- a/esp/esp/tagdict/__init__.py
+++ b/esp/esp/tagdict/__init__.py
@@ -23,7 +23,7 @@ all_global_tags = {
     'min_available_timeslots': (False, ""),
     'availability_group_timeslots': (True, "Group timeslots into contiguous blocks in the availability interface (enabled by default, set to 'False' to disable)"),
     'group_phone_number': (False, ""),
-    'finaid_form_fields': (False, ""),
+    'finaid_form_fields': (False, "A comma-separated list of which Financial Aid Request fields to include in the form"),
     'onsite_classlist_min_refresh': (False, ""),
     'oktimes_collapse': (False, ""),
     'qsd_display_date_author': (False, ""),

--- a/esp/templates/program/modules/financialaidappmodule/application.html
+++ b/esp/templates/program/modules/financialaidappmodule/application.html
@@ -75,22 +75,30 @@
 <font size="3">Financial Aid Request: {{ request.user.get_full_name }}</font>
 </th>
 </tr>
+{% if form.reduced_lunch %}
 <tr>
     <td width="30%">Do you qualify for free or reduced lunch at your school?</td>
     <td>{{ form.reduced_lunch }}</td>
 </tr>
+{% endif %}
+{% if form.household_income %}
 <tr>
     <td width="30%">What is your annual household income (round to the nearest $1,000)?</td>
     <td>{{ form.household_income }}</td>
 </tr>
+{% endif %}
+{% if form.extra_explaination %}
 <tr>
     <td width="30%">Please describe your family's financial situation:</td>
     <td>{{ form.extra_explaination }}</td>
 </tr>
+{% endif %}
+{% if form.student_prepare %}
 <tr>
     <td width="30%">Did anyone other than the student fill out any part of this form?</td>
     <td>{{ form.student_prepare }}</td>
 </tr>
+{% endif %}
 <tr style="border: 1px solid #CCCCCC">
  <th colspan="2" style="text-align: center;">
     {% if app.done %}


### PR DESCRIPTION
The form now hides the field labels if the fields don't exist in the form. I also added some documentation for the tag (mostly because I never knew this existed, so I imagine I wasn't alone). Finally, I added some filtering for the tag processing to only include fields from the tag that actually exist in the `FinancialAidRequest` model.

Fixes #2620.

Note to reviewer: you might need to comment out [this line](https://github.com/learning-unlimited/ESP-Website/blob/finaid-form-tag/esp/esp/program/modules/handlers/financialaidappmodule.py#L89) in order to access the financial aid application on a dev server