### PR TITLE
Class availability page

### DIFF
--- a/esp/esp/program/modules/handlers/adminclass.py
+++ b/esp/esp/program/modules/handlers/adminclass.py
@@ -35,7 +35,9 @@ Learning Unlimited, Inc.
 from esp.program.modules.base import ProgramModuleObj, needs_admin, aux_call
 from esp.program.modules.handlers.teacherclassregmodule import TeacherClassRegModule
 
+from esp.cal.models import Event
 from esp.program.models import ClassSubject, ClassSection, ClassFlagType
+from esp.tagdict.models import Tag
 from esp.users.models import ESPUser, User
 
 from esp.utils.web import render_to_response
@@ -420,7 +422,8 @@ class AdminClass(ProgramModuleObj):
                                    'ajax': ajax,
                                    'txtTeachers': txtTeachers,
                                    'coteachers': coteachers,
-                                   'conflict': conflictinguser})
+                                   'conflict': conflictinguser,
+                                   'program': prog})
 
     @aux_call
     @needs_admin
@@ -451,6 +454,57 @@ class AdminClass(ProgramModuleObj):
             return self.goToCore(tl)
 
         return TeacherClassRegModule.teacherlookup_logic(request, tl, one, two, module, extra, prog, newclass)
+
+    @aux_call
+    @needs_admin
+    def classavailability(self, request, tl, one, two, module, extra, prog):
+        """ Shows the collective availability of teachers for a class. """
+        cls = self.getClass(request,extra)
+        time_options = prog.getTimeSlots()
+        #   Group contiguous blocks
+        if not Tag.getBooleanTag('availability_group_timeslots', default=True):
+            time_groups = [list(time_options)]
+        else:
+            time_groups = Event.group_contiguous(list(time_options))
+
+        teachers = cls.get_teachers()
+
+        meeting_times = cls.all_meeting_times
+        unscheduled_sections = []
+        for section in cls.get_sections():
+            if len(section.get_meeting_times()) == 0:
+                unscheduled_sections.append(section)
+
+        viable_times = list(meeting_times)
+
+        unavail_teachers = {}
+        for time in time_options:
+            unavail_teachers[time] = []
+            for teacher in cls.get_teachers():
+                if time not in teacher.getAvailableTimes(prog):
+                    unavail_teachers[time].append(teacher)
+            if len(unavail_teachers[time]) == 0:
+                viable_times.append(time)
+
+        context =   {
+                        'groups': [
+                            [
+                                {
+                                    'available': t in viable_times,
+                                    'slot': t,
+                                    'id': t.id,
+                                    'section': cls.get_section(t),
+                                    'unavail_teachers': unavail_teachers.get(t),
+                                }
+                            for t in group]
+                        for group in time_groups]
+                    }
+        context['class'] = cls
+        context['unscheduled'] = unscheduled_sections
+        context['num_groups'] = len(context['groups'])
+        context['program'] = prog
+
+        return render_to_response(self.baseDir()+'classavailability.html', request, context)
 
     class Meta:
         proxy = True

--- a/esp/esp/program/modules/handlers/adminclass.py
+++ b/esp/esp/program/modules/handlers/adminclass.py
@@ -478,12 +478,16 @@ class AdminClass(ProgramModuleObj):
         viable_times = list(meeting_times)
 
         unavail_teachers = {}
+        teaching_teachers = {}
         for time in time_options:
             unavail_teachers[time] = []
+            teaching_teachers[time] = []
             for teacher in teachers:
-                if time not in teacher.getAvailableTimes(prog):
+                if time in teacher.getTaughtTimes(prog):
+                    teaching_teachers[time].append(teacher)
+                elif time not in teacher.getAvailableTimes(prog):
                     unavail_teachers[time].append(teacher)
