### PR TITLE
Always show availability link on userview, but indicate if not set

### DIFF
--- a/esp/esp/program/views.py
+++ b/esp/esp/program/views.py
@@ -45,7 +45,7 @@ from esp.qsd.forms import QSDMoveForm, QSDBulkMoveForm
 from django.http import HttpResponseRedirect, HttpResponseBadRequest
 
 from django.core.mail import send_mail
-from esp.users.models import ESPUser, Permission, admin_required, ZipCode
+from esp.users.models import ESPUser, Permission, admin_required, ZipCode, UserAvailability
 
 from django.contrib.auth.decorators import login_required
 from django.db.models.query import Q
@@ -393,6 +393,7 @@ def userview(request):
         'all_programs': Program.objects.all().order_by('-id'),
         'program': program,
         'volunteer': VolunteerOffer.objects.filter(request__program = program, user = user).exists(),
+        'avail_set': UserAvailability.objects.filter(event__program = program, user = user).exists(),
     }
     return render_to_response("users/userview.html", request, context )
 

--- a/esp/public/media/default_styles/userview.css
+++ b/esp/public/media/default_styles/userview.css
@@ -26,6 +26,16 @@
   margin-top: 5px;
 }
 
+#user-sidebar a.stripes:not(:hover) {
+  background: repeating-linear-gradient(
+    45deg,
+    lightgrey,
+    lightgrey 5px,
+    transparent 5px,
+    transparent 10px
+  );
+}
+
 #user-sidebar a.sidelink:hover {
   color: #ffffff;
   background-color: #3366cc;

--- a/esp/templates/users/userview.html
+++ b/esp/templates/users/userview.html
@@ -98,13 +98,13 @@
                     Teacher links<br/>
                     (for {{program.niceName}})
                 </h2>
+                {% if program|hasModule:"CheckAvailabilityModule" %}
+                    <a class="sidelink{% if not avail_set %} stripes{% endif %}" href="/manage/{{program.getUrlBase}}/edit_availability?user={{user.username}}">
+                    Check/edit availability{% if not avail_set %} (not set){% endif %}</a>
+                {% endif %}
                 {% if profile.teacher_info %}
-                    {% if program|hasModule:"CheckAvailabilityModule" %}
-                        <a class="sidelink" href="/manage/{{program.getUrlBase}}/edit_availability?user={{user.username}}">
-                        Check/edit availability</a>
-                    {% endif %}
                     <div id="print-teacher-schedule">
-                        <a id="getteacherschedulelink" class="sidelink" href="/teach/{{program.getUrlBase}}/teacherschedule?user={{profile.user.id}}" target="_new">Print schedule locally</a>
+                        <a id="getteacherschedulelink" class="sidelink" href="/teach/{{program.getUrlBase}}/teacherschedule?user={{user.id}}" target="_new">Print schedule locally</a>
                     </div>
                 {% else %}
                     (Teacher has no profile for this program)
@@ -116,7 +116,7 @@
                         Volunteer links<br/>
                         (for {{program.niceName}})
                     </h2>
-                    <a id="getvolunteerschedulelink" class="sidelink" href="/volunteer/{{program.getUrlBase}}/volunteerschedule?user={{profile.user.id}}" target="_new">Print schedule locally</a>
+                    <a id="getvolunteerschedulelink" class="sidelink" href="/volunteer/{{program.getUrlBase}}/volunteerschedule?user={{user.id}}" target="_new">Print schedule locally</a>
                 </div>
             {% endif %}
         {% endif %}


### PR DESCRIPTION
The availability link should always be show on the userview page, because we might want to set it even if a user doesn't have a profile, but if it isn't set, we should indicate that, so we don't have to go and check ourselves.

Fixes #2795.