### PR TITLE
Custom forms work even when users are deleted

### DIFF
--- a/esp/esp/customforms/DynamicForm.py
+++ b/esp/esp/customforms/DynamicForm.py
@@ -657,7 +657,7 @@ class FormHandler:
             link_instances_cache={}
 
             # Add in user if form is not anonymous
-            if not form.anonymous:
+            if not form.anonymous and response['user_id']:
                 user = users[response['user_id']]
                 response['user_id'] = unicode(response['user_id'])
                 response['user_display'] = user.name()


### PR DESCRIPTION
Custom forms were breaking if a user associated with a response was deleted. We probably shouldn't be deleting users anyways, but just in case this happens again, this is a fix for that (we just skip including user data in the response in such cases, but we can still fill in all of the other information).

Fixes #2673.