### PR TITLE
fix numpy version check

### DIFF
--- a/esp/esp/program/controllers/classchange.py
+++ b/esp/esp/program/controllers/classchange.py
@@ -35,7 +35,8 @@ Learning Unlimited, Inc.
 import logging
 logger = logging.getLogger(__name__)
 import numpy
-assert numpy.version.short_version >= "1.7.0"
+from pkg_resources import parse_version
+assert parse_version(numpy.version.short_version) >= parse_version("1.7.0")
 import numpy.random
 import Queue
 import random

--- a/esp/esp/program/controllers/lottery.py
+++ b/esp/esp/program/controllers/lottery.py
@@ -37,7 +37,8 @@ Learning Unlimited, Inc.
 import logging
 logger = logging.getLogger(__name__)
 import numpy
-assert numpy.version.short_version >= "1.7.0"
+from pkg_resources import parse_version
+assert parse_version(numpy.version.short_version) >= parse_version("1.7.0")
 import numpy.random
 
 from datetime import date, datetime


### PR DESCRIPTION
The numpy version check wasn't implemented correctly. It failed for version 1.16.0