### PR TITLE
Set max height for comm panel gui dropdowns

### DIFF
--- a/esp/templates/program/modules/commmodule/step2.html
+++ b/esp/templates/program/modules/commmodule/step2.html
@@ -17,6 +17,7 @@
 #finalsentence { border: 1px solid black; width: 550px; }
 /*Fix css for template tag button*/
 .jodit_icon_insertDate { width: 16px; height: 16px}
+.jodit_toolbar_list>.jodit_toolbar { max-height: 150px; }
 </style>
 {% endblock %}
 


### PR DESCRIPTION
This limits the height of the dropdowns so they don't extend beyond the bottom of the page.

Fixes #2763.