### PR TITLE
Calculate survey participants based on new tags

### DIFF
--- a/esp/esp/survey/models.py
+++ b/esp/esp/survey/models.py
@@ -53,6 +53,7 @@ from esp.db.fields import AjaxForeignKey
 # Models to depend on.
 from esp.middleware import ESPError
 from esp.program.models import Program
+from esp.tagdict.models import Tag
 
 class ListField(object):
     """ Create a list type field descriptor. Allows you to
@@ -110,9 +111,11 @@ class Survey(models.Model):
         prog = self.program
         if prog:
             if self.category == 'teach':
-                return prog.teachers()['class_approved'].count()
+                filters = [x.strip() for x in Tag.getProgramTag('survey_teacher_filter', prog, default = "class_submitted").split(",") if x.strip()]
+                return len(set().union(*[prog.teachers().get(filter, []) for filter in filters]))
             elif self.category == 'learn':
-                return prog.students()['confirmed'].count()
+                filters = [x.strip() for x in Tag.getProgramTag('survey_student_filter', prog, default = "classreg").split(",") if x.strip()]
+                return len(set().union(*[prog.students().get(filter, []) for filter in filters]))
             else:
                 return 0
         else:

--- a/esp/esp/survey/views.py
+++ b/esp/esp/survey/views.py
@@ -72,9 +72,9 @@ def survey_view(request, tl, program, instance, template = 'survey/survey.html',
                 users = prog.students()
             else:
                 users = prog.teachers()
-            if not user.isAdmin() and user not in {item for sublist in [users[filter] for filter in filters] for item in sublist}:
+            if not user.isAdmin() and user not in {item for sublist in [users[filter] for filter in filters if filter in users] for item in sublist}:
                 descs = prog.getListDescriptions()
-                raise ESPError('Only ' + " or ".join([descs[filter].lower() for filter in filters]) + ' may participate in this survey.  Please contact the directors directly if you have additional feedback.', log=False)
+                raise ESPError('Only ' + " or ".join([descs[filter].lower() for filter in filters if filter in descs]) + ' may participate in this survey.  Please contact the directors directly if you have additional feedback.', log=False)
 
     if 'done' in request.GET:
         return render_to_response('survey/completed_survey.html', request, {'prog': prog})


### PR DESCRIPTION
I fixed the survey participant calculation to use the new tags `survey_student_filter` and `survey_teacher_filter`. I also realized that the survey page would break if the tag contained invalid keys (bug introduced in https://github.com/learning-unlimited/ESP-Website/pull/2871), so I fixed that, too.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/2927.