### PR TITLE
Show scheduled classes on availability form, even if unavailable

### DIFF
--- a/esp/public/media/default_styles/availability.css
+++ b/esp/public/media/default_styles/availability.css
@@ -84,6 +84,10 @@ td.group, table.group {
   background: #42b3f4;
 }
 
+.teaching:not(.canDo) {
+  border: solid 2px red !important;
+}
+
 .headerText {
   font-size: 18px;
 }

--- a/esp/public/media/scripts/program/modules/availability.js
+++ b/esp/public/media/scripts/program/modules/availability.js
@@ -19,23 +19,24 @@ var Availability = (function () {
     var noclick = false;
     
     function isSet(td) {
-        return td.className == "canDo" || td.className == "teaching";
+        return $j(td).hasClass("canDo");
     }
     
     //Activate checkbox
     function checkbox_on(td) {
         var checkbox = $j('input[value='+td.getAttribute("name")+']')[0]
-        if (td.className != "teaching") {
-            td.className = "canDo";
-            checkbox.checked = true;
-        }
+        $j(td).removeClass("proposed");
+        $j(td).addClass("canDo");
+        checkbox.checked = true;
+        checkbox.disabled = false;
     }
 
     //Deactivate checkbox
     function checkbox_off(td) {
         var checkbox = $j('input[value='+td.getAttribute("name")+']')[0]
-        if (td.className == "canDo") {
-            td.className = "proposed";
+        if (!$j(td).hasClass("teaching") && $j(td).hasClass("canDo")) {
+            $j(td).removeClass("canDo");
+            $j(td).addClass("proposed");
             checkbox.checked = false;
         }
     }
@@ -108,11 +109,15 @@ var Availability = (function () {
 
         //Sets classes of cells based on status of checkboxes upon loading page
         $j('#checkboxes input').each(function(i, e) {
+            var cell = document.getElementsByName($j(this).attr('value'))[0]
             if (this.disabled == true) {
-                document.getElementsByName($j(this).attr('value'))[0].className = "teaching";
-                document.getElementsByName($j(this).attr('value'))[0].title = disabledText;
-            } else if (this.checked == true) {
-                document.getElementsByName($j(this).attr('value'))[0].className = "canDo";
+                $j(cell).removeClass("proposed");
+                $j(cell).addClass("teaching");
+                cell.title = disabledText;
+            }
+            if (this.checked == true) {
+                $j(cell).removeClass("proposed");
+                $j(cell).addClass("canDo");
             }
         });
 

--- a/esp/public/media/scripts/program/modules/availability.js
+++ b/esp/public/media/scripts/program/modules/availability.js
@@ -107,11 +107,11 @@ var Availability = (function () {
         }
 
         //Sets classes of cells based on status of checkboxes upon loading page
-        $j('#checkboxes input:checked').each(function(i, e) {
+        $j('#checkboxes input').each(function(i, e) {
             if (this.disabled == true) {
                 document.getElementsByName($j(this).attr('value'))[0].className = "teaching";
                 document.getElementsByName($j(this).attr('value'))[0].title = disabledText;
-            } else {
+            } else if (this.checked == true) {
                 document.getElementsByName($j(this).attr('value'))[0].className = "canDo";
             }
         });

--- a/esp/templates/program/modules/availabilitymodule/availability_form.html
+++ b/esp/templates/program/modules/availabilitymodule/availability_form.html
@@ -52,7 +52,7 @@ We have detected that you are currently signed up to teach more hours of class t
 {% if conflict_found %}
 {% inline_program_qsd_block prog "teacher_conflict" %}
 <p style="color: red;">
-You are scheduled to teach a class during at least one timeslot in which you are not marked as available.  Please <a href="mailto:{{ prog.director_email }}">contact the directors</a> immediately to resolve this conflict.
+You are scheduled to teach a class during at least one timeslot in which you are not marked as available (indicated with a red border below).  Please <a href="mailto:{{ prog.director_email }}">contact the directors</a> immediately to resolve this conflict.
 </p>
 {% end_inline_program_qsd_block %}
 {% endif %}


### PR DESCRIPTION
Instead of only looking for the checked checkboxes to set the classes for the different cells, we just check all of the checkboxes, which allows for cells to have the teaching CSS class (the checkbox is disabled) even if the teacher isn't available (the checkbox isn't checked).

Fixes #2716.