### PR TITLE
Required fields bug

### DIFF
--- a/esp/esp/users/forms/user_profile.py
+++ b/esp/esp/users/forms/user_profile.py
@@ -49,10 +49,10 @@ class UserContactForm(FormUnrestrictedOtherUser, FormWithTagInitialValues):
     phone_day = USPhoneNumberField(required=False)
     phone_cell = USPhoneNumberField(required=False)
     receive_txt_message = forms.TypedChoiceField(coerce=lambda x: x =='True', choices=((True, 'Yes'),(False, 'No')), widget=forms.RadioSelect)
-    address_street = StrippedCharField(required=False, length=40, max_length=100)
-    address_city = StrippedCharField(required=False, length=20, max_length=50)
-    address_state = forms.ChoiceField(required=False, choices=zip(_states,_states), widget=forms.Select(attrs={'class': 'input-mini'}))
-    address_zip = StrippedCharField(required=False, length=5, max_length=5, widget=forms.TextInput(attrs={'class': 'input-small'}))
+    address_street = StrippedCharField(required=True, length=40, max_length=100)
+    address_city = StrippedCharField(required=True, length=20, max_length=50)
+    address_state = forms.ChoiceField(required=True, choices=zip(_states,_states), widget=forms.Select(attrs={'class': 'input-mini'}))
+    address_zip = StrippedCharField(required=True, length=5, max_length=5, widget=forms.TextInput(attrs={'class': 'input-small'}))
     address_postal = forms.CharField(required=False, widget=forms.HiddenInput())
 
     def __init__(self, *args, **kwargs):
@@ -61,11 +61,11 @@ class UserContactForm(FormUnrestrictedOtherUser, FormWithTagInitialValues):
             del self.fields['phone_day']
         if not Tag.getBooleanTag('text_messages_to_students') or not self.user.isStudent():
             del self.fields['receive_txt_message']
-        if not self.user.isTeacher() or Tag.getBooleanTag('teacher_address_required', default = False):
-            self.fields['address_street'].required = True
-            self.fields['address_city'].required = True
-            self.fields['address_state'].required = True
-            self.fields['address_zip'].required = True
+        if self.user.isTeacher() and not Tag.getBooleanTag('teacher_address_required', default = False):
+            self.fields['address_street'].required = False
+            self.fields['address_city'].required = False
+            self.fields['address_state'].required = False
+            self.fields['address_zip'].required = False
 
     def clean(self):
         super(UserContactForm, self).clean()
