### PR TITLE
Tweak some commpanel formatting

### DIFF
--- a/esp/public/media/default_styles/commpanel.css
+++ b/esp/public/media/default_styles/commpanel.css
@@ -6,6 +6,11 @@ label .commpanel_list_preferred {
     color: red;
 }
 
+.ui-widget select {
+    width: auto;
+    max-width: 100%;
+}
+
 #filter_accordion h4 {
     font-weight: bold;
     font-style: normal;
@@ -81,7 +86,7 @@ div #combo_list_form li {
 
 #combo_list_form label.ui-button {
     margin: 0px;
-    margin-left: -5px;
+    margin-left: 2px;
     padding: 2px;
 }
 


### PR DESCRIPTION
While looking into #2550, I noticed some little things that could use tweaking:

1. I spaced out the AND/OR/NOT buttons a little (they were overlapping before)
2. I allowed the combination list dropdown to expand in width to show more of the text for the selected option.