### PR TITLE
Fix classroom import with incomplete availability

### DIFF
--- a/esp/esp/program/modules/handlers/resourcemodule.py
+++ b/esp/esp/program/modules/handlers/resourcemodule.py
@@ -357,28 +357,29 @@ class ResourceModule(ProgramModuleObj):
                 for i in range(min(len(ts_old), len(ts_new))):
                     ts_map[ts_old[i].id] = ts_new[i]
 
-                #   Iterate over the resources in the previous program
-                for res in past_program.getClassrooms():
-                    furnishing_dict[res.name] = set()
-                    #   If we know what timeslot to put it in, make a copy
-                    if res.event.id in ts_map:
-                        new_res = Resource(
-                            name = res.name,
-                            res_type = res.res_type,
-                            num_students = res.num_students,
-                            is_unique = res.is_unique,
-                            user = res.user,
-                            event = ts_map[res.event.id]
-                        )
-                        #   Check to avoid duplicating rooms (so the process is idempotent)
-                        if import_mode == 'save' and not Resource.objects.filter(name=new_res.name, event=new_res.event).exists() and str(res.id) in to_import:
-                            new_res.save()
-                        else:
-                            new_res.old_id = res.id
-                        if import_furnishings:
-                            new_furns = self.furnishings_import(res, new_res, self.program, import_mode, to_import)
-                            furnishing_dict[res.name].update(new_furn.res_type.name + (" (Hidden)" if new_furn.res_type.hidden else "") + ((": " + new_furn.attribute_value) if new_furn.attribute_value else "") for new_furn in new_furns)
-                        resource_list.append(new_res)
+                #   Iterate over the classrooms in the previous program
+                for resource in past_program.groupedClassrooms():
+                    for event in resource.timegroup:
+                        furnishing_dict[resource.name] = set()
+                        #   If we know what timeslot to put it in, make a copy
+                        if event.id in ts_map:
+                            new_res = Resource(
+                                name = resource.name,
+                                res_type = resource.res_type,
+                                num_students = resource.num_students,
+                                is_unique = resource.is_unique,
+                                user = resource.user,
+                                event = ts_map[event.id]
+                            )
+                            #   Check to avoid duplicating rooms (so the process is idempotent)
+                            if import_mode == 'save' and not Resource.objects.filter(name=new_res.name, event=new_res.event).exists() and str(resource.id) in to_import:
+                                new_res.save()
+                            else:
+                                new_res.old_id = resource.id
+                            if import_furnishings:
+                                new_furns = self.furnishings_import(resource, new_res, self.program, import_mode, to_import)
+                                furnishing_dict[resource.name].update(new_furn.res_type.name + (" (Hidden)" if new_furn.res_type.hidden else "") + ((": " + new_furn.attribute_value) if new_furn.attribute_value else "") for new_furn in new_furns)
+                            resource_list.append(new_res)
 
             #   Render a preview page showing the resources for the previous program if desired
             context['past_program'] = past_program

--- a/esp/esp/program/modules/handlers/resourcemodule.py
+++ b/esp/esp/program/modules/handlers/resourcemodule.py
@@ -359,8 +359,8 @@ class ResourceModule(ProgramModuleObj):
 
                 #   Iterate over the classrooms in the previous program
                 for resource in past_program.groupedClassrooms():
+                    furnishing_dict[resource.name] = set()
                     for event in resource.timegroup:
-                        furnishing_dict[resource.name] = set()
                         #   If we know what timeslot to put it in, make a copy
                         if event.id in ts_map:
                             new_res = Resource(


### PR DESCRIPTION
When I implemented the selective import (#2653), I actual broke the functionality of importing classrooms with matching availability (incomplete availability). This _should_ fix it again.

Fixes #2670.