### PR TITLE
Student schedules with barcodes

### DIFF
--- a/esp/templates/program/modules/programprintables/studentschedule.tex
+++ b/esp/templates/program/modules/programprintables/studentschedule.tex
@@ -71,7 +71,7 @@ Student Schedule for \\
 {% for cls in student.classes %}\hline
 {% if cls.friendly_times|length_is:"0" %}N/A{% endif %}{{ cls.friendly_times|join:", " }} \newline
 \footnotesize{ {% if cls.initial_rooms|length_is:0 %}N/A{% else %}{{ cls.prettyrooms.0|texescape }}{% endif %} } &
-{% if cls.title|length_is:"0" %}N/A{% endif %} {{ cls.title|truncatewords_char:45|texescape }} \newline
+{% if cls.event_type.description == "Compulsory" %}{{ cls.description }}{% elif cls.title|length_is:"0" %}N/A{% else %}{{ cls.title|truncatewords_char:45|texescape }}{% endif %} \newline
 \footnotesize{ {{ cls.parent_class.getTeacherNames|join:", "|truncatewords_char:50|texescape }} }  &
 \texttt{% templatetag openbrace %}{{ cls.emailcode }}{% templatetag closebrace %} \\
 {% endfor %}\hline

--- a/esp/templates/program/modules/programprintables/studentschedule.tex
+++ b/esp/templates/program/modules/programprintables/studentschedule.tex
@@ -79,16 +79,16 @@ Student Schedule for \\
 
 \end{center}
 
-\begin{center}	
-\begin{tabularx}{17cm}{X c}	
-\multicolumn{2}{c}{\small	
-\textit{Please see your map for building directions, or ask anyone for help.}	
-\normalsize } \\	
-\multicolumn{2}{c}{\small	
-\textit{If you are not signed up for a full day of classes, we encourage you to add more!}	
-\normalsize } \\	
-~ & ~ 	
-\end{tabularx}	
+\begin{center}
+\begin{tabularx}{17cm}{X c}
+\multicolumn{2}{c}{\small
+\textit{Please see your map for building directions, or ask anyone for help.}
+\normalsize } \\
+\multicolumn{2}{c}{\small
+\textit{If you are not signed up for a full day of classes, we encourage you to add more!}
+\normalsize } \\
+~ & ~
+\end{tabularx}
 \end{center}
 
 

--- a/esp/templates/program/modules/programprintables/studentschedule.tex
+++ b/esp/templates/program/modules/programprintables/studentschedule.tex
@@ -79,6 +79,18 @@ Student Schedule for \\
 
 \end{center}
 
+\begin{center}	
+\begin{tabularx}{17cm}{X c}	
+\multicolumn{2}{c}{\small	
+\textit{Please see your map for building directions, or ask anyone for help.}	
+\normalsize } \\	
+\multicolumn{2}{c}{\small	
+\textit{If you are not signed up for a full day of classes, we encourage you to add more!}	
+\normalsize } \\	
+~ & ~ 	
+\end{tabularx}	
+\end{center}
+
 
 {% if not forloop.last %}\pagebreak{% endif %}
 {% endfor %}

--- a/esp/templates/program/modules/programprintables/studentschedule.tex
+++ b/esp/templates/program/modules/programprintables/studentschedule.tex
@@ -1,85 +1,84 @@
-{% autoescape off %}
-{% load latex %}
-\documentclass[landscape,letterpaper,12pt]{article}
+{% autoescape off %} {% load latex %} {% load main %}
+\documentclass[letterpaper,12pt]{article}
+\usepackage[left=.75in,top=1in,bottom=.75in,right=.75in]{geometry}
 \usepackage[utf8]{inputenc}
-\usepackage{fullpage}
-\usepackage{textpos}
+\usepackage{multicol}
+\usepackage{fancyhdr}
+\usepackage{pst-barcode}
 \usepackage{tabularx}
-\usepackage{graphicx}
-\usepackage{color}
-\usepackage{colortbl}
 \usepackage{array}
+\usepackage{setspace}
 \usepackage{amsfonts, amsmath, amsthm, amssymb}
-\usepackage[left=.5in,top=1cm,right=.5in]{geometry}
-\graphicspath{% templatetag openbrace %}{% templatetag openbrace %}{{ PROJECT_ROOT }}templates/program/modules/programprintables/{% templatetag closebrace %}{% templatetag closebrace %}
-\graphicspath{% templatetag openbrace %}{% templatetag openbrace %}{{ MEDIA_ROOT }}uploaded/{% templatetag closebrace %}{% templatetag closebrace %}
+\usepackage[code=Code39,X=.5mm,ratio=2.25,H=2cm]{makebarcode}
 