@@ -115,6 +115,7 @@ class GuardContactForm(FormUnrestrictedOtherUser):
         return self.cleaned_data
 
 HEARD_ABOUT_ESP_CHOICES = (
+    '',
     'Other...',
     'Teacher or Counselor',
     'Splash representative visited my school',
@@ -130,6 +131,7 @@ HEARD_ABOUT_ESP_CHOICES = (
     )
 
 WHAT_TO_DO_AFTER_HS = (
+    '',
     'Other...',
     "I don't know yet",
     'Get a job',
@@ -140,6 +142,7 @@ WHAT_TO_DO_AFTER_HS = (
     )
 
 HOW_TO_GET_TO_PROGRAM = (
+    '',
     'Other...',
     'My school has already arranged for a bus',
     'I will ask my teachers and counselors to arrange for a bus for me and my peers',
@@ -317,10 +320,10 @@ StudentInfoForm.base_fields['studentrep_expl'].widget.attrs['rows'] = 8
 StudentInfoForm.base_fields['studentrep_expl'].widget.attrs['cols'] = 45
 
 AFFILIATION_CHOICES = (
-    (AFFILIATION_OTHER, 'Other (please specify your affiliation)'),
     (AFFILIATION_UNDERGRAD, 'Undergraduate Student'),
     (AFFILIATION_GRAD, 'Graduate Student'),
     (AFFILIATION_POSTDOC, 'Postdoc'),
+    (AFFILIATION_OTHER, 'Other (please specify your affiliation)'),
     (AFFILIATION_NONE, 'No affiliation (please specify your school or employer)')
 )
 

--- a/esp/templates/users/profiles/studentinfo.html
+++ b/esp/templates/users/profiles/studentinfo.html
@@ -80,7 +80,7 @@ detailed explanation of our age and grade level policy, please click
     <label for="id_heardofesp" class="control-label">How did you hear of this program?
     </label>
     <div class="controls controls-row">
-    <span style="font-size: 0.8em; font-style: italic;">(If you select "Other," please explain in the right-hand box.)</span><br />
+    <span style="font-size: 0.8em; font-style: italic;">(If you select "Other," please explain in the lower box.)</span><br />
     {{ form.heard_about }} {% if form.heard_about.errors %}
     <br /><span class="form_error">{{ form.heard_about.errors|join:", " }}</span>
     {% endif %}
@@ -162,7 +162,8 @@ T-shirts are available at some of our programs. When you reserve a t-shirt, this
 {% if form.transportation %}
 <div class="control-group">
     <label for="id_transportation" class="control-label">How do you plan to get to/from the program?</label>
-    <div class="controls">
+    <div class="controls controls-row">
+    <span style="font-size: 0.8em; font-style: italic;">(If you select "Other," please explain in the lower box.)</span><br />
     {{ form.transportation }} {% if form.transportation.errors %}
     <br /><span class="form_error">{{ form.transportation.errors|join:", " }}</span>
     {% endif %}

--- a/esp/templates/users/profiles/teacherinfo.html
+++ b/esp/templates/users/profiles/teacherinfo.html
@@ -5,12 +5,13 @@
 <h3>Teacher Information</h3>
 
 <div class="control-group">
-<label for="id_affiliation" class="control-label">{{ form.affiliation.label }}</label>
-<div class="controls">
+    <label for="id_affiliation" class="control-label">{{ form.affiliation.label }}<font color="red">*</font></label>
+    <div class="controls controls-row">
+    <span style="font-size: 0.8em; font-style: italic;">(If you select "Other" or "No affiliation," please explain in the lower box.)</span><br />
     {{ form.affiliation }} {% if form.affiliation.errors %}
-  <br /><span class="form_error">{{ form.affiliation.errors|join:", " }}</span>
-  {% endif %}
-</div>
+    <br /><span class="form_error">{{ form.affiliation.errors|join:", " }}</span>
+    {% endif %}
+    </div>
 </div>
 
 <div class="control-group">

--- a/esp/templates/users/profiles/usercontact.html
+++ b/esp/templates/users/profiles/usercontact.html
@@ -1,5 +1,12 @@
 <!-- User ContactInfo -->
 
+<style>
+div.required label:after {
+  content:"*";
+  color:red;
+}
+</style>
+
 <h3>Contact Information</h3>
 
  <div class="control-group">
@@ -74,7 +81,7 @@
 
 {{ form.address_postal }}
 
-<h4>Phone number{% if form.phone_day and form.phone_cell %}s{% endif %}:</h4>
+<h4>Phone number{% if form.phone_day and form.phone_cell %}s{% endif %}:<font color="red">*</font></h4>
 
 {% if form.phone_day %}
 <div class="control-group">

--- a/esp/templates/users/profiles/usercontact.html
+++ b/esp/templates/users/profiles/usercontact.html
@@ -1,12 +1,5 @@
 <!-- User ContactInfo -->
 
-<style>
-div.required label:after {
-  content:"*";
-  color:red;
-}
-</style>
-
 <h3>Contact Information</h3>
 
  <div class="control-group">


### PR DESCRIPTION
This PR addresses edge cases in required fields that were not caught by the broad * adding behavior in #2420. This fixes #2629. 

This is not super great code, but builds upon the spaghettiness of the current code? Let me know if anyone has better ideas. The fixes involve:

- starting the address fields as required and then changing them to not required based on tag behavior instead of vice versa (this is trivial but allows the fields to be caught by the * behavior)
- adding a blank option to otherdropdown fields that are not required
- adding asterisk manually to otherdropdown fields that are basically required
- adding asterisk manually to the "Phone numbers" label above the home/cell fields, one of which is required

PS. I made decisions in this PR about which other drop down fields I felt should be required vs not-- please let me know if any of my decisions are unwise.
- Required: teacher affiliation with school
- Not required: student transportation, student post-high school plans, student heard of esp