### PR TITLE
Identify sections that are scheduled with unavailable teachers on class availability page

### DIFF
--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -432,7 +432,7 @@ class BaseESPUser(object):
         return total_time
 
     def getTaughtTimes(self, program = None, exclude = []):
-        """ Return the times taught as a set. If a program is specified, return the times taught for that program. 
+        """ Return the times taught as a set. If a program is specified, return the times taught for that program.
             If exclude is specified (as a list of classes), exclude sections from the specified classes. """
         user_sections = self.getTaughtSections(program)
         times = set()

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -431,12 +431,14 @@ class BaseESPUser(object):
                 total_time = total_time + timedelta(hours=rounded_hours(s.duration))
         return total_time
 
-    def getTaughtTimes(self, program = None):
-        """ Return the times taught as a set. If a program is specified, return the times taught for that program. """
+    def getTaughtTimes(self, program = None, exclude = []):
+        """ Return the times taught as a set. If a program is specified, return the times taught for that program. 
+            If exclude is specified (as a list of classes), exclude sections from the specified classes. """
         user_sections = self.getTaughtSections(program)
         times = set()
         for s in user_sections:
-            times.update(s.meeting_times.all())
+            if s.parent_class not in exclude:
+                times.update(s.meeting_times.all())
         return times
 
     @staticmethod

--- a/esp/public/media/default_styles/availability.css
+++ b/esp/public/media/default_styles/availability.css
@@ -84,6 +84,10 @@ td.group, table.group {
   background: #42b3f4;
 }
 
+.teaching:not(.canDo) {
+  border: solid 2px red !important;
+}
+
 .headerText {
   font-size: 18px;
 }

--- a/esp/public/media/scripts/program/modules/availability.js
+++ b/esp/public/media/scripts/program/modules/availability.js
@@ -19,23 +19,24 @@ var Availability = (function () {
     var noclick = false;
     
     function isSet(td) {
-        return td.className == "canDo" || td.className == "teaching";
+        return $j(td).hasClass("canDo");
     }
     
     //Activate checkbox
     function checkbox_on(td) {
         var checkbox = $j('input[value='+td.getAttribute("name")+']')[0]
-        if (td.className != "teaching") {
-            td.className = "canDo";
-            checkbox.checked = true;
-        }
+        $j(td).removeClass("proposed");
+        $j(td).addClass("canDo");
+        checkbox.checked = true;
+        checkbox.disabled = false;
     }
 
     //Deactivate checkbox
     function checkbox_off(td) {
         var checkbox = $j('input[value='+td.getAttribute("name")+']')[0]
-        if (td.className == "canDo") {
-            td.className = "proposed";
+        if (!$j(td).hasClass("teaching") && $j(td).hasClass("canDo")) {
+            $j(td).removeClass("canDo");
+            $j(td).addClass("proposed");
             checkbox.checked = false;
         }
     }
@@ -108,11 +109,15 @@ var Availability = (function () {
 
         //Sets classes of cells based on status of checkboxes upon loading page
         $j('#checkboxes input').each(function(i, e) {
+            var cell = document.getElementsByName($j(this).attr('value'))[0]
             if (this.disabled == true) {
-                document.getElementsByName($j(this).attr('value'))[0].className = "teaching";
-                document.getElementsByName($j(this).attr('value'))[0].title = disabledText;
-            } else if (this.checked == true) {
-                document.getElementsByName($j(this).attr('value'))[0].className = "canDo";
+                $j(cell).removeClass("proposed");
+                $j(cell).addClass("teaching");
+                cell.title = disabledText;
+            }
+            if (this.checked == true) {
+                $j(cell).removeClass("proposed");
+                $j(cell).addClass("canDo");
             }
         });
 

--- a/esp/public/media/scripts/program/modules/availability.js
+++ b/esp/public/media/scripts/program/modules/availability.js
@@ -107,11 +107,11 @@ var Availability = (function () {
         }
 
         //Sets classes of cells based on status of checkboxes upon loading page
-        $j('#checkboxes input:checked').each(function(i, e) {
+        $j('#checkboxes input').each(function(i, e) {
             if (this.disabled == true) {
                 document.getElementsByName($j(this).attr('value'))[0].className = "teaching";
                 document.getElementsByName($j(this).attr('value'))[0].title = disabledText;
-            } else {
+            } else if (this.checked == true) {
                 document.getElementsByName($j(this).attr('value'))[0].className = "canDo";
             }
         });

--- a/esp/templates/program/modules/adminclass/classavailability.html
+++ b/esp/templates/program/modules/adminclass/classavailability.html
@@ -24,6 +24,18 @@ $j(document).ready(function() {
 
 <h1>Availability for <u>{{ class|escape }}</u></h1>
 
+{% if is_overbooked %}
+<p style="color: red;">
+This class is registered for more hours than the number of hours for which the teachers are jointly availabile.
+</p>
+{% endif %}
+
+{% if conflict_found %}
+<p style="color: red;">
+This class is scheduled during at least one timeslot in which at least one teacher is not marked as available (indicated with a red border).
+</p>
+{% endif %}
+
 <h2>Length:</h2>
 {{ class.prettyDuration }}
 </br></br>
@@ -44,11 +56,12 @@ $j(document).ready(function() {
     {% for group in groups %}
       {% for time in group %}
         <input type="checkbox" name="timeslots" value="{{ time.slot.id }}" {% if time.available %}checked{% endif %} 
-        {% if time.section %}disabled data-hover="{{ time.section }}"
-        {% elif time.unavail_teachers or time.teaching_teachers %}data-hover="
+        {% if time.section %}disabled {% endif %}
+        {% if time.unavail_teachers or time.teaching_teachers or time.section %}data-hover="
+        {% if time.section %}{{ time.section }}</br>{% endif %}
         {% for teacher in time.unavail_teachers %}{% if forloop.first %}Unavailable:</br>{% endif %}{{ teacher.nonblank_name }} ({{ teacher.username }})</br>{% endfor %}
-        {% for teacher in time.teaching_teachers %}{% if forloop.first %}Teaching:</br>{% endif %}{{ teacher.nonblank_name }} ({{ teacher.username }})</br>{% endfor %}"
-        {% endif %}>
+        {% for teacher in time.teaching_teachers %}{% if forloop.first %}Teaching:</br>{% endif %}{{ teacher.nonblank_name }} ({{ teacher.username }})</br>{% endfor %}
+        {% endif %}">
       {% endfor %}
     {% endfor %}
   </div>

--- a/esp/templates/program/modules/availabilitymodule/availability_form.html
+++ b/esp/templates/program/modules/availabilitymodule/availability_form.html
@@ -52,7 +52,7 @@ We have detected that you are currently signed up to teach more hours of class t
 {% if conflict_found %}
 {% inline_program_qsd_block prog "teacher_conflict" %}
 <p style="color: red;">
-You are scheduled to teach a class during at least one timeslot in which you are not marked as available.  Please <a href="mailto:{{ prog.director_email }}">contact the directors</a> immediately to resolve this conflict.
+You are scheduled to teach a class during at least one timeslot in which you are not marked as available (indicated with a red border below).  Please <a href="mailto:{{ prog.director_email }}">contact the directors</a> immediately to resolve this conflict.
 </p>
 {% end_inline_program_qsd_block %}
 {% endif %}


### PR DESCRIPTION
Adds a red border when a section is scheduled but teachers aren't available on the class availability page (and then identifies which teachers aren't available in the popup text). Also includes error messages like those for the teacher availability page when the class such a section or there isn't enough time to schedule all of the sections.

![image](https://user-images.githubusercontent.com/7232514/57578815-1462d700-7448-11e9-9aaf-d1c2aa548945.png)

Fixes #2738.