### PR TITLE
Autoescape off for cancellation emails

### DIFF
--- a/esp/templates/email/class_cancellation.txt
+++ b/esp/templates/email/class_cancellation.txt
@@ -1,3 +1,7 @@
+{% autoescape off %}
+
 Dear {{ user.first_name }},
 
 {% include "email/class_cancellation_body.txt" %}
+
+{% endautoescape %}

--- a/esp/templates/email/class_cancellation_admin.txt
+++ b/esp/templates/email/class_cancellation_admin.txt
@@ -1,3 +1,4 @@
+{% autoescape off %}
 -- Notice to directors --
 Class Section {{ sec.emailcode }} has been cancelled.  {% if email_students %}{{ num_students }} students have been sent the following email.{% else %}Students were not emailed.{% endif %} All students have been removed from the class.
 -------------------------
@@ -9,3 +10,4 @@ Additionally, all students with a StudentSubjectInterest were emailed the email 
 -------------------------
 
 {% endif %}
+{% endautoescape %}

--- a/esp/templates/email/class_cancellation_teacher.txt
+++ b/esp/templates/email/class_cancellation_teacher.txt
@@ -1,3 +1,4 @@
+{% autoescape off %}
 -- Notice to teachers --
 Class Section {{ sec.emailcode }} has been cancelled.  {% if email_students %}{{ num_students }} students have been sent the following email.{% else %}Students were not emailed.{% endif %} All students have been removed from the class.
 If you did not request this class cancellation, please contact us at {{ director_email }} immediately.
@@ -10,3 +11,4 @@ Additionally, all students that selected this class in the class lottery were em
 -------------------------
 
 {% endif %}
+{% endautoescape %}


### PR DESCRIPTION
This fixes the cancellation emails so apostrophes and other symbols are no longer escaped.

Fixes #2811.