### PR TITLE
classesbyFOO and sectionsbyFOO fixes/changes

### DIFF
--- a/esp/esp/program/modules/handlers/programprintables.py
+++ b/esp/esp/program/modules/handlers/programprintables.py
@@ -313,7 +313,7 @@ class ProgramPrintables(ProgramModuleObj):
     @needs_admin
     def classesbyFOO(self, request, tl, one, two, module, extra, prog, sort_exp = lambda x,y: cmp(x,y), filt_exp = lambda x: True, split_teachers = False):
         classes = ClassSubject.objects.filter(parent_program = self.program)
-        
+
         if 'clsids' in request.GET:
             clsids = [int(clsid) for clsid in request.GET['clsids'].split(",")]
             classes = [cls for cls in classes if cls.id in clsids]

--- a/esp/templates/program/modules/programprintables/options.html
+++ b/esp/templates/program/modules/programprintables/options.html
@@ -51,13 +51,47 @@ Please select from options below.
 
 <h3>Admin Binder Stuff</h3>
 <ul>
-<li><a href="./classesbytime" title="Classes by Time">Class Sections sorted by time</a>
+<li><a href="./classesbytime" title="Classes by Time">Class Sections Sorted by Time</a>
     <ul>
     <li><a href="./classesbytime?grade_min=7&grade_max=8" title="Classes by Time">Limit to middle school (grades 7-8)</a></li>
     <li><a href="./classesbytime?grade_min=9&grade_max=12" title="Classes by Time">Limit to high school (grades 9-12)</a></li>
+    <li><a href="./classesbytime?accepted" title="Classes by Time">Accepted Only</a></li>
+    <li><a href="./classesbytime?scheduled" title="Classes by Time">Scheduled Only</a></li>
+    <li><a href="./classesbytime?accepted&scheduled" title="Classes by Time">Accepted and Scheduled Only</a></li>
+    <li><a href="./classesbytime?cancelled" title="Classes by Time">Cancelled Only</a></li>
     </ul>
 </li>
-<li><a href="./classesbytime?cancelled" title="Classes by Time">Cancelled Class Sections</a></li>
+<li><a href="./classesbyid" title="Classes by ID">Class Subjects Sorted by ID</a></li>
+    <ul>
+    <li><a href="./classesbyid?grade_min=7&grade_max=8" title="Classes by ID">Limit to middle school (grades 7-8)</a></li>
+    <li><a href="./classesbyid?grade_min=9&grade_max=12" title="Classes by ID">Limit to high school (grades 9-12)</a></li>
+    <li><a href="./classesbyid?accepted" title="Classes by ID">Accepted Only</a></li>
+    <li><a href="./classesbyid?scheduled" title="Classes by ID">Scheduled Only</a></li>
+    <li><a href="./classesbyid?accepted&scheduled" title="Classes by ID">Accepted and Scheduled Only</a></li>
+    <li><a href="./classesbyid?cancelled" title="Classes by ID">Cancelled Only</a></li>
+    </ul>
+<li><a href="./classesbytitle" title="Classes by Name">Class Subjects Sorted by Title</a></li>
+    <ul>
+    <li><a href="./classesbytitle?grade_min=7&grade_max=8" title="Classes by Name">Limit to middle school (grades 7-8)</a></li>
+    <li><a href="./classesbytitle?grade_min=9&grade_max=12" title="Classes by Name">Limit to high school (grades 9-12)</a></li>
+    <li><a href="./classesbytitle?accepted" title="Classes by Name">Accepted Only</a></li>
+    <li><a href="./classesbytitle?scheduled" title="Classes by Name">Scheduled Only</a></li>
+    <li><a href="./classesbytitle?accepted&scheduled" title="Classes by Name">Accepted and Scheduled Only</a></li>
+    <li><a href="./classesbytitle?cancelled" title="Classes by Name">Cancelled Only</a></li>
+    </ul>
+<li><a href="./classesbyteacher" title="Classes by Teacher">Class Subjects Sorted by Teacher</a></li>
+    <ul>
+    <li><a href="./classesbyteacher?grade_min=7&grade_max=8" title="Classes by Teacher">Limit to middle school (grades 7-8)</a></li>
+    <li><a href="./classesbyteacher?grade_min=9&grade_max=12" title="Classes by Teacher">Limit to high school (grades 9-12)</a></li>
+    <li><a href="./classesbyteacher?accepted" title="Classes by Teacher">Accepted Only</a></li>
+    <li><a href="./classesbyteacher?scheduled" title="Classes by Teacher">Scheduled Only</a></li>
+    <li><a href="./classesbyteacher?accepted&scheduled" title="Classes by Teacher">Accepted and Scheduled Only</a></li>
+    <li><a href="./classesbyteacher?cancelled" title="Classes by Teacher">Cancelled Only</a></li>
+    </ul>
+<li><a href="./teachersbyname" title="Teacher List">Teacher List</a> (can be sorted by name, class, or start time); <a href="./teachersbyname/secondday">teachers for second day of classes only</a></li>
+<li><a href="./roomsbytime" title="Room List">Open Rooms by Time</a></li>
+<li><a href="./studentsbyname" title="Student List">Students by Name</a> (by students)</li>
+<li><a href="./emergencycontacts" title="Student List">Students' Emergency Contact Info</a> (by students)</li>
 {% if not li_types|length_is:0 %}
 <li>Students who have ordered/reserved line items:
     <ul>