-            if len(unavail_teachers[time]) == 0:
+            if len(unavail_teachers[time]) + len(teaching_teachers[time]) == 0:
                 viable_times.append(time)
 
         context =   {
@@ -495,6 +499,7 @@ class AdminClass(ProgramModuleObj):
                                     'id': t.id,
                                     'section': cls.get_section(t),
                                     'unavail_teachers': unavail_teachers.get(t),
+                                    'teaching_teachers': teaching_teachers.get(t),
                                 }
                             for t in group]
                         for group in time_groups]

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -431,6 +431,14 @@ class BaseESPUser(object):
                 total_time = total_time + timedelta(hours=rounded_hours(s.duration))
         return total_time
 
+    def getTaughtTimes(self, program = None):
+        """ Return the times taught as a set. If a program is specified, return the times taught for that program. """
+        user_sections = self.getTaughtSections(program)
+        times = set()
+        for s in user_sections:
+            times.update(s.meeting_times.all())
+        return times
+
     @staticmethod
     def getUserFromNum(first, last, num):
         if num == '':

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Directory.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Directory.js
@@ -84,6 +84,8 @@ function TableRow(section, el, directory){
             "manageclass/" + this.section.parent_class +
             "'>Manage</a>" + " <a target='_blank' href='" + baseURL +
             "editclass/" + this.section.parent_class + "'>Edit</a>" +
+            " <a target='_blank' href='" + baseURL +
+            "classavailability/" + this.section.parent_class + "'>Class Availability</a>" +
             autoschedulerLink + "</td>";
         this.el.append(this.cell.el);
     };

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/SectionInfoPanel.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/SectionInfoPanel.js
@@ -82,6 +82,8 @@ function SectionInfoPanel(el, sections, togglePanel, sectionCommentDialog) {
                 "'>Manage</a>" +
                 " <a target='_blank' href='" + baseURL + "editclass/" + section.parent_class +
                 "'>Edit</a>" +
+                " <a target='_blank' href='" + baseURL + "classavailability/" + section.parent_class +
+                "'>Class Availability</a>" +
                 autoschedulerLink);
         toolbar.append(links);
         return toolbar;

--- a/esp/templates/program/modules/adminclass/classavailability.html
+++ b/esp/templates/program/modules/adminclass/classavailability.html
@@ -1,0 +1,74 @@
+{% extends "main.html" %}
+
+{% block title %}Class Availability for {{ program.niceName }}{% endblock %}
+
+{% block stylesheets %}
+{{ block.super }}
+<link rel="stylesheet" href="/media/styles/forms.css" type="text/css" />
+<link rel="stylesheet" href="/media/default_styles/availability.css" type="text/css" />
+{% endblock %}
+
+{% block xtrajs %}
+<script type="text/javascript" src="/media/scripts/program/modules/availability.js"></script>
+
+<script>
+$j(document).ready(function() {
+  Availability.init("true", "This class is scheduled at this time");
+});
+</script>
+{% endblock %}
+
+{% block content %}
+
+{% load render_qsd %}
+
+<h1>Availability for <u>{{ class|escape }}</u></h1>
+
+<h2>Teachers:</h2>
+{% for teacher in class.get_teachers %}
+<a href="/manage/userview?username={{ teacher.username|urlencode }}" target="_blank">{{ teacher.nonblank_name }}</a> (<a href="/manage/{{ program.getUrlBase }}/edit_availability?user={{ teacher.username|urlencode }}" target="_blank">edit availability</a>)
+</br>
+{% endfor %}
+</br>
+{% if groups %}
+<div id="program_form">
+
+<h2>Availability:</h2>
+<center>
+  {% include "program/modules/availability.html" %}
+  <div hidden id="checkboxes">
+    {% for group in groups %}
+      {% for time in group %}
+        <input type="checkbox" name="timeslots" value="{{ time.slot.id }}" {% if time.available %}checked{% endif %} {% if time.section %}disabled data-hover="{{ time.section }}"{% elif time.unavail_teachers %}data-hover="Unavailable:</br>{% for teacher in time.unavail_teachers %}{{ teacher.nonblank_name }} ({{ teacher.username }}){% if not forloop.last %}</br>{% endif %}{% endfor %}"{% endif %}>
+      {% endfor %}
+    {% endfor %}
+  </div>
+  <br>
+</center>
+
+<h2>Unscheduled sections:</h2>
+{% for s in unscheduled %}
+{{ s }} ({{ s.prettyDuration }})<br>
+{% endfor %}
+
+</div>
+
+<div class="side right" hidden>
+  <span class="summary" style="background-color: #EFEFEF;">Teachers Not Available</span>
+  <span class="summary" style="background-color: #00FF00;">All Teachers Available</span>
+  <span class="summary" style="background-color: #42b3f4;">Scheduled Section</span>
+</div>
+{% endif %}
+
+{% if search_form %}
+<br><br>
+<form method="POST" action="/manage/{{ program.getUrlBase }}/edit_availability">
+{{ search_form.as_p }}
+<input type="hidden" name="search" hidden />
+<input type="submit" value="Search" />
+</form>
+{% endif %}
+
+{% include "program/modules/adminclass/returnlink.html" %}
+
+{% endblock %}

