### PR TITLE
Hide global resources option by default

### DIFF
--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -906,7 +906,7 @@ class Program(models.Model, CustomFormsLinkModel):
             exclude_types += [ResourceType.get_or_create('Classroom')]
 
         if include_global is None:
-            include_global = Tag.getTag('allow_global_restypes')
+            include_global = Tag.getBooleanTag('allow_global_restypes', default = False)
 
         if include_global:
             Q_filters = Q(program=self) | Q(program__isnull=True)

--- a/esp/esp/program/modules/forms/resources.py
+++ b/esp/esp/program/modules/forms/resources.py
@@ -8,6 +8,7 @@ from esp.resources.models import ResourceType, Resource, ResourceAssignment
 from esp.cal.models import EventType, Event
 from esp.program.models import Program
 from esp.utils.widgets import DateTimeWidget, DateWidget
+from esp.tagdict.models import Tag
 
 class TimeslotForm(forms.Form):
     id = forms.IntegerField(required=False, widget=forms.HiddenInput)
@@ -46,8 +47,13 @@ class ResourceTypeForm(forms.Form):
     description = forms.CharField(required=False,widget=forms.Textarea)
     priority = forms.IntegerField(required=False, help_text='Assign this a unique number in relation to the priority of other resource types')
     only_one = forms.BooleanField(label='Only one?', required=False, help_text='Limit teachers to selecting only one of the options?')
-    is_global = forms.BooleanField(label='Global?', required=False)
+    is_global = forms.BooleanField(label='Global?', required=False, help_text='Should this resource be associated with all programs?')
     hidden = forms.BooleanField(label='Hidden?', required=False, help_text='Should this resource type be hidden during teacher registration?')
+
+    def __init__(self, *args, **kwargs):
+        super(ResourceTypeForm, self).__init__(*args, **kwargs)
+        if not Tag.getBooleanTag('allow_global_restypes', default = False):
+            self.fields['is_global'].widget = forms.HiddenInput()
 
     def load_restype(self, res_type):
         self.fields['name'].initial = res_type.name

--- a/esp/esp/program/modules/handlers/resourcemodule.py
+++ b/esp/esp/program/modules/handlers/resourcemodule.py
@@ -634,7 +634,7 @@ class ResourceModule(ProgramModuleObj):
         if 'timeslot_form' not in context:
             context['timeslot_form'] = TimeslotForm()
 
-        res_types = self.program.getResourceTypes(include_global=Tag.getBooleanTag('allow_global_restypes', program = prog, default = False))
+        res_types = self.program.getResourceTypes(include_global=Tag.getBooleanTag('allow_global_restypes', default = False))
         context['resource_types'] = sorted(res_types, key = lambda x: (not x.hidden, x.priority_default), reverse = True)
         for c in context['resource_types']:
             if c.program is None:

--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -588,13 +588,9 @@ class TeacherClassRegModule(ProgramModuleObj):
             # that we didn't start out with
             # Thus, if default_restype isn't set, we display everything
             # potentially relevant
-            if Tag.getTag('allow_global_restypes'):
-                resource_types = prog.getResourceTypes(include_classroom=True,
-                                                       include_global=True,
-                                                       include_hidden=False)
-            else:
-                resource_types = prog.getResourceTypes(include_classroom=True,
-                                                       include_hidden=False)
+            resource_types = prog.getResourceTypes(include_classroom=True,
+                                                   include_global=Tag.getBooleanTag('allow_global_restypes', default = False),
+                                                   include_hidden=False)
             resource_types = list(resource_types)
             resource_types.reverse()
 

--- a/esp/esp/resources/models.py
+++ b/esp/esp/resources/models.py
@@ -116,7 +116,7 @@ class ResourceType(models.Model):
 
         if program:
             base_q = Q(program=program)
-            if Tag.getTag('allow_global_restypes'):
+            if Tag.getBooleanTag('allow_global_restypes', default = False):
                 base_q = base_q | Q(program__isnull=True)
         else:
             base_q = Q(program__isnull=True)

--- a/esp/esp/tagdict/__init__.py
+++ b/esp/esp/tagdict/__init__.py
@@ -8,7 +8,7 @@
 # or Tag.getBooleanTag() with no program argument
 all_global_tags = {
     'teacherreg_custom_forms': (False, ""),
-    'allow_global_restypes': (False, "Include global resource types in the options shown"),
+    'allow_global_restypes': (True, "Include global resource types in the manage resources and teacher registration options"),
     'splashinfo_choices': (False, ""),
     'full_group_name': (False, ""),
     'nearly_full_threshold': (False, ""),


### PR DESCRIPTION
Ultimately, this adds help text to the global option in the resource types manage page. But while doing that, I realized it didn't really make much sense to have this option if the `allow_global_restypes` tag was set to False, since you would make the resource type then it would seemingly disappear (as discussed by @hwatheod in https://github.com/learning-unlimited/ESP-Website/pull/2432#issuecomment-333393148). I thought about just including a little tip in the help text about the tag, but then the help text seemed more confusing than before for chapters that aren't super familiar with tags. So, in the end I decided to actually hide the `is_global` field when that tag doesn't exist or is set to `False`. While I was at it, I realized the use of allow_global_restypes was really inconsistent, so I updated all the instances I could find to use getBooleanTag with a default of `False` and updated the tag documentation.

Fixes #2756.