### PR TITLE
Fix missingteachers for teachers without contact info

### DIFF
--- a/esp/esp/program/modules/handlers/teachercheckinmodule.py
+++ b/esp/esp/program/modules/handlers/teachercheckinmodule.py
@@ -193,13 +193,11 @@ class TeacherCheckinModule(ProgramModuleObj):
         return render_to_response(self.baseDir()+'classdetail.html', request, context)
 
     @staticmethod
-    def get_phones(users):
+    def get_phones(users, default = '(missing contact info)'):
         """
         Given a list or QuerySet of users, create a dictionary that maps user
         ids to phone numbers for displaying.
         """
-
-        default = '(missing contact info)'
 
         # This is an optimized version of doing this for each user:
 
@@ -220,7 +218,7 @@ class TeacherCheckinModule(ProgramModuleObj):
         return collections.defaultdict(lambda _: default, phone_entries)
 
     def getMissingTeachers(self, prog, date=None, starttime=None, when=None,
-                           show_flags=True):
+                           show_flags=True, default_phone = '(missing contact info)'):
         """Return a list of class sections with missing teachers as of 'when'.
 
         Parameters:
@@ -245,6 +243,8 @@ class TeacherCheckinModule(ProgramModuleObj):
           show_flags (bool, optional):  If True, prefetch class flags
                                         information for the list of class
                                         sections.
+          default_phone (string, opt):  A string that should be used if there
+                                        is no valid phone number for a teacher.
 
         NOTE: For multi-week programs, classes are only scheduled once on the
         website, even though they meet multiple times and teachers need to be
@@ -309,10 +309,10 @@ class TeacherCheckinModule(ProgramModuleObj):
 
         # To save multiple calls to getLastProfile, precompute the teacher
         # phones.
-        teacher_phones = self.get_phones(teachers)
+        teacher_phones = self.get_phones(teachers, default_phone)
         arrived = dict()
         for teacher in arrived_teachers:
-            teacher.phone = teacher_phones[teacher.id]
+            teacher.phone = teacher_phones.get(teacher.id, default_phone)
             arrived[teacher.id] = teacher
 
         sections_by_class = {}
@@ -330,7 +330,7 @@ class TeacherCheckinModule(ProgramModuleObj):
                     # make a new list and then modify that.
                     section.teachers_list = list(section.teachers)
                     for teacher in section.teachers_list:
-                        teacher.phone = teacher_phones[teacher.id]
+                        teacher.phone = teacher_phones.get(teacher.id, default_phone)
                     sections_by_class[section.parent_class_id] = section
 
         sections = [
@@ -358,8 +358,11 @@ class TeacherCheckinModule(ProgramModuleObj):
           'when' (optional):  See documentation for getMissingTeachers().
                               getMissingTeachers(). Should be given in the
                               format "%m/%d/%Y %H:%M".
+          'default_phone' (optional): A string that should be used if there
+                              is no valid phone number for a teacher.
         """
         starttime = date = next = previous = None
+        default_phone = request.GET.get('default_phone', '(missing contact info)')
         if 'start' in request.GET:
             starttime = Event.objects.get(id=request.GET['start'])
             date = starttime.start.date()
@@ -378,6 +381,7 @@ class TeacherCheckinModule(ProgramModuleObj):
             if i < len(dates) - 1:
                 next = dates[i + 1].strftime('%m/%d/%Y')
         context = {}
+        context['default_phone'] = default_phone
         context['text_configured'] = GroupTextModule.is_configured()
         form = TeacherCheckinForm(request.GET)
         if form.is_valid():
@@ -390,7 +394,7 @@ class TeacherCheckinModule(ProgramModuleObj):
         show_flags = self.program.program_modules.filter(handler='ClassFlagModule').exists()
         context['date'] = date
         context['sections'], context['arrived'] = self.getMissingTeachers(
-            prog, date, starttime, when, show_flags)
+            prog, date, starttime, when, show_flags, default_phone)
         if show_flags:
             context['show_flags'] = True
             context['flag_types'] = ClassFlagType.get_flag_types(self.program)

