### PR TITLE
Move grade change request link and change conditions for inclusion in profile form

### DIFF
--- a/esp/esp/web/views/myesp.py
+++ b/esp/esp/web/views/myesp.py
@@ -141,6 +141,7 @@ def profile_editor(request, prog_input=None, responseuponCompletion = True, role
     FormClass = getattr(mod, target_type['profile_form'])
 
     context['profiletype'] = role
+    context['allow_grade_change'] = Tag.getTag('allow_change_grade_level')
 
     if request.method == 'POST' and 'profile_page' in request.POST:
         form = FormClass(curUser, request.POST)

--- a/esp/templates/users/profile.html
+++ b/esp/templates/users/profile.html
@@ -55,7 +55,6 @@ div.required label:after {
             {% include "users/profiles/studentinfo.html" %}
             {% include "users/profiles/guardiancontact.html" %}
             {% include "users/profiles/emergencycontact.html" %}
-            {% include "users/profiles/gradechangerequestinfo.html" %}
         {% else %}
 
         {% ifequal profiletype "educator" %}

--- a/esp/templates/users/profiles/studentinfo.html
+++ b/esp/templates/users/profiles/studentinfo.html
@@ -42,6 +42,9 @@ detailed explanation of our age and grade level policy, please click
     {% endif %}
     </div>
 </div>
+{% if user.getGrade and allow_grade_change != "True" %}
+    {% include "users/profiles/gradechangerequestinfo.html" %}
+{% endif %}
 
 {% if form.gender %}
 <div class="control-group">


### PR DESCRIPTION
I moved the class change request link to right below the grade field on the profile page and modified the conditions for it to be included: 1) students can't be allowed to change their grade via the field (if the `allow_change_grade_level` tag is set to `True`), and 2) they must already have a grade associated with their account (i.e. not a new user).

Fixes https://github.com/learning-unlimited/ESP-Website/issues/2358, fixes https://github.com/learning-unlimited/ESP-Website/issues/1091, and fixes https://github.com/learning-unlimited/ESP-Website/issues/2117.