### PR TITLE
Filter classrooms in the scheduler

### DIFF
--- a/esp/esp/program/modules/handlers/ajaxschedulingmodule.py
+++ b/esp/esp/program/modules/handlers/ajaxschedulingmodule.py
@@ -117,15 +117,15 @@ class AJAXSchedulingModule(ProgramModuleObj):
 
         return self.makeret(prog, ret=True, msg="Schedule removed for Class Section '%s'" % cls.emailcode())
 
-    def ajax_schedule_assignreg(self, prog, cls, timeslot_ids, classroom_names, user=None):
+    def ajax_schedule_assignreg(self, prog, cls, timeslot_ids, classroom_ids, user=None):
         if len(timeslot_ids) < 1:
             return self.makeret(prog, ret=False, msg="No times specified!, can't assign to a timeblock")
 
-        if len(classroom_names) < 1:
+        if len(classroom_ids) < 1:
             return self.makeret(prog, ret=False, msg="No classrooms specified!, can't assign to a timeblock")
 
-        basic_cls = classroom_names[0]
-        for c in classroom_names:
+        basic_cls = classroom_ids[0]
+        for c in classroom_ids:
             if c != basic_cls:
                 return self.makeret(prog, ret=False, msg="Assigning one section to multiple rooms.  This interface doesn't support this feature currently; assign it to one room for now and poke a Webmin to do this for you manually.")
 
@@ -133,7 +133,7 @@ class AJAXSchedulingModule(ProgramModuleObj):
         if len(times) < 1:
             return self.makeret(prog, ret=False, msg="Specified Events not found in the database")
 
-        classrooms = Resource.objects.filter(name=basic_cls, res_type__name="Classroom")
+        classrooms = Resource.objects.filter(id=basic_cls, res_type__name="Classroom")
         if len(classrooms) < 1:
             return self.makeret(prog, ret=False, msg="Specified Classrooms not found in the database")
 
@@ -151,7 +151,7 @@ class AJAXSchedulingModule(ProgramModuleObj):
             return self.makeret(prog, ret=False, msg=" | ".join(errors))
 
         #add things to the change log here
-        self.get_change_log(prog).appendScheduling([int(t.id) for t in times], classroom_names[0], int(cls.id), user)
+        self.get_change_log(prog).appendScheduling([int(t.id) for t in times], classroom_ids[0], int(cls.id), user)
 
         return self.makeret(prog, ret=True, msg="Class Section '%s' successfully scheduled" % cls.emailcode())
 

--- a/esp/esp/program/modules/handlers/jsondatamodule.py
+++ b/esp/esp/program/modules/handlers/jsondatamodule.py
@@ -118,7 +118,7 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
     @no_auth
     @cached_module_view
     def resource_types(prog):
-        res_types = ResourceType.objects.filter(program = prog)
+        res_types = prog.getResourceTypes(include_global=Tag.getBooleanTag('allow_global_restypes', default = False))
         if len(res_types) == 0:
             res_types = ResourceType.objects.filter(program__isnull=True)
 

