### PR TITLE
Include debug toolbar when morphed

### DIFF
--- a/esp/esp/middleware/debugtoolbar/middleware.py
+++ b/esp/esp/middleware/debugtoolbar/middleware.py
@@ -45,7 +45,8 @@ class ESPDebugToolbarMiddleware(DebugToolbarMiddleware):
         # proxy caching. See Github issue #739.
         enabled = ((not request.is_ajax()) and settings.DEBUG_TOOLBAR and (
                 (settings.DEBUG and not request.session.get('debug_toolbar') == 'f') or
-                (request.session.get('debug_toolbar') == 't' and request.user.isAdmin())))
+                (request.session.get('debug_toolbar') == 't' and
+                (request.user.isAdmin() or request.user.isMorphed()))))
 
         # Avoid setting Vary: Cookie across this middleware in production and
         # testing (see above).

--- a/esp/esp/middleware/debugtoolbar/middleware.py
+++ b/esp/esp/middleware/debugtoolbar/middleware.py
@@ -46,7 +46,7 @@ class ESPDebugToolbarMiddleware(DebugToolbarMiddleware):
         enabled = ((not request.is_ajax()) and settings.DEBUG_TOOLBAR and (
                 (settings.DEBUG and not request.session.get('debug_toolbar') == 'f') or
                 (request.session.get('debug_toolbar') == 't' and
-                (request.user.isAdmin() or request.user.isMorphed()))))
+                (request.user.isAdmin() or request.user.is_morphed()))))
 
         # Avoid setting Vary: Cookie across this middleware in production and
         # testing (see above).


### PR DESCRIPTION
This allows for admins to use the debug toolbar even when they are morphed into a user.

Note: this is only necessary when `settings.DEBUG = False` (i.e. not a development server) because otherwise the debug toolbar is always on, no matter whether the user is an admin, morphed, etc..

Fixes #1193.