### PR TITLE
Resizable ajax scheduler panes

### DIFF
--- a/esp/public/media/default_styles/scheduling.css
+++ b/esp/public/media/default_styles/scheduling.css
@@ -78,17 +78,44 @@ input.numeric {
     margin-bottom: 20px;
 }
 
+#side-panel-wrapper {
+    height: 100%;
+}
+
+#info-panel {
+    height: 35%;
+    padding-top: 10px;
+    padding-bottom: 10px;
+    margin-bottom: calc(11px - .2em);
+}
+
 #message-div {
-    height: 150px;
-    margin-top: 10px;
-    margin-bottom: 10px;
+    height: 100%;
 }
 
 #section-info-div {
-    height: 150px;
+    height: 100%;
     font-size: 1em;
-    margin-top: 10px;
-    margin-bottom: 10px;
+}
+
+#separator {
+    cursor: row-resize;
+    background-color: #e9e9e9;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='30' height='10'><path d='M0 2 h30 M0 5 h30 M0 8 h30' fill='none' stroke='black'/></svg>");
+    background-repeat: no-repeat;
+    background-position: center;
+    height: 10px;
+    width: 100%;
+
+/* prevent browser's built-in drag from interfering */
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}
+
+#side-panel {
+    height: 65%;
+    bottom: 0;
 }
 
 th {

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Main.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Main.js
@@ -14,11 +14,9 @@ $j.getJSON('ajax_schedule_last_changed', function(data, status) {
 var resizeElements = function() {
     var window_height = window.innerHeight - 20;
     var window_width = window.innerWidth - 20;
-    var sidePanelTopHeight = 180;
     $j("#matrix-div").height(window_height)
         .width(window_width*3/4);
-    $j("#side-panel-wrapper").width(window_width/4);
-    $j("#side-panel").height(window_height - sidePanelTopHeight);
+    $j("#side-panel-wrapper").width(window_width/4).height(window_height);
 };
 
 // Resize window handler

--- a/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
+++ b/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
@@ -62,9 +62,11 @@
     </td>
     <td class="no-border">
       <div id="side-panel-wrapper" class="ui-widget">
-        <div id="section-info-div" class="component-div ui-widget ui-corner-all ui-helper-hidden"></div>
-        <div id="message-div" class="component-div ui-widget-content ui-corner-all"></div>
-
+        <div id="info-panel">
+          <div id="section-info-div" class="component-div ui-widget ui-corner-all ui-helper-hidden"></div>
+          <div id="message-div" class="component-div ui-widget-content ui-corner-all"></div>
+          <div id="separator" class="ui-resizable-handle ui-resizable-s"></div>
+        </div>
         <div id="side-panel" class="component-div ui-widget">
           <ul>
             <li><a href="#classes">Classes</a></li>
@@ -144,6 +146,16 @@
     </fieldset>
   </form>
 </div>
+
+<script>
+$j("#info-panel").resizable({
+  handles: {s: '#separator'},
+  containment: '#side-panel-wrapper',
+  resize: function() {
+    $j("#side-panel").outerHeight($j("#side-panel-wrapper").innerHeight() - $j("#info-panel").outerHeight());
+  }
+});
+</script>
 
 </body>
 </html>


### PR DESCRIPTION
This makes the side panels resizable so the class list and section info panels can be made smaller or larger. I added a separator that hopefully makes it obvious that you can resize the panels.

Example:
![image](https://user-images.githubusercontent.com/7232514/68075574-7f49f680-fd77-11e9-9640-27f5b74ff0d6.png)

Fixes #1407.
