### PR TITLE
Prevent signout loop on some themes

### DIFF
--- a/esp/esp/users/views/__init__.py
+++ b/esp/esp/users/views/__init__.py
@@ -61,7 +61,7 @@ def login_checked(request, *args, **kwargs):
                     context['next_title'] = 'the home page'
                 return render_to_response('users/login_duplicate_warning.html', request, context)
 
-    mask_locations = ['/', '/myesp/signout/', '/admin/logout/']
+    mask_locations = ['/', '/myesp/signout', '/myesp/signout/', '/admin/logout/']
     if reply.get('Location', '') in mask_locations:
         # We're getting redirected to somewhere undesirable.
         # Let's try to do something smarter.


### PR DESCRIPTION
The bigpicture and default loginboxes use `/myesp/signout` instead of `/myesp/signout/` for their logout button:
https://github.com/learning-unlimited/ESP-Website/blob/77dbf1a95d3d02de9813be93c614d9140bcfdf7b/esp/esp/themes/theme_data/bigpicture/templates/users/loginbox_content.html#L10
https://github.com/learning-unlimited/ESP-Website/blob/77dbf1a95d3d02de9813be93c614d9140bcfdf7b/esp/templates/users/loginbox_content.html#L17
This then gets passed on as the `next` param in the login form, which didn't caught in the login, so the user doesn't get redirected to teach/learn pages, causing a signout loop.

I suppose I could have just edited the templates, but I think it's more future-proof if we just add `/myesp/signout` to our check in the view.

Fixes #2694.