-\pagestyle{empty}
-\renewcommand*\arraystretch{1.5}
-\newcolumntype{+}{>{\global \let \currentrowstyle \relax }}
-\newcolumntype{^}{>{\currentrowstyle }}
-\newcommand{\rowstyle}[1]{\gdef \currentrowstyle{#1} #1\ignorespaces}
-\setlength{\parindent}{0pt}
-\setlength{\parskip}{0pt}
+\pagestyle{fancy}
+\fancyhead[C]{\Huge \textsf{\textbf{ {{ program.niceName }} } }}
+\setlength\headheight{16pt}
+\renewcommand{\headrulewidth}{3pt}
+\renewcommand{\footrulewidth}{0pt}
+\fancyfoot{}
+
+\newcommand{\nameblock}{}
+\newcommand{\barcodeblock}{}
 
 \begin{document}
 {% for student in students %}
-~\\
-\vspace*{0.25in}
-\begin{center}
-\begin{tabularx}{17cm}{X r}
-\noindent
-{% spaceless %}
-\begin{minipage}[b]{6in}
-\Huge\textbf{% templatetag openbrace %}{{ student.first_name|texescape }} {{ student.last_name|texescape }} $\bullet$ Grade {{ student.getGrade|texescape }} } \\
- \Large \textbf{ User name: {{ student.username|texescape }} $\bullet$ ID: {{ student.id }} } \\
-\end{minipage}
-{% endspaceless %}
-&
-%\includegraphics[width=0.6in]{splogol}
-\vspace{0.25in}
+\renewcommand{\nameblock}{
+\textbf{Name: {{ student.name|texescape }} \\
+Username: {{ student.username|texescape }} \\
+User ID: {{ student.id }} \\
+}
+}
 
-\end{tabularx}
+\renewcommand{\barcodeblock}{
+\barcode{% templatetag openbrace %}{{ student.id }}{% templatetag closebrace %}
+}
+
+\begin{multicols}{3}
+
+\begin{flushleft}
+\nameblock
+\vspace{1ex} \hrule \vspace{1ex}
+\textbf{Amount Owed: \fbox{\${{ student.itemizedcosttotal|floatformat:"-2" }} } }
+\end{flushleft}
+
+\columnbreak
+\begin{center}
+Student Schedule for \\
+
+\begin{spacing}{1}
+\LARGE \bfseries {{ student.name|texescape }}
+\end{spacing}
+
 \end{center}
 
+\columnbreak
 
+\begin{flushright}
+\barcodeblock
+\end{flushright}
 
-\normalsize
+\end{multicols}
+
+\renewcommand\tabularxcolumn[1]{m{#1}}
 
 \begin{center}
-\begin{tabularx}{17cm}{|X|p{1.5in}|m{3.63in}|}
+{\large \textbf{Class Schedule} \\}
+\vspace{0.25cm}
+\begin{tabularx}{\textwidth}{|m{1.7in}|X|m{0.55in}|}
 \hline
-\multicolumn{3}{c}{
-\rowstyle{\color{white}\cellcolor{black} } 
-\textbf{Class Schedule for {{ student.name|texescape }} } }  \\
-\multicolumn{1}{|c|}{\textbf{Class Time} } & \textbf{Room} & \multicolumn{1}{c|}{\textbf{Class} } \\
+\textbf{Time and Room} & \textbf{Class and Teacher} & \textbf{Code} \\
 {% for cls in student.classes %}\hline
-{% ifequal cls.event_type.description "Compulsory" %}
-  \multicolumn{1}{|c|}{ {{ cls.start|date:"f" }} -- {{ cls.end|date:"f A" }} } & \multicolumn{2}{|c|}{ \textbf{\textit{ {{ cls.description }} } } }
-{% else %}
-  {% ifequal cls.event_type.description "Class" %}
-  \multicolumn{1}{|c|}{ {{ cls.start|date:"f" }} -- {{ cls.end|date:"f A" }} } & \multicolumn{2}{c|}{[NO CLASS]}
-  {% else %}
-  \multicolumn{1}{|c|}{ {{ cls.time_blocks.0.start|date:"f" }} -- {{ cls.time_blocks.0.end|date:"f A" }} } & {% if cls.initial_rooms|length_is:0 %}N/A{% else %}{{ cls.prettyrooms|join:", "|texescape }}{% endif %} & {{ cls.emailcode }}: {{ cls.title|truncatewords:5|texescape }}
-  {% endifequal %}
-{% endifequal %}
-\\ 
+{% if cls.friendly_times|length_is:"0" %}N/A{% endif %}{{ cls.friendly_times|join:", " }} \newline
+\footnotesize{ {% if cls.initial_rooms|length_is:0 %}N/A{% else %}{{ cls.prettyrooms.0|texescape }}{% endif %} } &
+{% if cls.title|length_is:"0" %}N/A{% endif %} {{ cls.title|truncatewords_char:45|texescape }} \newline
+\footnotesize{ {{ cls.parent_class.getTeacherNames|join:", "|truncatewords_char:50|texescape }} }  &
+\texttt{% templatetag openbrace %}{{ cls.emailcode }}{% templatetag closebrace %} \\
 {% endfor %}\hline
 \end{tabularx}
+
 \end{center}
 
-
-\begin{center}
-\begin{tabularx}{17cm}{X c}
-\multicolumn{2}{c}{\small
-\textit{Please see your map for building directions, or ask anyone for help.}
-\normalsize } \\
-\multicolumn{2}{c}{\small
-\textit{If you are not signed up for a full day of classes, we encourage you to add more!}
-\normalsize } \\
-~ & ~ 
-\end{tabularx}
-\end{center}
 
 {% if not forloop.last %}\pagebreak{% endif %}
 {% endfor %}


### PR DESCRIPTION
I used the template overrides from Stanford and Yale to make a new student schedule LaTeX template. It has a barcode on it for use with the barcode scanning student checkin module. (also, wow, student schedules haven't been updated since 2011)

![image](https://user-images.githubusercontent.com/7232514/69904271-4e56e480-136a-11ea-8f5d-72b2e4995cdc.png)

Fixes https://github.com/learning-unlimited/ESP-Website/issues/2557.