--- a/esp/templates/program/modules/adminclass/classavailability.html
+++ b/esp/templates/program/modules/adminclass/classavailability.html
@@ -46,8 +46,8 @@ $j(document).ready(function() {
         <input type="checkbox" name="timeslots" value="{{ time.slot.id }}" {% if time.available %}checked{% endif %} 
         {% if time.section %}disabled data-hover="{{ time.section }}"
         {% elif time.unavail_teachers or time.teaching_teachers %}data-hover="
-        {% for teacher in time.unavail_teachers %}{% if forloop.first %}Unavailable:</br>{% endif %}{{ teacher.nonblank_name }} ({{ teacher.username }}){% if not forloop.last %}</br>{% endif %}{% endfor %}
-        {% for teacher in time.teaching_teachers %}{% if forloop.first %}Teaching:</br>{% endif %}{{ teacher.nonblank_name }} ({{ teacher.username }}){% if not forloop.last %}</br>{% endif %}{% endfor %}"
+        {% for teacher in time.unavail_teachers %}{% if forloop.first %}Unavailable:</br>{% endif %}{{ teacher.nonblank_name }} ({{ teacher.username }})</br>{% endfor %}
+        {% for teacher in time.teaching_teachers %}{% if forloop.first %}Teaching:</br>{% endif %}{{ teacher.nonblank_name }} ({{ teacher.username }})</br>{% endfor %}"
         {% endif %}>
       {% endfor %}
     {% endfor %}

--- a/esp/templates/program/modules/adminclass/classavailability.html
+++ b/esp/templates/program/modules/adminclass/classavailability.html
@@ -24,6 +24,10 @@ $j(document).ready(function() {
 
 <h1>Availability for <u>{{ class|escape }}</u></h1>
 
+<h2>Length:</h2>
+{{ class.prettyDuration }}
+</br></br>
+
 <h2>Teachers:</h2>
 {% for teacher in class.get_teachers %}
 <a href="/manage/userview?username={{ teacher.username|urlencode }}" target="_blank">{{ teacher.nonblank_name }}</a> (<a href="/manage/{{ program.getUrlBase }}/edit_availability?user={{ teacher.username|urlencode }}" target="_blank">edit availability</a>)
@@ -39,7 +43,12 @@ $j(document).ready(function() {
   <div hidden id="checkboxes">
     {% for group in groups %}
       {% for time in group %}
-        <input type="checkbox" name="timeslots" value="{{ time.slot.id }}" {% if time.available %}checked{% endif %} {% if time.section %}disabled data-hover="{{ time.section }}"{% elif time.unavail_teachers %}data-hover="Unavailable:</br>{% for teacher in time.unavail_teachers %}{{ teacher.nonblank_name }} ({{ teacher.username }}){% if not forloop.last %}</br>{% endif %}{% endfor %}"{% endif %}>
+        <input type="checkbox" name="timeslots" value="{{ time.slot.id }}" {% if time.available %}checked{% endif %} 
+        {% if time.section %}disabled data-hover="{{ time.section }}"
+        {% elif time.unavail_teachers or time.teaching_teachers %}data-hover="
+        {% for teacher in time.unavail_teachers %}{% if forloop.first %}Unavailable:</br>{% endif %}{{ teacher.nonblank_name }} ({{ teacher.username }}){% if not forloop.last %}</br>{% endif %}{% endfor %}
+        {% for teacher in time.teaching_teachers %}{% if forloop.first %}Teaching:</br>{% endif %}{{ teacher.nonblank_name }} ({{ teacher.username }}){% if not forloop.last %}</br>{% endif %}{% endfor %}"
+        {% endif %}>
       {% endfor %}
     {% endfor %}
   </div>

--- a/esp/templates/program/modules/adminclass/coteachers.html
+++ b/esp/templates/program/modules/adminclass/coteachers.html
@@ -93,4 +93,8 @@ There are currently no teachers associated with this class.
 </form>
 </div>
 
+<a class="btn" href="/manage/{{ program.getUrlBase }}/classavailability/{{ class.id }}">Check the class availability</a>
+
+{% include "program/modules/adminclass/returnlink.html" %}
+
 {% endblock %}

--- a/esp/templates/program/modules/adminclass/manageclass_class_info.html
+++ b/esp/templates/program/modules/adminclass/manageclass_class_info.html
@@ -3,7 +3,10 @@
 	<td>{% for teacher in class.get_teachers %}<a href="/manage/userview?username={{ teacher.username|urlencode }}">{{ teacher.nonblank_name }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}
 	<br />
     <a href="/manage/{{ program.getUrlBase }}/coteachers?clsid={{ class.id }}">
-    Edit Teacher List </a>
+    Edit Teacher List</a>
+    <br />
+    <a href="/manage/{{ program.getUrlBase }}/classavailability/{{ class.id }}">
+    Check Class Availability</a>
     </td>
 </tr>
 <tr>

--- a/esp/templates/program/modules/adminclass/returnlink.html
+++ b/esp/templates/program/modules/adminclass/returnlink.html
@@ -1,0 +1,11 @@
+<br />
+<br />
+<p>
+{% if prog %}
+<a class="btn" href="/manage/{{ prog.getUrlBase }}/manageclass/{{ class.id }}">Return to the class management page</a>
+{% else %}
+{% if program %}
+<a class="btn" href="/manage/{{ program.getUrlBase }}/manageclass/{{ class.id }}">Return to the class management page</a>
+{% endif %}
+{% endif %}
+</p>


### PR DESCRIPTION
This implements an availability page for a class. It looks just like the teacher/volunteer availability pages, but shows whether the teachers for a class are available or not for the time blocks:
![image](https://user-images.githubusercontent.com/7232514/56084214-b01b0c00-5de4-11e9-9a41-76b1ea319287.png)

If there are teachers that aren't available for a particular time block, hovering over that time block will show which teachers are already teaching:
![image](https://user-images.githubusercontent.com/7232514/56084219-c2954580-5de4-11e9-9a45-98ab14a741ee.png)

and/or which teachers are not available:
![image](https://user-images.githubusercontent.com/7232514/56084221-c88b2680-5de4-11e9-873e-61d882a9e314.png)

If a section of the class is scheduled, hovering over that time block will show that:
![image](https://user-images.githubusercontent.com/7232514/55693115-14ac1600-5962-11e9-9d16-184299ff77d1.png)

I added links to this page from the `manageclass_class_info.html` template, which is included in the `/manageclass` and `/classsearch` pages. I also included a link to this page from the manage coteachers page. Finally, I included links in the scheduler, so you can go directly to this page while scheduling classes. While I was at it, I added return links to the class manage page from the manage coteachers and class availability pages.

Fixes #2638 and #1402.