### PR TITLE
Generic program links for most recent/current program

### DIFF
--- a/esp/esp/context_processors.py
+++ b/esp/esp/context_processors.py
@@ -21,21 +21,34 @@ def email_settings(request):
     return context
 
 def program(request):
-    path_parts = request.path.lstrip('/').split('/')
-    if len(path_parts) > 3:
-        program_url = '/'.join(path_parts[1:3])
-        if Program.objects.filter(url=program_url).count() == 1:
-            return {'program': Program.objects.get(url=program_url)}
+    if getattr(request, "program", None):
+        return {'program': request.program}
+    elif getattr(request, "prog", None):
+        return {'program': request.prog}
+    else:
+        path_parts = request.path.lstrip('/').split('/')
+        if len(path_parts) > 3:
+            program_url = '/'.join(path_parts[1:3])
+            if Program.objects.filter(url=program_url).count() == 1:
+                return {'program': Program.objects.get(url=program_url)}
     return {}
 
 def schoolyear(request):
-    path_parts = request.path.lstrip('/').split('/')
-    if len(path_parts) > 3:
-        program_url = '/'.join(path_parts[1:3])
-        if Program.objects.filter(url=program_url).count() == 1:
-            program = Program.objects.get(url=program_url)
-            return {'schoolyear': ESPUser.program_schoolyear(program)}
-    return {'schoolyear': ESPUser.current_schoolyear()}
+    program = None
+    if getattr(request, "program", None):
+        program = request.program
+    elif getattr(request, "prog", None):
+        program = reqest.prog
+    else:
+        path_parts = request.path.lstrip('/').split('/')
+        if len(path_parts) > 3:
+            program_url = '/'.join(path_parts[1:3])
+            if Program.objects.filter(url=program_url).count() == 1:
+                program = Program.objects.get(url=program_url)
+    if program:
+        return {'schoolyear': ESPUser.program_schoolyear(program)}
+    else:
+        return {'schoolyear': ESPUser.current_schoolyear()}
 
 def index_backgrounds(request):
     #if request.path.strip() == '':

--- a/esp/esp/context_processors.py
+++ b/esp/esp/context_processors.py
@@ -38,7 +38,7 @@ def schoolyear(request):
     if getattr(request, "program", None):
         program = request.program
     elif getattr(request, "prog", None):
-        program = reqest.prog
+        program = request.prog
     else:
         path_parts = request.path.lstrip('/').split('/')
         if len(path_parts) > 3:

--- a/esp/esp/web/views/main.py
+++ b/esp/esp/web/views/main.py
@@ -85,6 +85,13 @@ def program(request, tl, one, two, module, extra = None):
     """ Return program-specific pages """
     from esp.program.models import Program
 
+    if two == "current":
+        try:
+            programs = Program.objects.all()
+            progs = [(program, program.dates()[-1]) for program in programs if program.program_type == one and len(program.dates()) > 0]        
+            two = sorted(progs, key=lambda x: x[1], reverse = True)[0][0].program_instance
+        except:
+            raise Http404("No current program of the type '" + one + "'.")
     try:
         prog = Program.by_prog_inst(one, two)
     except Program.DoesNotExist:

--- a/esp/esp/web/views/main.py
+++ b/esp/esp/web/views/main.py
@@ -88,7 +88,7 @@ def program(request, tl, one, two, module, extra = None):
     if two == "current":
         try:
             programs = Program.objects.all()
-            progs = [(program, program.dates()[-1]) for program in programs if program.program_type == one and len(program.dates()) > 0]        
+            progs = [(program, program.dates()[-1]) for program in programs if program.program_type == one and len(program.dates()) > 0]
             two = sorted(progs, key=lambda x: x[1], reverse = True)[0][0].program_instance
         except:
             raise Http404("No current program of the type '" + one + "'.")


### PR DESCRIPTION
This creates a system to generate/follow links for specific views within the most recent/current program (merely the one that is latest in time). The links are of the form `[site].learningu.org/[tl]/[one]/current/[view]`, where `[site]` is the specific chapter site; `[tl]` is "teach", "learn", "manage", or "volunteer"; `[one]` is the program type (e.g. "Splash", "Sprout", "HSSP"); and `[view]` is the specific page/view (e.g. "teacherreg", "studentreg", "dashboard", etc).

I should mention that any of the links on the page will then direct the user to a link with "current
 replaced with the actual instance (e.g. "2019_Spring"). I'm not sure if this is a good thing or a bad thing. We could make it maintain the "current" part, but that would require modifying a lot of templates.

The hope is that this will make it easier to set generic links on pages or even in emails.

Fixes #2793.