### PR TITLE
Stop archiving all emails

### DIFF
--- a/esp/esp/dbmail/models.py
+++ b/esp/esp/dbmail/models.py
@@ -58,7 +58,7 @@ from django.core.mail.message import sanitize_address
 from django.core.exceptions import ImproperlyConfigured
 
 
-def send_mail(subject, message, from_email, recipient_list, fail_silently=False, bcc=(settings.DEFAULT_EMAIL_ADDRESSES['archive'],),
+def send_mail(subject, message, from_email, recipient_list, fail_silently=False, bcc=None,
               return_path=settings.DEFAULT_EMAIL_ADDRESSES['bounces'], extra_headers={},
               *args, **kwargs):
     from_email = from_email.strip()

--- a/esp/mailgates/mailgate.py
+++ b/esp/mailgates/mailgate.py
@@ -77,11 +77,8 @@ try:
         if hasattr(instance, "direct_send") and instance.direct_send:
             if message['Bcc']:
                 bcc_recipients = [x.strip() for x in message['Bcc'].split(',')]
-                bcc_recipients += [ARCHIVE]
                 del(message['Bcc'])
                 message['Bcc'] = ", ".join(bcc_recipients)
-            else:
-                message['Bcc'] = ARCHIVE
 
             send_mail(str(message))
             continue
@@ -89,7 +86,6 @@ try:
         del(message['to'])
         del(message['cc'])
         message['X-ESP-SENDER'] = 'version 2'
-        message['Bcc'] = ARCHIVE
 
         if handler.subject_prefix:
             subject = message['subject']


### PR DESCRIPTION
Now that we're using sendgrid, we need to be a little better about the number of emails we send. Before, we were sending a duplicate email to our archive email address for every email that was sent from the server, but that ends up being a lot of emails. Since we already store the message data in the database or send a cc to the director email for all emails, we can just get rid of this separate "archiving" system.