### PR TITLE
Fix black cell backgrounds in scheduler

### DIFF
--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/CellColors.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/CellColors.js
@@ -5,6 +5,17 @@
  * @method color(section)
  * @method textColor(section)
  */
+var colors = palette('tol-rainbow', 100);
+
+function hexToRGB(hex) {
+    var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+    return result ? {
+        r: parseInt(result[1], 16),
+        g: parseInt(result[2], 16),
+        b: parseInt(result[3], 16)
+    } : null;
+}
+
 function CellColors() {
     this.specialColor = "rgb(255, 153, 0)";
     /**
@@ -15,17 +26,17 @@ function CellColors() {
      */
     this.color = function(section) {
         var code = section.emailcode;
-        var colcode = code.substr(1, code.lastIndexOf("s") - 1).padStart(3, "0");
-        return [16*(+colcode.charAt(colcode.length - 3)),
-                16*(+colcode.charAt(colcode.length - 2)),
-                16*(+colcode.charAt(colcode.length - 1))];
+        var colcode = code.substr(1, code.lastIndexOf("s") - 1).padStart(2, "0");
+        /* Use the last two digits of the class code to get a color */
+        var col = colors[parseInt(colcode.substr(colcode.length - 2)) * 23 % 100];
+        return hexToRGB(col);
     };
     this.background = function(section) {
         var color = this.color(section);
         var rgb = ("rgb(" +
-          color[0] + "," +
-          color[1] + "," +
-          color[2] + ")");
+          color.r + "," +
+          color.g + "," +
+          color.b + ")");
         if (section.flags.indexOf("Special scheduling needs") !== -1) {
           return ("linear-gradient(to bottom right, " +
             this.specialColor + " 0%," +
@@ -46,7 +57,7 @@ function CellColors() {
 
         // The relative luminance is a measure of how bright the color is.
         // Green counts more because human eyes are more sensitive to it.
-        relativeLuminance = 0.2126 * color[0] + 0.7152 * color[1] + 0.0722 * color[2];
+        relativeLuminance = 0.2126 * color.r + 0.7152 * color.g + 0.0722 * color.b;
         if(relativeLuminance < 128) {
             return "white";
         } else {

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/CellColors.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/CellColors.js
@@ -14,9 +14,11 @@ function CellColors() {
      * @param section: The section to compute the background color of
      */
     this.color = function(section) {
-        return [16*(+section.emailcode[2]),
-                16*(+section.emailcode[3]),
-                16*(+section.emailcode[4])];
+        var code = section.emailcode;
+        var colcode = code.substr(1, code.lastIndexOf("s") - 1).padStart(3, "0");
+        return [16*(+colcode.charAt(colcode.length - 3)),
+                16*(+colcode.charAt(colcode.length - 2)),
+                16*(+colcode.charAt(colcode.length - 1))];
     };
     this.background = function(section) {
         var color = this.color(section);

--- a/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
+++ b/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
@@ -27,6 +27,7 @@
 <script type='text/javascript' src='/media/scripts/common.js'></script>
 <script type="text/javascript" src="/media/scripts/csrf_init.js"></script>
 <script type="text/javascript" src="/media/scripts/ajaxschedulingmodule/lib/fixed_table_rc.js"></script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/google/palette.js@8418158452401c15d276d9632b88933aa581718f/palette.js"></script>
 
 <!--Scheduler-->
 <script type="text/javascript">


### PR DESCRIPTION
This fixes the coloring of cells (and text color) in the AJAX Scheduler for programs with class IDs with fewer than 4 digits. The new logic pads the class IDs with zeros to get at least 2 digits to work with, then uses the last 2 digits of the resulting IDs. ~~Therefore, programs with class IDs with fewer than 3 digits can expect very blue/green colors, but red is incorporated once class IDs have at least 3 digits.~~

Before:
![image](https://user-images.githubusercontent.com/7232514/56085166-9cc36d00-5df3-11e9-964b-df3bf9b83401.png)

After:
![image](https://user-images.githubusercontent.com/7232514/56461044-2679ba00-6361-11e9-8d9e-bd608c35672e.png)

Fixes #2361.