### PR TITLE
Use UserSearchController in nametags

### DIFF
--- a/esp/esp/program/modules/handlers/nametagmodule.py
+++ b/esp/esp/program/modules/handlers/nametagmodule.py
@@ -36,6 +36,7 @@ from django.conf import settings
 
 from esp.middleware import ESPError
 from esp.program.modules.base import ProgramModuleObj, needs_admin, main_call, aux_call
+from esp.users.controllers.usersearch import UserSearchController
 from esp.tagdict.models import Tag
 from esp.users.models import ESPUser
 from esp.utils.web import render_to_response
@@ -58,9 +59,11 @@ class NameTagModule(ProgramModuleObj):
     @main_call
     @needs_admin
     def selectidoptions(self, request, tl, one, two, module, extra, prog):
-        """ Display a teacher eg page """
+        """ Display a page for admins to pick users for nametags """
         context = {'module': self}
         context['groups'] = Group.objects.all()
+        usc = UserSearchController()
+        context.update(usc.prepare_context(prog, target_path='/manage/%s/generatetags' % prog.url))
 
         return render_to_response(self.baseDir()+'selectoptions.html', request, context)
 
@@ -91,7 +94,16 @@ class NameTagModule(ProgramModuleObj):
 
         user_title = idtype
 
-        if idtype == 'students':
+        if idtype == 'aul':
+            user_title = request.POST['blanktitle']
+            data = {}
+            for key in request.POST:
+                data[key] = request.POST[key]
+            usc = UserSearchController()
+            filterObj = usc.filter_from_postdata(prog, data)
+            users = self.nametag_data(ESPUser.objects.filter(filterObj.get_Q()).distinct(), user_title)
+
+        elif idtype == 'students':
             user_title = "Student"
             student_dict = self.program.students(QObjects = True)
             if 'classreg' in student_dict:

--- a/esp/templates/program/modules/nametagmodule/selectoptions.html
+++ b/esp/templates/program/modules/nametagmodule/selectoptions.html
@@ -1,10 +1,11 @@
-{% extends "main.html" %}
+{% extends "users/usersearch/support.html" %}
 
 {% block title %}{{program.niceName}} Management{% endblock %}
 
 {% block content %}
 <style type="text/css">
 .nocheckmark { border: 1px solid black; }
+#recipient_filter_done, #recipient_list_done { display: none }
 </style>
 <br />
 <br />
@@ -47,16 +48,14 @@ To have good quality IDs:<br />
 <strong>ID Type</strong>
 <ul>
   <li><input type="radio" name="type" value="students" id="students"
-       onclick="document.getElementById('misc_info').disabled = true; document.getElementById('group').disabled = true;" checked="checked" />
+       onclick=" " checked="checked" />
       <label for="students">Students</label>
   </li>
-  <li><input type="radio" name="type" value="teacher" id="teachers"
-       onclick="document.getElementById('misc_info').disabled = true; document.getElementById('group').disabled = true;" />
+  <li><input type="radio" name="type" value="teacher" id="teachers" />
       <label for="teachers">Teachers</label>
   </li>
-  <li><input type="radio" name="type" value="other" id="other"
-       onclick="document.getElementById('misc_info').disabled = true; document.getElementById('group').disabled = false;" />
-      <label for="teachers">Other Group</label>&nbsp;&nbsp;&nbsp;
+  <li><input type="radio" name="type" value="other" id="other" />
+      <label for="other">Other Group</label>&nbsp;&nbsp;&nbsp;
       <select name="group" id="group" disabled>
         {% for group in groups %}
         <option value="{{ group.id }}">{{ group.name }}</option>
@@ -65,37 +64,50 @@ To have good quality IDs:<br />
       </select>
   </li>
 
-  <li><input type="radio" name="type" value="volunteers" id="volunt"
-       onclick="document.getElementById('misc_info').disabled = true; document.getElementById('group').disabled = true;" />
+  <li><input type="radio" name="type" value="volunteers" id="volunt" />
       <label for="volunt">Volunteers</label>
   </li>
-  <li><input type="radio" name="type" value="misc" id="misc"
-       onclick="document.getElementById('misc_info').disabled = false; document.getElementById('group').disabled = true;" />
-      <label for="volunt">Miscellaneous (enter info below)</label>
+  <li><input type="radio" name="type" value="aul" id="aul" />
+      <label for="aul">Arbitrary User List (select users below)</label>
   </li>
-  <li><input type="radio" name="type" value="blank" id="blank"
-       onclick="document.getElementById('misc_info').disabled = true; document.getElementById('group').disabled = true;" />
-      <label for="blank">Blank</label>
+  <li><input type="radio" name="type" value="misc" id="misc" />
+      <label for="misc">Miscellaneous (enter info below)</label>
+  </li>
+  <li><input type="radio" name="type" value="blank" id="blank" />
+      <label for="blank">Blank (specify number below)</label>
   </li>
 </ul>
 
 <br />
 <br />
