### PR TITLE
Usersearch sort and include last program

### DIFF
--- a/esp/esp/program/views.py
+++ b/esp/esp/program/views.py
@@ -76,6 +76,7 @@ import re
 import pickle
 import operator
 import json
+import datetime
 from collections import defaultdict
 from decimal import Decimal
 from reversion import revisions as reversion
@@ -346,7 +347,7 @@ def usersearch(request):
         return HttpResponseRedirect('/manage/userview?%s' % urlencode({'username': found_users[0].username}))
     elif num_users > 1:
         found_users = found_users.all()
-        sorted_users = sorted(found_users, key=lambda x: x.get_last_program_with_profile().dates()[0], reverse=True)
+        sorted_users = sorted(found_users, key=lambda x: x.get_last_program_with_profile().dates()[0] if x.get_last_program_with_profile() and x.get_last_program_with_profile().dates() else datetime.date(datetime.MINYEAR, 1, 1), reverse=True)
         return render_to_response('users/userview_search.html', request, { 'found_users': sorted_users })
     else:
         raise ESPError("No user found by that name!", log=False)

--- a/esp/esp/program/views.py
+++ b/esp/esp/program/views.py
@@ -345,7 +345,9 @@ def usersearch(request):
         from urllib import urlencode
         return HttpResponseRedirect('/manage/userview?%s' % urlencode({'username': found_users[0].username}))
     elif num_users > 1:
-        return render_to_response('users/userview_search.html', request, { 'found_users': found_users })
+        found_users = found_users.all()
+        sorted_users = sorted(found_users, key=lambda x: x.get_last_program_with_profile().dates()[0], reverse=True)
+        return render_to_response('users/userview_search.html', request, { 'found_users': sorted_users })
     else:
         raise ESPError("No user found by that name!", log=False)
 

--- a/esp/templates/users/userview_search.html
+++ b/esp/templates/users/userview_search.html
@@ -80,7 +80,7 @@ tbody > tr:hover {
         {% endif %}
         {% endwith %}
       </td>
-      <td sorttable_customkey="{{ user.get_last_program_with_profile.dates.0|date:'Ymd' }}">{{ user.get_last_program_with_profile }}
+      <td sorttable_customkey="{{ user.get_last_program_with_profile.dates.0|date:'Ymd' }}">{{ user.get_last_program_with_profile }}</td>
       <td>{% if user.is_active %}<span>&#10003;</span>{% endif %}</td>
     </tr>
     {% endfor %}

--- a/esp/templates/users/userview_search.html
+++ b/esp/templates/users/userview_search.html
@@ -20,9 +20,21 @@
   color: red;
 }
 
-.sortable {
-  border-spacing: 5px 5px;
-  border-collapse: separate;
+th {
+  background: black;
+  color: white;
+}
+
+th, td {
+  border-bottom: 1px solid #ddd;
+  padding-top: 5px !important;
+  padding-left: 5px;
+  padding-bottom: 5px;
+  padding-right: 5px;
+}
+
+tbody > tr:hover {
+  background-color: #f5f5f5;
 }
 </style>
 {% endblock %}
@@ -39,36 +51,40 @@
 <p>Multiple users matched the criteria that you specified.  Please select one to view:</p>
 
 <table class="sortable">
-<tr>
-  <th>First Name</th>
-  <th>Last Name</th>
-  <th>Username</th>
-  <th>Email</th>
-  <th>User Type(s)</th>
-  <th class="sorttable_sorted_reverse">Last Program</th>
-  <th>Active?</th>
-</tr>
-{% for user in found_users %}
-<tr>
-  <td>{{ user.first_name }}</td>
-  <td>{{ user.last_name }}</td>
-  <td><a href="/manage/userview?username={{ user.username|urlencode }}">{{ user.username }}</a></td>
-  <td>{{ user.email }}</td>
-  <td>
-    {% with user.getUserTypes as types %}
-    {% if types %}
-    {% for type in user.getUserTypes %}
-    <span class="{{ type }}">{{ type }}</span>{% if not forloop.last %}, {% endif %}
+  <thead>
+    <tr>
+      <th>First Name</th>
+      <th>Last Name</th>
+      <th>Username</th>
+      <th>Email</th>
+      <th>User Type(s)</th>
+      <th>Last Program</th>
+      <th>Active?</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for user in found_users %}
+    <tr>
+      <td>{{ user.first_name }}</td>
+      <td>{{ user.last_name }}</td>
+      <td><a href="/manage/userview?username={{ user.username|urlencode }}">{{ user.username }}</a></td>
+      <td>{{ user.email }}</td>
+      <td>
+        {% with user.getUserTypes as types %}
+        {% if types %}
+        {% for type in user.getUserTypes %}
+        <span class="{{ type }}">{{ type }}</span>{% if not forloop.last %}, {% endif %}
+        {% endfor %}
+        {% else %}
+        <span class="no_usertype">None</span>
+        {% endif %}
+        {% endwith %}
+      </td>
+      <td sorttable_customkey="{{ user.get_last_program_with_profile.dates.0|date:'Ymd' }}">{{ user.get_last_program_with_profile }}
+      <td>{% if user.is_active %}<span>&#10003;</span>{% endif %}</td>
+    </tr>
     {% endfor %}
