### PR TITLE
Copy some old module info when using an old program as a template

### DIFF
--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -991,7 +991,7 @@ class Program(models.Model, CustomFormsLinkModel):
         return li_types
 
     @cache_function
-    def getModules_cached(self, tl = None):
+    def getModules_cached(self, tl = None, old_prog = None):
         """ Gets a list of modules for this program. """
         from esp.program.modules import base
 
@@ -1005,7 +1005,7 @@ class Program(models.Model, CustomFormsLinkModel):
             modules =  [ base.ProgramModuleObj.getFromProgModule(self, module)
                  for module in self.program_modules.filter(module_type = tl) ]
         else:
-            modules =  [ base.ProgramModuleObj.getFromProgModule(self, module)
+            modules =  [ base.ProgramModuleObj.getFromProgModule(self, module, old_prog)
                  for module in self.program_modules.all()]
 
         modules.sort(cmpModules)
@@ -1018,9 +1018,9 @@ class Program(models.Model, CustomFormsLinkModel):
     getModules_cached.depend_on_row('modules.ClassRegModuleInfo', lambda modinfo: {'self': modinfo.program})
     getModules_cached.depend_on_row('modules.StudentClassRegModuleInfo', lambda modinfo: {'self': modinfo.program})
 
-    def getModules(self, user = None, tl = None):
+    def getModules(self, user = None, tl = None, old_prog = None):
         """ Gets modules for this program, optionally attaching a user. """
-        modules = self.getModules_cached(tl)
+        modules = self.getModules_cached(tl, old_prog)
         if user:
             for module in modules:
                 module.setUser(user)

--- a/esp/esp/program/modules/base.py
+++ b/esp/esp/program/modules/base.py
@@ -210,7 +210,7 @@ class ProgramModuleObj(models.Model):
         raise Http404
 
     @staticmethod
-    def getFromProgModule(prog, mod):
+    def getFromProgModule(prog, mod, old_prog = None):
         import esp.program.modules.models
         """ Return an appropriate module object for a Module and a Program.
            Note that all the data is forcibly taken from the ProgramModuleObj table """
@@ -219,9 +219,16 @@ class ProgramModuleObj(models.Model):
         if len(BaseModuleList) < 1:
             BaseModule = ProgramModuleObj()
             BaseModule.program = prog
-            BaseModule.module  = mod
-            BaseModule.seq     = mod.seq
-            BaseModule.required = mod.required
+            BaseModule.module = mod
+            # If an old program is specified, use the seq and required values from that program
+            old_pmo = ProgramModuleObj.objects.filter(program = old_prog, module = mod)
+            if len(old_pmo) == 1:
+                BaseModule.seq = old_pmo[0].seq
+                BaseModule.required = old_pmo[0].required
+                BaseModule.required_label = old_pmo[0].required_label
+            else:
+                BaseModule.seq = mod.seq
+                BaseModule.required = mod.required
             BaseModule.save()
 
         elif len(BaseModuleList) > 1:

--- a/esp/esp/program/setup.py
+++ b/esp/esp/program/setup.py
@@ -63,7 +63,7 @@ def prepare_program(program, data):
 
     return perms, modules
 
-def commit_program(prog, perms, modules, cost=0, sibling_discount=None):
+def commit_program(prog, perms, cost=0, sibling_discount=None):
     #   This function implements the changes suggested by prepare_program.
 
     def gen_perm(tup):

--- a/esp/esp/program/tests.py
+++ b/esp/esp/program/tests.py
@@ -658,7 +658,7 @@ class ProgramFrameworkTest(TestCase):
         new_prog.save()
         pcf.save_m2m()
 
-        commit_program(new_prog, perms, modules, pcf.cleaned_data['base_cost'])
+        commit_program(new_prog, perms, pcf.cleaned_data['base_cost'])
 
         #   Add recursive permissions to open registration to the appropriate people
         (perm, created) = Permission.objects.get_or_create(role=Group.objects.get(name='Teacher'), permission_type='Teacher/All', program=new_prog)

--- a/esp/esp/program/tests.py
+++ b/esp/esp/program/tests.py
@@ -819,7 +819,7 @@ class ProgramFrameworkTest(TestCase):
         new_prog.save()
         pcf.save_m2m()
 
-        commit_program(new_prog, perms, modules, pcf.cleaned_data['base_cost'])
+        commit_program(new_prog, perms, pcf.cleaned_data['base_cost'])
 
         self.new_prog = new_prog
 

--- a/esp/esp/program/views.py
+++ b/esp/esp/program/views.py
@@ -449,6 +449,7 @@ def newprogram(request):
        #try:
         template_prog_id = int(request.GET["template_prog"])
         tprogram = Program.objects.get(id=template_prog_id)
+        request.session['template_prog'] = template_prog_id
         template_prog = {}
         template_prog.update(tprogram.__dict__)
         del template_prog["id"]
@@ -492,7 +493,7 @@ def newprogram(request):
 
             new_prog = pcf.save(commit = True)
 
-            commit_program(new_prog, context['perms'], context['modules'], context['cost'], context['sibling_discount'])
+            commit_program(new_prog, context['perms'], context['cost'], context['sibling_discount'])
 
             # Create the default resource types now
             default_restypes = Tag.getProgramTag('default_restypes', program=new_prog)
@@ -500,8 +501,13 @@ def newprogram(request):
                 resource_type_labels = json.loads(default_restypes)
                 resource_types = [ResourceType.get_or_create(x, new_prog) for x in resource_type_labels]
 
-            #   Force all ProgramModuleObjs and their extensions to be created now
-            new_prog.getModules()
+            # Force all ProgramModuleObjs and their extensions to be created now
+            # If we are using another program as a template, let's copy the seq and required values from that program.
+            if 'template_prog' in request.session:
+                old_prog = Program.objects.get(id=request.session['template_prog'])
+                new_prog.getModules(old_prog=old_prog)
+            else:
+                new_prog.getModules()
 
             manage_url = '/manage/' + new_prog.url + '/resources'
 


### PR DESCRIPTION
Many times, chapters make small changes to the `ProgramModuleObj` settings that are set up for their programs, including modifying the sequence of the modules, changing whether the modules should be required or not, and modifying `required_label` (which is confusingly shown whether or not the module is required). The website used to create brand new, blank module objects for each program, so chapters would need to implement these changes again for each program. Now, if a program is being used as a template to create a new program, the website will attempt to use the settings from the module objects from the template program while setting up the module objects for the new program.

Fixes #2644.