### PR TITLE
Onsite checkout module

### DIFF
--- a/esp/esp/program/modules/handlers/onsitecheckoutmodule.py
+++ b/esp/esp/program/modules/handlers/onsitecheckoutmodule.py
@@ -1,0 +1,120 @@
+
+__author__    = "Individual contributors (see AUTHORS file)"
+__date__      = "$DATE$"
+__rev__       = "$REV$"
+__license__   = "AGPL v.3"
+__copyright__ = """
+This file is part of the ESP Web Site
+Copyright (c) 2007 by the individual contributors
+  (see AUTHORS file)
+
+The ESP Web Site is free software; you can redistribute it and/or
+modify it under the terms of the GNU Affero General Public License
+as published by the Free Software Foundation; either version 3
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public
+License along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+Contact information:
+MIT Educational Studies Program
+  84 Massachusetts Ave W20-467, Cambridge, MA 02139
+  Phone: 617-253-4882
+  Email: esp-webmasters@mit.edu
+Learning Unlimited, Inc.
+  527 Franklin St, Cambridge, MA 02139
+  Phone: 617-379-0178
+  Email: web-team@learningu.org
+"""
+
+from esp.program.modules.forms.onsite import OnsiteBarcodeCheckinForm
+from esp.program.modules.base import ProgramModuleObj, needs_teacher, needs_student, needs_admin, usercheck_usetl, needs_onsite, main_call, aux_call
+from esp.program.modules import module_ext
+from esp.accounting.controllers import IndividualAccountingController
+from esp.utils.web import render_to_response
+from django.contrib.auth.decorators import login_required
+from esp.users.forms.generic_search_form import StudentSearchForm
+from esp.users.models    import ESPUser, User, Record
+from django              import forms
+from django.http import HttpResponse, HttpResponseRedirect
+from django.template.loader import render_to_string, select_template
+from esp.users.views    import search_for_user
+
+import json
+
+
+class OnSiteCheckoutModule(ProgramModuleObj):
+    @classmethod
+    def module_properties(cls):
+        return {
+            "admin_title": "On-Site User Check-Out",
+            "link_title": "Check-out Students",
+            "module_type": "onsite",
+            "seq": 1
+            }
+
+    def create_record(self, event):
+        if event=="paid":
+            self.updatePaid(True)
+
+        recs, created = Record.objects.get_or_create(user=self.student,
+                                                     event=event,
+                                                     program=self.program)
+        return created
+
+    def delete_record(self, event):
+        if event=="paid":
+            self.updatePaid(False)
+
+        recs, created = Record.objects.get_or_create(user=self.student,
+                                            event=event,
+                                            program=self.program)
+        recs.delete()
+        return True
+
+    def hasAttended(self):
+        return Record.user_completed(self.student, "attended",self.program)
+
+    def timeCheckedIn(self):
+        u = Record.objects.filter(event="attended",program=self.program, user=self.student).order_by("time")
+        return str(u[0].time.strftime("%H:%M %d/%m/%y"))
+
+    @main_call
+    @needs_onsite
+    def checkout(self, request, tl, one, two, module, extra, prog):
+        context = {}
+        if request.method == 'POST':
+            #   Handle submission of student
+            form = StudentSearchForm(request.POST)
+            if form.is_valid():
+                student = form.cleaned_data['target_user']
+                #   Check that this is a student user who is not also teaching (e.g. an admin)
+                if student.isStudent() and student not in self.program.teachers()['class_approved']:
+                    recs = Record.objects.filter(user=student, event="attended", program=prog)
+                    if not recs.exists():
+                        rec, created = Record.objects.get_or_create(user=student, event="attended", program=prog)
+                    context['message'] = '%s %s marked as attended.' % (student.first_name, student.last_name)
+                    if request.is_ajax():
+                        return self.ajax_status(request, tl, one, two, module, extra, prog, context)
+                else:
+                    context['message'] = '%s %s is not a student and has not been checked in' % (student.first_name, student.last_name)
+                    if request.is_ajax():
+                        return self.ajax_status(request, tl, one, two, module, extra, prog, context)
+                form = StudentSearchForm(initial={'target_user': student.id})
+        else:
+            form = StudentSearchForm()
+
+        context['module'] = self
+        context['form'] = form
+        return render_to_response(self.baseDir()+'checkout.html', request, context)
+
+
+    class Meta:
+        proxy = True
+        app_label = 'modules'

