### PR TITLE
Fix moving classes vertically in the scheduler

### DIFF
--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -897,8 +897,11 @@ class ClassSection(models.Model):
         Assumes meeting_times is a sorted QuerySet of correct length.
 
         """
-        # if meeting_times[0] not in self.viable_times(ignore_classes=ignore_classes):
-        # This set of error messages deserves a better home
+        # check if proposed times are the same as the current meeting_times
+        current_times = self.meeting_times.all()
+        if all(time in current_times for time in meeting_times):
+            return False
+        # otherwise, check if all teachers are available
         for t in self.teachers:
             available = t.getAvailableTimes(self.parent_program, ignore_classes=ignore_classes)
             for e in meeting_times:


### PR DESCRIPTION
Before https://github.com/learning-unlimited/ESP-Website/commit/09b4805f21e843a98f19f6ff27f074f565b109c7, we were always assuming that we should ignore teachers' classes when checking if a section could be scheduled at a particular time. This was of course an issue theoretically because you could schedule a class at the same time as a class that a teacher is already scheduling, but it didn't cause any actual issues because the scheduler did its own availability checks before pushing a schedule request to the server. When I implemented https://github.com/learning-unlimited/ESP-Website/commit/09b4805f21e843a98f19f6ff27f074f565b109c7, we were then not ignoring any classes (because `ignore_classes=False` when `cannotSchedule` is called by the scheduler, which meant you couldn't schedule the class at the time that it was already scheduled. Now, we just check if that is the case first before checking teacher availability (if you were able to schedule the class before, you should be able to schedule it at the same time now).

Fixes https://github.com/learning-unlimited/ESP-Website/issues/2902.