### PR TITLE
Lower bigboard Threshhold

### DIFF
--- a/esp/esp/program/modules/handlers/bigboardmodule.py
+++ b/esp/esp/program/modules/handlers/bigboardmodule.py
@@ -65,7 +65,7 @@ class BigBoardModule(ProgramModuleObj):
             ("signed up for classes", [(1, time) for time in self.times_classes(prog)]),
         ]
 
-        timess_data, start = self.make_graph_data(timess, 10, 10, 5)
+        timess_data, start = self.make_graph_data(timess, 4, 0, 5)
 
         left_axis_data = [
             {"axis_name": "#", "series_data": timess_data},

--- a/esp/esp/program/modules/handlers/bigboardmodule.py
+++ b/esp/esp/program/modules/handlers/bigboardmodule.py
@@ -65,7 +65,7 @@ class BigBoardModule(ProgramModuleObj):
             ("signed up for classes", [(1, time) for time in self.times_classes(prog)]),
         ]
 
-        timess_data, start = self.make_graph_data(timess, 10, 10, 25)
+        timess_data, start = self.make_graph_data(timess, 10, 10, 5)
 
         left_axis_data = [
             {"axis_name": "#", "series_data": timess_data},


### PR DESCRIPTION
Fixes #2899 

Changed threshold of graphing on big board to 5. Also changed the amount of registrations that are dropped to 4 from the beginning and 0 from the end.