### PR TITLE
Student acknowledgement module

### DIFF
--- a/docs/admin/program_modules.rst
+++ b/docs/admin/program_modules.rst
@@ -41,7 +41,7 @@ Student modules
 Student Acknowledgement (StudentAcknowledgementModule)
 ------------------------------------------------------
 
-Include this module if you would like students to submit a somewhat scary-looking form where they simply check a box to say that they will follow the code of conduct for the program.
+Include this module if you would like students to submit a somewhat scary-looking form where they simply check a box to say that they agree to follow by the policies in the QSD box.
 
 
 Extra Registration Info (CustomFormModule)

--- a/docs/admin/program_modules.rst
+++ b/docs/admin/program_modules.rst
@@ -38,6 +38,12 @@ Below we provide a more detailed explanation of what each program module is for 
 Student modules
 ===============
 
+Student Acknowledgement (StudentAcknowledgementModule)
+------------------------------------------------------
+
+Include this module if you would like students to submit a somewhat scary-looking form where they simply check a box to say that they will follow the code of conduct for the program.
+
+
 Extra Registration Info (CustomFormModule)
 ------------------------------------------
 

--- a/esp/esp/program/modules/handlers/studentacknowledgementmodule.py
+++ b/esp/esp/program/modules/handlers/studentacknowledgementmodule.py
@@ -1,0 +1,68 @@
+from esp.program.models import Program
+from esp.program.modules.base import ProgramModuleObj, needs_student, main_call, meets_deadline
+from esp.utils.web import render_to_response
+from esp.users.models   import ESPUser, Record
+from django import forms
+from django.db.models.query import Q
+from esp.middleware.threadlocalrequest import get_current_request
+
+def studentacknowledgementform_factory(prog):
+    name = "StudentAcknowledgementForm"
+    bases = (forms.Form,)
+
+    label = u"I have read the above, and commit to abiding by the code of conduct."
+
+    d = dict(acknowledgement=forms.BooleanField(required=True, label=label))
+    return type(name, bases, d)
+
+class StudentAcknowledgementModule(ProgramModuleObj):
+    @classmethod
+    def module_properties(cls):
+        return {
+            "admin_title": "Student Acknowledgement",
+            "link_title": "Student Acknowledgement",
+            "module_type": "learn",
+            "required": False,
+        }
+
+    def isCompleted(self):
+        return Record.objects.filter(user=get_current_request().user,
+                                     program=self.program,
+                                     event="studentacknowledgement").exists()
+
+    @main_call
+    @needs_student
+    @meets_deadline('/Acknowledgement')
+    def acknowledgement(self, request, tl, one, two, module, extra, prog):
+        context = {'prog': prog}
+        if request.method == 'POST':
+            context['form'] = studentacknowledgementform_factory(prog)(request.POST)
+            rec, created = Record.objects.get_or_create(user=request.user,
+                                                        program=self.program,
+                                                        event="studentacknowledgement")
+            if context['form'].is_valid():
+                return self.goToCore(tl)
+            else:
+                rec.delete()
+        elif self.isCompleted():
+            context['form'] = studentacknowledgementform_factory(prog)({'acknowledgement': True})
+        else:
+            context['form'] = studentacknowledgementform_factory(prog)()
+        return render_to_response(self.baseDir()+'acknowledgement.html', request, context)
+
+    def students(self, QObject = False):
+        """ Returns a list of students who have submitted the acknowledgement. """
+        qo = Q(record__program=self.program, record__event="studentacknowledgement")
+        if QObject is True:
+            return {'acknowledgement': qo}
+
+        student_list = ESPUser.objects.filter(qo).distinct()
+
+        return {'acknowledgement': student_list }
+
+    def studentDesc(self):
+        return {'acknowledgement': """Students who have submitted the acknowledgement for the program"""}
+
+    class Meta:
+        proxy = True
+        app_label = 'modules'

