### PR TITLE
Check for check availability module when linking to edit_availability

### DIFF
--- a/esp/templates/program/modules/adminclass/classavailability.html
+++ b/esp/templates/program/modules/adminclass/classavailability.html
@@ -21,6 +21,7 @@ $j(document).ready(function() {
 {% block content %}
 
 {% load render_qsd %}
+{% load modules %}
 
 <h1>Availability for <u>{{ class|escape }}</u></h1>
 
@@ -42,7 +43,7 @@ This class is scheduled during at least one timeslot in which at least one teach
 
 <h2>Teachers:</h2>
 {% for teacher in class.get_teachers %}
-<a href="/manage/userview?username={{ teacher.username|urlencode }}" target="_blank">{{ teacher.nonblank_name }}</a> (<a href="/manage/{{ program.getUrlBase }}/edit_availability?user={{ teacher.username|urlencode }}" target="_blank">edit availability</a>)
+<a href="/manage/userview?username={{ teacher.username|urlencode }}" target="_blank">{{ teacher.nonblank_name }}</a>{% if program|hasModule:"CheckAvailabilityModule" %} (<a href="/manage/{{ program.getUrlBase }}/edit_availability?user={{ teacher.username|urlencode }}" target="_blank">edit availability</a>){% endif %}
 </br>
 {% endfor %}
 </br>

--- a/esp/templates/program/modules/adminclass/coteachers.html
+++ b/esp/templates/program/modules/adminclass/coteachers.html
@@ -20,13 +20,15 @@
 
 {% block content %}
 
+{% load modules %}
+
 <h1>Setting Teachers for &quot;<u>{{ class|escape }}</u>&quot;</h1>
 
 <p>Please list all teachers that will be helping teach this class.  They will need to create accounts and mark their available times through the teacher registration page (for scheduling purposes).</p>
 
 {% if conflict %}
     <p>
-    <b><font color="red"><a href="/manage/{{ program.getUrlBase }}/edit_availability?user={{ conflict.username }}">{{ conflict.name}}</a> has a conflicting schedule.</b></font><br />
+    <b><font color="red">{% if program|hasModule:"CheckAvailabilityModule" %}<a href="/manage/{{ program.getUrlBase }}/edit_availability?user={{ conflict.username }}">{{ conflict.name }}</a>{% endif %}{{ conflict.name }} has a conflicting schedule.</b></font><br />
     </p>
 {% endif %}
 

--- a/esp/templates/program/modules/adminclass/coteachers.html
+++ b/esp/templates/program/modules/adminclass/coteachers.html
@@ -28,7 +28,7 @@
 
 {% if conflict %}
     <p>
-    <b><font color="red">{% if program|hasModule:"CheckAvailabilityModule" %}<a href="/manage/{{ program.getUrlBase }}/edit_availability?user={{ conflict.username }}">{{ conflict.name }}</a>{% endif %}{{ conflict.name }} has a conflicting schedule.</b></font><br />
+    <b><font color="red">{% if program|hasModule:"CheckAvailabilityModule" %}<a href="/manage/{{ program.getUrlBase }}/edit_availability?user={{ conflict.username }}">{{ conflict.name }}</a>{% else %}{{ conflict.name }}{% endif %} has a conflicting schedule.</b></font><br />
     </p>
 {% endif %}
 

--- a/esp/templates/program/modules/availabilitymodule/availability_form.html
+++ b/esp/templates/program/modules/availabilitymodule/availability_form.html
@@ -21,6 +21,7 @@ $j(document).ready(function() {
 {% block content %}
 
 {% load render_qsd %}
+{% load modules %}
 
 <h1>{% if isAdmin %}Manage{% else %}Your{% endif %} Availability for {{ prog.niceName }}</h1>
 
@@ -101,7 +102,7 @@ You submitted a schedule with no available times.  You can't register a class wi
 </div>
 {% endif %}
 
-{% if search_form %}
+{% if search_form and program|hasModule:"CheckAvailabilityModule" %}
 <br><br>
 <form method="POST" action="/manage/{{ program.getUrlBase }}/edit_availability">
 {{ search_form.as_p }}


### PR DESCRIPTION
Just in case the module isn't enabled, we should check before including links to the `edit_availability` page.

Fixes #2786.