@@ -67,12 +101,6 @@ Please select from options below.
     </ul>
 </li>
 {% endif %}
-<li><a href="./classesbytitle" title="Classes by Name">Class Subjects</a></li>
-<li><a href="./classesbyteacher" title="Classes by Teacher">Classes Sorted by Teacher</a></li>
-<li><a href="./teachersbyname" title="Teacher List">Teacher List</a> (can be sorted by name, class, or start time); <a href="./teachersbyname/secondday">teachers for second day of classes only</a></li>
-<li><a href="./roomsbytime" title="Room List">Open Rooms by Time</a></li>
-<li><a href="./studentsbyname" title="Student List">Students by Name</a> (by students)</li>
-<li><a href="./emergencycontacts" title="Student List">Students' Emergency Contact Info</a> (by students)</li>
 </ul>
 
 <h3>Other Printables</h3>

--- a/esp/templates/program/modules/programprintables/options.html
+++ b/esp/templates/program/modules/programprintables/options.html
@@ -53,8 +53,8 @@ Please select from options below.
 <ul>
 <li><a href="./classesbytime" title="Classes by Time">Class Sections Sorted by Time</a>
     <ul>
-    <li><a href="./classesbytime?grade_min=7&grade_max=8" title="Classes by Time">Limit to middle school (grades 7-8)</a></li>
-    <li><a href="./classesbytime?grade_min=9&grade_max=12" title="Classes by Time">Limit to high school (grades 9-12)</a></li>
+    <li><a href="./classesbytime?grade_min=7&grade_max=8" title="Classes by Time">Limit to Middle School (Grades 7-8)</a></li>
+    <li><a href="./classesbytime?grade_min=9&grade_max=12" title="Classes by Time">Limit to High School (Grades 9-12)</a></li>
     <li><a href="./classesbytime?accepted" title="Classes by Time">Accepted Only</a></li>
     <li><a href="./classesbytime?scheduled" title="Classes by Time">Scheduled Only</a></li>
     <li><a href="./classesbytime?accepted&scheduled" title="Classes by Time">Accepted and Scheduled Only</a></li>
@@ -63,8 +63,8 @@ Please select from options below.
 </li>
 <li><a href="./classesbyid" title="Classes by ID">Class Subjects Sorted by ID</a></li>
     <ul>
