### PR TITLE
Optionally skip texting coteachers of checked in classes

### DIFF
--- a/esp/public/media/scripts/onsite/teacher_checkin.js
+++ b/esp/public/media/scripts/onsite/teacher_checkin.js
@@ -142,13 +142,29 @@ $j(function(){
         textTeacher($j(this))
     });
 
+    var skip_semi_checked_in = false
+    $j("#skip-semi-checked-in").click(function() {
+        skip_semi_checked_in = !skip_semi_checked_in
+    });
+    
     $j(".text-all").click(function(){
         var $buttons = $j(".checkin:visible").closest('tr').find('.text:enabled');
-        var num_teachers = $buttons.length
+        if (skip_semi_checked_in) {
+            var keep = [];
+            for (i = 0; i < $buttons.length; i++) {
+                var teacher = $j($buttons[i]).closest("tr");
+                var sec_id = $j(teacher).data("sec-id");
+                if ($j(teacher).siblings("[data-sec-id='" + sec_id + "']").find("td.checked-in").length == 0) {
+                    keep.push($buttons[i]);
+                }
+            }
+            $buttons = $j($buttons).filter(keep);
+        }
+        var num_teachers = $buttons.length;
         var r = confirm("Are you sure you'd like to text " + num_teachers + " unchecked-in teachers?");
         if (r) {
             $buttons.each(function() {
-                textTeacher($j(this))
+                textTeacher($j(this));
             });
         }
     });

--- a/esp/public/media/scripts/onsite/teacher_checkin.js
+++ b/esp/public/media/scripts/onsite/teacher_checkin.js
@@ -151,7 +151,7 @@ $j(function(){
         var $buttons = $j(".checkin:visible").closest('tr').find('.text:enabled');
         if (skip_semi_checked_in) {
             var keep = [];
-            for (i = 0; i < $buttons.length; i++) {
+            for (var i = 0; i < $buttons.length; i++) {
                 var teacher = $j($buttons[i]).closest("tr");
                 var sec_id = $j(teacher).data("sec-id");
                 if ($j(teacher).siblings("[data-sec-id='" + sec_id + "']").find("td.checked-in").length == 0) {

--- a/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
+++ b/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
@@ -128,10 +128,12 @@
 <br>
 {% endif %}
 
-<p style="text-align:right">
+<div style="text-align:right; float: right; width: 225px; padding-bottom: 10px;">
 <input class="button text-all" type="button" value="Text All Unchecked-In Teachers"
     {% if not text_configured %} disabled title="Twilio texting settings are not configured"{% endif %}/>
-</p>
+</br>
+<input type="checkbox" id="skip-semi-checked-in" {% if not text_configured %} disabled{% endif %}/> Skip teachers of classes with at least one checked-in teacher
+</div>
 
 <p style="text-align: center">
 
@@ -157,7 +159,7 @@
 </tr>
 {% endif %}
 {% for section in sections %}
-<tr class="section-first-row">
+<tr class="section-first-row" data-sec-id="{{ section.emailcode }}">
     <td rowspan="{{ section.teachers|length }}" class="section-code">
         {{ section.parent_class.emailcode }}: {{ section.name }}
     </td>
@@ -193,7 +195,7 @@
                    {% if not text_configured %} disabled title="Twilio texting settings are not configured"
                    {% elif teacher.phone == default_phone %} disabled title="No contact info"{% endif %}/>
         </tr>
-        <tr>
+        <tr data-sec-id="{{ section.emailcode }}">
     {% endfor %}
     <td colspan="6" class="section-detail-td">
         <div class="section-detail fqr-class">


### PR DESCRIPTION
Adds a checkbox that admins can check to `/missingteachers` that changes the behavior of the "Text All Unchecked-in Teachers" button from texting all unchecked-in teachers to skipping teachers of classes with at least one checked-in teacher.

![image](https://user-images.githubusercontent.com/7232514/65096524-dee87000-d98a-11e9-8cb6-3ac3462433da.png)

Fixes #2735.
