### PR TITLE
Fix conflict message on class availability page

### DIFF
--- a/esp/esp/program/modules/handlers/adminclass.py
+++ b/esp/esp/program/modules/handlers/adminclass.py
@@ -485,7 +485,8 @@ class AdminClass(ProgramModuleObj):
             for teacher in teachers:
                 if time not in teacher.getAvailableTimes(prog, True):
                     unavail_teachers[time].append(teacher)
-                    conflict_found = True
+                    if time in meeting_times:
+                        conflict_found = True
                 if time in teacher.getTaughtTimes(prog, exclude = [cls]):
                     teaching_teachers[time].append(teacher)
             if (len(unavail_teachers[time]) + len(teaching_teachers[time])) == 0:


### PR DESCRIPTION
The message previously showed up any time a teacher wasn't available for any timeslot. Now it only shows up when that the class is scheduled during that timeslot.