### PR TITLE
Fixed Header for Fruit Salad Theme

### DIFF
--- a/esp/esp/themes/theme_data/fruitsalad/less/main.less
+++ b/esp/esp/themes/theme_data/fruitsalad/less/main.less
@@ -402,6 +402,7 @@ position: absolute;
 top: 15px;
 left: 35px;
 font-family: sans-serif;
+width: 340px;
 }
 #contact_info span {
 display: block;
@@ -456,10 +457,11 @@ width: 20px;
 #login_box {
 font-size: 1.0em;
 position: absolute;
-width: 245px;
+width: 230px;
 height: 70px;
-right: 25px;
+right: 35px;
 top: 15px;
+text-align: right;
 }
 
 #login_user {

--- a/esp/templates/users/loginbox_userinfo.html
+++ b/esp/templates/users/loginbox_userinfo.html
@@ -1,5 +1,5 @@
 <div id="loginbox_user_name">
-    Hello, <span id="user_first_name"></span> <span id="user_last_name"></span>
+    <span id="user_first_name"></span> <span id="user_last_name"></span>
     <br />
     <span id="user_data">
         <span id="user_username"></span> / <span id="user_userid"></span>


### PR DESCRIPTION
Fixes #1338 

Added size definition to the #contact_info box so that it can no longer overlap with the #login_box.
Right justified the login box to make it look better
Removed hello, because web team decided we didn't need it.
Changed the justification of the #login_box in order for it to be symmetrical with the contact box