-    {% else %}
-    <span class="no_usertype">None</span>
-    {% endif %}
-    {% endwith %}
-  </td>
-  <td>{{ user.get_last_program_with_profile }}
-  <td>{% if user.is_active %}<span>&#10003;</span>{% endif %}</td>
-</tr>
-{% endfor %}
+  </tbody>
 </table>
 
 {% endblock %}

--- a/esp/templates/users/userview_search.html
+++ b/esp/templates/users/userview_search.html
@@ -19,7 +19,17 @@
 .no {
   color: red;
 }
+
+.sortable {
+  border-spacing: 5px 5px;
+  border-collapse: separate;
+}
 </style>
+{% endblock %}
+
+{% block xtrajs %}
+{{ block.super }}
+<script type="text/javascript" src="/media/scripts/sorttable.js"></script>
 {% endblock %}
 
 {% block content %}
@@ -28,14 +38,21 @@
 
 <p>Multiple users matched the criteria that you specified.  Please select one to view:</p>
 
-<table>
-<tr><th>Name</th><th>Username</th><th>Email</th><th>User Type</th><th>Activated?</th></tr>
+<table class="sortable">
+<tr>
+  <th>First Name</th>
+  <th>Last Name</th>
+  <th>Username</th>
+  <th>Email</th>
+  <th>User Type(s)</th>
+  <th class="sorttable_sorted_reverse">Last Program</th>
+  <th>Active?</th>
+</tr>
 {% for user in found_users %}
 <tr>
-  <td>
-    <a href="/manage/userview?username={{ user.username|urlencode }}">{{ user.name }}</a>
-  </td>
-  <td>{{ user.username }}</td>
+  <td>{{ user.first_name }}</td>
+  <td>{{ user.last_name }}</td>
+  <td><a href="/manage/userview?username={{ user.username|urlencode }}">{{ user.username }}</a></td>
   <td>{{ user.email }}</td>
   <td>
     {% with user.getUserTypes as types %}
@@ -48,11 +65,8 @@
     {% endif %}
     {% endwith %}
   </td>
-  <td>{% if user.is_active %} 
-    <span>Activated</span>
-    {% else %}
-    <span>Deactivated</span>
-    {% endif %}</td>
+  <td>{{ user.get_last_program_with_profile }}
+  <td>{% if user.is_active %}<span>&#10003;</span>{% endif %}</td>
 </tr>
 {% endfor %}
 </table>


### PR DESCRIPTION
This makes the table on the usersearch results page sortable (using `sorttable.js`). I included the last program (with a profile) as a column, separated the name column into first and last name columns, and sorted the user list by the last program for the initial population of the table. I also added some styling to make it look nicer and moved the link to the userview page to the username field.

![image](https://user-images.githubusercontent.com/7232514/66443397-885bd800-ea04-11e9-8d40-bb558142f47a.png)

Fix #2395.