### PR TITLE
Remove old survey copy option from admin pages

### DIFF
--- a/esp/esp/survey/admin.py
+++ b/esp/esp/survey/admin.py
@@ -40,30 +40,7 @@ from django.conf import settings
 from esp.admin import admin_site
 from esp.survey.models import Survey, SurveyResponse, QuestionType, Question, Answer
 
-from copy import deepcopy
-from StringIO import StringIO
-import tempfile
-
-def copy_surveys(modeladmin, request, queryset):
-    survey_count = 0
-    question_count = 0
-    for survey in queryset:
-
-        newsurvey, created = Survey.objects.get_or_create(name=survey.name + " (copy)", program=survey.program, category = survey.category)
-        questions = survey.questions.order_by('id')
-        if created: survey_count += 1
-
-        for q in questions:
-            # Create a new question for the new survey
-            newq, created = Question.objects.get_or_create(survey=newsurvey, name=q.name, question_type=q.question_type, _param_values=q._param_values, per_class=q.per_class, seq=q.seq)
-            newq.save()
-            if created: question_count += 1
-
-        newsurvey.save()
-    modeladmin.message_user(request, "%s survey(s) copied, a total of %s question(s) copied" % (survey_count, question_count))
-
 class SurveyAdmin(admin.ModelAdmin):
-    actions = [ copy_surveys, ]
     list_filter = ('category',)
 admin_site.register(Survey, SurveyAdmin)
 


### PR DESCRIPTION
Previously, the only way to copy an old survey was to go into the admin pages and use the custom "Copy Survey" option, which created an exact duplicate for the same program. Surveys can now be imported from a previous program to a new program in the new survey management user interface (https://github.com/learning-unlimited/ESP-Website/pull/2929), so this functionality is no longer necessary (and is probably more confusing because it copies the survey to the old program). I've removed the code and the admin pages action option to reduce confusion.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/479.