### PR TITLE
Show flag names on teacher checkin

### DIFF
--- a/esp/templates/program/modules/teachercheckinmodule/classdetail.html
+++ b/esp/templates/program/modules/teachercheckinmodule/classdetail.html
@@ -1,19 +1,3 @@
-{% if show_flags %}
-    <span>
-        <button class="add-flag btn">add flag</button>
-        <div class="flag-name-list">
-            {% for flag in class.flags.all %}
-                {% include "program/modules/classflagmodule/flag_name.html" %}
-            {% endfor %}
-        </div>
-    </span>
-{% endif %}
 <div class="section-detail-include">
     {% include "program/modules/classsearchmodule/class_detail.html" %}
 </div>
-{% if show_flags %}
-    {% for flag in class.flags.all %}
-        {% include "program/modules/classflagmodule/flag_detail.html" %}
-    {% endfor %}
-    {% include "program/modules/classflagmodule/new_flag_form.html" %}
-{% endif %}

--- a/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
+++ b/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
@@ -203,12 +203,28 @@
                 {{section.title}}
                 (<a href="{{section.get_absolute_url|urlencode}}">manage</a> | <a href="{{section.get_edit_absolute_url|urlencode}}">edit</a>)
             </div>
+            {% if show_flags %}
+                <div class="flag-name-list fqr-class-flags">
+                    {% for flag in section.parent_class.flags.all %}
+                        {% include "program/modules/classflagmodule/flag_name.html" %}
+                    {% endfor %}
+                </div>
+                <button class="add-flag btn">add flag</button>
+            {% endif %}
             <div class="section-detail-info"
                  style="display: none;"
                  data-class-id="{{section.parent_class.id}}"
                  data-show-flags="{% if show_flags %}1{% endif %}">
                 Loading...
             </div>
+            {% if show_flags %}
+                <div class="fqr-class-flags-detail">
+                    {% for flag in section.parent_class.flags.all %}
+                        {% include "program/modules/classflagmodule/flag_detail.html" %}
+                    {% endfor %}
+                    {% include "program/modules/classflagmodule/new_flag_form.html" %}
+                </div>
+            {% endif %}
         </div>
     </td>
 </tr>


### PR DESCRIPTION
Originally, the flag names were hidden until the class name was clicked. This makes them shown all the time, and clicking them now shows the details (without the rest of the class details needing to shown).

Fixes https://github.com/learning-unlimited/ESP-Website/issues/1467.