### PR TITLE
Make clickable items more obvious and neater on /classsearch

### DIFF
--- a/esp/public/media/default_styles/flags.css
+++ b/esp/public/media/default_styles/flags.css
@@ -34,6 +34,8 @@ select.fqb-type {
 
 .fqr-class-header {
     font-size: 1.2em;
+    cursor: pointer;
+    padding: 5px;
 }
 
 .fqr-class-header.accepted {
@@ -48,12 +50,46 @@ select.fqb-type {
     background: #f7c6de;
 }
 
-.fqr-class-flags {
-    padding: 1px 0px
+.fqr-class-header:not(.active):after {
+    content: '\002B';
+    color: black;
+    font-weight: bold;
+    float: right;
 }
 
-.flag-name {
-    margin: 1px;
+.fqr-class-header.active:after {
+    content: '\2212';
+    color: black;
+    font-weight: bold;
+    float: right;
+}
+
+.fqr-class-flags {
+    padding: 4px;
+}
+
+.flag-header {
+    margin: 2px;
+    padding: 2px;
+    cursor: pointer;
+}
+
+.flag-header:not(.active) .flag-name:after {
+    content: '\002B';
+    font-weight: 900;
+}
+
+.flag-header.active .flag-name:after {
+    content: '\2212';
+    font-weight: 900;
+}
+
+.flag-detail {
+    cursor: pointer;
+}
+
+.flag-detail div {
+    padding: 2px;
 }
 
 .flag-detail table, .flag-detail form {
@@ -70,4 +106,13 @@ select.fqb-type {
 input.flag-submit-new {
     margin-left: auto;
     margin-right: 0px;
+}
+
+.flag-remove:after {
+    content: "\00d7";
+    font-weight: 900;
+}
+
+.flag-remove:hover {
+    color: white;
 }

--- a/esp/templates/program/modules/classflagmodule/flag_detail.html
+++ b/esp/templates/program/modules/classflagmodule/flag_detail.html
@@ -1,5 +1,5 @@
 <div class="flag-detail{% if flag.comment %} flag-has-comment{% endif %}" id="flag-detail-{{flag.id}}">
-    <div style="background: {{flag.flag_type.getColor}};" onclick="$j('#flag-detail-{{flag.id}}').toggle('blink');">{{flag.flag_type.name}}</div>
+    <div style="background: {{flag.flag_type.getColor}};" title="Click to toggle flag details" onclick="$j('#flag-detail-{{flag.id}}').toggle('blink');$j('#fqr-flag-header-{{flag.id}}').toggleClass('active');">{{flag.flag_type.name}}</div>
     <form method="post" class="flag-form" action="/manage/{{program.getUrlBase}}/editflag/{{flag.id}}/">{% csrf_token %}
         <table>
             <tbody>

--- a/esp/templates/program/modules/classflagmodule/flag_name.html
+++ b/esp/templates/program/modules/classflagmodule/flag_name.html
@@ -1,6 +1,14 @@
-<span class="flag-name"
+<span class="flag-header"
       id="fqr-flag-header-{{flag.id}}"
-      style="background: {{flag.flag_type.getColor}};"
-      onclick="$j('#flag-detail-{{flag.id}}').toggle('blink');">
-    {{flag.flag_type.name}}
+      style="background: {{flag.flag_type.getColor}};">
+    <span class="flag-name"
+          title="Click to toggle flag details"
+          onclick="$j('#flag-detail-{{flag.id}}').toggle('blink');$j('#fqr-flag-header-{{flag.id}}').toggleClass('active');">
+        {{flag.flag_type.name}}
+    </span>
+    <span class="flag-remove"
+          title="Click to remove flag"
+          onclick="removeFlag('/manage/{{program.getUrlBase}}/deleteflag/',{{flag.id}});">
+    </span>
 </span>
+

--- a/esp/templates/program/modules/classsearchmodule/class_search.html
+++ b/esp/templates/program/modules/classsearchmodule/class_search.html
@@ -53,8 +53,8 @@ Your query returned {{queryset|length}} of {{program.classsubject_set.count}} cl
 <div class="flag-query-results" id="program_form">
     {% for class in queryset %}
         <div class="fqr-class" id="fqr-class-{{class.id}}">
-            <div class="fqr-class-header {% if class.isReviewed %}{% if class.isAccepted %}accepted{% else %}rejected{% endif %}{% else %}unreviewed{% endif %}" onclick="$j(this).siblings('.fqr-class-detail').toggle('blink');">
-                {{class.emailcode}}: {{class.title}} <br/>
+            <div class="fqr-class-header {% if class.isReviewed %}{% if class.isAccepted %}accepted{% else %}rejected{% endif %}{% else %}unreviewed{% endif %}" title="Click to toggle class details" onclick="$j(this).siblings('.fqr-class-detail').toggle('blink');$j(this).toggleClass('active');">
+                {{class.emailcode}}: {{class.title}}
             </div>
             <div class="fqr-class-flags">
                 Flags: 


### PR DESCRIPTION
I added some annotations to the flag names to indicate that you can click them to expand the flag details. I also did the same for the class titles. I added little "x" buttons to the flag names that allow you to remove the flag without expanding the flag. Finally, I added a little more CSS to clean some things up and make them less cramped.

I am pretty sure this should not conflict with #2833.

Fixes #1375 and fixes #1356.