### PR TITLE
Make teacher address optional by default

### DIFF
--- a/docs/admin/releases/10/README.rst
+++ b/docs/admin/releases/10/README.rst
@@ -268,8 +268,9 @@ as some performance improvements.  Other improvements and bug fixes include:
 - The lunch constraint page now clobbers old lunch blocks, allowing lunch
   constraints to be edited.
 
-- The address field in teacher profile may be made optional by setting the
-  ``teacher_address_required`` Tag to ``False``.
+- The address field in teacher profile is no longer required by default. It can
+  be made required by setting the
+  ``teacher_address_required`` Tag to ``True``.
 
 - Medical bypasses can be added, removed, or queried with a new interface.
 

--- a/esp/esp/tagdict/__init__.py
+++ b/esp/esp/tagdict/__init__.py
@@ -55,7 +55,7 @@ all_global_tags = {
     'text_messages_to_students': (True, ""),
     'local_state': (False, ""),
     'grade_ranges': (False, "Replaces min and max grade options in teacher class reg with grade ranges, as specified by tag"),
-    'teacher_address_required': (True, "Is an address required for a teacher profile? (enabled by default, set to 'False' to disable)")
+    'teacher_address_required': (True, "Is an address required for a teacher profile? (disabled by default, set to 'True' to enable)")
 }
 
 # Any tag used with Tag.getProgramTag(),

--- a/esp/esp/users/forms/user_profile.py
+++ b/esp/esp/users/forms/user_profile.py
@@ -61,7 +61,7 @@ class UserContactForm(FormUnrestrictedOtherUser, FormWithTagInitialValues):
             del self.fields['phone_day']
         if not Tag.getBooleanTag('text_messages_to_students') or not self.user.isStudent():
             del self.fields['receive_txt_message']
-        if not self.user.isTeacher() or Tag.getBooleanTag('teacher_address_required', default = True):
+        if not self.user.isTeacher() or Tag.getBooleanTag('teacher_address_required', default = False):
             self.fields['address_street'].required = True
             self.fields['address_city'].required = True
             self.fields['address_state'].required = True


### PR DESCRIPTION
Most programs probably have no need for teacher addresses and it's annoying for teachers to fill them out (especially when you have people making accounts at a teacher recruitment event). Make the default to have them optional so that programs don't need to change the tag unless they have a reason to want all teachers to have addresses.