### PR TITLE
Form to change start_date on /manage/emails

### DIFF
--- a/esp/esp/program/views.py
+++ b/esp/esp/program/views.py
@@ -724,9 +724,10 @@ def emails(request):
     """
     context = {}
     if request.GET and "start_date" in request.GET:
-        start_date = datetime.datetime.strptime(request.GET["start_date"], "%m/%d/%Y")
+        start_date = datetime.datetime.strptime(request.GET["start_date"], "%Y-%m-%d")
     else:
         start_date = datetime.date.today() - datetime.timedelta(30)
+    context['start_date'] = start_date
     requests = MessageRequest.objects.filter(created_at__gte=start_date).order_by('-created_at')
 
     requests_list = []

--- a/esp/templates/admin/emails.html
+++ b/esp/templates/admin/emails.html
@@ -27,10 +27,10 @@ tr.email-header > th, tr.email-header > td {
 }
 
 th, td {
-  padding-top: 5px;
-  padding-left: 5px;
-  padding-bottom: 5px;
-  padding-right: 5px;
+  padding-top: 5px !important;
+  padding-left: 5px !important;
+  padding-bottom: 5px !important;
+  padding-right: 5px !important;
 }
 
 tr.email-header:hover {
@@ -48,8 +48,10 @@ tr.email-details {
 
 {% block content %}
 
-<p>This page lets you monitor emails that have been sent through the website via a program's comm panel within the last month.</p>
-<p>You can extend the search by appending "?start_date=MM/DD/YYYY" to the URL.</p>
+<p>This page lets you monitor emails that have been sent through the website via a program's comm panel.</p>
+<form action="/manage/emails" method="get">
+<p>Currently showing emails since <input name="start_date" type="date" onchange="$j(this).parents('form').submit();return false;" value="{{ start_date|date:"Y-m-d" }}"></p>
+</form>
 <p>If you notice any problems (emails aren't getting processed, emails won't send, emails are not sent to everyone, etc.), please contact <a href="mailto:websupport@learningu.org">websupport</a>.</p>
 
 {% if not requests %}

--- a/esp/templates/program/manage_programs.html
+++ b/esp/templates/program/manage_programs.html
@@ -32,6 +32,8 @@
           <li><a href="/customforms/">Create and edit custom survey forms</a></li>
           
           <li><a href="/manage/statistics/">View statistics about students</a></li>
+          
+          <li><a href="/manage/emails/">Monitor comm panel email status</a></li>
         </ul>
         </p>
 


### PR DESCRIPTION
This adds a small form on the new email monitoring page at `/manage/emails` (https://github.com/learning-unlimited/ESP-Website/pull/2852) that sets the `start_date` for the user (instead of the original behavior of having to manually set the GET flag). It basically works just like the program dropdown on the userview page. I also added a link to this page on the `/manage/programs` page.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/2910.