### PR TITLE
Allow for overriding teacher availability in scheduler

### DIFF
--- a/esp/esp/program/modules/handlers/ajaxschedulingmodule.py
+++ b/esp/esp/program/modules/handlers/ajaxschedulingmodule.py
@@ -117,7 +117,7 @@ class AJAXSchedulingModule(ProgramModuleObj):
 
         return self.makeret(prog, ret=True, msg="Schedule removed for Class Section '%s'" % cls.emailcode())
 
-    def ajax_schedule_assignreg(self, prog, cls, timeslot_ids, classroom_ids, user=None):
+    def ajax_schedule_assignreg(self, prog, cls, timeslot_ids, classroom_ids, user=None, override=False):
         if len(timeslot_ids) < 1:
             return self.makeret(prog, ret=False, msg="No times specified!, can't assign to a timeblock")
 
@@ -139,7 +139,9 @@ class AJAXSchedulingModule(ProgramModuleObj):
 
         classroom = classrooms[0]
 
-        cannot_schedule = cls.cannotSchedule(times, ignore_classes=False)
+        cannot_schedule = False
+        if not override:
+            cannot_schedule = cls.cannotSchedule(times, ignore_classes=False)
         if cannot_schedule:
             return self.makeret(prog, ret=False, msg=cannot_schedule)
 
@@ -227,7 +229,8 @@ class AJAXSchedulingModule(ProgramModuleObj):
                 timeslot, classroom = br.split(",", 1)
                 times.append(timeslot)
                 classrooms.append(classroom)
-            retval = self.ajax_schedule_assignreg(prog, cls, times, classrooms, request.user)
+            override = request.POST['override'] == "true"
+            retval = self.ajax_schedule_assignreg(prog, cls, times, classrooms, request.user, override)
         else:
             return self.makeret(prog, ret=False, msg="Unrecognized command: '%s'" % action)
 

--- a/esp/esp/program/modules/handlers/jsondatamodule.py
+++ b/esp/esp/program/modules/handlers/jsondatamodule.py
@@ -237,12 +237,8 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
                 teacher_dict[t.id] = teacher
 
         # Build up teacher availability
-        availabilities = UserAvailability.objects.filter(user__id__in=teacher_dict.keys()).filter(event__program=prog).values_list('user_id', 'event_id')
-        avail_for_user = defaultdict(list)
-        for user_id, event_id in availabilities:
-            avail_for_user[user_id].append(event_id)
         for teacher in teachers:
-            teacher['availability'] = avail_for_user[teacher['id']]
+            teacher['availability'] = [event.id for event in ESPUser.objects.get(id=teacher['id']).getAvailableTimes(prog, ignore_classes=True)]
 
         return {'sections': sections, 'teachers': teachers}
     sections.cached_function.depend_on_row(ClassSection, lambda sec: {'prog': sec.parent_class.parent_program})
@@ -314,12 +310,8 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
                 teacher_dict[t.id] = teacher
 
         # Build up teacher availability
-        availabilities = UserAvailability.objects.filter(user__id__in=teacher_dict.keys()).filter(event__program=prog).values_list('user_id', 'event_id')
-        avail_for_user = defaultdict(list)
-        for user_id, event_id in availabilities:
-            avail_for_user[user_id].append(event_id)
         for teacher in teachers:
-            teacher['availability'] = avail_for_user[teacher['id']]
+            teacher['availability'] = [event.id for event in ESPUser.objects.get(id=teacher['id']).getAvailableTimes(prog, ignore_classes=True)]
 
         return {'sections': sections, 'teachers': teachers}
     sections_admin.method.cached_function.depend_on_cache(sections.cached_function, lambda extra=wildcard, prog=wildcard, **kwargs: {'prog': prog, 'extra': extra})
@@ -417,12 +409,8 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
                 teacher_dict[t.id] = teacher
 
         # Build up teacher availability
-        availabilities = UserAvailability.objects.filter(user__in=teacher_dict.keys()).filter(event__program=prog).values_list('user_id', 'event_id')
-        avail_for_user = defaultdict(list)
-        for user_id, event_id in availabilities:
-            avail_for_user[user_id].append(event_id)
         for teacher in teachers:
