### PR TITLE
Fix catalog classes

### DIFF
--- a/esp/templates/inclusion/program/class_catalog.html
+++ b/esp/templates/inclusion/program/class_catalog.html
@@ -1,6 +1,6 @@
 {% if show_class %}
   {% load class_render %}
-  <div id="class_{{ class.id }}" class="{% for grade in class.grades %}grade_{{ grade }} {% endfor %}show_class{% if errormsg %}class_error{% endif %}">
+  <div id="class_{{ class.id }}" class="{% for grade in class.grades %}grade_{{ grade }} {% endfor %}show_class{% if errormsg %} class_error{% endif %}">
   {% render_class_core class %}
   {% if prereg_url %}
       <div id="class_{{ class.id }}_regbuttons" class="class_buttons">


### PR DESCRIPTION
I accidentally removed a space between classes in #2405, so the catalog wasn't getting styled correctly when there was an `errormsg` for a class (e.g. a student is outside the grade range or the class is full). This ensures that there will always be a space between the classes.

Fixes #2731.