### PR TITLE
Show all per class survey results for admins and add teacher search form

### DIFF
--- a/esp/esp/db/forms.py
+++ b/esp/esp/db/forms.py
@@ -55,6 +55,11 @@ class AjaxForeignKeyFieldBase:
         else:
             shadow_field_javascript = ""
 
+        if hasattr(self, "prog"):
+            prog = self.prog
+        else:
+            prog = ""
+
         javascript = """
 <script type="text/javascript">
 <!--
@@ -70,7 +75,8 @@ $j(function () {
                     model_module: "%(model_module)s",
                     model_name: "%(model_name)s",
                     ajax_func: "%(ajax_func)s",
-                    ajax_data: request.term
+                    ajax_data: request.term,
+                    prog: "%(prog)s",
                 },
                 success: function(data) {
                     var output = $j.map(data.result, function(item) {
@@ -102,7 +108,8 @@ $j(function () {
               shadow_field=self.shadow_field,
               model_module=model_module, model_name=model_name,
               ajax_func=(self.ajax_func or 'ajax_autocomplete'),
-              shadow_field_javascript=shadow_field_javascript)
+              shadow_field_javascript=shadow_field_javascript,
+              prog = prog)
 
         html = """
 <div class="raw_id_admin" style="display: none;">

--- a/esp/esp/survey/views.py
+++ b/esp/esp/survey/views.py
@@ -249,11 +249,10 @@ def display_survey(user, prog, surveys, request, tl, format, template = 'survey/
     if tl == 'manage':
         if teacher:
             teacher_form = ApprovedTeacherSearchForm(initial={'target_user': teacher.id}, prog = prog)
-            context['teacher'] = teacher
         elif teacher_form is None:
             teacher_form = ApprovedTeacherSearchForm(prog = prog)
     context['teacher_form'] = teacher_form
-    context.update({'user': user, 'surveys': survey_list, 'program': prog, 'perclass_data': perclass_data, 'tl': tl})
+    context.update({'user': user, 'teacher': teacher, 'surveys': survey_list, 'program': prog, 'perclass_data': perclass_data, 'tl': tl})
 
     #   Choose+use appropriate output format
     if format == 'html':

--- a/esp/esp/users/forms/generic_search_form.py
+++ b/esp/esp/users/forms/generic_search_form.py
@@ -10,6 +10,15 @@ class TeacherSearchForm(forms.Form):
     target_user = AjaxForeignKeyNewformField(key_type=ESPUser, field_name='target_user', label='Target Teacher',
         help_text='Select a teacher.', ajax_func='ajax_autocomplete_teacher')
 
+class ApprovedTeacherSearchForm(forms.Form):
+    target_user = AjaxForeignKeyNewformField(key_type=ESPUser, field_name='target_user', label='Target Teacher',
+        help_text='Select a teacher.', ajax_func='ajax_autocomplete_approved_teacher')
+    def __init__(self,*args,**kwargs):
+        prog = kwargs.pop('prog', None)
+        super(ApprovedTeacherSearchForm,self).__init__(*args,**kwargs)
+        if prog:
+            self.fields['target_user'].widget.prog = prog.id
+
 class StudentSearchForm(forms.Form):
     target_user = AjaxForeignKeyNewformField(key_type=ESPUser, field_name='target_user', label='Target Student',
         help_text='Select a student.', ajax_func='ajax_autocomplete_student')

--- a/esp/templates/outlines/review_base.tex
+++ b/esp/templates/outlines/review_base.tex
@@ -10,6 +10,7 @@
 \usepackage{enumerate}
 \usepackage{subfigure}
 \usepackage{boxedminipage}
+\usepackage{array}
 
 {% block headers %}
 \definecolor{esphead}{rgb}{0.773,0.867,0.965}
@@ -21,6 +22,8 @@
 }
 {% load latex %}
 {% endblock %}
