### PR TITLE
Prevent flags from totally disappearing

### DIFF
--- a/esp/esp/program/modules/handlers/classflagmodule.py
+++ b/esp/esp/program/modules/handlers/classflagmodule.py
@@ -32,17 +32,17 @@ Learning Unlimited, Inc.
   Email: web-team@learningu.org
 """
 from django.db.models.query import Q
-from django.http import HttpResponseBadRequest, HttpResponse
-from django.http import HttpResponseRedirect
+from django.http import HttpResponseBadRequest, HttpResponse, HttpResponseRedirect
+from django.template.loader import render_to_string
 
-from esp.program.modules.base import ProgramModuleObj
-from esp.program.modules.base import main_call, aux_call, needs_admin
+from esp.program.modules.base import ProgramModuleObj, main_call, aux_call, needs_admin
 from esp.utils.web import render_to_response
 
 from esp.program.models import ClassFlag, ClassFlagType
 from esp.program.forms import ClassFlagForm
 from esp.users.models import ESPUser
 
+import json
 
 class ClassFlagModule(ProgramModuleObj):
     doc = """Flag classes, such as for further review."""
@@ -110,7 +110,11 @@ class ClassFlagModule(ProgramModuleObj):
         if form.is_valid():
             flag = form.save()
             context = { 'flag' : flag }
-            return render_to_response(self.baseDir()+'flag_detail.html', request, context)
+            response = json.dumps({
+                'flag_name': render_to_string(self.baseDir()+'flag_name.html', context = context, request = request),
+                'flag_detail': render_to_string(self.baseDir()+'flag_detail.html', context = context, request = request),
+            })
+            return HttpResponse(response, content_type='application/json')
         else:
             # The user shouldn't be able to get here unless they're doing something really weird, so let's not bother to try to tell them where the error was; since this is asynchronous that would be a bit tricky.
             return HttpResponseBadRequest('')

--- a/esp/public/media/scripts/program/modules/flag-edit.js
+++ b/esp/public/media/scripts/program/modules/flag-edit.js
@@ -3,7 +3,7 @@ function submitFlagForm (event) {
     var form = $j(this)
     var data = form.serialize();
     $j.post(form.attr("action"), data, function (data) {
-        form.parents("div.fqr-class").children("div.fqr-class-flags").append(data.flag_name);
+        form.parents("div.fqr-class").find("div.fqr-class-flags").append(data.flag_name);
         form.parents("div.flag-detail").replaceWith(data.flag_detail);
     }, 'json')
     event.preventDefault();

--- a/esp/public/media/scripts/program/modules/flag-edit.js
+++ b/esp/public/media/scripts/program/modules/flag-edit.js
@@ -3,8 +3,9 @@ function submitFlagForm (event) {
     var form = $j(this)
     var data = form.serialize();
     $j.post(form.attr("action"), data, function (data) {
-        form.parents("div.flag-detail").replaceWith(data);
-    })
+        form.parents("div.fqr-class").children("div.fqr-class-flags").append(data.flag_name);
+        form.parents("div.flag-detail").replaceWith(data.flag_detail);
+    }, 'json')
     event.preventDefault();
 }
 

--- a/esp/templates/program/modules/classflagmodule/class_flag_list.html
+++ b/esp/templates/program/modules/classflagmodule/class_flag_list.html
@@ -2,11 +2,18 @@
 {% if flag_types %}
     <h3>Manage class flags</h3>
     <div class="class-flag-list fqr-class">
-        {% for flag in class.flags.all %}
-            {% include "program/modules/classflagmodule/flag_detail.html" %}
-        {% endfor %}
-        {% include "program/modules/classflagmodule/new_flag_form.html" %}
-        <button class="add-flag btn btn-default">Add flag</button>
+        <div class="fqr-class-flags">
+            {% for flag in class.flags.all %}
+                {% include "program/modules/classflagmodule/flag_name.html" %}
+            {% endfor %}
+        </div>
+        <div class="fqr-class-flags-detail">
+            {% for flag in class.flags.all %}
+                {% include "program/modules/classflagmodule/flag_detail.html" %}
+            {% endfor %}
+            {% include "program/modules/classflagmodule/new_flag_form.html" %}
+            <button class="add-flag btn btn-default">Add flag</button>
+        </div>
     </div>
 {% else %}
     You need to enable some flags for this program in the <a href="/admin/program/program/{{program.id}}/#add_id_flag_types">admin panel</a> before you can edit them.


### PR DESCRIPTION
Previously newly added class flags could completely disappear if you clicked on the header. This fixes this by adding the `flag_name` objects where they weren't before (manageclass and editclass), then modifying the behavior when new flags are saved to also add a new `flag_name` object. Now, even if you minimize the flag details, there will always be the flag name above that you can click to maximize the details again.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/1580.