### PR TITLE
QSD button fix for bigpicture

### DIFF
--- a/esp/esp/themes/theme_data/bigpicture/less/main.less
+++ b/esp/esp/themes/theme_data/bigpicture/less/main.less
@@ -23,7 +23,7 @@
     }
     .btn {
         border: 1px solid @identity-blue;
-
+		background-image: none;
         &:active, &:focus {
             outline: none;
             border-color: @highlight-orange;

--- a/esp/esp/themes/theme_data/bigpicture/less/main.less
+++ b/esp/esp/themes/theme_data/bigpicture/less/main.less
@@ -21,7 +21,15 @@
         color: @identity-blue;
         text-decoration: underline;
     }
-    .btn, .button {
+    .btn {
+        border: 1px solid @identity-blue;
+
+        &:active, &:focus {
+            outline: none;
+            border-color: @highlight-orange;
+        }
+    }
+	.module_link_large {
         border: 1px solid @identity-blue;
         background: @pale;
         &:active, &:focus {
@@ -35,6 +43,8 @@
     }
     .btn-primary {
         background: @identity-blue;
+		color: white;
+		text-decoration: none;
     }
     .btn-inverse {
         background: #333;


### PR DESCRIPTION
Fixes #2926 

Removed a hard coded button styling from main.less
This allowed the default button colors to show through. Also had the effect that the theme settings from the theme page are no longer overridden. For some reason the default button is a gradient that uses the user setting along with white. That seemed silly to me so I added a line to hardcoded that away in main.less

Because of this change many programs may notice that their buttons might look different. To reset this back to default they should go into theme editor -> buttons -> and set all three button types to white. If the want their buttons to be a new color they can also to that too.

Note that this does not effect all buttons? Only buttons with type .btn - buttons with type .btn-primary buttons with still be dark blue.

Speaking of .btn-primary - these buttons were hard coded to have the same text and button color making them unreadable. NEPTUN added CSS to main.html quite a while ago to fix this, but I thought I should share the love and pass that fix on to everyone. That is why there is the addition of btn-primary color white and .btn-primary: text-decoration: none

😄 