### PR TITLE
Add emailcode to subject line for class/section lists

### DIFF
--- a/esp/esp/dbmail/receivers/classlist.py
+++ b/esp/esp/dbmail/receivers/classlist.py
@@ -22,6 +22,8 @@ class ClassList(BaseHandler):
         except ESPUser.DoesNotExist:
             return
 
+        self.emailcode = cls.emailcode()
+
         program = cls.parent_program
         self.recipients = ['%s Directors <%s>' % (program.niceName(), program.director_email)]
 

--- a/esp/esp/dbmail/receivers/sectionlist.py
+++ b/esp/esp/dbmail/receivers/sectionlist.py
@@ -26,6 +26,8 @@ class SectionList(BaseHandler):
         except:
             return
 
+        self.emailcode = section.emailcode()
+
         program = cls.parent_program
         self.recipients = ['%s Directors <%s>' % (program.niceName(), program.director_email)]
 

--- a/esp/mailgates/mailgate.py
+++ b/esp/mailgates/mailgate.py
@@ -87,11 +87,13 @@ try:
         del(message['cc'])
         message['X-ESP-SENDER'] = 'version 2'
 
+        subject = message['subject']
+        del(message['subject'])
+        if instance.emailcode:
+            subject = '[%s]%s' % (instance.emailcode, subject)
         if handler.subject_prefix:
-            subject = message['subject']
-            del(message['subject'])
-            message['Subject'] = '%s%s' % (handler.subject_prefix,
-                                           subject)
+            subject = '%s%s' % (handler.subject_prefix, subject)
+        message['Subject'] = subject
 
         if handler.from_email:
             del(message['from'])

--- a/esp/mailgates/mailgate.py
+++ b/esp/mailgates/mailgate.py
@@ -90,9 +90,9 @@ try:
         subject = message['subject']
         del(message['subject'])
         if instance.emailcode:
-            subject = '[%s]%s' % (instance.emailcode, subject)
+            subject = '[%s] %s' % (instance.emailcode, subject)
         if handler.subject_prefix:
-            subject = '%s%s' % (handler.subject_prefix, subject)
+            subject = '[%s] %s' % (handler.subject_prefix, subject)
         message['Subject'] = subject
 
         if handler.from_email:


### PR DESCRIPTION
This adds the `emailcode` for a class (e.g. A1234) or section (e.g. A1234s1) to the subject line for any emails that are sent to the lists for those classes or sections (e.g. A1234-teachers@site.learningu.org). The email code is placed in brackets, with the prefix (if one is set through the admin pages) also placed in brackets before it (i.e. "[prefix] [emailcode] subject"). I tested this on the dev3 site with @kkbrum and it worked well. dev3 is still on this git branch, in case whoever reviews this wants to test it more.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/1600.