### PR TITLE
Barebones and Bigpicture Theme Fix

### DIFF
--- a/esp/esp/themes/theme_data/barebones/templates/sidebar/admin.html
+++ b/esp/esp/themes/theme_data/barebones/templates/sidebar/admin.html
@@ -1,7 +1,7 @@
 <li class="hidden nav-header admin">Admin</li>
 
 <li class="admin hidden"><a href="/admin/">
-  <i class="icon-cog"></i> Admin Home
+  <i class="icon-cog"></i> Administration Pages
 </a></li>
 <li class="admin hidden"><a href="/manage/programs/">
   <i class="icon-time"></i> Programs

--- a/esp/esp/themes/theme_data/bigpicture/templates/sidebar/admin.html
+++ b/esp/esp/themes/theme_data/bigpicture/templates/sidebar/admin.html
@@ -2,7 +2,7 @@
 
 {# TODO(benkraft): Allow configuring these too. #}
 <li class="admin hidden"><a href="/admin/">
-    <i class="glyphicon glyphicon-cog"></i> Admin Home
+    <i class="glyphicon glyphicon-cog"></i> Administration Pages
 </a></li>
 <li class="admin hidden"><a href="/manage/programs/">
     <i class="glyphicon glyphicon-time"></i> Programs


### PR DESCRIPTION
This changes the administration page title on the barebones and bigpicture themes from "Admin Home" to "Administration Pages". This aligns the two themes with all the rest of the themes.

Fixes #2889 