### PR TITLE
Catalog errors

### DIFF
--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -1096,10 +1096,10 @@ class ClassSection(models.Model):
             return eventList[0]
 
     def isFull(self, ignore_changes=False):
-        if (self.num_students() == self._get_capacity(ignore_changes) == 0):
-            return False
-        elif len(self.get_meeting_times()) == 0:
+        if len(self.get_meeting_times()) == 0:
             return True
+        elif (self.num_students() == self._get_capacity(ignore_changes) == 0):
+            return False
         else:
             return (self.num_students() >= self._get_capacity(ignore_changes))
 

--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -1098,6 +1098,8 @@ class ClassSection(models.Model):
     def isFull(self, ignore_changes=False):
         if (self.num_students() == self._get_capacity(ignore_changes) == 0):
             return False
+        elif len(self.get_meeting_times()) == 0:
+            return True
         else:
             return (self.num_students() >= self._get_capacity(ignore_changes))
 
@@ -1574,7 +1576,7 @@ class ClassSubject(models.Model, CustomFormsLinkModel):
         else:
             sections = self.get_sections()
         for s in sections:
-            if len(s.get_meeting_times()) > 0 and not s.isFull(ignore_changes=ignore_changes):
+            if not s.isFull(ignore_changes=ignore_changes):
                 return False
         return True
 

--- a/esp/esp/program/templatetags/class_render.py
+++ b/esp/esp/program/templatetags/class_render.py
@@ -92,7 +92,12 @@ def _render_class_helper(cls, user=None, filter=False, timeslot=None):
 
     show_class = (not filter) or (not errormsg)
 
+    # Allow tag configuration of whether class descriptions get collapsed
+    # when the class is full (default: yes)
+    collapse_full = Tag.getBooleanTag('collapse_full_classes', cls.parent_program, True)
+
     return {'class':      cls,
+            'collapse_full': collapse_full,
             'section':    section,
             'user':       user,
             'prereg_url': prereg_url,

--- a/esp/public/media/default_styles/catalog.css
+++ b/esp/public/media/default_styles/catalog.css
@@ -152,14 +152,16 @@ input.addbutton_added {
 }
 
 input.addbutton_disabled {
-    color: #ffffff;
-    background-color: #ed1c24;
+    color: #000000;
+    background-color: #ffcccc;
     border: 0px solid black;
     font-weight: bold;
-    font-size: 0.9em;
+    font-size: 1.0em;
     padding: 3px;
+    margin: 0px !important;
     width: 100%;
     font-family: Helvetica, Arial, sans-serif;
+    border-radius: 0px;
 }
 
 input .addbutton_error {
@@ -172,4 +174,5 @@ input .addbutton_error {
     margin: 0px !important;
     width: 100%;
     font-family: Helvetica, Arial, sans-serif;
+    border-radius: 0px;
 }

--- a/esp/templates/inclusion/program/class_catalog.html
+++ b/esp/templates/inclusion/program/class_catalog.html
@@ -40,10 +40,16 @@
                       <form id="prereg_{{ sec.id }}" name="prereg_{{ sec.id }}" method="post" action="{{ prereg_url }}" style="margin: 0px;">
                       <script type="text/javascript">add_csrf_token();</script>
                       <input type="hidden" name="class_id" value="{{ class.id }}" />
-                      <input type="hidden" name="section_id" value="{{ sec.id }}" />
+                      <input type="hidden" name="section_id" value="{{ sec.id }}" />                      
                       <div id="addbutton_catalog_sec{{ sec.id }}">
-                      <input type="submit" class="addbutton" name="action" value="Register for section {{ sec.index }} (Please choose just one section)" />
-                      <!--                      <input type="submit" class="addbutton" name="action" value="Register for section {{ sec.index }}" onclick="return submit_prereg({{ sec.id }});" id="submitbutton{{ sec.id }}" /> -->
+                      {% if not sec.isFull %}
+                          <input type="submit" class="addbutton" name="action" value="Register for section {{ sec.index }} (Please choose just one section)" />
+                          <!--                      <input type="submit" class="addbutton" name="action" value="Register for section {{ sec.index }}" onclick="return submit_prereg({{ sec.id }});" id="submitbutton{{ sec.id }}" /> -->
+                      {% elif not class.isFullOrClosed %}
+                          <input type="submit" class="addbutton_disabled" name="action" value="Section {{ sec.index }} is full; check other sections of this class" id="submitbutton{{ sec.id }}" disabled />
+                      {% else %}
+                          <input type="submit" class="addbutton_disabled" name="action" value="Section {{ sec.index }} is full; please check back later" id="submitbutton{{ sec.id }}" disabled />
+                      {% endif %}
                       </div>
                       </form>
                   {% endif %}

--- a/esp/templates/inclusion/program/class_catalog.html
+++ b/esp/templates/inclusion/program/class_catalog.html
@@ -83,4 +83,12 @@
     setTimeout(initialize_prereg_{{ class.id }}, Math.random()*1000);
   }
   </script>
+  {% if collapse_full %}
+  {% if class.isFull or class.isRegClosed %}
+  <!-- This class is already full; hide any buttons -->
+  <script type="text/javascript">
+  swap_visible('class_{{ class.id }}_regbuttons');
+  </script>
+  {% endif %}
+  {% endif %}
 {% endif %}

--- a/esp/templates/inclusion/program/class_catalog.html
+++ b/esp/templates/inclusion/program/class_catalog.html
@@ -90,7 +90,7 @@
   }
   </script>
   {% if collapse_full %}
