### PR TITLE
Remove catalog deadline

### DIFF
--- a/esp/esp/program/modules/handlers/studentclassregmodule.py
+++ b/esp/esp/program/modules/handlers/studentclassregmodule.py
@@ -567,19 +567,11 @@ class StudentClassRegModule(ProgramModuleObj):
         json.dump(reg_bits_data, resp)
         return resp
 
-    # This function exists only to apply the @meets_deadline decorator.
-    @meets_deadline('/Catalog')
-    def catalog_student(self, request, tl, one, two, module, extra, prog, timeslot=None):
-        """ Return the program class catalog, after checking the deadline """
-        return self.catalog_render(request, tl, one, two, module, extra, prog, timeslot)
-
-    # This function gets called and branches off to the two above depending on the user's role
     @disable_csrf_cookie_update
     @aux_call
     @no_auth
     @cache_control(public=True, max_age=120)
     def catalog(self, request, tl, one, two, module, extra, prog, timeslot=None):
-        """ Check user role and maybe return the program class catalog """
         return self.catalog_render(request, tl, one, two, module, extra, prog, timeslot)
 
     @disable_csrf_cookie_update

--- a/esp/esp/program/setup.py
+++ b/esp/esp/program/setup.py
@@ -48,7 +48,6 @@ def prepare_program(program, data):
     modules = []
 
     perms += [('Student/All', None, data['student_reg_start'], data['student_reg_end'])] #it is recursive
-    perms += [('Student/Catalog', None, data['student_reg_start'], None)]
     perms += [('Student/Profile', None, data['student_reg_start'], None)]
     perms += [('Teacher/All', None, data['teacher_reg_start'], data['teacher_reg_end'])]
     perms += [('Teacher/Classes/View', None, data['teacher_reg_start'], None)]

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -2304,7 +2304,6 @@ class Permission(ExpirableModel):
             ("Student/All", "All student deadlines"),
             ("Student/Acknowledgement", "Student acknowledgement"),
             ("Student/Applications", "Apply for classes"),
-            ("Student/Catalog", "View the catalog"),
             ("Student/Classes", "Register for classes"),
             ("Student/Classes/Lunch", "Register for lunch"),
             ("Student/Classes/Lottery", "Enter the lottery"),


### PR DESCRIPTION
This removes the "Student/Catalog" deadline and also removes old code that was seemingly dependent on it but was never actually called from anywhere.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/1215.