### PR TITLE
Add option to include unreviewed classes in scheduling diagnostics

### DIFF
--- a/esp/esp/program/modules/handlers/schedulingcheckmodule.py
+++ b/esp/esp/program/modules/handlers/schedulingcheckmodule.py
@@ -10,6 +10,8 @@ from esp.users.models import ESPUser
 from esp.tagdict.models import Tag
 from esp.cal.models import Event
 
+from esp.middleware.threadlocalrequest import get_current_request
+
 import json
 import re
 
@@ -32,7 +34,7 @@ class SchedulingCheckModule(ProgramModuleObj):
               results = s.run_diagnostics([extra])
               return HttpResponse(results)
          else:
-              context = {'check_list': s.all_diagnostics}
+              context = {'check_list': s.all_diagnostics, 'unreviewed': "unreviewed" in request.GET}
               return render_to_response(self.baseDir()+'output.html', request, context)
 
     class Meta:
@@ -105,6 +107,9 @@ class SchedulingCheckRunner:
           """
           self.p = program
           self.formatter = formatter
+
+          request = get_current_request()
+          self.incl_unreview = "unreviewed" in request.GET
 
           self.lunch_blocks = self._getLunchByDay()
 
@@ -188,9 +193,13 @@ class SchedulingCheckRunner:
                if include_walkins == False:
                     #filter out walkins
                     qs = qs.exclude(parent_class__category__id=self.p.open_class_category.id)
-               #filter out non-approved classes
-               qs = qs.exclude(status__lte=0)
-               qs = qs.exclude(resourceassignment__isnull=True)
+               if self.incl_unreview:
+                   #filter out rejected/cancelled sections
+                   qs = qs.exclude(status__lt=0)
+               else:
+                   #filter out non-approved and unscheduled sections
+                   qs = qs.exclude(status__lte=0)
+                   qs = qs.exclude(resourceassignment__isnull=True)
                #filter out lunch
                qs = qs.exclude(parent_class__category__category=u'Lunch')
                qs = qs.select_related('parent_class', 'parent_class__parent_program', 'parent_class__category')
@@ -505,8 +514,12 @@ class SchedulingCheckRunner:
          l = []
          teachers = self.p.teachers()['class_approved'].distinct()
          for teacher in teachers:
-             sections = ClassSection.objects.filter(
-                 parent_class__in=teacher.getTaughtClassesFromProgram(self.p).filter(status=10).distinct(),status=10).distinct().order_by('meeting_times__start')
+             if self.incl_unreview:
+                 sections = ClassSection.objects.filter(
+                     parent_class__in=teacher.getTaughtClassesFromProgram(self.p).filter(status__gte=0).distinct(),status__gte=0).distinct().order_by('meeting_times__start')
+             else:
+                 sections = ClassSection.objects.filter(
+                     parent_class__in=teacher.getTaughtClassesFromProgram(self.p).filter(status__gt=0).distinct(),status__gt=0).distinct().order_by('meeting_times__start')
              for i in range(sections.count()-1):
                  try:
                      time1 = sections[i+1].meeting_times.all().order_by('start')[0]

--- a/esp/esp/program/modules/handlers/schedulingcheckmodule.py
+++ b/esp/esp/program/modules/handlers/schedulingcheckmodule.py
@@ -197,9 +197,10 @@ class SchedulingCheckRunner:
                    #filter out rejected/cancelled sections
                    qs = qs.exclude(status__lt=0)
                else:
-                   #filter out non-approved and unscheduled sections
+                   #filter out non-approved
                    qs = qs.exclude(status__lte=0)
-                   qs = qs.exclude(resourceassignment__isnull=True)
+               #filter out unscheduled classes
+               qs = qs.exclude(resourceassignment__isnull=True)
                #filter out lunch
                qs = qs.exclude(parent_class__category__category=u'Lunch')
                qs = qs.select_related('parent_class', 'parent_class__parent_program', 'parent_class__category')

--- a/esp/templates/program/modules/schedulingcheckmodule/output.html
+++ b/esp/templates/program/modules/schedulingcheckmodule/output.html
@@ -21,21 +21,23 @@ function updateDocs(docs) {
     {{ block.super }}
     <link rel="stylesheet" type="text/css" href="/media/styles/forms.css" />
     <link rel="stylesheet" type="text/css" href="/media/styles/scheduling_checks.css" />
+    <style type="text/css">
+    .nocheckmark { border: 1px solid black; }
+    </style>
 {% endblock %}
 
 {% block content %}
-<style type="text/css">
-.nocheckmark { border: 1px solid black; }
-</style>
+{% include "program/modules/admincore/returnlink.html" %}
 
 <h1>Schedule Diagnostic Output for {{program.niceName}} </h1>
+<a class="btn" href="scheduling_checks{% if unreviewed %}">Exclude{% else %}?unreviewed">Include{% endif %} unreviewed classes</a>
 
 <div id="scheduling-check-wrapper" />
 <script type="text/jsx">
   React.render(
     <SchedulingCheckList>
       {% for slug, title in check_list %}
-        <SchedulingCheck slug="{{slug}}" title="{{title}}" />
+        <SchedulingCheck slug="{{slug}}{% if unreviewed %}?unreviewed{% endif %}" title="{{title}}" />
       {% endfor %}
     </SchedulingCheckList>,
     document.getElementById("scheduling-check-wrapper"));


### PR DESCRIPTION
This adds a button to the scheduling diagnostics page which allows you to switch between 1) only including approved classes and 2) including unreviewed and approved classes.

(I also included a backlink to the main manage page)

Fixes #2718.