+<div id="aul_wrapper" hidden>
+<label for="aul"><strong>Arbitrary User List:</strong></label>
+<br />
+{% include "users/usersearch/list_selector.html" %}
+<br />
+<br />
+</div>
+<div id="misc_wrapper" hidden>
 <label for="misc_info"><strong>Miscellaneous:</strong></label>
 <br />
 (&quot;Name, Title&quot; on each line, without quotes.)<br />
 <textarea name="misc_info" id="misc_info" rows="25" cols="40" disabled></textarea>
 <br />
 <br />
-<label for="number"><strong>Number (if blank chosen) of IDs:</strong></label>
+</div>
+<div id="num_wrapper" hidden>
+<label for="number"><strong>Number of IDs:</strong></label>
 <br />
 <input type="text" id="number" name="number" value="20" size="5" />
 <br />
-<label for="blanktitle"><strong>Title (if "Blank" or "Other Group" chosen) of IDs:</strong></label>
+</div>
+<div id="title_wrapper" hidden>
+<label for="blanktitle"><strong>Title of IDs:</strong></label>
 <br />
 <input type="text" id="blanktitle" name="blanktitle" value="Student" size="15" />
 <br />
 <br />
+</div>
 <label for="programname"><strong>Program Name for IDs:</strong></label>
 <br />
 <input type="text" id="programname" size="40" name="progname" value="{{ program.niceName }}" />
@@ -105,7 +117,33 @@ To have good quality IDs:<br />
 </fieldset>
 </form>
 
+<script type="text/javascript">
+var $old_this = $j('#students');
+$j('input:radio[name="type"]').change( function(e){
+    option = $j(this).val();
+    if (option == "misc_info") {
+        $j('#misc_wrapper').toggle();
+    } else if (option == "other") {
+        $j('#group').prop('disabled', function(i, v) { return !v; });
+        $j('#title_wrapper').toggle();
+    } else if (option == "aul") {
+        $j('#aul_wrapper').toggle();
+        $j('#title_wrapper').toggle();
+    } else if (option == "blank") {
+        $j('#num_wrapper').toggle();
+        $j('#title_wrapper').toggle();
+    } else if (option == "misc") {
+        $j('#misc_wrapper').toggle();
+    }
 
+    // trigger "change" for the old radio button
+    if (e.hasOwnProperty('originalEvent')) {
+        $old_this.trigger("change");
+        // set current radio button as old
+        $old_this = $j(this);
+    }
+});
+</script>
 
 
 {% endblock %}

--- a/esp/templates/program/modules/nametagmodule/selectoptions.html
+++ b/esp/templates/program/modules/nametagmodule/selectoptions.html
@@ -47,8 +47,7 @@ To have good quality IDs:<br />
 <fieldset>
 <strong>ID Type</strong>
 <ul>
-  <li><input type="radio" name="type" value="students" id="students"
-       onclick=" " checked="checked" />
+  <li><input type="radio" name="type" value="students" id="students" checked="checked" />
       <label for="students">Students</label>
   </li>
   <li><input type="radio" name="type" value="teacher" id="teachers" />

--- a/esp/templates/program/modules/nametagmodule/selectoptions.html
+++ b/esp/templates/program/modules/nametagmodule/selectoptions.html
@@ -120,7 +120,7 @@ To have good quality IDs:<br />
 <script type="text/javascript">
 var $old_this = $j('#students');
 $j('input:radio[name="type"]').change( function(e){
-    option = $j(this).val();
+    var option = $j(this).val();
     if (option == "misc_info") {
         $j('#misc_wrapper').toggle();
     } else if (option == "other") {


### PR DESCRIPTION
This finally integrates the `UserSearchController` into the nametags module. Users can now query for any arbitrary list of users as they can for the comm panel or list gen modules. However, since many people probably use the custom options, those are still available (e.g. "Blank" nametags), and I've kept the original "Student", "Teacher", and "Volunteer" options as shortcuts for admins (although these shortcuts still have the possibility of conflicting with other printables like described in https://github.com/learning-unlimited/ESP-Website/issues/2469). If an admin wants 1:1 matching of printables (e.g. schedules) to nametags, they should use the same query for both.

I also cleaned up the page a little bit, since it was getting cluttered with optional fields that were only necessary for certain nametag types. Now only the relevant form fields will show up based on the selected nametag type.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/2469 and fixes https://github.com/learning-unlimited/ESP-Website/issues/1472.