### PR TITLE
Skip calculating teacher big board graph data if missing any timestamps

### DIFF
--- a/esp/esp/program/modules/handlers/teacherbigboardmodule.py
+++ b/esp/esp/program/modules/handlers/teacherbigboardmodule.py
@@ -1,5 +1,4 @@
 import datetime
-import operator
 import subprocess
 
 from django.db.models.aggregates import Min, Sum


### PR DESCRIPTION
Many old programs have classes without timestamps (pre-2016). If this is the case, we'll just skip calculating the data that would be used for the graph on the teacher big board (even if there are some classes with timestamps, because any solution for those would either be misleading because we'd need to assign an arbitrary timestamp or it wouldn't match up with the static numbers because we'd skip the ones without timestamps). I also added a little fix to `get_hours()` just in case there are some (but not all) classes without timestamps for when we are calculating the static numbers (which we want to do regardless of whether there are timestamps or not).

Fixes #2753.