+
+\newcolumntype{C}[1]{>{\centering\let\newline\\\arraybackslash\hspace{0pt}}m{#1}}
 
 \begin{document}
 

--- a/esp/templates/survey/answers.html
+++ b/esp/templates/survey/answers.html
@@ -1,6 +1,6 @@
 {% comment %}
 Expects:
-    "q": a list of dictionaries {
+    "q": a dictionary {
         'question': <Question object>,
         'answers': [iterable of <Answer object>s],
         }

--- a/esp/templates/survey/answers.html
+++ b/esp/templates/survey/answers.html
@@ -12,11 +12,11 @@ Expects:
 
 <table width="100%">
 <tr>
-    <td width="100%" valign="top" colspan="2"><b>{{ q.question.name }}</b></td>
+    <td width="100%" valign="top" colspan="2"><b>{{ q.question.name }}</b> ({{ q.answers|length }}/{{ num_participants }} responses)</td>
 </tr>
 {% if q.question.question_type.is_countable %}
     <tr>
-        <td width = "50%">
+        <td {% if q.question.question_type.is_numeric %}width="50%"{% else %}colspan="2"{% endif %}>
             {% if not q.answers|length_is:0 %}
                 {% with q.question.get_params as params %}
                     {% if q.question.question_type.is_numeric and params.number_of_ratings %}
@@ -39,19 +39,18 @@ Expects:
                 There are no responses to this question.
             {% endif %}
         </td>
+        {% if q.question.question_type.is_numeric %}
         <td width = "50%">
             <b>Statistics:</b>
             <ul>
-                <li>Number of responses: {{ q.answers|length }}/{{ num_participants }}</li>
-                {% if q.question.question_type.is_numeric %}
-                    <li>Average: {{ q.answers|unpack_answers|average }}</li>
-                    <li>Std. deviation: {{ q.answers|unpack_answers|stdev }}</li>
-                    {% if q.question.per_class %}
-                        <li>Average for all classes: {{ q.question.global_average }}</li>
-                    {% endif %}
+                <li>Average: {{ q.answers|unpack_answers|average }}</li>
+                <li>Std. deviation: {{ q.answers|unpack_answers|stdev }}</li>
+                {% if q.question.per_class %}
+                    <li>Average for all classes: {{ q.question.global_average }}</li>
                 {% endif %}
             </ul>
         </td>
+        {% endif %}
     </tr>
 {% else %}
     <tr>

--- a/esp/templates/survey/answers.html
+++ b/esp/templates/survey/answers.html
@@ -10,7 +10,7 @@ Expects:
 {% load survey %}
 {% load main %}
 
-<table width="100%" style="margin-bottom: 10px;">
+<table width="100%">
 <tr>
     <td width="100%" valign="top" colspan="2"><b>{{ q.question.name }}</b></td>
 </tr>

--- a/esp/templates/survey/answers.tex
+++ b/esp/templates/survey/answers.tex
@@ -3,7 +3,9 @@
 {% load latex %}
 
 {% if q.question.question_type.is_countable %}
-    \begin{minipage}[b]{3in} {{ q.question.name|texescape }}: \\
+    \begin{minipage}[b]{3in}
+        \vspace*{0.1in}
+        {{ q.question.name|texescape }}: \\
         (Numerical responses) \vspace*{0.5in}
 
         \textbf{Number of responses:} {{ q.answers|length }}/{{ num_participants }} \\
@@ -22,9 +24,12 @@
             {{ q.answers|unpack_answers|histogram:"format=tex"|safe }}
         {% endif %}
     {% else %} There are no responses to this question.
-    {% endif %} \\ \hline
+    {% endif %}
+    \vspace*{0.1in}
+    \\ \hline
 {% else %}
-    \begin{minipage}{3in} 
+    \begin{minipage}{3in}
+        \vspace*{0.1in}
         {{ q.question.name|texescape }} \vspace*{0.5in}
 
         \textbf{Number of responses:} {{ q.answers|length }}/{{ num_participants }} \\
@@ -38,7 +43,8 @@
         {% empty %}
             \item There are no responses to this question.
         {% endfor %}
-        \end{enumerate} \vspace*{0.1in}
+        \end{enumerate}
+        \vspace*{0.1in}
     {% else %}
         {% if not q.answers|length_is:0 %}
         \vspace*{0.1in} Responses include: \\ 
@@ -46,9 +52,12 @@
         \begin{itemize2}
         {% for a in q.answers|unpack_answers %}{% if not a|length_is:0 %}\item {{ a|texescape }}
         {% endif %}{% endfor %}
-        \end{itemize2} \vspace*{0.1in} 
-        {% else %} There are no responses to this question.
+        \end{itemize2}
+        {% else %}
+        \vspace*{0.5in}
+        There are no responses to this question.
         {% endif %}
+        \vspace*{0.1in}
     {% endifequal %}
     \end{minipage} \\ \hline
 {% endif %}

--- a/esp/templates/survey/review.html
+++ b/esp/templates/survey/review.html
@@ -17,9 +17,15 @@
 {% if teacher_form %}
 <form method="POST" action="{{ request.get_full_path }}">
 <h2>Search for a teacher to retrieve their specific survey results:</h2>
+{% for error in teacher_form.target_user.errors %}
+<span style="color:red;">{{ error|escape }}</span></br>
+{% endfor %}
 {{ teacher_form.target_user }}
 <input type="submit" value="Search" />
 </form>
+{% if teacher %}
+</br>(<a href="{{ request.path }}">Return To All Survey Results</a>)
+{% endif %}
 <br><br>
 {% endif %}
 
@@ -38,9 +44,14 @@
     <li><a href="#survey{{ s.id }}">Responses for: {{ s.name }}</a>
     <ul style="list-style-type:circle;">
     {% for q in s.display_data.questions %}
-        {% ifchanged q.question.per_class %}
-            <li><a href="#survey{{ s.id }}-{{ q.question.per_class }}">{% if q.question.per_class %}Per Class{% else %}Individual{% endif %} Questions</a></li>
-        {% endifchanged %}
+        {% if forloop.first %}
+            <li><a href="#survey{{ s.id }}-individual">Individual Questions</a></li>
+        {% endif %}
+    {% endfor %}
+    {% for c in s.perclass_data %}
+        {% if forloop.first %}
+            <li><a href="#survey{{ s.id }}-perclass">Per Class Questions</a></li>
+        {% endif %}
     {% endfor %}
     </ul>
     </li>
@@ -67,16 +78,32 @@
 {% for s in surveys %}
     <table class="fullwidth">
     <tr>
-        <th><h2><a name="survey{{ s.id }}"></a>Responses for: {{ s.name }}<span style="float:right;font-weight: normal;"><a href="#top">[to top]</a></span></h2></th>
+        <th><h1><a name="survey{{ s.id }}"></a>Responses for: {{ s.name }}<span style="float:right;font-weight: normal;"><a href="#top">[to top]</a></span></h1></th>
     </tr>
     </table>
     {% for q in s.display_data.questions %}
-        {% ifchanged q.question.per_class %}
-            <h2><a name="survey{{ s.id }}-{{ q.question.per_class }}"></a>{% if q.question.per_class %}Per Class{% else %}Individual{% endif %} Questions<span style="float:right;font-weight: normal;"><a href="#top">[to top]</a></span></h2>
-        {% endifchanged %}
+        {% if forloop.first %}
+            <h2><a name="survey{{ s.id }}-individual"></a>Individual Questions<span style="float:right;font-weight: normal;"><a href="#top">[to top]</a></span></h2>
+        {% endif %}
         {% with s.num_participants as num_participants %}
             {% include "survey/answers.html" %}
         {% endwith %}
+    {% endfor %}
+    {% for c in s.perclass_data %}
+        {% if forloop.first %}
+        <h2><a name="survey{{ s.id }}-perclass"></a>Per Class Questions<span style="float:right;font-weight: normal;"><a href="#top">[to top]</a></span></h2>
+        {% endif %}
+        <table class="fullwidth">
+            {% ifchanged c.class.parent_class %}
+            <tr><th><h2><a name="class{{ c.class.parent_class.id }}"></a>Responses for {{ c.class.parent_class.emailcode }}: {{ c.class.title }}<span style="float:right;font-weight: normal;"><a href="#top">[to top]</a></span></h2></th></tr>
+            {% endifchanged %}
+            <tr><th><h3><a name="class{{ c.class.parent_class.id }}-{{ c.class.index }}"></a>Responses for Section {{ c.class.index }}<span style="float:right;font-weight: normal;"><a href="#top">[to top]</a></span></h3></th></tr>
+        </table>
+        {% for q in c.questions %}
+            {% with c.class.num_students as num_participants %}
+                {% include "survey/answers.html" %}
+            {% endwith %}
+        {% endfor %}
     {% endfor %}
 {% endfor %}
 
@@ -86,7 +113,7 @@
         {% ifchanged c.class.parent_class %}
         <tr><th><h2><a name="class{{ c.class.parent_class.id }}"></a>Responses for {{ c.class.parent_class.emailcode }}: {{ c.class.title }}<span style="float:right;font-weight: normal;"><a href="#top">[to top]</a></span></h2></th></tr>
         {% endifchanged %}
-        <tr><th><h2><a name="class{{ c.class.parent_class.id }}-{{ c.class.index }}"></a>Responses for Section {{ c.class.index }}<span style="float:right;font-weight: normal;"><a href="#top">[to top]</a></span></h2></th></tr>
+        <tr><th><h3><a name="class{{ c.class.parent_class.id }}-{{ c.class.index }}"></a>Responses for Section {{ c.class.index }}<span style="float:right;font-weight: normal;"><a href="#top">[to top]</a></span></h3></th></tr>
     </table>
     {% for q in c.questions %}
         {% with c.class.num_students as num_participants %}

--- a/esp/templates/survey/review.html
+++ b/esp/templates/survey/review.html
@@ -12,11 +12,23 @@
 <style type="text/css">
 .nocheckmark { border: 1px solid black; }
 </style>
-<br /><br />
 <h1>Survey Responses for {{ program.niceName }} </h1>
+
+{% if teacher_form %}
+<form method="POST" action="{{ request.get_full_path }}">
+<h2>Search for a teacher to retirieve their specific survey results:</h2>
+{{ teacher_form.target_user }}
+<input type="submit" value="Search" />
+</form>
+<br><br>
+{% endif %}
 
 <div id="program_form">
 <center>
+
+{% if teacher %}
+<h2>Survey results for {{ teacher.name }}</h2>
+{% endif %}
 
 {% for s in surveys %}
     <table class="fullwidth">

--- a/esp/templates/survey/review.html
+++ b/esp/templates/survey/review.html
@@ -11,6 +11,12 @@
 
 <style type="text/css">
 .nocheckmark { border: 1px solid black; }
+.bordered {
+    border: 2px solid black;
+}
+td, th {
+    padding: 5px !important;
+}
 </style>
 <a name="top"></a><h1>Survey Responses for {{ program.niceName }} </h1>
 
@@ -76,50 +82,58 @@
 
 <center>
 {% for s in surveys %}
-    <table class="fullwidth">
-    <tr>
-        <th><h1><a name="survey{{ s.id }}"></a>Responses for: {{ s.name }}<span style="float:right;font-weight: normal;"><a href="#top">[to top]</a></span></h1></th>
-    </tr>
-    </table>
+    <h1><a name="survey{{ s.id }}"></a>Responses for: {{ s.name }}<span style="float:right;font-weight: normal;"><a href="#top">[to top]</a></span></h1>
     {% for q in s.display_data.questions %}
         {% if forloop.first %}
             <h2><a name="survey{{ s.id }}-individual"></a>Individual Questions<span style="float:right;font-weight: normal;"><a href="#top">[to top]</a></span></h2>
+            <table class="fullwidth bordered">
         {% endif %}
         {% with s.num_participants as num_participants %}
-            {% include "survey/answers.html" %}
+            <tr><td>{% include "survey/answers.html" %}</td></tr>
         {% endwith %}
     {% endfor %}
+    </table>
     {% for c in s.perclass_data %}
         {% if forloop.first %}
         <h2><a name="survey{{ s.id }}-perclass"></a>Per Class Questions<span style="float:right;font-weight: normal;"><a href="#top">[to top]</a></span></h2>
         {% endif %}
-        <table class="fullwidth">
-            {% ifchanged c.class.parent_class %}
-            <tr><th><h2><a name="class{{ c.class.parent_class.id }}"></a>Responses for {{ c.class.parent_class.emailcode }}: {{ c.class.title }}<span style="float:right;font-weight: normal;"><a href="#top">[to top]</a></span></h2></th></tr>
-            {% endifchanged %}
-            <tr><th><h3><a name="class{{ c.class.parent_class.id }}-{{ c.class.index }}"></a>Responses for Section {{ c.class.index }}<span style="float:right;font-weight: normal;"><a href="#top">[to top]</a></span></h3></th></tr>
-        </table>
+        {% ifchanged c.class.parent_class %}
+        {% if not forloop.first %}
+        </table></br></br>
+        {% endif %}
+        <table class="fullwidth bordered">
+        <tr><th><h2><a name="class{{ c.class.parent_class.id }}"></a>Responses for {{ c.class.parent_class.emailcode }}: {{ c.class.title }}<span style="float:right;font-weight: normal;"><a href="#top">[to top]</a></span></h2></th></tr>
+        {% endifchanged %}
+        <tr style="border-top: 1px dashed black;"><th><h3><a name="class{{ c.class.parent_class.id }}-{{ c.class.index }}"></a>Responses for Section {{ c.class.index }}<span style="float:right;font-weight: normal;"><a href="#top">[to top]</a></span></h3></th></tr>
         {% for q in c.questions %}
             {% with c.class.num_students as num_participants %}
-                {% include "survey/answers.html" %}
+                <tr><td>{% include "survey/answers.html" %}</td></tr>
             {% endwith %}
         {% endfor %}
+        {% if forloop.last %}
+        </table></br></br>
+        {% endif %}
     {% endfor %}
 {% endfor %}
 
 {% if perclass_data %}
 {% for c in perclass_data %}
-    <table class="fullwidth">
-        {% ifchanged c.class.parent_class %}
-        <tr><th><h2><a name="class{{ c.class.parent_class.id }}"></a>Responses for {{ c.class.parent_class.emailcode }}: {{ c.class.title }}<span style="float:right;font-weight: normal;"><a href="#top">[to top]</a></span></h2></th></tr>
-        {% endifchanged %}
-        <tr><th><h3><a name="class{{ c.class.parent_class.id }}-{{ c.class.index }}"></a>Responses for Section {{ c.class.index }}<span style="float:right;font-weight: normal;"><a href="#top">[to top]</a></span></h3></th></tr>
-    </table>
+    {% ifchanged c.class.parent_class %}
+    {% if not forloop.first %}
+    </table></br></br>
+    {% endif %}
+    <table class="fullwidth bordered">
+    <tr><th><h2><a name="class{{ c.class.parent_class.id }}"></a>Responses for {{ c.class.parent_class.emailcode }}: {{ c.class.title }}<span style="float:right;font-weight: normal;"><a href="#top">[to top]</a></span></h2></th></tr>
+    {% endifchanged %}
+    <tr style="border-top: 1px dashed black;"><th><h3><a name="class{{ c.class.parent_class.id }}-{{ c.class.index }}"></a>Responses for Section {{ c.class.index }}<span style="float:right;font-weight: normal;"><a href="#top">[to top]</a></span></h3></th></tr>
     {% for q in c.questions %}
         {% with c.class.num_students as num_participants %}
-            {% include "survey/answers.html" %}
+            <tr><td>{% include "survey/answers.html" %}</td></tr>
         {% endwith %}
     {% endfor %}
+    {% if forloop.last %}
+    </table>
+    {% endif %}
 {% endfor %}
 {% endif %}
 </center>

--- a/esp/templates/survey/review.html
+++ b/esp/templates/survey/review.html
@@ -92,7 +92,7 @@ td, th {
             <tr><td>{% include "survey/answers.html" %}</td></tr>
         {% endwith %}
     {% endfor %}
-    </table>
+    </table></br></br>
     {% for c in s.perclass_data %}
         {% if forloop.first %}
         <h2><a name="survey{{ s.id }}-perclass"></a>Per Class Questions<span style="float:right;font-weight: normal;"><a href="#top">[to top]</a></span></h2>

--- a/esp/templates/survey/review.html
+++ b/esp/templates/survey/review.html
@@ -12,11 +12,11 @@
 <style type="text/css">
 .nocheckmark { border: 1px solid black; }
 </style>
-<h1>Survey Responses for {{ program.niceName }} </h1>
+<a name="top"></a><h1>Survey Responses for {{ program.niceName }} </h1>
 
 {% if teacher_form %}
 <form method="POST" action="{{ request.get_full_path }}">
-<h2>Search for a teacher to retirieve their specific survey results:</h2>
+<h2>Search for a teacher to retrieve their specific survey results:</h2>
 {{ teacher_form.target_user }}
 <input type="submit" value="Search" />
 </form>
@@ -24,19 +24,56 @@
 {% endif %}
 
 <div id="program_form">
-<center>
 
 {% if teacher %}
+<center>
 <h2>Survey results for {{ teacher.name }}</h2>
+</center>
 {% endif %}
 
+
+<h2>Table of Contents</h2>
+<ul>
+{% for s in surveys %}
+    <li><a href="#survey{{ s.id }}">Responses for: {{ s.name }}</a>
+    <ul style="list-style-type:circle;">
+    {% for q in s.display_data.questions %}
+        {% ifchanged q.question.per_class %}
+            <li><a href="#survey{{ s.id }}-{{ q.question.per_class }}">{% if q.question.per_class %}Per Class{% else %}Individual{% endif %} Questions</a></li>
+        {% endifchanged %}
+    {% endfor %}
+    </ul>
+    </li>
+{% endfor %}
+
+{% if perclass_data %}
+{% for c in perclass_data %}
+    {% ifchanged c.class.parent_class %}
+        {% if not forloop.first %}
+            </ul>
+        {% endif %}
+        <li><a href="#class{{ c.class.parent_class.id }}">Responses for {{ c.class.parent_class.emailcode }}: {{ c.class.title }}</a></li>
+        <ul style="list-style-type:circle;">
+    {% endifchanged %}
+    <li><a href="#class{{ c.class.parent_class.id }}-{{ c.class.index }}">Responses for Section {{ c.class.index }}</a></li>
+    {% if forloop.last %}
+        </ul>
+    {% endif %}
+{% endfor %}
+{% endif %}
+</ul>
+
+<center>
 {% for s in surveys %}
     <table class="fullwidth">
     <tr>
-        <th><h2>Responses for: {{ s.name }}</h2></th>
+        <th><h2><a name="survey{{ s.id }}"></a>Responses for: {{ s.name }}<span style="float:right;font-weight: normal;"><a href="#top">[to top]</a></span></h2></th>
     </tr>
     </table>
     {% for q in s.display_data.questions %}
+        {% ifchanged q.question.per_class %}
+            <h2><a name="survey{{ s.id }}-{{ q.question.per_class }}"></a>{% if q.question.per_class %}Per Class{% else %}Individual{% endif %} Questions<span style="float:right;font-weight: normal;"><a href="#top">[to top]</a></span></h2>
+        {% endifchanged %}
         {% with s.num_participants as num_participants %}
             {% include "survey/answers.html" %}
         {% endwith %}
@@ -46,9 +83,10 @@
 {% if perclass_data %}
 {% for c in perclass_data %}
     <table class="fullwidth">
-    <tr>
-        <th class="small">Responses for {{ c.class.emailcode }}: {{ c.class.title }}</th>
-    </tr>
+        {% ifchanged c.class.parent_class %}
+        <tr><th><h2><a name="class{{ c.class.parent_class.id }}"></a>Responses for {{ c.class.parent_class.emailcode }}: {{ c.class.title }}<span style="float:right;font-weight: normal;"><a href="#top">[to top]</a></span></h2></th></tr>
+        {% endifchanged %}
+        <tr><th><h2><a name="class{{ c.class.parent_class.id }}-{{ c.class.index }}"></a>Responses for Section {{ c.class.index }}<span style="float:right;font-weight: normal;"><a href="#top">[to top]</a></span></h2></th></tr>
     </table>
     {% for q in c.questions %}
         {% with c.class.num_students as num_participants %}
@@ -57,7 +95,6 @@
     {% endfor %}
 {% endfor %}
 {% endif %}
-
 </center>
 </div>
 

--- a/esp/templates/survey/review.tex
+++ b/esp/templates/survey/review.tex
@@ -27,7 +27,7 @@
     \end{longtable}
     \end{center}
     {% for c in s.perclass_data %}
-        {% if not forloop.first %}\clearpage{% endif %}
+        \clearpage
         \begin{center}
         \begin{longtable}{|p{0.5\linewidth}|p{0.5\linewidth}|} \hline
         \multicolumn{2}{|C{\linewidth}|}{\cellcolor{esphead} ~ } \\

--- a/esp/templates/survey/review.tex
+++ b/esp/templates/survey/review.tex
@@ -15,7 +15,7 @@
 \vspace{0.25in}
 {% if not forloop.first %}\clearpage{% endif %}
     \begin{center}
-    \begin{longtable}{|p{0.5\linewidth}|p{0.5\linewidth}|} \hline
+    \begin{longtable}{|p{0.48\linewidth}|p{0.48\linewidth}|} \hline
     \multicolumn{2}{|C{\linewidth}|}{\cellcolor{esphead} ~ } \\
     \multicolumn{2}{|C{\linewidth}|}{\cellcolor{esphead} \Large {Responses for {{ s.name }}} } \\ 
     \multicolumn{2}{|C{\linewidth}|}{\cellcolor{esphead} ~ } \\\hline
@@ -29,7 +29,7 @@
     {% for c in s.perclass_data %}
         \clearpage
         \begin{center}
-        \begin{longtable}{|p{0.5\linewidth}|p{0.5\linewidth}|} \hline
+        \begin{longtable}{|p{0.48\linewidth}|p{0.48\linewidth}|} \hline
         \multicolumn{2}{|C{\linewidth}|}{\cellcolor{esphead} ~ } \\
         \multicolumn{2}{|C{\linewidth}|}{\cellcolor{esphead} \Large {Responses for {{ c.class.emailcode }}: {{ c.class.title|texescape }}} } \\ 
         \multicolumn{2}{|C{\linewidth}|}{\cellcolor{esphead} ~ } \\\hline
@@ -57,7 +57,7 @@ Students were also asked a few questions about each of their classes.  The resul
 {% for c in perclass_data %}
 {% if not forloop.first %}\clearpage{% endif %}
     \begin{center}
-    \begin{longtable}{|p{0.5\linewidth}|p{0.5\linewidth}|} \hline
+    \begin{longtable}{|p{0.48\linewidth}|p{0.48\linewidth}|} \hline
     \multicolumn{2}{|C{\linewidth}|}{\cellcolor{esphead} ~ } \\
     \multicolumn{2}{|C{\linewidth}|}{\cellcolor{esphead} \Large {Responses for {{ c.class.emailcode }}: {{ c.class.title|texescape }}} } \\ 
     \multicolumn{2}{|C{\linewidth}|}{\cellcolor{esphead} ~ } \\\hline

--- a/esp/templates/survey/review.tex
+++ b/esp/templates/survey/review.tex
@@ -11,18 +11,14 @@
 
 \vspace{0.3in}
 
-{% if not surveys|length_is:0 %}
-Students from {{ prog.niceName }} filled out an online survey asking some questions about the program as a whole.  Their responses are summarized below.
-{% endif %}
-
 {% for s in surveys %}
 \vspace{0.25in}
 {% if not forloop.first %}\clearpage{% endif %}
     \begin{center}
-    \begin{longtable}{|l|l|} \hline
-    \multicolumn{2}{|c|}{\cellcolor{esphead} ~ } \\
-    \multicolumn{2}{|c|}{\cellcolor{esphead} \Large {Responses for {{ s.name }}} } \\ 
-    \multicolumn{2}{|c|}{\cellcolor{esphead} ~ } \\\hline
+    \begin{longtable}{|p{0.5\linewidth}|p{0.5\linewidth}|} \hline
+    \multicolumn{2}{|C{\linewidth}|}{\cellcolor{esphead} ~ } \\
+    \multicolumn{2}{|C{\linewidth}|}{\cellcolor{esphead} \Large {Responses for {{ s.name }}} } \\ 
+    \multicolumn{2}{|C{\linewidth}|}{\cellcolor{esphead} ~ } \\\hline
     {% for q in s.display_data.questions %}
         {% with s.num_participants as num_participants %}
             {% include "survey/answers.tex" %}
@@ -30,6 +26,22 @@ Students from {{ prog.niceName }} filled out an online survey asking some questi
     {% endfor %}
     \end{longtable}
     \end{center}
+    {% for c in s.perclass_data %}
+        {% if not forloop.first %}\clearpage{% endif %}
+        \begin{center}
+        \begin{longtable}{|p{0.5\linewidth}|p{0.5\linewidth}|} \hline
+        \multicolumn{2}{|C{\linewidth}|}{\cellcolor{esphead} ~ } \\
+        \multicolumn{2}{|C{\linewidth}|}{\cellcolor{esphead} \Large {Responses for {{ c.class.emailcode }}: {{ c.class.title|texescape }}} } \\ 
+        \multicolumn{2}{|C{\linewidth}|}{\cellcolor{esphead} ~ } \\\hline
+        \multicolumn{2}{|C{\linewidth}|}{Teachers: {{ c.class.parent_class.getTeacherNames|join:", "|texescape }} } \\ \hline
+        {% for q in c.questions %}
+            {% with c.class.num_students as num_participants %}
+                {% include "survey/answers.tex" %}
+            {% endwith %}
+        {% endfor %}
+        \end{longtable}
+        \end{center}
+    {% endfor %}
 {% endfor %}
 
 
@@ -42,11 +54,11 @@ Students were also asked a few questions about each of their classes.  The resul
 {% for c in perclass_data %}
 {% if not forloop.first %}\clearpage{% endif %}
     \begin{center}
-    \begin{longtable}{|l|l|} \hline
-    \multicolumn{2}{|c|}{\cellcolor{esphead} ~ } \\
-    \multicolumn{2}{|c|}{\cellcolor{esphead} \Large {Responses for {{ c.class.emailcode }}: {{ c.class.title|texescape }}} } \\ 
-    \multicolumn{2}{|c|}{\cellcolor{esphead} ~ } \\\hline
-    \multicolumn{2}{|c|}{Teachers: {{ c.class.parent_class.getTeacherNames|join:", "|texescape }} } \\ \hline
+    \begin{longtable}{|p{0.5\linewidth}|p{0.5\linewidth}|} \hline
+    \multicolumn{2}{|C{\linewidth}|}{\cellcolor{esphead} ~ } \\
+    \multicolumn{2}{|C{\linewidth}|}{\cellcolor{esphead} \Large {Responses for {{ c.class.emailcode }}: {{ c.class.title|texescape }}} } \\ 
+    \multicolumn{2}{|C{\linewidth}|}{\cellcolor{esphead} ~ } \\\hline
+    \multicolumn{2}{|C{\linewidth}|}{Teachers: {{ c.class.parent_class.getTeacherNames|join:", "|texescape }} } \\ \hline
     {% for q in c.questions %}
         {% with c.class.num_students as num_participants %}
             {% include "survey/answers.tex" %}

--- a/esp/templates/survey/review.tex
+++ b/esp/templates/survey/review.tex
@@ -33,7 +33,10 @@
         \multicolumn{2}{|C{\linewidth}|}{\cellcolor{esphead} ~ } \\
         \multicolumn{2}{|C{\linewidth}|}{\cellcolor{esphead} \Large {Responses for {{ c.class.emailcode }}: {{ c.class.title|texescape }}} } \\ 
         \multicolumn{2}{|C{\linewidth}|}{\cellcolor{esphead} ~ } \\\hline
-        \multicolumn{2}{|C{\linewidth}|}{Teachers: {{ c.class.parent_class.getTeacherNames|join:", "|texescape }} } \\ \hline
+        \multicolumn{2}{|C{\linewidth}|}{
+            \rule{0pt}{3ex}
+            Teachers: {{ c.class.parent_class.getTeacherNames|join:", "|texescape }}
+            \rule[-1.5ex]{0pt}{0pt} } \\\hline
         {% for q in c.questions %}
             {% with c.class.num_students as num_participants %}
                 {% include "survey/answers.tex" %}
@@ -58,7 +61,10 @@ Students were also asked a few questions about each of their classes.  The resul
     \multicolumn{2}{|C{\linewidth}|}{\cellcolor{esphead} ~ } \\
     \multicolumn{2}{|C{\linewidth}|}{\cellcolor{esphead} \Large {Responses for {{ c.class.emailcode }}: {{ c.class.title|texescape }}} } \\ 
     \multicolumn{2}{|C{\linewidth}|}{\cellcolor{esphead} ~ } \\\hline
-    \multicolumn{2}{|C{\linewidth}|}{Teachers: {{ c.class.parent_class.getTeacherNames|join:", "|texescape }} } \\ \hline
+    \multicolumn{2}{|C{\linewidth}|}{
+            \rule{0pt}{3ex}
+            Teachers: {{ c.class.parent_class.getTeacherNames|join:", "|texescape }}
+            \rule[-1.5ex]{0pt}{0pt} } \\\hline
     {% for q in c.questions %}
         {% with c.class.num_students as num_participants %}
             {% include "survey/answers.tex" %}


### PR DESCRIPTION
Before we only showed numerical per class survey results. Now we include the non-numerical results as well. Also, the results are now grouped into individual and per class sections. I also tweaked some of the styling of the page overall, added a table of contents to the top, and added a search box to select a teacher by which to filter the survey results.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/2938.