--- a/esp/esp/program/modules/handlers/studentacknowledgementmodule.py
+++ b/esp/esp/program/modules/handlers/studentacknowledgementmodule.py
@@ -10,7 +10,7 @@ def studentacknowledgementform_factory(prog):
     name = "StudentAcknowledgementForm"
     bases = (forms.Form,)
 
-    label = u"I have read the above, and commit to abiding by the code of conduct."
+    label = u"By checking this box, I acknowledge that I have read and understood the above contract, and agree to abide by it. I understand that should I break this contract, I may be asked to leave the program."
 
     d = dict(acknowledgement=forms.BooleanField(required=True, label=label))
     return type(name, bases, d)

--- a/esp/esp/program/modules/handlers/studentacknowledgementmodule.py
+++ b/esp/esp/program/modules/handlers/studentacknowledgementmodule.py
@@ -22,7 +22,7 @@ class StudentAcknowledgementModule(ProgramModuleObj):
             "admin_title": "Student Acknowledgement",
             "link_title": "Student Acknowledgement",
             "module_type": "learn",
-            "required": False,
+            "required": True,
         }
 
     def isCompleted(self):

--- a/esp/esp/program/modules/handlers/teacheracknowledgementmodule.py
+++ b/esp/esp/program/modules/handlers/teacheracknowledgementmodule.py
@@ -26,7 +26,7 @@ class TeacherAcknowledgementModule(ProgramModuleObj):
             "admin_title": "Teacher Acknowledgement",
             "link_title": "Teacher Acknowledgement",
             "module_type": "teach",
-            "required": False,
+            "required": True,
         }
 
     def isCompleted(self):

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -2176,6 +2176,7 @@ class Record(models.Model):
         ("onsite","Registered for program onsite"),
         ("schedule_printed","Printed student schedule onsite"),
         ("teacheracknowledgement","Did teacher acknowledgement"),
+        ("studentacknowledgement", "Did student acknowledgement"),
         ("lunch_selected","Selected a lunch block"),
         ("extra_form_done","Filled out Custom Form"),
         ("extra_costs_done","Filled out Student Extra Costs Form"),
