### PR TITLE
Added blank teacher info for coteachers added manually

### DIFF
--- a/esp/esp/program/modules/handlers/adminclass.py
+++ b/esp/esp/program/modules/handlers/adminclass.py
@@ -46,6 +46,9 @@ from esp.program.modules.forms.management import ClassManageForm, SectionManageF
 from django.http import HttpResponseRedirect, HttpResponse
 from esp.middleware import ESPError
 from esp.program.controllers.classreg import ClassCreationController
+from esp.users.models import TeacherInfo
+from esp.program.models import RegistrationProfile
+
 
 """ Module in the middle of a rewrite. -Michael """
 
@@ -396,6 +399,10 @@ class AdminClass(ProgramModuleObj):
             if cls.conflicts(teacher):
                 conflictinguser = teacher
             else:
+                if not RegistrationProfile.getLastForProgram(teacher, prog).teacher_info:
+                    lastProf = RegistrationProfile.getLastForProgram(teacher, prog)
+                    lastProf.teacher_info = TeacherInfo.addOrUpdate(teacher, lastProf, {'graduation_year': ''})
+                    lastProf.save()
                 coteachers.append(teacher)
                 txtTeachers = ",".join([str(coteacher.id) for coteacher in coteachers ])
                 ccc.associate_teacher_with_class(cls, teacher)


### PR DESCRIPTION
Automatically add a teacher info if a coteacher is added but hasn't filled it out. This would really only happen if they started a basic account/ had an account from previous programs and then an admin manually added proper availability for the program and added them to a class. 

Fixes #2759 