--- a/esp/esp/program/modules/handlers/onsitecheckoutmodule.py
+++ b/esp/esp/program/modules/handlers/onsitecheckoutmodule.py
@@ -88,7 +88,7 @@ class OnSiteCheckoutModule(ProgramModuleObj):
             # Get most recent check-in record
             recs = Record.objects.filter(user=student, event="attended", program=prog)
             if recs.count() == 0:
-                context['checkout_message'] = "%s (%s) is not checked in for this program" % (student.name(), student.username)
+                context['checkout_message'] = "Caution: %s (%s) is not checked in for this program!" % (student.name(), student.username)
 
             if 'checkout_student' in request.POST:
                 # Make checked_out record

--- a/esp/esp/program/modules/handlers/onsitecheckoutmodule.py
+++ b/esp/esp/program/modules/handlers/onsitecheckoutmodule.py
@@ -84,7 +84,7 @@ class OnSiteCheckoutModule(ProgramModuleObj):
         if student:
             context['student'] = student
             form = StudentSearchForm(initial={'target_user': student.id})
-            
+
             # Get most recent check-in record
             recs = Record.objects.filter(user=student, event="attended", program=prog)
             if recs.count() == 0:

--- a/esp/esp/program/modules/handlers/onsitecheckoutmodule.py
+++ b/esp/esp/program/modules/handlers/onsitecheckoutmodule.py
@@ -33,23 +33,13 @@ Learning Unlimited, Inc.
   Email: web-team@learningu.org
 """
 
-from esp.program.modules.forms.onsite import OnsiteBarcodeCheckinForm
-from esp.program.modules.base import ProgramModuleObj, needs_teacher, needs_student, needs_admin, usercheck_usetl, needs_onsite, main_call, aux_call
-from esp.program.modules import module_ext
+from esp.program.modules.base import ProgramModuleObj, needs_onsite, main_call
 from esp.program.models import ClassSection
-from esp.accounting.controllers import IndividualAccountingController
 from esp.utils.web import render_to_response
-from django.contrib.auth.decorators import login_required
 from esp.users.forms.generic_search_form import StudentSearchForm
-from esp.users.models    import ESPUser, User, Record
-from django              import forms
-from django.http import HttpResponse, HttpResponseRedirect
-from django.template.loader import render_to_string, select_template
-from esp.users.views    import search_for_user
+from esp.users.models    import ESPUser, Record
 from esp.program.modules.handlers.studentclassregmodule import StudentClassRegModule
-
-import json
-
+from esp.middleware.esperrormiddleware import ESPError
 
 class OnSiteCheckoutModule(ProgramModuleObj):
     @classmethod

--- a/esp/esp/program/modules/handlers/studentclassregmodule.py
+++ b/esp/esp/program/modules/handlers/studentclassregmodule.py
@@ -199,18 +199,24 @@ class StudentClassRegModule(ProgramModuleObj):
                    super(StudentClassRegModule, self).deadline_met('/Classes/Lottery')
 
     def prepare(self, context={}):
+        user = get_current_request().user
+        program = self.program
+        scrmi = self.program.studentclassregmoduleinfo
+        return self.prepare_static(user, program, context=context, scrm = self)
+
+    @staticmethod
+    def prepare_static(user, program, context={}, scrm = ""):
         from esp.program.controllers.studentclassregmodule import RegistrationTypeController as RTC
-        verbs = RTC.getVisibleRegistrationTypeNames(prog=self.program)
-        regProf = RegistrationProfile.getLastForProgram(get_current_request().user, self.program)
-        timeslots = self.program.getTimeSlots(types=['Class Time Block', 'Compulsory'])
+        verbs = RTC.getVisibleRegistrationTypeNames(prog=program)
+        regProf = RegistrationProfile.getLastForProgram(user, program)
+        timeslots = program.getTimeSlots(types=['Class Time Block', 'Compulsory'])
         classList = ClassSection.prefetch_catalog_data(regProf.preregistered_classes(verbs=verbs))
 
         prevTimeSlot = None
         blockCount = 0
 
-        user = get_current_request().user
-        is_onsite = user.isOnsite(self.program)
-        scrmi = self.program.studentclassregmoduleinfo
+        is_onsite = user.isOnsite(program)
+        scrmi = program.studentclassregmoduleinfo
 
         #   Filter out volunteer timeslots
         timeslots = [x for x in timeslots if x.event_type.description != 'Volunteer']
@@ -267,7 +273,8 @@ class StudentClassRegModule(ProgramModuleObj):
         context['num_classes'] = len(classList)
         context['timeslots'] = schedule
         context['use_priority'] = scrmi.use_priority
-        context['allow_removal'] = self.deadline_met('/Removal')
+        if scrm:
+            context['allow_removal'] = scrm.deadline_met('/Removal')
 
         return context
 

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -2167,6 +2167,7 @@ class Record(models.Model):
         ("teacher_survey", "Completed teacher survey"),
         ("reg_confirmed", "Confirmed registration"),
         ("attended", "Attended program"),
+        ("checked_out", "Checked out of program"),
         ("conf_email","Was sent confirmation email"),
         ("teacher_quiz_done","Completed teacher quiz"),
         ("paid","Paid for program"),

--- a/esp/templates/program/modules/onsitecheckoutmodule/checkout.html
+++ b/esp/templates/program/modules/onsitecheckoutmodule/checkout.html
@@ -110,6 +110,9 @@ $j(function() {
 
 {% if student %}
 <br />
+{% if checkout_message %}
+<h3 style="color:red;">{{ checkout_message }}</h3>
+{% endif %}
 <div id="return_options">
     <h2>
         Choose one of the following checkout options for {{ student.first_name }} {{ student.last_name }} ({{ student.username }}):<br />
@@ -122,9 +125,6 @@ $j(function() {
 </div>
 
 <br />
-{% if checkout_message %}
-<h3 style="color:red;">{{ checkout_message }}</h3>
-{% endif %}
 <form id="checkoutform" name="checkoutform" method="POST" action="{{ request.path }}">
 <input type="hidden" name="user" value="{{ student.id }}"/>
 <input type="hidden" name="checkout_student"/>

--- a/esp/templates/program/modules/onsitecheckoutmodule/checkout.html
+++ b/esp/templates/program/modules/onsitecheckoutmodule/checkout.html
@@ -5,9 +5,7 @@
 {% block stylesheets %}
 {{ block.super }}
 <link rel='stylesheet' type='text/css' href='/media/styles/forms.css' />
-
-<style type="text/css">
-.nocheckmark { border: 1px solid black; }
+<style>
 table {
     table-layout: fixed;
     width: 100%;
@@ -19,28 +17,23 @@ table {
 {% endblock %}
 
 {% block content %}
-<br />
-<br />
-
 <br /><br />
-<h1>Rapid Checkin &mdash; For {{ program.niceName }}</h1>
+<h1>Student Checkout &mdash; For {{ program.niceName }}</h1>
 
 <div id='program_form'>
 
 <p style="margin: 10px">
-Welcome to student check-in for {{program.niceName}}.  Make sure that the students have handed in all necessary forms and payments.
-
-{% if message %}
-<p align="center">{{ message }}</p>
-{% endif %}
-
+Welcome to student checkout for {{ program.niceName }}.
+{% if student %}
+<!--Put student form here-->
+{% else %}
 <form id="checkinform" name="checkinform" method="POST" action="{{ request.path }}">
 <table>
     <col width="85%">
     <col width="15%">
     <tr>
         <th colspan="2">
-            Choose Students to Check In
+            Choose Students to Checkout
         </th>
     </tr>
     <tr>
@@ -52,26 +45,15 @@ Welcome to student check-in for {{program.niceName}}.  Make sure that the studen
             </table>
         </td>
         <td align="center">
-            <input class="button" type="submit" value="Check-In" />
+            <input class="button" type="submit" value="Checkout" />
         </td>
     </tr>
 </table>
 
 </form>
 
-<br />
-{% load render_qsd %}
-{% render_inline_program_qsd program "onsite:status" %}
-
-<h1>Advanced Checkin &mdash; For {{ program.niceName }}</h1>
-<p style="margin: 10px;">
-  <a href="/onsite/{{ program.url }}/checkin">Click here to view and edit the check-in of a user</a>
-</p>
-
-<h1>Barcode Checkin &mdash; For {{ program.niceName }}</h1>
-<p style="margin: 10px;">
-  <a href="/onsite/{{ program.url }}/barcodecheckin">Click here to check in many users at once by ID</a>
-</p>
+<!--Button to checkout everyone-->
+{% endif %}
 
 </div>
 

--- a/esp/templates/program/modules/onsitecheckoutmodule/checkout.html
+++ b/esp/templates/program/modules/onsitecheckoutmodule/checkout.html
@@ -24,16 +24,13 @@ table {
 
 <p style="margin: 10px">
 Welcome to student checkout for {{ program.niceName }}.
-{% if student %}
-<!--Put student form here-->
-{% else %}
-<form id="checkinform" name="checkinform" method="POST" action="{{ request.path }}">
+<form id="checkoutsearchform" name="checkoutsearchform" method="POST" action="{{ request.path }}">
 <table>
     <col width="85%">
     <col width="15%">
     <tr>
         <th colspan="2">
-            Choose Students to Checkout
+            Choose Student to Checkout
         </th>
     </tr>
     <tr>
@@ -49,11 +46,14 @@ Welcome to student checkout for {{ program.niceName }}.
         </td>
     </tr>
 </table>
-
 </form>
 
-<!--Button to checkout everyone-->
+{% if student %}
+<!--Put student form here-->
+{{ student }}
 {% endif %}
+
+<!--Button to checkout everyone-->
 
 </div>
 

--- a/esp/templates/program/modules/onsitecheckoutmodule/checkout.html
+++ b/esp/templates/program/modules/onsitecheckoutmodule/checkout.html
@@ -42,10 +42,37 @@ $j(function() {
     midnight.setHours(23,59,59);
     updateCheckboxes(from = now, to = midnight);
     
+    // If new option is chosen, change checkboxes accordingly
+    $j('input[type=radio][name=return_option]').change(function() {
+        if (this.value == 'checkout_all_day') {
+            // Unenroll from remaining classes today
+            updateCheckboxes(from = now, to = midnight);
+        }
+        else if (this.value == 'checkout_forever') {
+            // Unenroll from all remaining classes
+            updateCheckboxes(from = now, to = Infinity);
+        }
+        else if (this.value == 'returntime') {
+            // Unenroll from classes until specified time
+            var returntime = new Date($j("#returntime").val());
+            updateCheckboxes(from = now, to = returntime);
+        }
+    });
+    
     // If a specific time is set, mark classes until then
     $j("#returntime").change(function() {
+        $j("input[type=radio][name=return_option][value=returntime]").prop("checked", true).trigger("click");
         var returntime = new Date($j(this).val());
         updateCheckboxes(from = now, to = returntime);
+    });
+    
+    $j("#confirm").change(function() {
+        $j("#checkoutallsubmit").attr("disabled", !$j(this).prop( "checked" ));
+    });
+    
+    $j("#checkoutallform").submit(function(event) {
+        var c = confirm('Are you sure you want to checkout ALL checked-in students?');
+        return c;
     });
 });
 </script>
@@ -56,14 +83,14 @@ $j(function() {
 <h1>Student Checkout &mdash; For {{ program.niceName }}</h1>
 
 <div id='program_form'>
-
+<center>
 <form id="checkoutsearchform" name="checkoutsearchform" method="POST" action="{{ request.path }}">
 <table>
     <col width="85%">
     <col width="15%">
     <tr>
         <th colspan="2">
-            Choose Student to Checkout
+            Choose Individual Student to Checkout
         </th>
     </tr>
     <tr>
@@ -80,24 +107,36 @@ $j(function() {
     </tr>
 </table>
 </form>
-<br /><br />
 
 {% if student %}
-<center>
-<h3>When is the student returning? <input type="datetime-local" id="returntime" name="returntime" value="{% now 'Y-m-d' %}T{% now 'H:i' %}" min="{% now 'Y-m-d' %}T{% now 'H:i' %}"></h3>
-</center>
-<br /><br />
+<br />
+<div id="return_options">
+    <h2>
+        Choose one of the following checkout options for {{ student.first_name }} {{ student.last_name }} ({{ student.username }}):<br />
+    </h2>
+    <h3>
+        <input type="radio" name="return_option" value="checkout_all_day" checked /> This student is not returning today<br />
+        <input type="radio" name="return_option" value="checkout_forever" /> This student is not returning for the entire program<br />
+        <input type="radio" name="return_option" value="returntime" /> This student is returning at: <input type="datetime-local" id="returntime" name="returntime" value="{% now 'Y-m-d' %}T{% now 'H:i' %}" min="{% now 'Y-m-d' %}T{% now 'H:i' %}">
+    </h3>
+</div>
+
+<br />
+{% if checkout_message %}
+<h3 style="color:red;">{{ checkout_message }}</h3>
+{% endif %}
 <form id="checkoutform" name="checkoutform" method="POST" action="{{ request.path }}">
 <input type="hidden" name="user" value="{{ student.id }}"/>
 <input type="hidden" name="checkout_student"/>
+
 <table class="studentschedule">
-  <col width="25%">
+  <col width="20%">
   <col width="60%">
-  <col width="15%">
-  <tbody>
+  <col width="20%">
+  <thead>
     <tr>
-        <th colspan="3" class="user_info">
-            <i>Classes for {{ student.first_name }} {{ student.last_name }} - ID: {{ student.id }}</i>
+        <th colspan="3" align="center">
+            {{ student.first_name }} {{ student.last_name }} ({{ student.username }}) will be unenrolled from the checked classes below:
         </th>
     </tr>
     <tr>
@@ -111,6 +150,8 @@ $j(function() {
             Unenroll?
         </th>
     </tr>
+  </thead>
+  <tbody>
     {% for timeslot in timeslots %}
         {% ifchanged timeslot.0.start.day %}
             <tr>
@@ -119,32 +160,40 @@ $j(function() {
         {% endifchanged %}
         <tr class="schedule_row">
         {% with timeslot.1.0 as cls %}
-            <td class="time">{{ timeslot.0.short_time }}</td>
-            <td class="cls">
+            <td class="time" align="center">{{ timeslot.0.short_time }}</td>
+            <td class="cls" align="center">
             {% if cls %}
-                <!--link to course details?-->
                 <b>{{ cls.section.title }}{% if not cls.first_meeting_time %} (continued){% endif %}</b>
             {% else %}
                 No class
             {% endif %}
             </td>
             <td class="checkbox" align="center">
-                <input type="checkbox" value="{{ cls.section.id }}" data-start="{{ cls.section.start_time.start|date:'Y-m-d' }}T{{ cls.section.start_time.start|date:'H:i' }}" name="unenroll">
+                <input type="checkbox" {% if cls %}value="{{ cls.section.id }}" data-start="{{ cls.section.start_time.start|date:'Y-m-d' }}T{{ cls.section.start_time.start|date:'H:i' }}"{% else %}disabled{% endif %} name="unenroll">
             </td>
         {% endwith %}
     </tr>
     {% endfor %}
-    <tr>
-        <td colspan="3" align="center">
-            <input class="button" type="submit" value="Submit" />
-        </td>
-    </tr>
   </tbody>
 </table>
+<br />
+<input class="button" type="submit" value="Checkout Student" />
 </form>
 {% endif %}
-
-<!--Button to checkout everyone-->
+<hr>
+<form id="checkoutallform" name="checkoutallform" method="POST" action="{{ request.path }}">
+{% csrf_token %}
+<input type="hidden" name="checkoutall" />
+{% if checkout_all_message %}
+<h3 style="color:red;">{{ checkout_all_message }}</h3>
+{% endif %}
+<table>
+<tr><th>Checkout ALL Checked-In Students</th></tr>
+<tr><td align="center"><input type="checkbox" name="confirm" id="confirm"> I would like to checkout all checked-in students</td></tr>
+<tr><td align="center"><input class="button" id="checkoutallsubmit" type="submit" value="Checkout ALL Checked-In Students" disabled /></td></tr>
+</table>
+</form>
+</center>
 
 </div>
 

--- a/esp/templates/program/modules/onsitecheckoutmodule/checkout.html
+++ b/esp/templates/program/modules/onsitecheckoutmodule/checkout.html
@@ -13,7 +13,42 @@ table {
 #id_target_user {
     width: calc(100% - 10px);
 }
+.studentschedule input[type="checkbox"] {
+    float:none !important;
+    margin: 0px !important;
+}
+#returntime {
+    width: auto !important;
+}
 </style>
+{% endblock %}
+
+{% block javascript %}
+{{ block.super }}
+<script>
+function updateCheckboxes(from, to) {
+    $j(".studentschedule input[type='checkbox']").each(function() {
+        if ($j(this).val()) {
+            var sec_time = new Date($j(this).data('start'));
+            $j(this).prop("checked", from < sec_time && sec_time < to);
+        }
+    });
+}
+
+$j(function() {
+    // When loaded, mark rest of classes today
+    var now = new Date();
+    var midnight = new Date();
+    midnight.setHours(23,59,59);
+    updateCheckboxes(from = now, to = midnight);
+    
+    // If a specific time is set, mark classes until then
+    $j("#returntime").change(function() {
+        var returntime = new Date($j(this).val());
+        updateCheckboxes(from = now, to = returntime);
+    });
+});
+</script>
 {% endblock %}
 
 {% block content %}
@@ -22,8 +57,6 @@ table {
 
 <div id='program_form'>
 
-<p style="margin: 10px">
-Welcome to student checkout for {{ program.niceName }}.
 <form id="checkoutsearchform" name="checkoutsearchform" method="POST" action="{{ request.path }}">
 <table>
     <col width="85%">
@@ -47,10 +80,68 @@ Welcome to student checkout for {{ program.niceName }}.
     </tr>
 </table>
 </form>
+<br /><br />
 
 {% if student %}
-<!--Put student form here-->
-{{ student }}
+<center>
+<h3>When is the student returning? <input type="datetime-local" id="returntime" name="returntime" value="{% now 'Y-m-d' %}T{% now 'H:i' %}" min="{% now 'Y-m-d' %}T{% now 'H:i' %}"></h3>
+</center>
+<br /><br />
+<form id="checkoutform" name="checkoutform" method="POST" action="{{ request.path }}">
+<input type="hidden" name="user" value="{{ student.id }}"/>
+<input type="hidden" name="checkout_student"/>
+<table class="studentschedule">
+  <col width="25%">
+  <col width="60%">
+  <col width="15%">
+  <tbody>
+    <tr>
+        <th colspan="3" class="user_info">
+            <i>Classes for {{ student.first_name }} {{ student.last_name }} - ID: {{ student.id }}</i>
+        </th>
+    </tr>
+    <tr>
+        <th>
+            Time
+        </th>
+        <th>
+            Class
+        </th>
+        <th>
+            Unenroll?
+        </th>
+    </tr>
+    {% for timeslot in timeslots %}
+        {% ifchanged timeslot.0.start.day %}
+            <tr>
+                <th colspan="3" class="day">{{ timeslot.0.pretty_date }}</th>
+            </tr>
+        {% endifchanged %}
+        <tr class="schedule_row">
+        {% with timeslot.1.0 as cls %}
+            <td class="time">{{ timeslot.0.short_time }}</td>
+            <td class="cls">
+            {% if cls %}
+                <!--link to course details?-->
+                <b>{{ cls.section.title }}{% if not cls.first_meeting_time %} (continued){% endif %}</b>
+            {% else %}
+                No class
+            {% endif %}
+            </td>
+            <td class="checkbox" align="center">
+                <input type="checkbox" value="{{ cls.section.id }}" data-start="{{ cls.section.start_time.start|date:'Y-m-d' }}T{{ cls.section.start_time.start|date:'H:i' }}" name="unenroll">
+            </td>
+        {% endwith %}
+    </tr>
+    {% endfor %}
+    <tr>
+        <td colspan="3" align="center">
+            <input class="button" type="submit" value="Submit" />
+        </td>
+    </tr>
+  </tbody>
+</table>
+</form>
 {% endif %}
 
 <!--Button to checkout everyone-->


### PR DESCRIPTION
This module adds a new record to keep track of students that have checked _out_ of a program (as opposed to check _in_). The module allows an onsite user to select a student with a search bar, then choose which classes, if any, the student will be unenrolled from when they are checked out. The three options given do not affect the `checked_out` record that is created, rather they are short-hands to select the correct classes in the schedule below for unenrollment. There is also an option to check out all students that have checked in (with multiple confirmation checks).

The module itself is done, but I marked this as "Work in progress" because the record doesn't actually affect anything else on the site at this point.

![image](https://user-images.githubusercontent.com/7232514/72774087-fbade200-3bce-11ea-8137-546b56ade8d9.png)

Fixes https://github.com/learning-unlimited/ESP-Website/issues/2874, and thanks to the SplashCon admins that helped design this!