-  {% if class.isFull or class.isRegClosed %}
+  {% if class.isFullOrClosed %}
   <!-- This class is already full; hide any buttons -->
   <script type="text/javascript">
   swap_visible('class_{{ class.id }}_regbuttons');

--- a/esp/templates/inclusion/program/class_catalog_core.html
+++ b/esp/templates/inclusion/program/class_catalog_core.html
@@ -124,7 +124,7 @@
     </div>
     
 {% if collapse_full %}
-{% if class.isFull or class.isRegClosed %}
+{% if isFullOrClosed %}
 <!-- This class is already full; start it off as invisible -->
 <script type="text/javascript">
 swap_visible('class_{{ class.id }}_content');

--- a/esp/templates/inclusion/program/class_catalog_core.html
+++ b/esp/templates/inclusion/program/class_catalog_core.html
@@ -2,7 +2,7 @@
           {% if class.got_index_qsd %}
            <a href="Classes/{{ class.emailcode }}/index.html">{% if show_emailcodes %}{{ class.emailcode }}: {% endif %}{{ class.title|escape }}</a>
           {% else %}
-           {% if show_emailcodes %}{{ class.emailcode }}: {% endif %}{{ class.title|escape }} {% if class.hasScheduledSections and class.isFull and collapse_full %}<font color="#990000" style="font-size: 14px">Full!</font>{% else %}{% if class.isRegClosed %}<font color="#990000" style="font-size: 14px">Closed!</font>{% endif %}{% endif %}
+           {% if show_emailcodes %}{{ class.emailcode }}: {% endif %}{{ class.title|escape }} {% if class.hasScheduledSections and collapse_full %}{% if class.isFull %}<font color="#990000" style="font-size: 14px">Full!</font>{% elif class.isRegClosed %}<font color="#990000" style="font-size: 14px">Closed!</font>{% elif class.isFullOrClosed %}<font color="#990000" style="font-size: 14px">Full/Closed!</font>{% endif %}{% endif %}
           {% endif %}
 	 </div>
      <div class="class_subtitle_row">
@@ -124,7 +124,7 @@
     </div>
     
 {% if collapse_full %}
-{% if isFullOrClosed %}
+{% if class.isFullOrClosed %}
 <!-- This class is already full; start it off as invisible -->
 <script type="text/javascript">
 swap_visible('class_{{ class.id }}_content');


### PR DESCRIPTION
This fixes a couple of error-message-related things in the catalog:

1. Hide all registration buttons if an entire class is full/closed (if `collapse_full` is `True`)
2. Hide a class (and its buttons) if a class `isFullOrClosed` (if `collapse_full` is `True`)
3. An unscheduled section is now considered "Full"
4. Error messages all now have the same styling
5. Registration buttons are disabled with an error message if a section is Full/Closed. If there are other sections that are still open/not full, the message suggests students enroll in them.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/1461.