### PR TITLE
Replace go.gif with glyphicon

### DIFF
--- a/esp/esp/themes/theme_data/circles/less/main.less
+++ b/esp/esp/themes/theme_data/circles/less/main.less
@@ -188,10 +188,6 @@ div.nav_button :hover {
 */
 }
 
-#navbar_content {
-  margin: 15px;
-}
-
 #loginbox {
     width: 170px;
     clear: both;
@@ -211,22 +207,6 @@ div.nav_button :hover {
 #loginbox form {
     margin: 0px;
 }
-
-#loginbox input.gobutton {
-    margin-left: 5px;
-    padding: 2px;
-    background-color: #666666;
-    text-align: center;
-    vertical-align: center;
-    border: 1px solid black;
-    color: #000000;
-}
-
-#loginbox input.gobutton:hover {
-    background-color: #CCCCCC;
-    border: 1px solid black;
-}
-
 
 #chicago_main {
   background: @bodyBackground;

--- a/esp/esp/themes/theme_data/circles/templates/users/loginbox_content.html
+++ b/esp/esp/themes/theme_data/circles/templates/users/loginbox_content.html
@@ -42,7 +42,7 @@
       <tr>
         <td><div class="divformcol1"><label for="pass">Password:</label></div></td>
         <td><div class="divformcol2"><input type="password" name="password" id="pass" size="8" value="" maxlength="255" class="inputbox input-small" /></div></td>
-        <td><div class="divformcol3"><input type="image" name="gologin" id="gologin" src="/media/images/go.gif" class="gobutton" alt="Go" title="" /></div></td>
+        <td style="vertical-align: top;"><div class="divformcol3"><button class="btn btn-inverse glyphicon glyphicon-log-in" id="gologin" type="submit" style="margin-left:5px;"></button></div></td>
       </tr>
       <tr>
 


### PR DESCRIPTION
@milescalabresi fixed the name of the go.gif icon for the circles theme in #2534, but it was really weird looking (probably because it was designed in the 90s). I've replaced it with a bootstrap icon instead and tweaked some CSS in the theme to make it look good:

![image](https://user-images.githubusercontent.com/7232514/57575031-af7f9080-73f7-11e9-9d29-192299e46cd7.png)

Fixes #2733.