### PR TITLE
Support recurring classes for attendance

### DIFF
--- a/esp/esp/program/modules/handlers/onsiteattendance.py
+++ b/esp/esp/program/modules/handlers/onsiteattendance.py
@@ -65,9 +65,10 @@ class OnSiteAttendance(ProgramModuleObj):
             if len(timeslots) == 1:
                 timeslot = timeslots[0]
                 context['timeslot'] = timeslot
-                if request.GET and "when" in request.GET:
+                when_get = request.GET.get("when", "")
+                if when_get != "":
                     # if a date is specified, use that date and the end time of the timeblock
-                    date = datetime.datetime.strptime(request.GET["when"], "%Y-%m-%d").date()
+                    date = datetime.datetime.strptime(when_get, "%Y-%m-%d").date()
                     when = datetime.datetime.combine(date, timeslot.end.time())
                 else:
                     # otherwise, just use the end time (and date) of the timeblock

--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -282,9 +282,13 @@ class TeacherClassRegModule(ProgramModuleObj):
                                     for rt in [enrolled, onsite]:
                                         srs = StudentRegistration.objects.filter(user = student, section = section, relationship = rt)
                                         if srs.count() > 0:
-                                            srs[0].unexpire()
+                                            sr = srs[0]
+                                            sr.unexpire()
                                         else:
-                                            StudentRegistration.objects.create(user = student, section = section, relationship = rt)
+                                            sr = StudentRegistration.objects.create(user = student, section = section, relationship = rt)
+                                        if rt.name=='OnSite/AttendedClass':
+                                            sr.end_date = today_max
+                                            sr.save()
 
                 section.enrolled_list = []
                 section.attended_list = []

--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -55,6 +55,7 @@ from django.template.loader      import render_to_string
 from esp.middleware.threadlocalrequest import get_current_request
 
 import json
+import datetime
 from copy import deepcopy
 
 class TeacherClassRegModule(ProgramModuleObj):
@@ -226,6 +227,9 @@ class TeacherClassRegModule(ProgramModuleObj):
         context['user'] = user
         context['not_found'] = []
 
+        today_min = datetime.datetime.combine(datetime.date.today(), datetime.time.min)
+        today_max = datetime.datetime.combine(datetime.date.today(), datetime.time.max)
+
         secid = 0
         if 'secid' in request.POST:
             secid = request.POST['secid']
@@ -245,9 +249,11 @@ class TeacherClassRegModule(ProgramModuleObj):
                     for student in section.students(verbs=["Enrolled","Attended"]):
                         if student.id in attending_students:
                             Record.objects.get_or_create(user=student, program=prog, event='attended')
-                            StudentRegistration.objects.get_or_create(user = student, section = section, relationship = attended)[0].unexpire()
+                            sr = StudentRegistration.objects.get_or_create(user = student, section = section, relationship = attended, start_date__range=(today_min, today_max))[0]
+                            sr.end_date = today_max
+                            sr.save()
                         else:
-                            srs = StudentRegistration.objects.filter(user = student, section = section, relationship = attended)
+                            srs = StudentRegistration.valid_objects().filter(user = student, section = section, relationship = attended)
                             for sr in srs:
                                 sr.expire()
                     misc_students = request.POST.get('misc_students').split()
@@ -262,7 +268,9 @@ class TeacherClassRegModule(ProgramModuleObj):
                                 continue
                         if student.isStudent():
                             Record.objects.get_or_create(user=student, program=prog, event='attended')
-                            StudentRegistration.objects.get_or_create(user = student, section = section, relationship = attended)[0].unexpire()
+                            sr = StudentRegistration.objects.get_or_create(user = student, section = section, relationship = attended, start_date__range=(today_min, today_max))[0]
+                            sr.end_date = today_max
+                            sr.save()
                             if student not in section.students():
                                 if 'unenroll' in request.POST:
                                     sm = ScheduleMap(student, prog)

--- a/esp/templates/program/modules/onsiteattendance/attendance.html
+++ b/esp/templates/program/modules/onsiteattendance/attendance.html
@@ -51,7 +51,7 @@ Please select a timeslot from the dropdown below:
         If this timeslot is for reccuring classes, select the preferred date here:<br />
         (the <a href="/onsite/{{ one }}/{{ two }}/attendance/{{ timeslot.id }}">default</a> is the date associated with the timeslot)
         </p>
