### PR TITLE
Make null=False for ProgramModuleObj.required_label

### DIFF
--- a/esp/esp/program/modules/base.py
+++ b/esp/esp/program/modules/base.py
@@ -70,7 +70,7 @@ class ProgramModuleObj(models.Model):
     module   = models.ForeignKey(ProgramModule)
     seq      = models.IntegerField()
     required = models.BooleanField(default=False)
-    required_label = models.CharField(max_length=80, blank=True, null=True)
+    required_label = models.CharField(max_length=80, blank=True, null=False)
 
     def docs(self):
         if hasattr(self, 'doc') and self.doc is not None and str(self.doc).strip() != '':

--- a/esp/esp/program/modules/base.py
+++ b/esp/esp/program/modules/base.py
@@ -70,7 +70,7 @@ class ProgramModuleObj(models.Model):
     module   = models.ForeignKey(ProgramModule)
     seq      = models.IntegerField()
     required = models.BooleanField(default=False)
-    required_label = models.CharField(max_length=80, blank=True, null=False)
+    required_label = models.CharField(max_length=80, blank=True, null=False, default="")
 
     def docs(self):
         if hasattr(self, 'doc') and self.doc is not None and str(self.doc).strip() != '':

--- a/esp/esp/program/modules/migrations/0019_auto_20200502_1251.py
+++ b/esp/esp/program/modules/migrations/0019_auto_20200502_1251.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import esp.program.modules.base
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('modules', '0018_studentonsite'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='programmoduleobj',
+            name='required_label',
+            field=models.CharField(default=b'', max_length=80, blank=True),
+        ),
+    ]


### PR DESCRIPTION
This makes `Null=False` for the `required_label` field for `ProgramModuleObj`, which should solve erroneous cases of "(not required)" not showing up when it should.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/1521.