### PR TITLE
Give teacher info higher priority than student info on /myesp/profile

### DIFF
--- a/esp/esp/web/views/myesp.py
+++ b/esp/esp/web/views/myesp.py
@@ -86,17 +86,20 @@ def edit_profile(request):
 
     curUser = request.user
 
-    if curUser.isStudent():
-        return profile_editor(request, None, True, 'student')
-
-    elif curUser.isTeacher():
+    if curUser.isTeacher():
         return profile_editor(request, None, True, 'teacher')
+
+    elif curUser.isStudent():
+        return profile_editor(request, None, True, 'student')
 
     elif curUser.isGuardian():
         return profile_editor(request, None, True, 'guardian')
 
     elif curUser.isEducator():
         return profile_editor(request, None, True, 'educator')
+
+    elif curUser.isVolunteer():
+        return profile_editor(request, None, True, 'volunteer')
 
     else:
         user_types = curUser.groups.all().order_by('-id')

--- a/esp/templates/users/profile.html
+++ b/esp/templates/users/profile.html
@@ -41,48 +41,48 @@ div.required label:after {
       {% endif %}
 
     <form action="{{request.path}}" method="post" class="form-horizontal">
-	<fieldset>
-	<input type="hidden" name="profile_page" value="true" />
-	<input type="hidden" name="current_role" value="{{ profiletype }}" />
+        <fieldset>
+        <input type="hidden" name="profile_page" value="true" />
+        <input type="hidden" name="current_role" value="{{ profiletype }}" />
 
-	{% ifequal profiletype "student" %}
-	{% include "users/profiles/usercontact.html" %}
-	{% include "users/profiles/studentinfo.html" %}
-	{% include "users/profiles/guardiancontact.html" %}
-	{% include "users/profiles/emergencycontact.html" %}
-	{% include "users/profiles/gradechangerequestinfo.html" %}
+        {% ifequal profiletype "teacher" %}
+            {% include "users/profiles/usercontact.html" %}
+            {% include "users/profiles/teacherinfo.html" %}
+        {% else %}
+        
+        {% ifequal profiletype "student" %}
+            {% include "users/profiles/usercontact.html" %}
+            {% include "users/profiles/studentinfo.html" %}
+            {% include "users/profiles/guardiancontact.html" %}
+            {% include "users/profiles/emergencycontact.html" %}
+            {% include "users/profiles/gradechangerequestinfo.html" %}
+        {% else %}
 
-	{% else %}
-	{% ifequal profiletype "teacher" %}
-	{% include "users/profiles/usercontact.html" %}
-	{% include "users/profiles/teacherinfo.html" %}
-	{% else %}
+        {% ifequal profiletype "educator" %}
+            {% include "users/profiles/usercontact.html" %}
+            {% include "users/profiles/educatorinfo.html" %}
+        {% else %}
 
-	{% ifequal profiletype "educator" %}
-	{% include "users/profiles/usercontact.html" %}
-	{% include "users/profiles/educatorinfo.html" %}
-	{% else %}
+        {% ifequal profiletype "guardian" %}
+            {% include "users/profiles/usercontact.html" %}
+            {% include "users/profiles/guardianinfo.html" %}
+        {% else %}
+        
+        {% ifequal profiletype "volunteer" %}
+            {% include "users/profiles/usercontact.html" %}
+        {% else %}
 
-	{% ifequal profiletype "guardian" %}
-	{% include "users/profiles/usercontact.html" %}
-	{% include "users/profiles/guardianinfo.html" %}
-	{% else %}
-    
-    {% ifequal profiletype "Volunteer" %}
-    {% include "users/profiles/usercontact.html" %}
-    {% else %}
+        {% include "../templates/themes/bs_form.html" %}
 
-	{% include "../templates/themes/bs_form.html" %}
+        {% endifequal %}
+        {% endifequal %}
+        {% endifequal %}
+        {% endifequal %}
+        {% endifequal %}
 
-	{% endifequal %}
-	{% endifequal %}
-	{% endifequal %}
-	{% endifequal %}
-    {% endifequal %}
+        <div class="form-actions"><input type="submit" class="btn btn-primary" value="Update your Information!" /></div>
 
-	<div class="form-actions"><input type="submit" class="btn btn-primary" value="Update your Information!" /></div>
-
-	</fieldset>
+        </fieldset>
     </form>
   </div>
 </div>


### PR DESCRIPTION
`/myesp/profile` currently picks a single user type for which to show contact info fields within the form. That's probably a larger issue which I've documented in #2748. For now, I've just adjusted the priorities for determining which user type to use. Before, "Student" had a higher priority than "Teacher", but I imagine in most cases, if a user is both of these user types it is because they are a former student who is now a teacher, so we probably want to prioritize the teacher info (which I've done). I also added "Volunteer" to the priorities list (as the lowest priority).

Teacher -> Student -> Guardian -> Educator -> Volunteer -> Other

Fixes #2721.