### PR TITLE
Fix profile form errors for admins

### DIFF
--- a/esp/esp/tagdict/__init__.py
+++ b/esp/esp/tagdict/__init__.py
@@ -33,7 +33,7 @@ all_global_tags = {
     'theme_template_control': (False, ""),
     'current_theme_palette': (False, ""),
     'request_student_phonenum': (True, ""),
-    'allow_change_grade_level': (False, ""),
+    'allow_change_grade_level': (True, "Should students be allowed to change their grade level in the profile form? Default is False."),
     'show_studentrep_application': (False, ""),
     'show_student_tshirt_size_options': (False, ""),
     'show_student_vegetarianism_options': (False, ""),

--- a/esp/esp/users/forms/user_profile.py
+++ b/esp/esp/users/forms/user_profile.py
@@ -181,7 +181,7 @@ class StudentInfoForm(FormUnrestrictedOtherUser):
         from esp.users.models import ESPUser
         super(StudentInfoForm, self).__init__(user, *args, **kwargs)
 
-        self.allow_change_grade_level = Tag.getTag('allow_change_grade_level')
+        self.allow_change_grade_level = Tag.getBooleanTag('allow_change_grade_level', default = False)
 
         ## All of these Tags may someday want to be made per-program somehow.
         ## We don't know the current program right now, though...
@@ -229,7 +229,7 @@ class StudentInfoForm(FormUnrestrictedOtherUser):
         if not Tag.getTag('ask_student_about_transportation_to_program'):
             del self.fields['transportation']
 
-        if not Tag.getTag('allow_change_grade_level'):
+        if not Tag.getBooleanTag('allow_change_grade_level', default = False):
             if 'initial' in kwargs:
                 initial_data = kwargs['initial']
 
@@ -286,7 +286,7 @@ class StudentInfoForm(FormUnrestrictedOtherUser):
             if self.studentrep_error and self.cleaned_data['studentrep'] and expl == '':
                 raise forms.ValidationError("Please enter an explanation if you would like to become a student rep.")
 
-        if not Tag.getTag('allow_change_grade_level'):
+        if not Tag.getBooleanTag('allow_change_grade_level', default = False):
             user = self._user
 
             orig_prof = RegistrationProfile.getLastProfile(user)

--- a/esp/esp/web/views/myesp.py
+++ b/esp/esp/web/views/myesp.py
@@ -141,7 +141,6 @@ def profile_editor(request, prog_input=None, responseuponCompletion = True, role
     FormClass = getattr(mod, target_type['profile_form'])
 
     context['profiletype'] = role
-    context['allow_grade_change'] = Tag.getTag('allow_change_grade_level')
 
     if request.method == 'POST' and 'profile_page' in request.POST:
         form = FormClass(curUser, request.POST)
@@ -204,7 +203,7 @@ def profile_editor(request, prog_input=None, responseuponCompletion = True, role
             except:
                 pass
             form = FormClass(curUser, replacement_data)
-            if not Tag.getTag('allow_change_grade_level'):
+            if not Tag.getBooleanTag('allow_change_grade_level', default = False):
                 if prog_input is None:
                     regProf = RegistrationProfile.getLastProfile(curUser)
                 else:
@@ -212,11 +211,11 @@ def profile_editor(request, prog_input=None, responseuponCompletion = True, role
                 if regProf.id is None:
                     regProf = RegistrationProfile.getLastProfile(curUser)
                 if regProf.student_info:
-                    if regProf.student_info.dob:
+                    if regProf.student_info.dob and 'dob' in form.fields:
                         form.data['dob'] = regProf.student_info.dob
                         form.fields['dob'].widget.attrs['disabled'] = "true"
                         form.fields['dob'].required = False
-                    if regProf.student_info.graduation_year:
+                    if regProf.student_info.graduation_year and 'graduation_year' in form.fields:
                         form.data['graduation_year'] = regProf.student_info.graduation_year
                         form.fields['graduation_year'].widget.attrs['disabled'] = "true"
                         form.fields['graduation_year'].required = False

--- a/esp/templates/users/profiles/gradechangerequestinfo.html
+++ b/esp/templates/users/profiles/gradechangerequestinfo.html
@@ -1,8 +1,9 @@
 {% load i18n %}
 <!-- Begin Grade Change Request Section -->
 <div class="alert" id="id-grade-change-request-info">
-	<p> 
-		<a href="{% url 'grade_change_request' %}" id="id-grade-change-request" title="{% trans "Send Grade Change Request" %}">{% trans "Send Grade Change Request" %}</a>
-	</p>
+<button type="button" class="close" data-dismiss="alert">x</button>
+You may not change your grade or age. Your grade level will update automatically every August.
+If you skipped a grade or took a year off, please click this link to request a grade change:<br /> <br />
+<a href="{% url 'grade_change_request' %}" id="id-grade-change-request" title="{% trans "Send Grade Change Request" %}">{% trans "Send Grade Change Request" %}</a>
 </div>
 <!-- End Grade Change Request Section -->

--- a/esp/templates/users/profiles/studentinfo.html
+++ b/esp/templates/users/profiles/studentinfo.html
@@ -3,26 +3,29 @@
 
 {{ form.errors }}
 
-{% if not form.allow_change_grade_level %}
+{% if not user.getGrade or form.allow_change_grade_level %}
 <div class="alert">
 <button type="button" class="close" data-dismiss="alert">x</button>
-You will only be able to set your age and grade level ONCE. 
-After you click "Update Your Information!" below, or if you've already
-done so in the past, you will not be able to change your age or grade level. 
-<br /> <br />
 Please fill out your current age and grade accurately and honestly.
 We trust our students to represent themselves honestly, but
 students have abused this trust in the past to circumvent grade
-requirements for higher-level classes.  Lying about your age is fraud
+requirements for higher-level classes. Lying about your age is fraud
 and is extremely frustrating for our teachers, who set these grade
 requirements with full knowledge of the outstanding students in the
-program.  Please be honest and support the community. 
+program. Please be honest and support the community.
 <br /> <br />
-Your grade level updates automatically every August; if you skip a grade or 
-take a year off, please email us and we will fix your grade. For a more 
-detailed explanation of our age and grade level policy, please click 
-<a href="/learn/parents/agelimit.html">here</a>.
+{% if not user.getGrade and not form.allow_change_grade_level %}
+You will only be able to set your age and grade level ONCE. 
+After you click "Update Your Information!" below, you will not be
+able to change your age or grade level.
+<br /> <br />
+{% endif %}
+Your grade level will update automatically every August.
 </div>
+{% endif %}
+
+{% if user.getGrade and not form.allow_change_grade_level %}
+    {% include "users/profiles/gradechangerequestinfo.html" %}
 {% endif %}
 
 <div class="control-group">
@@ -42,9 +45,6 @@ detailed explanation of our age and grade level policy, please click
     {% endif %}
     </div>
 </div>
-{% if user.getGrade and allow_grade_change != "True" %}
-    {% include "users/profiles/gradechangerequestinfo.html" %}
-{% endif %}
 
 {% if form.gender %}
 <div class="control-group">


### PR DESCRIPTION
I fixed the bug introduced by https://github.com/learning-unlimited/ESP-Website/pull/2688 that caused an error when an admin that had a studentinfo associated with their account submitted a profile form with an error in it (missing field, invalid responses, etc.). However, this then revealed a larger issue where we weren't treating the `allow_change_grade_level` tag as a boolean tag, which meant that the value was always effectively `True` if the tag was set, no matter what the tag was set to. I changed all the uses of the tag to use `getBooleanTag` and then decided to change some of the conditions and text for the alerts in the student profile form (including changes I just recently made in https://github.com/learning-unlimited/ESP-Website/pull/2867).

Fixes https://github.com/learning-unlimited/ESP-Website/issues/2898.