--- a/esp/esp/program/modules/handlers/jsondatamodule.py
+++ b/esp/esp/program/modules/handlers/jsondatamodule.py
@@ -96,8 +96,8 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
             classrooms_grouped[room.name].append(room)
         classrooms_dicts = [
             {
-                'id': room_id,
-                'uid': room_id,
+                'id': classrooms_grouped[room_id][0].identical_id(prog),
+                'uid': classrooms_grouped[room_id][0].identical_id(prog),
                 'text': classrooms_grouped[room_id][0].name,
                 'availability': [ r.event_id for r in classrooms_grouped[room_id] ],
                 'associated_resources': [
@@ -138,11 +138,14 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
     resource_types.cached_function.depend_on_model(ResourceType)
 
     @aux_call
-    @json_response({'resourceassignment__resource__name': 'room_name'})
+    @json_response({'resourceassignment__resource__name': 'room_name', 'resourceassignment__resource__id': 'room_id'})
     @needs_admin
     @cached_module_view
     def schedule_assignments(prog):
-        data = ClassSection.objects.filter(status__gte=0, parent_class__status__gte=0, parent_class__parent_program=prog).select_related('resourceassignment__resource__name', 'resourceassignment__resource__event').extra({'timeslots': 'ARRAY(SELECT resources_resource.event_id FROM resources_resource, resources_resourceassignment WHERE resources_resource.id = resources_resourceassignment.resource_id AND resources_resourceassignment.target_id = program_classsection.id)'}).values('id', 'resourceassignment__resource__name', 'timeslots').distinct()
+        data = ClassSection.objects.filter(status__gte=0, parent_class__status__gte=0, parent_class__parent_program=prog).select_related('resourceassignment__resource__name', 'resourceassignment__resource__event').extra({'timeslots': 'ARRAY(SELECT resources_resource.event_id FROM resources_resource, resources_resourceassignment WHERE resources_resource.id = resources_resourceassignment.resource_id AND resources_resourceassignment.target_id = program_classsection.id)'}).values('id', 'resourceassignment__resource__name', 'resourceassignment__resource__id', 'timeslots').distinct()
+        for i in range(len(data)):
+            if data[i]['resourceassignment__resource__id'] != None:
+                data[i]['resourceassignment__resource__id'] = Resource.objects.get(id=data[i]['resourceassignment__resource__id']).identical_id(prog)
         return {'schedule_assignments': list(data)}
     schedule_assignments.method.cached_function.depend_on_row(ClassSection, lambda sec: {'prog': sec.parent_class.parent_program})
     schedule_assignments.method.cached_function.depend_on_row(ResourceAssignment, lambda ra: {'prog': ra.target.parent_class.parent_program})

--- a/esp/esp/program/modules/tests/ajaxschedulingmodule.py
+++ b/esp/esp/program/modules/tests/ajaxschedulingmodule.py
@@ -129,10 +129,10 @@ class AJAXSchedulingModuleTest(AJAXSchedulingModuleTestBase):
         # Fetch two consecutive vacancies in two different rooms
         rooms = self.rooms[0].identical_resources().filter(event__in=self.timeslots).order_by('event__start')
         self.assertTrue(rooms.count() >= 2, "Not enough timeslots to run this test.")
-        a1 = '\n'.join(['%s,%s' % (r.event.id, r.name) for r in rooms[0:2]])
+        a1 = '\n'.join(['%s,%s' % (r.event.id, r.identical_id()) for r in rooms[0:2]])
         rooms = self.rooms.exclude(name=rooms[0].name)[0].identical_resources().filter(event__in=self.timeslots).order_by('event__start')
         self.assertTrue(rooms.count() >= 2, "Not enough timeslots to run this test.")
-        a2 = '\n'.join(['%s,%s' % (r.event.id, r.name) for r in rooms[0:2]])
+        a2 = '\n'.join(['%s,%s' % (r.event.id, r.identical_id()) for r in rooms[0:2]])
 
         # Schedule one class.
         ajax_url = '/manage/%s/ajax_schedule_class' % self.program.getUrlBase()

--- a/esp/esp/program/modules/tests/support/program_manager.py
+++ b/esp/esp/program/modules/tests/support/program_manager.py
@@ -31,7 +31,7 @@ class TestProgramManager():
         (section, timeslots, rooms) = self.getClassToSchedule(section=section, teacher=teacher, timeslots=timeslots, rooms=rooms)
 
         #schedule the class
-        blocks = '\n'.join(['%s,%s' % (r.event.id, r.name) for r in rooms[0:2]])
+        blocks = '\n'.join(['%s,%s' % (r.event.id, r.identical_id()) for r in rooms[0:2]])
         response = self.client.post(self.schedule_class_url, {'action': 'assignreg', 'cls': section.id, 'block_room_assignments': blocks})
         assert response.status_code == 200
 

--- a/esp/esp/resources/models.py
+++ b/esp/esp/resources/models.py
@@ -207,9 +207,15 @@ class Resource(models.Model):
     __sub__ = distance
 
 
-    def identical_resources(self):
+    def identical_resources(self, prog = None):
         res_list = Resource.objects.filter(name=self.name)
+        if prog:
+            res_list = res_list.filter(event__program=prog)
         return res_list
+
+    def identical_id(self, prog=None):
+        res_list = self.identical_resources(prog=prog)
+        return min(res_list.values_list("id", flat = True))
 
     def satisfies_requests(self, req_class):
         #   Returns a list of 2 items.  The first element is boolean and the second element is a list of the unsatisfied requests.

--- a/esp/public/media/default_styles/scheduling.css
+++ b/esp/public/media/default_styles/scheduling.css
@@ -109,3 +109,7 @@ button.sidetoolbar {
 .room-description {
 	font-size: .7em;
 }
+
+.ft_c {
+    height: unset !important; /* allows us to hide rows properly */
+}

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/ApiClient.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/ApiClient.js
@@ -50,14 +50,14 @@ function ApiClient() {
      *
      * @param section_id: The ID of the section to schedule
      * @param timeslot_ids: A list of ids of all timeslots the class should be scheduled during.
-     * @param room_name: The name of the room (its ID).
+     * @param room_id: The id of the room.
      * @param callback: If successful, this function will be called. Takes no params.
      * @param errorReporter: If server reports an error, this function will be called.
      *                       Takes one param msg with an error message.
      */
-    this.schedule_section = function(section_id, timeslot_ids, room_name, callback, errorReporter){
+    this.schedule_section = function(section_id, timeslot_ids, room_id, callback, errorReporter){
         assignments = timeslot_ids.map(function(id) {
-            return id + "," + room_name;
+            return id + "," + room_id;
         }).join("\n");
 
         var req = {

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Cell.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Cell.js
@@ -3,14 +3,14 @@
  *
  * @param el: The jquery element that this cell should be rendered on.
  * @param section: The section that should be rendered on this cell (may be null).
- * @param room_name: The name (ID) of the room that corresponds to this cell.
+ * @param room_id: The ID of the room that corresponds to this cell.
  * @param timeslot_id: The ID of the timeslot that corresponds to this cell.
  * @param matrix: The matrix that created the cell.
  *
  * Public properties and methods:
  * @prop el:
  * @prop cellColors
- * @prop room_name
+ * @prop room_id
  * @prop timeslot_id
  * @prop matrix
  * @prop disabled
@@ -22,11 +22,11 @@
  * @method addSection(section)
  * @method removeSection()
  */
-function Cell(el, section, room_name, timeslot_id, matrix) {
+function Cell(el, section, room_id, timeslot_id, matrix) {
     this.el = el;
 
     this.cellColors = new CellColors();
-    this.room_name = room_name;
+    this.room_id = room_id;
     this.timeslot_id = timeslot_id;
     this.matrix = matrix;
     this.disabled = false;
@@ -196,8 +196,8 @@ function Cell(el, section, room_name, timeslot_id, matrix) {
 /**
  * This is a cell where a room is not available in that time block.
  */
-function DisabledCell(el, room_name, timeslot_id) {
-    this.room_name = room_name;
+function DisabledCell(el, room_id, timeslot_id) {
+    this.room_id = room_id;
     this.timeslot_id = timeslot_id;
     this.el = el;
     this.disabled = true;

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/ChangelogFetcher.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/ChangelogFetcher.js
@@ -47,7 +47,7 @@ function ChangelogFetcher(matrix, api_client, start_index){
                 if (change.timeslots.length == 0){
                     this.matrix.sections.unscheduleSectionLocal(section);
                 } else {
-                    this.matrix.sections.scheduleSectionLocal(section, change.room_name, change.timeslots);
+                    this.matrix.sections.scheduleSectionLocal(section, parseInt(change.room_name,10), change.timeslots);
                 }
             } else {
                 this.matrix.sections.setComment(section, change.comment, change.locked, true);

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Matrix.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Matrix.js
@@ -123,18 +123,18 @@ function Matrix(
         // set up cells
         var matrix = this;
         this.cells = function(){
-            // cells has room names as keys to the outer object and timeslots as keys to the
+            // cells has room ids as keys to the outer object and timeslots as keys to the
             // inner object
             var cells = {};
-            $j.each(rooms, function(room_name, room){
-                cells[room_name] = [];
+            $j.each(rooms, function(room_id, room){
+                cells[room_id] = [];
                 $j.each(this.timeslots.timeslots, function(timeslot_id_string, timeslot){
                     var timeslot_id = parseInt(timeslot_id_string);
                     if (room.availability.indexOf(timeslot_id) >= 0){
-                        cells[room_name][timeslot.order] = new Cell($j("<td/>"), null, room_name,
+                        cells[room_id][timeslot.order] = new Cell($j("<td/>"), null, room_id,
                             timeslot_id, matrix);
                     } else {
-                        cells[room_name][timeslot.order] = new DisabledCell($j("<td/>"), room_name,
+                        cells[room_id][timeslot.order] = new DisabledCell($j("<td/>"), room_id,
                             timeslot_id)
                     }
                 }.bind(this));
@@ -246,13 +246,13 @@ function Matrix(
         // Associated already scheduled classes with rooms
         $j.each(this.sections.scheduleAssignments, function(class_id, assignmentData){
             $j.each(assignmentData.timeslots, function(j, timeslot_id){
-                var cell = this.getCell(assignmentData.room_name, timeslot_id);
+                var cell = this.getCell(assignmentData.room_id, timeslot_id);
                 if(cell && !cell.disabled) {
                     cell.addSection(sections.getById(class_id));
                 } else {
                     if(!cell) {
-                        var errorMessage = "Error: Could not find cell with room "
-                            + assignmentData.room_name
+                        var errorMessage = "Error: Could not find cell with room with id "
+                            + assignmentData.room_id
                             + " and timeslot with id "
                             + timeslot_id
                             + " to schedule section with id "
@@ -261,8 +261,8 @@ function Matrix(
                         messagePanel.addMessage(errorMessage);
                     }
                     else {
-                        var errorMessage = "Error: Room "
-                            + assignmentData.room_name
+                        var errorMessage = "Error: Room with id "
+                            + assignmentData.room_id
                             + " appears to be unavailable during timeslot with id "
                             + timeslot_id
                             + " but section with id "
@@ -278,28 +278,28 @@ function Matrix(
 
 
     /**
-     * Gets the cell that represents room_name and timeslot_id.
+     * Gets the cell that represents room_id and timeslot_id.
      *
-     * @param room_name: The name of the room corresponding to the cell
+     * @param room_id: The id of the room corresponding to the cell
      * @param timeslot_id: The ID of the timeslot corresponding to the cell
      */
-    this.getCell = function(room_name, timeslot_id){
-        return this.cells[room_name][this.timeslots.get_by_id(timeslot_id).order];
+    this.getCell = function(room_id, timeslot_id){
+        return this.cells[room_id][this.timeslots.get_by_id(timeslot_id).order];
     };
 
 
     /**
-     * Checks a section we want to schedule in room_name during schedule_timeslots
+     * Checks a section we want to schedule in room_id during schedule_timeslots
      * to make sure the room is available during that time and the length is nonzero.
      *
      * Returns an object with property valid that is set to whether the assignment is valid
      * and reason which contains a message if valid is false.
      *
      * @param section: The section to validate.
-     * @param room_name: The name of the room we want to put the section into.
+     * @param room_id: The name of the room we want to put the section into.
      * @param schedule_timeslots: The array of timeslots we want to put the section into.
      */
-    this.validateAssignment = function(section, room_name, schedule_timeslots){
+    this.validateAssignment = function(section, room_id, schedule_timeslots){
         var result = {
             valid: true,
             reason: null,
@@ -318,7 +318,7 @@ function Matrix(
                     availableTimeslots.indexOf(schedule_timeslots[index]) == -1);
         };
 
-        var firstCell = this.getCell(room_name, schedule_timeslots[0]);
+        var firstCell = this.getCell(room_id, schedule_timeslots[0]);
         if (section.length <= 1 && !validateIndividualCell(0, firstCell)) {
             result.valid = false;
             result.reason = "first cell is not valid"
@@ -327,11 +327,11 @@ function Matrix(
 
         // Check to make sure all the cells are available
         for(var timeslot_index in schedule_timeslots){
-            var cell = this.getCell(room_name, schedule_timeslots[timeslot_index]);
+            var cell = this.getCell(room_id, schedule_timeslots[timeslot_index]);
             if (!validateIndividualCell(timeslot_index, cell)){
                 result.valid = false;
                 result.reason = "Error: timeslot" +  schedule_timeslots[timeslot_index] +
-                    " already has a class in " + room_name + "."
+                    " already has a class in " + room_id + "."
                 return result;
             }
         }
@@ -390,18 +390,18 @@ function Matrix(
         var room_ids = Object.keys(this.rooms);
         room_ids.sort(function (room1, room2) {
             // sort by building number
-            var bldg1 = parseInt(room1, 10);
-            var bldg2 = parseInt(room2, 10);
+            var bldg1 = parseInt(room1.text, 10);
+            var bldg2 = parseInt(room2.text, 10);
             if (!isNaN(bldg1) && !isNaN(bldg2) && bldg1 != bldg2) {
                 return bldg1 - bldg2;
             }
-            return room1.localeCompare(room2);
+            return rooms[room1].text.localeCompare(rooms[room2].text);
         });
         $j.each(this.rooms, function(id, room){
             room = this.rooms[id];
             var room_header = $j("<td>")
                 .addClass('room')
-                .text(id + " [" + room['num_students'] + "]")
+                .text(room.text + " [" + room['num_students'] + "]")
                 .attr('data-id', id);
             var row = $j("<tr></tr>");
             room_header.appendTo(row);

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Matrix.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Matrix.js
@@ -54,7 +54,7 @@ function Matrix(
             if(filterObject.type==="number") {
                 filterObject.val = parseInt(filterObject.val);
             } else if(filterObject.type==="string") {
-                filterObject.val = filterObject.val.replace(" ", "").toLowerCase()
+                filterObject.val = filterObject.val.toLowerCase()
             } else if(filterObject.type==="boolean") {
                 filterObject.val = filterObject.el.prop('checked');
             }

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Scheduler.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Scheduler.js
@@ -24,12 +24,18 @@ function Scheduler(
     // Populate data with resources
     $j.each(data.rooms, function(index, room) {
         room.resources = [];
+        room.resource_lines = [];
         $j.each(room.associated_resources, function(index, resource) {
             var resource_type = data.resource_types[resource.res_type_id];
             room.resources.push({
                 'resource_type': resource_type,
                 'value': resource.value,
             });
+            var desc = resource_type.name;
+            if(resource.value) {
+                desc += ': ' + resource.value;
+            }
+            room.resource_lines.push(desc);
         });
     });
 

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Scheduler.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Scheduler.js
@@ -131,7 +131,7 @@ function Scheduler(
         var cell = $j(evt.currentTarget).data("cell");
         if(this.sections.selectedSection) {
             this.sections.scheduleSection(this.sections.selectedSection,
-                                          cell.room_name, cell.timeslot_id);
+                                          cell.room_id, cell.timeslot_id);
         }
     }.bind(this));
 
@@ -141,7 +141,7 @@ function Scheduler(
 
    $j("body").on("mouseenter", "td.teacher-available-cell", function(evt, ui) {
         var cell = $j(evt.currentTarget).data("cell");
-        this.sections.scheduleAsGhost(cell.room_name, cell.timeslot_id);
+        this.sections.scheduleAsGhost(cell.room_id, cell.timeslot_id);
     }.bind(this));
 
     // Render all the objects on the page

--- a/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
+++ b/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
@@ -17,7 +17,6 @@
 <link id='sch_css' href='/media/default_styles/scheduling.css' type='text/css' rel='stylesheet' />
 <link id='tooltip_css' href='/media/default_styles/tooltips.css' type='text/css' rel='stylesheet' />
 <link rel="stylesheet" href='/media/default_styles/jquery-ui/jquery-ui.css'/>
-<link rel="stylesheet" type="text/css" href="/media/default_styles/scheduling.css" />
 <link rel="stylesheet" type="text/css" href="/media/scripts/ajaxschedulingmodule/lib/fixed_table_rc.css" />
 
 <!-- 3rd party -->
@@ -68,7 +67,8 @@
         <div id="side-panel" class="component-div ui-widget">
           <ul>
             <li><a href="#classes">Classes</a></li>
-            <li><a href="#filters">Filters</a></li>
+            <li><a href="#filters">Class Filters</a></li>
+            <li><a href="#filters2">Room Filters</a></li>
           </ul>
           <div id="side-panel-inner">
                 <div id="classes">
@@ -124,6 +124,28 @@
                     <div id="section-filter-unapproved">
                         <input id="section-filter-unapproved" type="checkbox"></input>
                         <label for="section-filter-unapproved">Hide unapproved classes</label>
+                    </div>
+                  </form>
+                </div>
+                <div id="filters2">
+                  <form>
+                    <label for="room-filter-capacity"><b>Room Capacity</b></label><br />
+                    <div id="room-filter-capacity">
+                        <label for="room-filter-capacity-min">Min:</label>
+                        <input id="room-filter-capacity-min" class="numeric"></input> Students
+                        <br />
+                        <label for="room-filter-capacity-max">Max:</label>
+                        <input id="room-filter-capacity-max" class="numeric"></input> Students
+                    </div>
+                    <br />
+                    <div id="room-filter-resource">
+                        <label for="room-filter-resource-text"><b>Resource</b></label><br />
+                        <input id="room-filter-resource-text"></input>
+                    </div>
+                    <br />
+                    <div id="room-filter-name">
+                        <label for="room-filter-name-text"><b>Name</b></label><br />
+                        <input id="room-filter-name-text"></input>
                     </div>
                   </form>
                 </div>


### PR DESCRIPTION
This adds a third tab to the ajax scheduler to allows you to filter classrooms by capacity 
(min/max), resources/values (regex), and name (regex). The classes that don't match the filters are hidden.

While I was at it, I fixed the problem where classrooms were stored as names instead of IDs. Since classrooms don't have true IDs, I used the minimum ID of the resources that make up the classroom. This should fix a lot of problems related to renaming classrooms during scheduling. I was going to modify the ajax change log models, but it doesn't really seem necessary for the amount of work required, so I kept the room field as `room_name` but now it will store the room's ID. This shouldn't be a problem.

Also, I'm pretty sure this will break the automatic scheduling assistant, but I honestly don't have enough experience with it to know what to adjust to fix it. I'd be happy to work with @jerrywu64 to integrate these changes.

Also also, I may have to fix some tests or the ajax scheduler spec, but I'm pushing for now to start the review process.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/1408.
Also fixes https://github.com/learning-unlimited/ESP-Website/issues/1391 and probably fixes https://github.com/learning-unlimited/ESP-Website/issues/2385.