### PR TITLE
Round Event durations to match the rounding of class/section durations

### DIFF
--- a/esp/esp/cal/models.py
+++ b/esp/esp/cal/models.py
@@ -73,7 +73,10 @@ class Event(models.Model):
         return self.name
 
     def duration(self):
-        return self.end - self.start
+        # Matches the rounding of class/section durations
+        dur = self.end - self.start
+        hrs = round(dur.total_seconds() / 3600.0, 2)
+        return timedelta(hours = hrs)
 
     def duration_str(self):
         dur = self.end - self.start
@@ -106,7 +109,10 @@ class Event(models.Model):
         event_list = list(event_list)
         event_list.sort(key=lambda x:x.start)
         if len(event_list) > 0:
-            return event_list[-1].end - event_list[0].start
+            # Matches the rounding of class/section durations
+            dur = event_list[-1].end - event_list[0].start
+            hrs = round(dur.total_seconds() / 3600.0, 2)
+            return timedelta(hours = hrs)
         else:
             return timedelta(seconds=0)
 

--- a/esp/esp/program/controllers/lunch_constraints.py
+++ b/esp/esp/program/controllers/lunch_constraints.py
@@ -119,7 +119,7 @@ class LunchConstraintGenerator(object):
         lunch_subjects = ClassSubject.objects.filter(parent_program__id=self.program.id, category=self.get_lunch_category(), message_for_directors=day.isoformat())
         lunch_subject = None
         example_timeslot = self.days[day]['lunch'][0]
-        timeslot_length = (example_timeslot.end - example_timeslot.start).seconds / 3600.0
+        timeslot_length = (example_timeslot.duration()).total_seconds() / 3600.0
 
         if lunch_subjects.count() == 0:
             #   If no lunch was found, create a new subject

--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -786,7 +786,7 @@ class Program(models.Model, CustomFormsLinkModel):
         ts_list = Event.collapse(list(self.getTimeSlots()), tol=timedelta(minutes=15))
         time_sum = timedelta()
         for t in ts_list:
-            time_sum = time_sum + (t.end - t.start)
+            time_sum = time_sum + t.duration()
         return time_sum
 
     def dates(self):
@@ -959,7 +959,7 @@ class Program(models.Model, CustomFormsLinkModel):
             n = len(t_list)
             for i in range(0, n):
                 for j in range(i, n):
-                    time_option = t_list[j].end - t_list[i].start
+                    time_option = Event.total_length([t_list[i], t_list[j]])
                     durationSeconds = time_option.seconds
                     #   If desired, round up to the nearest 15 minutes
                     if round:
@@ -967,7 +967,7 @@ class Program(models.Model, CustomFormsLinkModel):
                     else:
                         rounded_seconds = durationSeconds
                     if (max_seconds is None) or (durationSeconds <= max_seconds):
-                        durationDict[(Decimal(durationSeconds) / 3600).quantize(Decimal('.01'))] = \
+                        durationDict[(Decimal(durationSeconds) / 3600)] = \
                                         str(rounded_seconds / 3600) + ':' + \
                                         str((rounded_seconds / 60) % 60).rjust(2,'0')
 

--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -570,9 +570,7 @@ class ClassSection(models.Model):
 
         if event_list is None:
             event_list = list(self.meeting_times.all().order_by('start'))
-        #   If you're 15 minutes short that's OK.
-        time_tolerance = 15 * 60
-        if Event.total_length(event_list).seconds + time_tolerance < duration * 3600:
+        if Event.total_length(event_list).total_seconds() < duration * 3600:
             return False
         else:
             return True
@@ -1689,7 +1687,7 @@ class ClassSubject(models.Model, CustomFormsLinkModel):
         time_avail = 0.0
         #   Start with amount of total time pledged as available
         for tg in avail:
-            td = tg.end - tg.start
+            td = tg.duration()
             time_avail += (td.seconds / 3600.0)
         #   Subtract out time already pledged for teaching classes other than this one
         for cls in user.getTaughtClasses(self.parent_program):

--- a/esp/esp/program/modules/handlers/schedulingcheckmodule.py
+++ b/esp/esp/program/modules/handlers/schedulingcheckmodule.py
@@ -3,7 +3,6 @@ from esp.program.models import Program, ClassSection, ClassSubject
 from esp.program.modules.base import ProgramModuleObj, needs_admin, main_call, aux_call
 from esp.resources.models import ResourceRequest
 from copy import deepcopy
-from math import ceil
 from esp.cal.models import *
 from datetime import date
 from esp.utils.web import render_to_response


### PR DESCRIPTION
I'm pretty sure this fixes all of the potential places that we might have different rounding between Event durations and class/section durations. At the very least, I've modified the `duration()` method, which will now always return a `timedelta` that is rounded appropriately. I think there may be other issues specifically in the AJAX scheduler, but I'll discuss that in a new issue.

Fixes #2696.