### PR TITLE
Prevent autofill of list_selector

### DIFF
--- a/esp/templates/users/usersearch/list_selector.html
+++ b/esp/templates/users/usersearch/list_selector.html
@@ -13,7 +13,7 @@
         {% endif %}
     </ul>
     <div id="tab_basic">
-        <form id="form_basic_list" method="POST" action="{{ action_path }}">
+        <form id="form_basic_list" method="POST" action="{{ action_path }}" autocomplete="off">
 
         <div id="basic_step_container">
 
@@ -74,7 +74,7 @@
                 <div>Enter an ID number: <input type="text" size="6" name="userid" id="userid" /></div>
 
                 <h4><a href="#">User name</a></h4>
-                <div>Enter a username: <input type="text" size="30" name="username" id="username" /></div>
+                <div>Enter a username: <input type="text" size="30" name="username" id="username" autocomplete="new-username" /></div>
 
                 <h4><a href="#">Last name</a></h4>
                 <div>Enter a portion of the last name: <input type="text" size="30" name="last_name" id="last_name" /></div>
@@ -136,7 +136,7 @@
     </div>
 
     <div id="tab_combo">
-        <form id="form_combo_list" method="POST" action="{{ action_path }}">
+        <form id="form_combo_list" method="POST" action="{{ action_path }}" autocomplete="off">
         <div id="combo_step_container">
 
         <div id="starting_list_select">
@@ -200,7 +200,7 @@
                 <div>Enter an ID number: <input type="text" size="6" name="userid" id="userid" /></div>
 
                 <h4><a href="#">User name</a></h4>
-                <div>Enter a username: <input type="text" size="30" name="username" id="username" /></div>
+                <div>Enter a username: <input type="text" size="30" name="username" id="username" autocomplete="new-username" /></div>
 
                 <h4><a href="#">Last name</a></h4>
                 <div>Enter a portion of the last name: <input type="text" size="30" name="last_name" id="last_name" /></div>
@@ -262,7 +262,7 @@
     {% if include_prev_list %}
     <div id="tab_previous">
 
-        <form id="form_previous" method="POST" action="{{ action_path }}">
+        <form id="form_previous" method="POST" action="{{ action_path }}" autocomplete="off">
         <div id="previous_step_container">
 
         <div id="msgreq_selector_area" class="ui-widget">Begin typing an e-mail title to find a previous message:


### PR DESCRIPTION
I believe this should fix any autofill issues with the `list_selector.html` template used by the commpanel, arbitrary user list generator, and group text modules. Apparently there's  some politics around the specifics of the `autocomplete` field, specifically with how Chrome handles them. [caniuse](https://caniuse.com/#feat=input-autocomplete-onoff) specifies that Firefox and IE should follow the `autocomplete="off"` setting for anything but a password field, so the `autocomplete="off"` in the `form` tags should cover those browsers. Chrome, on the other hand, apparently will just ignore this setting completely. [Their suggestion](https://bugs.chromium.org/p/chromium/issues/detail?id=468153#c164) is to use a slightly modified keyword as I have done (`autocomplete="new-username"`), such that they don't use their data to autofill the field. This isn't supported by Firefox, but I'm hoping that the `form` tag addition will take precedence in that case?

I personally can't test this since I didn't have the problem before and am not able to reproduce the problem on my dev server.

Fixes #2680.