### PR TITLE
Mit walkin imports fix

### DIFF
--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -505,9 +505,20 @@ class TeacherClassRegModule(ProgramModuleObj):
         # Select the correct action
         if cls.category == self.program.open_class_category:
             action = 'editopenclass'
+            # allows walkins to be copied without setting specific hidden fields
+            # set walkin hidden fields to defaults
+            cls_data = cls.__dict__
+            cls_data['grade_min'] = prog.grade_min
+            cls_data['grade_max'] = prog.grade_max
+            cls_data['class_size_max'] = 200            
         else:
             action = 'edit'
-
+        # This way to import classes seems better than the hidden fields
+        # method in makeaclass_logic? since that method requires hiding the fields from
+        # both walkins and regular classes, which seems less versitile than 
+        # just setting the walkins hidden field values separately
+        # Regardless the hide fields functionality is probably still useful
+ 
         return self.makeaclass_logic(request, tl, one, two, module, extra, prog, cls, action, populateonly = True)
 
     @aux_call
@@ -671,6 +682,7 @@ class TeacherClassRegModule(ProgramModuleObj):
                         field.initial = initial_requests[field.label]
                         if form.resource_type.only_one and len(field.initial):
                             field.initial = field.initial[0]
+                    print field.label, field.initial
 
             else:
                 if action=='create':

--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -682,7 +682,6 @@ class TeacherClassRegModule(ProgramModuleObj):
                         field.initial = initial_requests[field.label]
                         if form.resource_type.only_one and len(field.initial):
                             field.initial = field.initial[0]
-                    print field.label, field.initial
 
             else:
                 if action=='create':

--- a/fabfile.py
+++ b/fabfile.py
@@ -296,7 +296,7 @@ def loaddb(filename=None):
 
         # Download database dump into VM
         escaped_url = pipes.quote(config["url"])
-        run("wget " + escaped_url + " -O " + env.encfab + "dbdump")
+        run("wget " + escaped_url + " -O " + env.encfab + "dbdump --no-check-certificate")
 
     # HACK: detect the Postgres user used in the dump. We run strings in case
     # the dump is in binary format, then we look for the grant for an arbitrary
@@ -306,7 +306,7 @@ def loaddb(filename=None):
     #   GRANT ALL ON TABLE program_class TO esp;
     #
     # ...which we can then parse to get the user. :D
-    query = "ALTER TABLE public.program_class OWNER TO|GRANT ALL ON TABLE program_class TO"
+    query = "ALTER TABLE public.program_class OWNER TO|GRANT ALL ON TABLE public.program_class TO"
     contents = run("strings " + env.encfab + "dbdump | grep -E '" + query + "'")
     pg_owner = contents.split()[-1][:-1]
 


### PR DESCRIPTION
Bug fix for walkins imports for Spark 2020:
Allows importing walkins from previous programs without setting teacher reg hidden fields
Instead sets walkin hidden field values to default when copying the class