-            teacher['availability'] = avail_for_user[teacher['id']]
+            teacher['availability'] = [event.id for event in ESPUser.objects.get(id=teacher['id']).getAvailableTimes(prog, ignore_classes=True)]
 
         return {'classes': classes, 'teachers': teachers}
     class_subjects.cached_function.depend_on_row(ClassSubject, lambda cls: {'prog': cls.parent_program})
@@ -939,16 +927,11 @@ teachers[key].filter(is_active = True).distinct().count()))
         """
 
         teachers = ESPUser.objects.filter(classsubject__parent_program=prog).distinct()
-        resources = UserAvailability.objects.filter(user__in=teachers).filter(event__program = prog).values('user_id', 'event_id')
-        resources_for_user = defaultdict(list)
-
-        for resource in resources:
-            resources_for_user[resource['user_id']].append(resource['event_id'])
 
         teacher_dicts = [
             {   'uid': t.id,
                 'text': t.name(),
-                'availability': resources_for_user[t.id]
+                'availability': [event.id for event in t.getAvailableTimes(prog, ignore_classes=True)]
             } for t in teachers ]
 
         return {'teachers': teacher_dicts}

--- a/esp/esp/program/modules/handlers/jsondatamodule.py
+++ b/esp/esp/program/modules/handlers/jsondatamodule.py
@@ -177,6 +177,7 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
         for i in range(len(lunch_timeslots)):
             lunch_timeslots[i]['is_lunch'] = True
         return {'timeslots': lunch_timeslots}
+    lunch_timeslots.cached_function.depend_on_m2m(ClassSection, 'meeting_times', lambda sec, event: {'prog': sec.parent_class.parent_program})
 
     @aux_call
     @json_response()

--- a/esp/esp/program/modules/tests/ajaxschedulingmodule.py
+++ b/esp/esp/program/modules/tests/ajaxschedulingmodule.py
@@ -139,7 +139,7 @@ class AJAXSchedulingModuleTest(AJAXSchedulingModuleTestBase):
         s1, s2 = t.getTaughtSections(self.program)[:2]
         timeslots = self.program.getTimeSlots().order_by('start')
         self.client.post(ajax_url, {'action': 'deletereg', 'cls': s1.id})
-        self.client.post(ajax_url, {'action': 'assignreg', 'cls': s1.id, 'block_room_assignments': a1})
+        self.client.post(ajax_url, {'action': 'assignreg', 'cls': s1.id, 'block_room_assignments': a1, 'override': 'false'})
         self.assertTrue(set(s1.get_meeting_times()) == set(timeslots[0:2]), "Failed to assign meeting times.")
         # Try to schedule the other class.
         self.client.post(ajax_url, {'action': 'deletereg', 'cls': s2.id})

--- a/esp/esp/program/modules/tests/ajaxschedulingmodule.py
+++ b/esp/esp/program/modules/tests/ajaxschedulingmodule.py
@@ -143,7 +143,7 @@ class AJAXSchedulingModuleTest(AJAXSchedulingModuleTestBase):
         self.assertTrue(set(s1.get_meeting_times()) == set(timeslots[0:2]), "Failed to assign meeting times.")
         # Try to schedule the other class.
         self.client.post(ajax_url, {'action': 'deletereg', 'cls': s2.id})
-        self.client.post(ajax_url, {'action': 'assignreg', 'cls': s2.id, 'block_room_assignments': a2})
+        self.client.post(ajax_url, {'action': 'assignreg', 'cls': s2.id, 'block_room_assignments': a2, 'override': 'false'})
         self.assertTrue(set(s1.get_meeting_times()) == set(timeslots[0:2]), "Existing meeting times clobbered.")
         self.assertTrue(set(s2.get_meeting_times()) == set(), "Failed to prevent teacher conflict.")
 

--- a/esp/esp/program/modules/tests/support/program_manager.py
+++ b/esp/esp/program/modules/tests/support/program_manager.py
@@ -32,7 +32,7 @@ class TestProgramManager():
 
         #schedule the class
         blocks = '\n'.join(['%s,%s' % (r.event.id, r.identical_id()) for r in rooms[0:2]])
-        response = self.client.post(self.schedule_class_url, {'action': 'assignreg', 'cls': section.id, 'block_room_assignments': blocks})
+        response = self.client.post(self.schedule_class_url, {'action': 'assignreg', 'cls': section.id, 'block_room_assignments': blocks, 'override': 'false'})
         assert response.status_code == 200
 
         #make sure the scheduling had the expected result

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/ApiClient.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/ApiClient.js
@@ -64,7 +64,8 @@ function ApiClient() {
             action: 'assignreg',
             csrfmiddlewaretoken: csrf_token(),
             cls: section_id,
-            block_room_assignments: assignments
+            block_room_assignments: assignments,
+            override: $j("input#schedule-override").prop('checked')
         };
         return this.send_request(req, callback, errorReporter);
     };

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
@@ -260,28 +260,35 @@ function Sections(sections_data, section_details_data, teacher_data, scheduleAss
      * @param section: The section to check availability.
      */
     this.getAvailableTimeslots = function(section) {
-        var availabilities = [];
+        var availableTimeslots = [];
         var already_teaching = [];
-        $j.each(section.teacher_data, function(index, teacher) {
-            var teacher_availabilities = teacher.availability.slice();
-            teacher_availabilities = teacher_availabilities.filter(function(val) {
-                return this.matrix.timeslots.get_by_id(val);
+        if($j("input#schedule-override").prop('checked')){
+            $j.each(this.matrix.timeslots.timeslots, function(index, timeslot) {
+                availableTimeslots.push(timeslot.id);
             }.bind(this));
-            $j.each(teacher.sections, function(index, section_id) {
-                var assignment = this.scheduleAssignments[section_id];
-                if(assignment && section_id != section.id) {
-                    $j.each(assignment.timeslots, function(index, timeslot_id) {
-                        var availability_index = teacher_availabilities.indexOf(timeslot_id);
-                        if(availability_index >= 0) {
-                            teacher_availabilities.splice(availability_index, 1);
-                            already_teaching.push(timeslot_id);
-                        }
-                    }.bind(this));
-                }
+        } else {
+            var availabilities = []
+            $j.each(section.teacher_data, function(index, teacher) {
+                var teacher_availabilities = teacher.availability.slice();
+                teacher_availabilities = teacher_availabilities.filter(function(val) {
+                    return this.matrix.timeslots.get_by_id(val);
+                }.bind(this));
+                $j.each(teacher.sections, function(index, section_id) {
+                    var assignment = this.scheduleAssignments[section_id];
+                    if(assignment && section_id != section.id) {
+                        $j.each(assignment.timeslots, function(index, timeslot_id) {
+                            var availability_index = teacher_availabilities.indexOf(timeslot_id);
+                            if(availability_index >= 0) {
+                                teacher_availabilities.splice(availability_index, 1);
+                                already_teaching.push(timeslot_id);
+                            }
+                        }.bind(this));
+                    }
+                }.bind(this));
+                availabilities.push(teacher_availabilities);
             }.bind(this));
-            availabilities.push(teacher_availabilities);
-        }.bind(this));
-        var availableTimeslots = helpersIntersection(availabilities, true);
+            availableTimeslots = helpersIntersection(availabilities, true);
+        }
         return [availableTimeslots, already_teaching];
     };
 

--- a/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
+++ b/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
@@ -127,6 +127,10 @@
                         <input id="section-filter-unapproved" type="checkbox"></input>
                         <label for="section-filter-unapproved">Hide unapproved classes</label>
                     </div>
+                    <div id="schedule-override-wrapper">
+                        <input id="schedule-override" type="checkbox"></input>
+                        <label for="schedule-override">Override teacher availability</label>
+                    </div>
                   </form>
                 </div>
                 <div id="filters2">


### PR DESCRIPTION
I added a checkbox under the class filters tab that allows admins to override teacher availability (or lack thereof) when scheduling classes. Importantly, this will NOT override lunch constraints, already scheduled classes, or whether a class will actually fit time-wise where you are trying to schedule it. 

While I was at it, I fixed the lunch constraints bug where they would require a cache flush to update in the scheduler. I also made it so the scheduler should work even if availability module isn't enabled by using getAvailableTimes instead of querying the user availability objects. This sets the teachers to available for all timeslots if the module isn't enabled.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/1401, fixes https://github.com/learning-unlimited/ESP-Website/issues/1399, and fixes https://github.com/learning-unlimited/ESP-Website/issues/1005.

I personally think this is a better way to fix #1401 than https://github.com/learning-unlimited/ESP-Website/pull/2391.