@@ -2281,6 +2282,7 @@ class Permission(ExpirableModel):
         ("Student Deadlines", (
             ("Student", "Basic student access"),
             ("Student/All", "All student deadlines"),
+            ("Student/Acknowledgement", "Student acknowledgement"),
             ("Student/Applications", "Apply for classes"),
             ("Student/Catalog", "View the catalog"),
             ("Student/Classes", "Register for classes"),

--- a/esp/templates/program/modules/studentacknowledgementmodule/acknowledgement.html
+++ b/esp/templates/program/modules/studentacknowledgementmodule/acknowledgement.html
@@ -1,0 +1,15 @@
+{% extends "main.html" %}
+{% block title %}{{program.niceName}} Student Acknowledgement{% endblock %}
+{% block content %}
+<h2>Student Acknowledgement for {{program.niceName}} </h2>
+<br />
+{% load render_qsd %}
+{% inline_program_qsd_block program "learn:acknowledgement_instructions" %}
+Please acknowledge that you are aware of the student conduct policy. If you do not abide by this policy, you may be asked to leave the program and unable to attend future programs.
+{% end_inline_program_qsd_block %}
+<br />
+<form action="acknowledgement" method="post">
+{{ form.as_p }}
+<input type="submit" value="Submit" class="btn btn-primary" />
+</form>
+{% endblock %}

--- a/esp/templates/program/modules/studentacknowledgementmodule/acknowledgement.html
+++ b/esp/templates/program/modules/studentacknowledgementmodule/acknowledgement.html
@@ -10,8 +10,12 @@
 {% end_inline_program_qsd_block %}
 <form action="acknowledgement" method="post">
 {{ form.acknowledgement.errors }}
-{{ form.acknowledgement }}
-{{ form.acknowledgement.label_tag }}
+<table>
+    <tr>
+        <td valign="top">{{ form.acknowledgement }}</td>
+        <td>{{ form.acknowledgement.label_tag }}</td>
+    </tr>
+</table>
 <br />
 <br />
 <input type="submit" value="Submit" class="btn btn-primary" />

--- a/esp/templates/program/modules/studentacknowledgementmodule/acknowledgement.html
+++ b/esp/templates/program/modules/studentacknowledgementmodule/acknowledgement.html
@@ -1,15 +1,19 @@
 {% extends "main.html" %}
-{% block title %}{{program.niceName}} Student Acknowledgement{% endblock %}
+{% block title %}{{ program.niceName }} Student Acknowledgement{% endblock %}
 {% block content %}
-<h2>Student Acknowledgement for {{program.niceName}} </h2>
+<h2>Student Acknowledgement for {{ program.niceName }} </h2>
 <br />
 {% load render_qsd %}
 {% inline_program_qsd_block program "learn:acknowledgement_instructions" %}
-Please acknowledge that you are aware of the student conduct policy. If you do not abide by this policy, you may be asked to leave the program and unable to attend future programs.
+<p>I understand that by participating in {{ program.niceName }}, I agree to abide by all rules of the Program, as explained to me by {{ settings.ORGANIZATION_SHORT_NAME }} admins, and all rules of {{ settings.INSTITUTION_NAME }}, as well as any laws of the state and country in which the Program is to be held.</p>
+<p>In particular, I will attend all of my classes as indicated by my schedule and I will follow all instructions of {{ settings.ORGANIZATION_SHORT_NAME }} admins. I will leave class only to use the bathroom, change my class, or go to the student lounge, unless otherwise instructed by a {{ settings.ORGANIZATION_SHORT_NAME }} admin. After signing in to the program and until the conclusion of the last class, I will remain in program buildings except if lunch is served outdoors, my class is led outside by the teacher, I am signed out at the admin desk by a parent/guardian, or there is an emergency. I will be respectful of others at all times and I will not do anything to put myself or others at risk of harm. I will not use illicit or controlled substances (unless specifically prescribed to me by a certified physician). I understand that participating in the program is a privilege, and I agree to comport myself appropriately.</p>
 {% end_inline_program_qsd_block %}
-<br />
 <form action="acknowledgement" method="post">
-{{ form.as_p }}
+{{ form.acknowledgement.errors }}
+{{ form.acknowledgement }}
+{{ form.acknowledgement.label_tag }}
+<br />
+<br />
 <input type="submit" value="Submit" class="btn btn-primary" />
 </form>
 {% endblock %}

--- a/esp/templates/program/modules/teacheracknowledgementmodule/acknowledgement.html
+++ b/esp/templates/program/modules/teacheracknowledgementmodule/acknowledgement.html
@@ -7,9 +7,12 @@
 {% inline_program_qsd_block program "teach:acknowledgement_instructions" %}
 {{ prog.niceName }} will be on {{ prog.date_range }}! Please acknowledge that you are aware of this and commit to teaching at one of the times you have specified for your availability. You may not cancel your classes after student registration opens. In the case of extenuating circumstances like illness or serious emergency, you must notify the directors ASAP at <a href="mailto:{{ prog.director_email }}">{{ prog.director_email }}</a> and assist in finding a substitute for your classes. If you do not meet these expectations, it is unfair for the students who registered for your class and makes organization difficult for us. Note that not being responsible with respect to your classes will affect your ability to teach for us in the future.
 {% end_inline_program_qsd_block %}
-<br />
 <form action="acknowledgement" method="post">
-{{ form.as_p }}
+{{ form.acknowledgement.errors }}
+{{ form.acknowledgement }}
+{{ form.acknowledgement.label_tag }}
+<br />
+<br />
 <input type="submit" value="Submit" class="btn btn-primary" />
 </form>
 {% endblock %}


### PR DESCRIPTION
Add a student acknowledgement module for students to agree to a code of conduct during student registration (similar to teacher acknowledgement module). Fixes #2869 and also moves the checkbox in the teacher acknowledgement module to suit @willgearty's preferences.