### PR TITLE
Add flag, resource, and admin class filters to scheduler

### DIFF
--- a/esp/esp/program/modules/handlers/jsondatamodule.py
+++ b/esp/esp/program/modules/handlers/jsondatamodule.py
@@ -304,7 +304,8 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
                     'username': t.username,
                     'first_name': t.first_name,
                     'last_name': t.last_name,
-                    'sections': [s.id]
+                    'sections': [s.id],
+                    'is_admin': t.isAdmin()
                 }
                 teachers.append(teacher)
                 teacher_dict[t.id] = teacher

--- a/esp/public/media/default_styles/scheduling.css
+++ b/esp/public/media/default_styles/scheduling.css
@@ -114,7 +114,7 @@ input.numeric {
 }
 
 #side-panel {
-    height: 65%;
+    height: 61%;
     bottom: 0;
 }
 

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
@@ -28,6 +28,9 @@ function Sections(sections_data, section_details_data, teacher_data, scheduleAss
         gradeMax: {active: false, el: $j("input#section-filter-grade-max"), type: "number"},
         classTeacher: {active: false, el: $j("input#section-filter-teacher-text"), type: "string"},
         classHideUnapproved: {active: false, el: $j("input#section-filter-unapproved"), type: "boolean"},
+        classHasAdmin: {active: false, el: $j("input#section-filter-admin"), type: "boolean"},
+        classFlags: {active: false, el: $j("input#section-filter-flags-text"), type: "string"},
+        classResources: {active: false, el: $j("input#section-filter-resources-text"), type: "string"},
     };
     this.filter.classLengthMin.valid = function(a) {
         return Math.ceil(a.length) >= this.filter.classLengthMin.val;
@@ -56,8 +59,23 @@ function Sections(sections_data, section_details_data, teacher_data, scheduleAss
         }.bind(this));
         return result;
     }.bind(this);
+    this.filter.classHasAdmin.valid = function(a) {
+        var result = false;
+        $j.each(a.teacher_data, function(index, teacher) {
+            if(teacher.is_admin) {
+                result = true;
+            }
+        }.bind(this));
+        return result;
+    }.bind(this);
     this.filter.classHideUnapproved.valid = function(a) {
         return a.status > 0;
+    }.bind(this);
+    this.filter.classFlags.valid = function(a) {
+        return a.flags.toLowerCase().search(this.filter.classFlags.val)>-1;
+    }.bind(this);
+    this.filter.classResources.valid = function(a) {
+        return this.getResourceString(a).toLowerCase().search(this.filter.classResources.val)>-1;
     }.bind(this);
 
     $j.each(this.filter, function(filterName, filterObject) {
@@ -66,7 +84,7 @@ function Sections(sections_data, section_details_data, teacher_data, scheduleAss
             if(filterObject.type==="number") {
                 filterObject.val = parseInt(filterObject.val);
             } else if(filterObject.type==="string") {
-                filterObject.val = filterObject.val.replace(" ", "").toLowerCase()
+                filterObject.val = filterObject.val.toLowerCase()
             } else if(filterObject.type==="boolean") {
                 filterObject.val = filterObject.el.prop('checked');
             }

--- a/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
+++ b/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
@@ -92,7 +92,7 @@
                 </div>
                 <div id="filters">
                   <form>
-                    <div id="section-filter-unapproved">
+                    <div id="section-filter-unapproved-wrapper">
                         <input id="section-filter-unapproved" type="checkbox"></input>
                         <label for="section-filter-unapproved">Hide unapproved classes</label>
                     </div>
@@ -107,7 +107,7 @@
                     </div>
                     <br />
                     <label for="section-filter-capacity"><b>Class Capacity</b></label><br />
-                    <div id="section-filter-length">
+                    <div id="section-filter-capacity">
                         <label for="section-filter-capacity-min">Min:</label>
                         <input id="section-filter-capacity-min" class="numeric"></input> Students
                         <br />
@@ -116,7 +116,7 @@
                     </div>
                     <br />
                     <label for="section-filter-grade"><b>Class Grades</b></label><br />
-                    <div id="section-filter-length">
+                    <div id="section-filter-grade">
                         <label for="section-filter-grade-min">Min:</label>
                         <input id="section-filter-grade-min" class="numeric"></input>
                         <br />
@@ -128,7 +128,7 @@
                         <label for="section-filter-teacher-text"><b>Teacher</b></label><br />
                         <input id="section-filter-teacher-text"></input>
                     </div>
-                    <div id="section-filter-admin">
+                    <div id="section-filter-admin-wrapper">
                         <input id="section-filter-admin" type="checkbox"></input>
                         <label for="section-filter-admin">Has admin teacher</label>
                     </div>

--- a/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
+++ b/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
@@ -92,6 +92,11 @@
                 </div>
                 <div id="filters">
                   <form>
+                    <div id="section-filter-unapproved">
+                        <input id="section-filter-unapproved" type="checkbox"></input>
+                        <label for="section-filter-unapproved">Hide unapproved classes</label>
+                    </div>
+                    <br />
                     <label for="section-filter-length"><b>Class Length</b></label><br />
                     <div id="section-filter-length">
                         <label for="section-filter-length-min">Min:</label>
@@ -123,9 +128,19 @@
                         <label for="section-filter-teacher-text"><b>Teacher</b></label><br />
                         <input id="section-filter-teacher-text"></input>
                     </div>
-                    <div id="section-filter-unapproved">
-                        <input id="section-filter-unapproved" type="checkbox"></input>
-                        <label for="section-filter-unapproved">Hide unapproved classes</label>
+                    <div id="section-filter-admin">
+                        <input id="section-filter-admin" type="checkbox"></input>
+                        <label for="section-filter-admin">Has admin teacher</label>
+                    </div>
+                    <br />
+                    <div id="section-filter-flags">
+                        <label for="section-filter-flags-text"><b>Flag(s)</b></label><br />
+                        <input id="section-filter-flags-text"></input>
+                    </div>
+                    <br />
+                    <div id="section-filter-resources">
+                        <label for="section-filter-resources-text"><b>Resource(s)</b></label><br />
+                        <input id="section-filter-resources-text"></input>
                     </div>
                   </form>
                 </div>


### PR DESCRIPTION
This adds a few more class filters to the ajax scheduler, including a field to search flags, a field to search resources, and a checkbox to filter for classes that have at least one teacher that is an admin (suggested by @kkbrum).

Fixes https://github.com/learning-unlimited/ESP-Website/issues/1355