### PR TITLE
Admin page to monitor emails

### DIFF
--- a/esp/esp/program/modules/handlers/commmodule.py
+++ b/esp/esp/program/modules/handlers/commmodule.py
@@ -123,7 +123,8 @@ class CommModule(ProgramModuleObj):
                                                'body': body,
                                                'renderedtext': renderedtext})
 
-    def approx_num_of_recipients(self, filterObj, sendto_fn):
+    @staticmethod
+    def approx_num_of_recipients(filterObj, sendto_fn):
         """
         Approximates the number of recipients of a message, given the filter
         and the sendto function.

--- a/esp/esp/program/urls.py
+++ b/esp/esp/program/urls.py
@@ -15,6 +15,7 @@ urlpatterns = [
     url(r'^manage/unenroll_student/?$', views.unenroll_student),
     url(r'^manage/usersearch/?$', views.usersearch),
     url(r'^manage/flushcache/?$', views.flushcache),
+    url(r'^manage/emails/?$', views.emails),
     url(r'^manage/statistics/?$', views.statistics),
     url(r'^manage/preview/?$', views.template_preview),
     url(r'^manage/mergeaccounts/?$', esp.users.views.merge.merge_accounts),

--- a/esp/esp/program/views.py
+++ b/esp/esp/program/views.py
@@ -728,7 +728,7 @@ def emails(request):
     else:
         start_date = datetime.date.today() - datetime.timedelta(30)
     requests = MessageRequest.objects.filter(created_at__gte=start_date).order_by('-created_at')
-    
+
     requests_list = []
     for req in requests:
         toes = TextOfEmail.objects.filter(created_at=req.created_at,
@@ -744,7 +744,7 @@ def emails(request):
         else:
             req.finished_at = "(Not finished)"
         requests_list.append(req)
-    
+
     context['requests'] = requests_list
 
     return render_to_response('admin/emails.html', request, context)

--- a/esp/esp/program/views.py
+++ b/esp/esp/program/views.py
@@ -64,9 +64,11 @@ from esp.program.forms import ProgramCreationForm, StatisticsQueryForm
 from esp.program.setup import prepare_program, commit_program
 from esp.program.controllers.confirmation import ConfirmationEmailController
 from esp.program.modules.handlers.studentregcore import StudentRegCore
+from esp.program.modules.handlers.commmodule import CommModule
 from esp.middleware import ESPError
 from esp.accounting.controllers import ProgramAccountingController, IndividualAccountingController
 from esp.accounting.models import CybersourcePostback
+from esp.dbmail.models import MessageRequest, TextOfEmail
 from esp.mailman import create_list, load_list_settings, apply_list_settings, add_list_members
 from esp.resources.models import ResourceType
 from esp.tagdict.models import Tag
@@ -712,6 +714,40 @@ def flushcache(request):
 
     return render_to_response('admin/cache_flush.html', request, context)
 
+@admin_required
+def emails(request):
+    """
+    View that displays information for recent email requests.
+    GET data:
+      'start_date' (optional):  Starting date to filter email requests by.
+                                Should be given in the format "%m/%d/%Y".
+    """
+    context = {}
+    if request.GET and "start_date" in request.GET:
+        start_date = datetime.datetime.strptime(request.GET["start_date"], "%m/%d/%Y")
+    else:
+        start_date = datetime.date.today() - datetime.timedelta(30)
+    requests = MessageRequest.objects.filter(created_at__gte=start_date).order_by('-created_at')
+    
+    requests_list = []
+    for req in requests:
+        toes = TextOfEmail.objects.filter(created_at=req.created_at,
+                                          subject = req.subject,
+                                          send_from = req.sender).order_by('sent')
+        if req.processed:
+            req.num_rec = toes.count()
+        else:
+            req.num_rec = CommModule.approx_num_of_recipients(req.recipients, req.get_sendto_fn())
+        req.num_sent = sum(toe.sent is not None for toe in toes)
+        if req.num_rec == req.num_sent:
+            req.finished_at = toes[0].sent
+        else:
+            req.finished_at = "(Not finished)"
+        requests_list.append(req)
+    
+    context['requests'] = requests_list
+
+    return render_to_response('admin/emails.html', request, context)
 
 @admin_required
 def statistics(request, program=None):

--- a/esp/templates/admin/emails.html
+++ b/esp/templates/admin/emails.html
@@ -1,0 +1,104 @@
+{% extends "main.html" %}
+
+{% block title %}Monitor Emails{% endblock %}
+{% block content_title %}Monitor Emails{% endblock %}
+
+{% block stylesheets %}
+{{ block.super }}
+<style>
+table.emails-table {
+  border: 1px solid black;
+}
+  
+table {
+  width: 100%;
+  table-layout: fixed;
+  word-wrap: break-word;
+  border-collapse: collapse;
+}
+
+th {
+  background: black;
+  color: white;
+}
+
+tr.email-header > th, tr.email-header > td {
+  border-bottom: 1px solid #ddd;
+}
+
+th, td {
+  padding-top: 5px;
+  padding-left: 5px;
+  padding-bottom: 5px;
+  padding-right: 5px;
+}
+
+tr.email-header:hover {
+  background-color: #f5f5f5;
+}
+
+tr.email-details {
+  display: none;
+  border-left: 1px solid #ddd;
+  border-right: 1px solid #ddd;
+  border-bottom: 1px solid #ddd;
+}
+</style>
+{% endblock %}
+
+{% block content %}
+
+<p>This page lets you monitor emails that have been sent through the website via a program's comm panel within the last month.</p>
+<p>You can extend the search by appending "?start_date=MM/DD/YYYY" to the URL.</p>
+<p>If you notice any problems (emails aren't getting processed, emails won't send, emails are not sent to everyone, etc.), please contact <a href="mailto:websupport@learningu.org">websupport</a>.</p>
+
+{% if not requests %}
+<p>There are no emails to monitor.</p>
+{% else %}
+<p>Click on a row for more details:</p>
+<table class="emails-table">
+    <tr>
+        <th style="width:5%;"></th>
+        <th style="width:50%;">Subject</th>
+        <th>Request Processed</th>
+        <th># Recipients</th>
+        <th># Emails Sent</th>
+    </tr>
+    {% for req in requests %}
+        <tr class="email-header">
+            <td>+</td>
+            <td><b>{{ req.subject }}</b></td>
+            <td style="text-align:center;">{% if req.processed %}&#10003;{% else %}&#10005;{% endif %}</td>
+            <td style="text-align:center;">{{ req.num_rec }}</td>
+            <td style="text-align:center;">{{ req.num_sent }}</td>
+        </tr>
+        <tr class="email-details">
+            {% autoescape off %}
+            <td colspan="3" style="vertical-align:top;">{{ req.msgtext }}</td>
+            {% endautoescape %}
+            <td colspan="2" style="vertical-align:top;padding:0;"><table>
+                <tr><td><i>Sent by:</i><br /><a href="/manage/userview?username={{ req.creator|urlencode }}">{{ req.creator }}</a></td></tr>
+                <tr><td><i>Sending address:</i><br />{{ req.sender }}</td></tr>
+                <tr><td><i>Created at:</i><br />{{ req.created_at }}</td></tr>
+                <tr><td><i>Finished at:</i><br />{{ req.finished_at }}</td></tr>
+            </table></td>
+        </tr>
+    {% endfor %}
+</table>
+{% endif %}
+
+<script>
+$j(function() {
+    $j("tr.email-header").click(function(event) {
+        var $target = $j(event.target).parent("tr.email-header");
+        $target.next("tr").toggle();
+        if ($target.find("td:first").html() == "+") {
+            $target.find("td:first").html("-");
+        } else {
+            $target.find("td:first").html("+");
+        }
+    });
+});
+</script>
+
+{% endblock %}


### PR DESCRIPTION
This adds a page that admins can use to more easily (and quickly) monitor email requests that have been sent through the comm panel. It includes information about the email request (subject, text, sender), whether the request has been processed, how many recipients there are/will be, and how many emails have been sent so far.

By default the view only pulls email requests from the last 30 days, but that can be overrided with the `start_date` GET parameter (as described in the template).

Fixes https://github.com/learning-unlimited/ESP-Website/issues/2626.