### PR TITLE
Fix within-page anchors on qsd pages

### DIFF
--- a/esp/templates/inclusion/qsd/render_qsd.html
+++ b/esp/templates/inclusion/qsd/render_qsd.html
@@ -4,20 +4,22 @@
 <script src="https://cdn.jsdelivr.net/gh/pie6k/jquery.initialize@eb28c24e2eef256344777b45a455173cba36e850/jquery.initialize.js"></script>
 
 {% load markup %}
-
+<div class="qsd_header qsd_bits hidden" id="inline_edit_msg_{{ qsdrec.edit_id }}" onclick="qsd_inline_edit('{{ qsdrec.url }}', '{{ qsdrec.edit_id }}');">
+    <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
+    <span class="inline_edit_msg_text">
+    {% if qsdrec.id %}
+        This is editable text.
+    {% else %}
+        This is a placeholder for editable text that has not yet been added.
+    {% endif %}
+    Click here to edit the text.
+    </span>
+    <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
+</div>
+<div class="qsd_view_visible prettify" id="inline_qsd_{{ qsdrec.edit_id }}">
+    {% autoescape off %}{{ qsdrec.content|markdown }}{% endautoescape %}
+</div>
 <div class="qsd_bits hidden">
-    <div class="qsd_header qsd_bits hidden" id="inline_edit_msg_{{ qsdrec.edit_id }}" onclick="qsd_inline_edit('{{ qsdrec.url }}', '{{ qsdrec.edit_id }}');">
-        <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-        <span class="inline_edit_msg_text">
-        {% if qsdrec.id %}
-            This is editable text.
-        {% else %}
-            This is a placeholder for editable text that has not yet been added.
-        {% endif %}
-        Click here to edit the text.
-        </span>
-        <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-    </div>
     <div class="hidden" id="inline_edit_{{ qsdrec.edit_id }}">
         <div class="qsd_buttons">
             <button type="button" onclick="qsd_inline_finish('{{ qsdrec.url }}', '{{ qsdrec.edit_id }}', 'save');"
@@ -34,9 +36,6 @@
                   class="qsd_editor {% if not inline %}qsd_fullsize{% endif %} qsd_bits hidden {% if inline and not qsdrec.id %}qsd_halfsize{% endif %}"
                   name="qsd_content">{% autoescape on %}{{ qsdrec.content }}{% endautoescape %}</textarea>
     </div>
-</div>
-<div class="qsd_view_visible prettify" id="inline_qsd_{{ qsdrec.edit_id }}">
-    {% autoescape off %}{{ qsdrec.content|markdown }}{% endautoescape %}
 </div>
 
 <script type="text/javascript">


### PR DESCRIPTION
Adding the new QSD GUI basically duplicated all of the elements on the page, and the hidden duplicates were above the visible ones, so when you tried to link to a part of the page (e.g. in an FAQ), you were linking to hidden elements and it didn't work. Due to how the QSD works, I don't think we can get around the duplicates, but we can put the visible elements _above_ the hidden ones, such that the within-page links should work. I made sure the "Click here to edit the text." bar is still at the top of the page, though. This should work for inline QSDs and static pages.

Fixes #2701.