### PR TITLE
Class flags printable

### DIFF
--- a/esp/esp/program/modules/handlers/programprintables.py
+++ b/esp/esp/program/modules/handlers/programprintables.py
@@ -36,7 +36,7 @@ from esp.program.modules.base import ProgramModuleObj, needs_admin, needs_onsite
 from esp.utils.web import render_to_response
 from esp.users.models    import ESPUser, User
 from esp.program.models  import ClassSubject, ClassSection, StudentRegistration
-from esp.program.models  import ClassFlagType, ClassFlag
+from esp.program.models  import ClassFlagType
 from esp.program.models.class_ import ACCEPTED
 from esp.users.views     import search_for_user
 from esp.users.controllers.usersearch import UserSearchController
@@ -373,12 +373,18 @@ class ProgramPrintables(ProgramModuleObj):
 
         for cls in classes:
             flags = cls.flags.all()
-            type_dict = {flag.flag_type:flag for flag in flags}
+            type_dict = {}
+            for flag in flags:
+                if flag.flag_type in type_dict:
+                    type_dict[flag.flag_type].append(flag)
+                else:
+                    type_dict[flag.flag_type] = [flag]
             cls.flag_list = []
             for type in flag_types:
                 if type in type_dict.keys():
-                    if type_dict[type].comment and comments:
-                        cls.flag_list.append(type_dict[type].comment)
+                    comms = [flag.comment for flag in type_dict[type] if flag.comment]
+                    if len(comms) > 0 and comments:
+                        cls.flag_list.append(comms)
                     else:
                         cls.flag_list.append(True)
                 else:

--- a/esp/templates/program/modules/classsearchmodule/class_search.html
+++ b/esp/templates/program/modules/classsearchmodule/class_search.html
@@ -49,6 +49,11 @@ Your query returned {{queryset|length}} of {{program.classsubject_set.count}} cl
     <a class="btn btn-reject" href="./classesbytime?clsids={{ IDs|join:',' }}" target="_blank">spreadsheet (by time)</a>
 </div>
 </br>
+<div class="btn-group">
+    <a class="btn btn-approve" href="./classflagdetails?clsids={{ IDs|join:',' }}" target="_blank">class flags</a>
+    <a class="btn btn-unreview" href="./classflagdetails?comments&clsids={{ IDs|join:',' }}" target="_blank">class flags (with comments)</a>
+</div>
+</br>
 
 <div class="flag-query-results" id="program_form">
     {% for class in queryset %}

--- a/esp/templates/program/modules/programprintables/classes_flags.html
+++ b/esp/templates/program/modules/programprintables/classes_flags.html
@@ -1,0 +1,51 @@
+<html>
+<head>
+<title>Class Flags for {{ program.niceName }}</title>
+<style type="text/css" media="print,screen">
+body { font-family: georgia; margin: 0; font-size: 12px;}
+.title { text-align: center; font-size: 12pt; font-family: georgia; }
+.title span { font-weight:bolder; text-decoration: underline;
+              font-size:16pt; }
+.title { padding: 1in 0 0 0; }
+td, th {
+       border: 1px solid black; 
+       border-collapse: collapse
+}
+table.sortable thead {
+    background-color:#eee;
+    color:#666666;
+    font-weight: bold;
+    cursor: default;
+}
+</style>
+<script src="/media/scripts/sorttable.js"></script>
+
+</head>
+<body>
+{% load main %}
+
+<table class="sortable" style="border: 1px solid black; border-collapse: collapse;">
+<tr>
+ <!-- <th>#</th> -->
+ <th>Class Code</th>
+ <th>Class Title</th>
+ <th>Teachers</th>
+ {% for type in flag_types %}
+ <th>{{ type.name }}</th>
+ {% endfor %}
+</tr>
+{% for cls in classes %}
+<tr>
+ <!-- <td>{{ forloop.counter }}</td> -->
+ <td sorttable_customkey="{{ cls.id }}">{{ cls.emailcode }}</td>
+ <td>{{ cls.title }}</td>
+ <td>{% for teacher in cls.teachers.all %}{% if teacher.id == cls.split_teacher.id %}<b>{% endif %}{{ teacher.name_last_first }}{% if teacher.id == cls.split_teacher.id %}</b>{% endif %}{% if not forloop.last %}; {% endif %}{% endfor %}</td>
+ {% for flag in cls.flag_list %}
+ <td sorttable_customkey="{% if flag %}{% if flag != True %}1{% else %}2{% endif %}{% else %}3{% endif %}">{% if flag %}{% if flag != True %}{{ flag }}{% else %}&#10003;{% endif %}{% else %}&#10005;{% endif %}</td>
+ {% endfor %}
+</tr>
+{% endfor %}
+</table>
+
+</body>
+</html>

--- a/esp/templates/program/modules/programprintables/classes_flags.html
+++ b/esp/templates/program/modules/programprintables/classes_flags.html
@@ -41,7 +41,7 @@ table.sortable thead {
  <td>{{ cls.title }}</td>
  <td>{% for teacher in cls.teachers.all %}{% if teacher.id == cls.split_teacher.id %}<b>{% endif %}{{ teacher.name_last_first }}{% if teacher.id == cls.split_teacher.id %}</b>{% endif %}{% if not forloop.last %}; {% endif %}{% endfor %}</td>
  {% for flag in cls.flag_list %}
- <td sorttable_customkey="{% if flag %}{% if flag != True %}1{% else %}2{% endif %}{% else %}3{% endif %}">{% if flag %}{% if flag != True %}{{ flag }}{% else %}&#10003;{% endif %}{% else %}&#10005;{% endif %}</td>
+ <td sorttable_customkey="{% if flag %}{% if flag != True %}1{% else %}2{% endif %}{% else %}3{% endif %}">{% if flag %}{% if flag != True %}{{ flag|join:"; " }}{% else %}&#10003;{% endif %}{% else %}&#10005;{% endif %}</td>
  {% endfor %}
 </tr>
 {% endfor %}

--- a/esp/templates/program/modules/programprintables/options.html
+++ b/esp/templates/program/modules/programprintables/options.html
@@ -114,6 +114,7 @@ Please select from options below.
 <li><a href="./all_classes_spreadsheet" title="All Classes Spreadsheet">All Classes Spreadsheet</a> (CSV format; opens in most spreadsheet programs)</li>
 <li><a href="./oktimes_spr" title="Viable Times for Classes">Viable Times for Sections Spreadsheet</a> (CSV format; 'X' indicates a viable time)</li>
 <li><a href="./classpopularity" title="Class Popularity">Class Subject Popularity</a></li>
+<li><a href="./classflagdetails" title="Class Flags">Class Flags</a> (<a href="./classflagdetails?comments">with comments</a>)</li>
 </ul>
 
 <p>


### PR DESCRIPTION
I made a new printable for classes that has a column for each of the potential flag types for a program. If "comments" is specified as a GET parameter, comments are shown for flags with comments, otherwise checks and x's are shown. As with other class printables, you can also specify specific "clsids" or class statuses ("accepted", "cancelled", "all", "scheduled") to filter the classes that are shown. I've linked to the printable on the "All Printables" and "Class Search" pages.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/1357.