### PR TITLE
Update studentchecklist with record status

### DIFF
--- a/esp/templates/program/modules/programprintables/studentchecklist.html
+++ b/esp/templates/program/modules/programprintables/studentchecklist.html
@@ -40,8 +40,8 @@ body { font-family: georgia; }
    <th>Checked In?</th>
    <th>Paid?</th>
    <th>Amount Due</th>
-   <th>Med/Liability?</th>
-   <th>Agreement?</th>
+   <th>Medical Form?</th>
+   <th>Liability Form?</th>
    <th>Aid Status</th>
    <th>Name</th>
    <th>Email</th>
@@ -51,11 +51,11 @@ body { font-family: georgia; }
 {% for student in studentList %}
 <tr>
    <td>{{forloop.counter}}</td>
-   <td><div class="box">&nbsp;</div></td>
-   <td><div class="box">{{ student.paid }}</div></td>
+   <td><div class="box">{% if student.checked_in %}X{% endif %}</div></td>
+   <td><div class="box">{% if student.paid %}X{% endif %}</div></td>
    <td>${{ student.amount_due|floatformat:2 }}</td>
-   <td><div class="box">&nbsp;</div></td>
-   <td><div class="box">&nbsp;</div></td>
+   <td><div class="box">{% if student.med %}X{% endif %}</div></td>
+   <td><div class="box">{% if student.liab %}X{% endif %}</div></td>
    <td>{{ student.finaid }}</td>
    <td>{{ student.user.name }}</td>
    <td>{{ student.user.email}}</td>


### PR DESCRIPTION
This uses records to populate the student checklist in case any students have already submitted forms or been checked in (in the hopes that in the future, most of this will be through the website). This also allows the student checklist to be used after programs to see which users checked in/submitted forms/paid.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/2843