### PR TITLE
Add null program option in userview

### DIFF
--- a/esp/templates/users/userview.html
+++ b/esp/templates/users/userview.html
@@ -25,6 +25,9 @@
             <input type="hidden" name="username" value="{{user.username}}"/>
             View:
             <select name="program" onchange="$j(this).parent().submit();return false;">
+                <option disabled {% if not program %}selected="selected"{% endif %}>
+                    (Select a program)
+                </option>
                 {% for prog in all_programs %}
                     <option value="{{prog.id}}" {% if prog == program %}selected="selected"{% endif %}>
                         {{prog.name}}


### PR DESCRIPTION
This adds a null option to the program dropdown in case the user has no registration profiles (since there's no program to select by default in such cases).

![image](https://user-images.githubusercontent.com/7232514/62500717-a0ad3d80-b79c-11e9-808c-e975793cb35d.png)

Fixes #2787.