### PR TITLE
Specify number of unique items for a floating resource

### DIFF
--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -724,6 +724,7 @@ class Program(models.Model, CustomFormsLinkModel):
                 result[c.name].furnishings = c.associated_resources()
                 result[c.name].sequence = c.schedule_sequence(self)
                 result[c.name].prog_available_times = c.available_times_html(self)
+                result[c.name].num_items = c.number_duplicates()
             else:
                 result[c.name].timeslots.append(c.event)
 

--- a/esp/esp/resources/models.py
+++ b/esp/esp/resources/models.py
@@ -211,6 +211,13 @@ class Resource(models.Model):
         res_list = Resource.objects.filter(name=self.name)
         return res_list
 
+    def duplicates(self):
+        res_list = Resource.objects.filter(name=self.name, event = self.event)
+        return res_list
+
+    def number_duplicates(self):
+        return self.duplicates().count()
+
     def satisfies_requests(self, req_class):
         #   Returns a list of 2 items.  The first element is boolean and the second element is a list of the unsatisfied requests.
         #   If there are no unsatisfied requests but the room isn't big enough, the first element will be false.

--- a/esp/templates/program/modules/resourcemodule/classrooms.html
+++ b/esp/templates/program/modules/resourcemodule/classrooms.html
@@ -1,4 +1,4 @@
-{% ifequal open_section "restype" %}
+{% ifequal open_section "classroom" %}
 <button class="dsphead active">
    <b>Step 3: Classrooms</b> (click to expand/contract)
 </button>

--- a/esp/templates/program/modules/resourcemodule/equipment.html
+++ b/esp/templates/program/modules/resourcemodule/equipment.html
@@ -1,4 +1,4 @@
-{% ifequal open_section "restype" %}
+{% ifequal open_section "equipment" %}
 <button class="dsphead active">
    <b>Step 4: Floating Resources</b> (click to expand/contract)
 </button>
@@ -32,10 +32,11 @@
 </form>
 
 <table align="center" cellpadding="0" cellspacing="0" width="100%">
-    <tr><th colspan="2">Floating Resources for {{ prog.niceName }}</th></tr>
-    <tr><td colspan="2"><table cellpadding="0" cellspacing="0" width="100%">
+    <tr><th colspan="5">Floating Resources for {{ prog.niceName }}</th></tr>
+    <tr><td colspan="5"><table cellpadding="0" cellspacing="0" width="100%">
     <tr>
         <td class="underline"><b>Name</b></td>
+        <td class="underline"><b>Number</b></td>
         <td class="underline"><b>Type</b></td>
         <td class="underline"><b>Choice</b></td>
         <td class="underline"><b>Available Times</b></td>
@@ -47,6 +48,7 @@
                 <a href="/manage/{{ prog.url }}/resources/equipment?op=edit&id={{ r.id }}">[Edit]</a>
                 <a href="/manage/{{ prog.url }}/resources/equipment?op=delete&id={{ r.id }}">[Delete]</a>
             </td>
+            <td class="underline">{{ r.num_items }}</td>
             <td class="underline">{{ r.res_type.name }}{% if r.res_type.hidden %} (Hidden){% endif %}</td>
             <td class="underline">{{ r.attribute_value }}</td>
             <td class="underline">{% for t in r.timegroup %}{{ t }}<br />{% endfor %}</td>


### PR DESCRIPTION
This adds a field to the floating resources form that allows the user to specify the number of unique floating resources that will be available (e.g. 5 expo markers or 15 VGA cables). It doesn't change the models because it just makes that many duplicate resource objects for each of the specified timeslots. I also fixed a little HTML copy-paste bug I introduced in https://github.com/learning-unlimited/ESP-Website/pull/2817, so a resource section should always be open when using that specific resource section.

Fixes #2832.