### PR TITLE
Distinguish between teacher and student reg profiles for RegProfileModule

### DIFF
--- a/esp/esp/program/modules/handlers/regprofilemodule.py
+++ b/esp/esp/program/modules/handlers/regprofilemodule.py
@@ -114,7 +114,7 @@ class RegProfileModule(ProgramModuleObj):
         return response
 
     def isCompleted(self):
-        regProf = RegistrationProfile.getLastForProgram(get_current_request().user, self.program)
+        regProf = RegistrationProfile.getLastForProgram(get_current_request().user, self.program, self.module.module_type)
         return regProf.id is not None
 
     class Meta:


### PR DESCRIPTION
Instead of just looking for any registration profile for a program, this now lets us look for a student- or teacher-specific registration profile (one associated with the relevant info). This is mostly useful for admins that are testing things, but could be useful for users that are both students and teachers for the same program.

Fixes #2722.