-        <input name="when" type="date" onchange="$j(this).parents('form').submit();return false;" value="{{ when|date:'Y-m-d' }}" style="width:auto;">
+        <input name="when" type="date" value="{{ when|date:'Y-m-d' }}" style="width:auto;"><input type="submit" value="Change Date">
     </form>
     {% endif %}
 </center>
@@ -232,7 +232,7 @@ Please select a timeslot from the dropdown below:
 <br />
 <table>
 <tr>
-    <th colspan="6">Sections During This Timeslot with No Attendance Recorded</th>
+    <th colspan="6">Sections During This Timeslot with No Attendance Recorded{% if when != timeslot.end %} on {{ when|date:'n/j/Y' }}{% endif %}</th>
 </tr>
 <tr>
     <th width="5%">#</th>

--- a/esp/templates/program/modules/onsiteattendance/attendance.html
+++ b/esp/templates/program/modules/onsiteattendance/attendance.html
@@ -16,7 +16,9 @@
 
 <p>
 {% if timeslot %}
-Here is an attendance summary for {{ timeslot }}. Here you can see attendance statistics and details for students that have been checked in during this timeslot, students that are not attending class, and students that are attending classes they were not originally enrolled in. If you are looking for a different timeslot, you can select it from the dropdown below.
+<form action="/onsite/{{ one }}/{{ two }}/attendance/{{ timeslot.id }}" method="get">
+Here is an attendance summary for {{ timeslot }} at <input name="when" type="datetime-local" onchange="$j(this).parents('form').submit();return false;" value="{{ when|date:'Y-m-d' }}T{{ when|time:'H:i' }}">. Here you can see attendance statistics and details for students that have been checked in during this timeslot, students that are not attending class, and students that are attending classes they were not originally enrolled in. If you are looking for a different timeslot, you can select it from the dropdown below.
+</form>
 {% else %}
 Please select a timeslot from the dropdown below.
 {% endif %}

--- a/esp/templates/program/modules/onsiteattendance/attendance.html
+++ b/esp/templates/program/modules/onsiteattendance/attendance.html
@@ -14,19 +14,24 @@
 
 <div id="program_form">
 
+{% if timeslot %}
+<p>
+Here is an attendance summary for {{ timeslot }}. Here you can see attendance statistics and details for students that have been checked in during this timeslot, students that are not attending class, and students that are attending classes they were not originally enrolled in.
+</p>
+{% endif %}
+<center>
 <p>
 {% if timeslot %}
-<form action="/onsite/{{ one }}/{{ two }}/attendance/{{ timeslot.id }}" method="get">
-Here is an attendance summary for {{ timeslot }} at <input name="when" type="datetime-local" onchange="$j(this).parents('form').submit();return false;" value="{{ when|date:'Y-m-d' }}T{{ when|time:'H:i' }}">. Here you can see attendance statistics and details for students that have been checked in during this timeslot, students that are not attending class, and students that are attending classes they were not originally enrolled in. If you are looking for a different timeslot, you can select it from the dropdown below.
-</form>
+If you are looking for a different timeslot, you can select it from the dropdown below:
 {% else %}
-Please select a timeslot from the dropdown below.
+Please select a timeslot from the dropdown below:
 {% endif %}
-<br />
 </p>
+</center>
+
 
 <center>
-    <select name="tsid" onchange="location.href='/onsite/{{ one }}/{{ two }}/attendance/'+$j(this).children('option:selected').val()" style="width: 400px;">
+    <select name="tsid" onchange="location.href='/onsite/{{ one }}/{{ two }}/attendance/'+$j(this).children('option:selected').val(){% if when %}+'?when={{ when|date:'Y-m-d' }}'{% endif %}" style="width:auto;">
         {% if not timeslot %}
             <option disabled selected="selected">
                 (Select a timeslot)
@@ -38,15 +43,26 @@ Please select a timeslot from the dropdown below.
             </option>
         {% endfor %}
     </select>
+
+    {% if timeslot %}
+    <!--Could possibly hide this with a tag-->
+    <form action="/onsite/{{ one }}/{{ two }}/attendance/{{ timeslot.id }}" method="get">
+        <p>
+        If this timeslot is for reccuring classes, select the preferred date here:<br />
+        (the <a href="/onsite/{{ one }}/{{ two }}/attendance/{{ timeslot.id }}">default</a> is the date associated with the timeslot)
+        </p>
+        <input name="when" type="date" onchange="$j(this).parents('form').submit();return false;" value="{{ when|date:'Y-m-d' }}" style="width:auto;">
+    </form>
+    {% endif %}
 </center>
 
 {% if timeslot %}
 <center>
 <table>
 <tr>
