### PR TITLE
Extend background on userview

### DIFF
--- a/esp/templates/users/userview.html
+++ b/esp/templates/users/userview.html
@@ -13,6 +13,7 @@
 
 {% block content %}
 <h1>User Information</h1>
+<div class="clearfix">
 {% if not user.is_active %} <b>This user has been deactivated.</b> {% endif %}
 
 <div id="user-sidebar">
@@ -266,5 +267,5 @@
     {% if forloop.last %}</ul>{% endif %}
     {% endfor %}
 {% endif %}{% endwith %}
-
+</div>
 {% endblock %}


### PR DESCRIPTION
I used clearfix to clear the floats and extend the background on the userview page if the floating div on the right is longer than the table on the left.

Fixes #2754.