-    <li><a href="./classesbyid?grade_min=7&grade_max=8" title="Classes by ID">Limit to middle school (grades 7-8)</a></li>
-    <li><a href="./classesbyid?grade_min=9&grade_max=12" title="Classes by ID">Limit to high school (grades 9-12)</a></li>
+    <li><a href="./classesbyid?grade_min=7&grade_max=8" title="Classes by ID">Limit to Middle School (Grades 7-8)</a></li>
+    <li><a href="./classesbyid?grade_min=9&grade_max=12" title="Classes by ID">Limit to High School (Grades 9-12)</a></li>
     <li><a href="./classesbyid?accepted" title="Classes by ID">Accepted Only</a></li>
     <li><a href="./classesbyid?scheduled" title="Classes by ID">Scheduled Only</a></li>
     <li><a href="./classesbyid?accepted&scheduled" title="Classes by ID">Accepted and Scheduled Only</a></li>
@@ -72,8 +72,8 @@ Please select from options below.
     </ul>
 <li><a href="./classesbytitle" title="Classes by Name">Class Subjects Sorted by Title</a></li>
     <ul>
-    <li><a href="./classesbytitle?grade_min=7&grade_max=8" title="Classes by Name">Limit to middle school (grades 7-8)</a></li>
-    <li><a href="./classesbytitle?grade_min=9&grade_max=12" title="Classes by Name">Limit to high school (grades 9-12)</a></li>
+    <li><a href="./classesbytitle?grade_min=7&grade_max=8" title="Classes by Name">Limit to Middle School (Grades 7-8)</a></li>
+    <li><a href="./classesbytitle?grade_min=9&grade_max=12" title="Classes by Name">Limit to High School (Grades 9-12)</a></li>
     <li><a href="./classesbytitle?accepted" title="Classes by Name">Accepted Only</a></li>
     <li><a href="./classesbytitle?scheduled" title="Classes by Name">Scheduled Only</a></li>
     <li><a href="./classesbytitle?accepted&scheduled" title="Classes by Name">Accepted and Scheduled Only</a></li>
@@ -81,8 +81,8 @@ Please select from options below.
     </ul>
 <li><a href="./classesbyteacher" title="Classes by Teacher">Class Subjects Sorted by Teacher</a></li>
     <ul>
-    <li><a href="./classesbyteacher?grade_min=7&grade_max=8" title="Classes by Teacher">Limit to middle school (grades 7-8)</a></li>
-    <li><a href="./classesbyteacher?grade_min=9&grade_max=12" title="Classes by Teacher">Limit to high school (grades 9-12)</a></li>
+    <li><a href="./classesbyteacher?grade_min=7&grade_max=8" title="Classes by Teacher">Limit to Middle School (Grades 7-8)</a></li>
+    <li><a href="./classesbyteacher?grade_min=9&grade_max=12" title="Classes by Teacher">Limit to High School (Grades 9-12)</a></li>
     <li><a href="./classesbyteacher?accepted" title="Classes by Teacher">Accepted Only</a></li>
     <li><a href="./classesbyteacher?scheduled" title="Classes by Teacher">Scheduled Only</a></li>
     <li><a href="./classesbyteacher?accepted&scheduled" title="Classes by Teacher">Accepted and Scheduled Only</a></li>


### PR DESCRIPTION
I fixed the classesbyFOO and sectionsbyFOO functions so they now don't break when unapproved class or sections IDs are supplied. I also reordered the filtering to what I believe is the most efficient order. Finally, I changed the default of these functions to return all classes that are not cancelled or rejected (i.e. `status >= 0`), but that can be overridden by various `GET` parameters (I'm happy to discuss if the anyone thinks that there is a better default).

To make it easier for admins to utilize these different options, I've added a large number of new links to the printables page.

I tested all of the different options for all of the different types of printables, and they all seem to work properly for my setup.

Fixes #2710.