### PR TITLE
Fix styling of big board numbers

### DIFF
--- a/esp/public/media/default_styles/bigboard.css
+++ b/esp/public/media/default_styles/bigboard.css
@@ -37,7 +37,7 @@
 
 .bigboard-number-block {
   display: inline-block;
-  width: 250px;
+  min-width: 250px;
   height: 140px;
   padding: 10px 25px;
   vertical-align: bottom;

--- a/esp/public/media/default_styles/bigboard.css
+++ b/esp/public/media/default_styles/bigboard.css
@@ -32,6 +32,7 @@
   text-align: center;
   margin-top: 25px;
   margin-bottom: 25px;
+  line-height: normal;
 }
 
 .bigboard-number-block {


### PR DESCRIPTION
Some themes were changing the line heights of the big board numbers, so this fixes the line-heights no matter the theme to ensure none of the numbers and text are overlapping. I also tweaked the CSS to allow the number blocks to expand if they have really large numbers.

Before:
![image](https://user-images.githubusercontent.com/7232514/56461246-347d0a00-6364-11e9-9a6e-a324ad55e2de.png)

with Line Height Fix:
![image](https://user-images.githubusercontent.com/7232514/56461254-4e1e5180-6364-11e9-9331-8f4346251ab7.png)

with Width Fix:
![image](https://user-images.githubusercontent.com/7232514/56461282-ba995080-6364-11e9-9ee3-920b97d43c58.png)

Fixes #2695.