### PR TITLE
Add floating resource choices

### DIFF
--- a/esp/public/media/scripts/program/modules/resources.js
+++ b/esp/public/media/scripts/program/modules/resources.js
@@ -37,6 +37,7 @@ function update_furnishing_choices(furnishing_select_obj, value) {
         if (choices.length > 1) {
             $j(furnishing_select_obj).after($j('<select>').css('margin-left', '4px').attr('id','id_furnishings-' + num + '-choice').attr('name','furnishings-' + num + '-choice').attr('type', 'text'));
             $j('#id_furnishings-' + num + '-choice').append($j('<option>').text('(option)'));
+            var i;
             for (i in choices) {
                 $j('#id_furnishings-' + num + '-choice').append($j('<option>').val(choices[i]).text(choices[i]));
             }
@@ -80,6 +81,7 @@ function update_floating_choices(floating_select_obj, floating_choice_obj, value
             $j(floating_choice_obj).remove();
             $j("#id_choice").append($j('<option>').text('(choice)').hide().css("display", "none"));
             $j("#id_choice > option")[0].disabled = true;
+            var i;
             for (i in choices) {
                 $j('#id_choice').append($j('<option>').val(choices[i]).text(choices[i]));
             }

--- a/esp/public/media/scripts/program/modules/resources.js
+++ b/esp/public/media/scripts/program/modules/resources.js
@@ -27,8 +27,8 @@ function getChoices(furnishing, callback){
     $j.post('/manage/' + prog_url + '/ajaxfurnishingchoices', data, "json").success(callback);
 }
 
-//Update the option field to reflect whether there are specific choices (dropdown) or not (open response). If a value is supplied, set that value as selected afterwards.
-function update_choices(furnishing_select_obj, value) {
+//Update the furnishing option field to reflect whether there are specific choices (dropdown) or not (open response). If a value is supplied, set that value as selected afterwards.
+function update_furnishing_choices(furnishing_select_obj, value) {
     var furnishing = $j(furnishing_select_obj).val()
     getChoices(furnishing, function(response) {
         var choices = response.choices;
@@ -57,17 +57,58 @@ $j.initialize("select", function() {
     $j(opt).css("display", "none");
     opt.disabled = true;
     //Convert option field to dropdown if necessary
-    if ($j(this).attr('id').split("-")[2] == "furnishing") {
+    if ($j(this).attr('id').split("-")[2] == "furnishing" & $j(this).val()) {
         var num = $j(this).attr('id').split("-")[1];
         //Make sure to preserve selected value
         var value = $j('#id_furnishings-' + num + '-choice').val();
-        if (value) {
-            update_choices($j(this), value);
-        }
+        update_furnishing_choices($j(this), value);
     }
 }, { target: document.getElementById('furnishing_formset') });
 
 //Whenever a new furnishing is selected, update the respective option field
 $j('.furnishing-dynamic-form select').change(function() {
-    update_choices($j(this));
+    update_furnishing_choices($j(this));
 });
+
+//Update the floating resource option field to reflect whether there are specific choices (dropdown) or not (open response). If a value is supplied, set that value as selected afterwards.
+function update_floating_choices(floating_select_obj, floating_choice_obj, value) {
+    var furnishing = $j(floating_select_obj).val()
+    getChoices(furnishing, function(response) {
+        var choices = response.choices;
+        if (choices.length > 1) {
+            $j(floating_choice_obj).after($j('<select>').attr('id','id_choice').attr('name','choice').attr('type', 'text'));
+            $j(floating_choice_obj).remove();
+            $j("#id_choice").append($j('<option>').text('(choice)').hide().css("display", "none"));
+            $j("#id_choice > option")[0].disabled = true;
+            for (i in choices) {
+                $j('#id_choice').append($j('<option>').val(choices[i]).text(choices[i]));
+            }
+        } else {
+            $j(floating_choice_obj).after($j('<input>').attr('id','id_choice').attr('name','choice').attr('maxlength', '50').attr('type', 'text'));
+            $j(floating_choice_obj).remove();
+        }
+        if (value) {
+            $j("#id_choice").val(value);
+        }
+    });
+}
+
+//Setup floating resources form
+var res_type = $j("#id_resource_type");
+var null_opt = $j(res_type).find("option")[0];
+//Hide null option in resource type dropdown
+$j(null_opt).hide();
+$j(null_opt).css("display", "none");
+null_opt.disabled = true;
+
+//Convert option field to dropdown if necessary
+//Make sure to preserve selected value
+if ($j(res_type).val()) {
+    update_floating_choices($j(res_type), $j("#id_choice"), $j("#id_choice").val());
+}
+
+//Whenever a new floating resource type is selected, update the option field
+$j('#id_resource_type').change(function() {
+    update_floating_choices($j(res_type), $j("#id_choice"));
+});
+

--- a/esp/templates/program/modules/resourcemodule/equipment.html
+++ b/esp/templates/program/modules/resourcemodule/equipment.html
@@ -36,6 +36,7 @@
     <tr>
         <td class="underline"><b>Name</b></td>
         <td class="underline"><b>Type</b></td>
+        <td class="underline"><b>Choice</b></td>
         <td class="underline"><b>Available Times</b></td>
     </tr>
     {% for r in prog.getFloatingResources %}
@@ -46,6 +47,7 @@
                 <a href="/manage/{{ prog.url }}/resources/equipment?op=delete&id={{ r.id }}">[Delete]</a>
             </td>
             <td class="underline">{{ r.res_type.name }}{% if r.res_type.hidden %} (Hidden){% endif %}</td>
+            <td class="underline">{{ r.attribute_value }}</td>
             <td class="underline">{% for t in r.timegroup %}{{ t }}<br />{% endfor %}</td>
         </tr>
     {% endfor %}

--- a/esp/templates/program/modules/resourcemodule/equipment_import.html
+++ b/esp/templates/program/modules/resourcemodule/equipment_import.html
@@ -34,11 +34,12 @@ You have chosen to import the floating resources from {{ past_program.niceName }
 <input type="hidden" name="program" value="{{ past_program.id }}" />
 <input type="hidden" name="complete_availability" value="{{ complete_availability }}" />
 <table align="center" cellpadding="0" cellspacing="0" width="550">
-    <tr><th colspan="4">Proposed floating resources for {{ prog.niceName }}</th></tr>
-    <tr><td colspan="4"><table cellpadding="0" cellspacing="0" width="100%">
+    <tr><th colspan="5">Proposed floating resources for {{ prog.niceName }}</th></tr>
+    <tr><td colspan="5"><table cellpadding="0" cellspacing="0" width="100%">
     <tr>
         <td class="underline"><b>Name</b></td>
         <td class="underline"><b>Type</b></td>
+        <td class="underline"><b>Choice</b></td>
         <td class="underline"><b>Available Times</b></td>
         <td class="underline"><b>Import? <input type="checkbox" onclick=toggle(this) checked></b></td>
     </tr>
@@ -46,12 +47,13 @@ You have chosen to import the floating resources from {{ past_program.niceName }
     <tr>
         <td class="underline">{{ r.name }}</td>
         <td class="underline">{{ r.res_type.name }}{% if r.res_type.hidden %} (Hidden){% endif %}</td>
+        <td class="underline">{{ r.attribute_value }}</td>
         <td class="underline">{% for t in r.timegroup %}{{ t }}<br />{% endfor %}</td>
-        <td class="underline"><input type="checkbox" name="to_import" value="{{r.old_id}}" checked></td>
+        <td class="underline"><input type="checkbox" name="to_import" value="{{ r.old_id }}" checked></td>
     </tr>
     {% endfor %}
     </table></td></tr>
-    <tr><td colspan="4" align="center"><input class="fancybutton" type="submit" value="Complete Import" /></td></tr>
+    <tr><td colspan="5" align="center"><input class="fancybutton" type="submit" value="Complete Import" /></td></tr>
 </table>
 </form>
 </div>


### PR DESCRIPTION
This adds a choice field to the floating resource form now that #2311 is implemented (and to follow up on #2547 where this was implemented for the classroom form and #2432 where this was implemented for the resource type form). Just as in #2547, the choices field is changed to a dropdown menu if the selected resource type has set options. The selected choice is also now displayed in the table of floating resources.

I also fixed a couple bugs with the floating resource form when editing floating resources (I guess no one really does that, because they haven't been reported before to my knowledge). And I fixed a couple bugs with my previous implementation in #2547 related to the initialization of the classroom form.

I tested this pretty thoroughly. The creation and editing of floating resources seems to work perfectly, and the creation and editing of classrooms still works as it did before.

Fixes #2615.