### PR TITLE
Link to all class email addresses on teacher reg page

### DIFF
--- a/esp/public/media/default_styles/battlescreen.css
+++ b/esp/public/media/default_styles/battlescreen.css
@@ -33,7 +33,7 @@ font-size: 12px;
 color: #006600;
 }
 
-#battlescreen a.abutton, #battlescreen input.button {
+#battlescreen a.abutton, #battlescreen input.button, #battlescreen button.button {
    color: #000000;
    font-family:Arial,helvetica,sans-serif;
    font-size:12px;
@@ -51,7 +51,7 @@ color: #006600;
    border-radius: 0;
 }
 
-#battlescreen a.abutton:hover, #battlescreen input.button:hover
+#battlescreen a.abutton:hover, #battlescreen input.button:hover, #battlescreen button.button:hover
 {
    color:#0000cc;
    border: #000000 1px solid;
@@ -207,24 +207,6 @@ color: #006600;
 
 .clsmiddle {
     vertical-align: middle;
-}
-
-.cancelbutton {
-    color: #000000;
-    font-family: Arial,helvetica,sans-serif;
-    font-size: 11px;
-    font-weight: bold;
-    border: #cccccc 1px solid;
-    background-color: #cccccc;
-    cursor: default;
-    padding: 2px 5px 2px 5px;
-    text-decoration: none;
-    margin: 0px;
-    line-height: normal;
-    cursor: pointer;
-    box-shadow: none;
-    transition: border linear 0.2s, box-shadow linear 0.2s;
-    border-radius: 0;
 }
 
 .teachbutton {

--- a/esp/templates/inclusion/program/class_teacher_list_row.html
+++ b/esp/templates/inclusion/program/class_teacher_list_row.html
@@ -74,7 +74,7 @@ Popup div for class cancellation request
       View Students
     </a>
     &emsp;
-    <a href="mailto:{{ cls.emailcode }}-class@{{ email_host_sender }}"
+    <a href="mailto:{{ cls.emailcode }}-students@{{ email_host_sender }}"
        title="Email Class' Students" class="abutton">
       Email Students
     </a>

--- a/esp/templates/inclusion/program/class_teacher_list_row.html
+++ b/esp/templates/inclusion/program/class_teacher_list_row.html
@@ -73,6 +73,7 @@ Popup div for class cancellation request
        title="View Class' Students" class="abutton">
       View Students
     </a>
+    <a href="mailto:{{ cls.emailcode }}-class@{{ email_host_sender }}" class="abutton">Email Students</a>
     {% endif %}
   {% endblock %}
   </td>
@@ -124,7 +125,7 @@ Popup div for class cancellation request
   </td>
   <td class="clsright" valign="top">
   {% block cls_row_5_buttons %}
-    <a class="abutton" href="mailto:{{ sec.emailcode }}-students@{{ email_host_sender }}">Email students</a>
+    <a class="abutton" href="mailto:{{ sec.emailcode }}-students@{{ email_host_sender }}">Email section students</a>
   {% endblock %}
   </td>
 </tr>

--- a/esp/templates/inclusion/program/class_teacher_list_row.html
+++ b/esp/templates/inclusion/program/class_teacher_list_row.html
@@ -56,7 +56,7 @@ Popup div for class cancellation request
 </div>
 
 <tr>
-  <td class="clsleft" colspan="6">
+  <td class="clsleft" colspan="5">
     <b>Directors' review status</b>: {% if cls.isReviewed %}{% if cls.isAccepted %}
     <span style="font-weight: bold; color: #0C0;">Accepted</span>
     {% else %}
@@ -66,17 +66,22 @@ Popup div for class cancellation request
     <span style="font-weight: bold; color: #00C;">Unreviewed</span>
     {% endif %}
   </td>
-  <td class="clsright" colspan="1">
+  <td class="clsright" colspan="2">
   {% block cls_row_2_buttons %}
     {% if cls.isAccepted %}
     <a href="/teach/{{program.getUrlBase}}/class_students/{{cls.id}}" 
        title="View Class' Students" class="abutton">
       View Students
     </a>
-    <a href="mailto:{{ cls.emailcode }}-class@{{ email_host_sender }}" class="abutton">Email Students</a>
+    &emsp;
+    <a href="mailto:{{ cls.emailcode }}-class@{{ email_host_sender }}"
+       title="Email Class' Students" class="abutton">
+      Email Students
+    </a>
     {% endif %}
   {% endblock %}
   </td>
+  
 </tr>
 
 <tr>
@@ -92,7 +97,7 @@ Popup div for class cancellation request
 
 {% if crmi.allow_coteach %}
 <tr>
-  <td class="clsleft"><b>(Co-)Teachers: </b></td>
+  <td class="clsleft"><b>Teachers (<a href="mailto:{{ cls.emailcode }}-teachers@{{ email_host_sender }}">email</a>): </b></td>
   <td class="clsmiddle" colspan="5">{% for t in cls.get_teachers %}{% ifnotequal t request.user %}{{ t.first_name }} {{ t.last_name }}{% if not forloop.last %}, {% endif %}{% endifnotequal %}{% endfor %}</td>
   <td class="clsright">
   {% block cls_row_4_buttons %}
@@ -123,9 +128,12 @@ Popup div for class cancellation request
   <td class="clsmiddle" valign="top">{{ sec.num_students }} / {{ sec.capacity }} students
     <br />(<a href="/teach/{{ program.getUrlBase }}/section_students/{{ sec.id }}">view list</a>) 
   </td>
-  <td class="clsright" valign="top">
+  <td class="clsright" valign="middle">
   {% block cls_row_5_buttons %}
-    <a class="abutton" href="mailto:{{ sec.emailcode }}-students@{{ email_host_sender }}">Email section students</a>
+    <a href="mailto:{{ sec.emailcode }}-students@{{ email_host_sender }}"
+       title="Email Section's Students" class="abutton">
+      Email S{{ sec.index }} Students
+    </a>
   {% endblock %}
   </td>
 </tr>

--- a/esp/templates/inclusion/program/class_teacher_list_row.html
+++ b/esp/templates/inclusion/program/class_teacher_list_row.html
@@ -12,7 +12,7 @@
   {% block cls_row_1_buttons %}
   <td class="clsmiddle bordertop2">
     {% if can_req_cancel %}
-        <button class="cancelbutton" onclick="requestCancel({{cls.id}})">Request Cancellation</button>
+        <button class="button" onclick="requestCancel({{cls.id}})">Request Cancellation</button>
     {% endif %}
   </td>
   <td class="clsmiddle bordertop2">


### PR DESCRIPTION
This adds the class and teacher email addresses to each class on the teacher reg main page. It also cleans up some of the other buttons.

Here's a preview of what each class looks like:
![image](https://user-images.githubusercontent.com/7232514/64626714-e2d92880-d3b3-11e9-88a4-519d08b3b73e.png)

Fixes #1067.