--- a/esp/public/media/scripts/onsite/teacher_checkin.js
+++ b/esp/public/media/scripts/onsite/teacher_checkin.js
@@ -94,11 +94,14 @@ $j(function(){
         var $me = $j(this);
         var $td = $j(this.parentNode);
         var $msg = $td.children('.message');
+        var $txtbtn = $j(this).closest('tr').find('.text');
         checkIn(username, function(response) {
             $msg.text(response.message);
             $td.prev().prop('class', 'checked-in');
             checkins.push({username: username, name: response.name, $td: $td});
             $me.hide().prop('disabled', true);
+            $txtbtn.prop('disabled', true);
+            $txtbtn.attr("title","Teacher already checked-in");
             updateSelected(false);
 
             var $undoButton = $j(document.createElement('button'));
@@ -131,6 +134,7 @@ $j(function(){
             $j(msg).text(response.message);
         });
         $j(btn).attr("disabled",true);
+        $j(btn).attr("title","Teacher already texted");
         $j(msg).text('Texting teacher...');
     }
 
@@ -139,14 +143,13 @@ $j(function(){
     });
 
     $j(".text-all").click(function(){
-        var num_teachers = $j(".checkin:visible").length
+        var $buttons = $j(".checkin:visible").closest('tr').find('.text:enabled');
+        var num_teachers = $buttons.length
         var r = confirm("Are you sure you'd like to text " + num_teachers + " unchecked-in teachers?");
         if (r) {
-            $j(".checkin:visible").closest('tr').find('.text').each(function() {
+            $buttons.each(function() {
                 textTeacher($j(this))
             });
-            $j(this).attr("disabled",true);
-            $j(this).attr("title","Teachers already texted");
         }
     });
 
@@ -188,6 +191,7 @@ $j(function(){
         }
         username = targetCheckin.username;
         var $td = targetCheckin.$td;
+        var $txtbtn = $td.closest('tr').find('.text');
         var $msg = $td.children('.message');
         var $undoButton = $msg.children('.undo-button');
         $undoButton.text('Undoing...').prop('disabled', true);
@@ -201,6 +205,8 @@ $j(function(){
             }
             $msg.html(response.message+"<br/>");
             $td.children('.checkin').show().prop('disabled', false);
+            $txtbtn.prop('disabled', false);
+            $txtbtn.removeAttr("title");
             $td.prev().prop('class', 'not-checked-in');
             selected = $j('.checkin:enabled').index($td.find('.checkin'));
             updateSelected(true);

--- a/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
+++ b/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
@@ -190,7 +190,8 @@
             <span class="message"></span>
             <input data-username="{{ teacher.username }}" data-section="{{ section.id }}"
                    class="button text" type="button" value="Text Teacher"
-                   {% if not text_configured %} disabled title="Twilio texting settings are not configured"{% endif %}/>
+                   {% if not text_configured %} disabled title="Twilio texting settings are not configured"
+                   {% elif teacher.phone == default_phone %} disabled title="No contact info"{% endif %}/>
         </tr>
         <tr>
     {% endfor %}


### PR DESCRIPTION
Sometimes teachers don't have contact info, but are manually added as co-teachers to classes by admins (presumably by editing their availability and then adding them through the manage class page). However, there was a bug that broke the `/missingteachers` page when looking up the contact info for these teachers. I've fixed that bug and also modified the downstream texting functionality of the `/missingteachers` page to handle missing phone numbers (plus some tweaks to disable the text buttons when teachers are checked-in and re-enabling them if teachers are unchecked-in).

To test this, I made a new account without filling out the profile information, manually edited it's availability, and added it as a co-teacher to a scheduled class. Everything worked as expected.

Fixes #2633.