-    <th width="33%"># Students<br />Checked In<br />To the Program</th>
-    <th width="33%"># Students<br />Enrolled in Classes<br />This Timeslot</th>
-    <th width="33%"># Students<br />Attending Classes<br />This Timeslot</th>
+    <th width="33%"># Students<br />Checked In<br />To the Program<br />Before {{ timeslot.end|date:"g:i A" }}{% if when != timeslot.end %} on {{ when|date:'n/j/Y' }}{% endif %}</th>
+    <th width="33%"># Students<br />Enrolled in Classes<br />During This Timeslot</th>
+    <th width="33%"># Students<br />Attending Classes<br />During This Timeslot{% if when != timeslot.end %}<br />on {{ when|date:'n/j/Y' }}{% endif %}</th>
 </tr>
 <tr>
     <td align="center">{{ checked_in.count }}</td>
@@ -57,7 +73,7 @@ Please select a timeslot from the dropdown below.
 <br />
 <table>
 <tr>
-    <th colspan="6">Students Checked In Between {{ timeslot.start_w_buffer|date:"g:i A" }} and {{ timeslot.end|date:"g:i A" }} </th>
+    <th colspan="6">Students Checked In Between {{ timeslot.start_w_buffer|date:"g:i A" }} and {{ timeslot.end|date:"g:i A" }}{% if when != timeslot.end %} on {{ when|date:'n/j/Y' }}{% endif %}</th>
 </tr>
 <tr>
     <th width="5%">#</th>
@@ -108,7 +124,7 @@ Please select a timeslot from the dropdown below.
 <br />
 <table>
 <tr>
-    <th colspan="7">Students Checked In But Not Attending Class</th>
+    <th colspan="7">Students Checked In Before {{ timeslot.end|date:"g:i A" }} But Not Attending Class During This Timeslot{% if when != timeslot.end %} on {{ when|date:'n/j/Y' }}{% endif %}</th>
 </tr>
 <tr>
     <th width="5%">#</th>
@@ -161,7 +177,7 @@ Please select a timeslot from the dropdown below.
 <br />
 <table>
 <tr>
-    <th colspan="8">Students Attending Classes In Which They Weren't Originally Enrolled</th>
+    <th colspan="8">Students Attending Classes In Which They Weren't Originally Enrolled During This Timeslot{% if when != timeslot.end %} on {{ when|date:'n/j/Y' }}{% endif %}</th>
 </tr>
 <tr>
     <th width="5%">#</th>
@@ -216,7 +232,7 @@ Please select a timeslot from the dropdown below.
 <br />
 <table>
 <tr>
-    <th colspan="6">Sections with No Attendance Recorded</th>
+    <th colspan="6">Sections During This Timeslot with No Attendance Recorded</th>
 </tr>
 <tr>
     <th width="5%">#</th>

--- a/esp/templates/program/modules/teacherclassregmodule/section_attendance.html
+++ b/esp/templates/program/modules/teacherclassregmodule/section_attendance.html
@@ -178,8 +178,8 @@ Please select a section from the dropdown below.
         <br /><span style="color:red">{{ not_found|join:", " }} not found</span>
         {% endif %}
         <br /><h3>For any attending students not enrolled in this section:</h3>
-        <input type="checkbox" name="enroll" checked>Enroll them in this section
-        <br /><input type="checkbox" name="unenroll" checked>Unenroll them from their conflicting sections
+        <input type="checkbox" name="enroll" checked> Enroll them in this section
+        <br /><input type="checkbox" name="unenroll" checked> Unenroll them from their conflicting sections
     </td>
 </tr>
 </tbody>


### PR DESCRIPTION
This extends the work I did in #2868 to support classes that occur on multiple days but rely on the same timeslot (e.g. Sprout classes). The first step was to make it so that attendance now expires at midnight on the day it is set. This then makes it so we can set or check attendance for specific days. I added a field that allows admins to pick this date for the onsite attendance module (the default is the day of the timeslot). For teachers, they won't notice any difference, except that the students they marked as attending for previous instances of the class will no longer be marked as attending. To make sure all of this is clear, I've made the code a lot clearer with more verbose comments, and I've made the headings for the various tables on the page much clearer and more precise. If a day other than the default is selected, this will be noted in lots of places on the page as a reminder.

![image](https://user-images.githubusercontent.com/7232514/75215251-b5135080-5755-11ea-98fc-405b090a922c.png)