### PR TITLE
Credit Card Viewpay Fixes

### DIFF
--- a/esp/esp/program/modules/handlers/creditcardviewer.py
+++ b/esp/esp/program/modules/handlers/creditcardviewer.py
@@ -32,15 +32,9 @@ Learning Unlimited, Inc.
   Phone: 617-379-0178
   Email: web-team@learningu.org
 """
-from esp.program.modules.base import ProgramModuleObj, needs_teacher, needs_student, needs_admin, usercheck_usetl, meets_deadline, main_call, aux_call
-from esp.program.modules import module_ext
+from esp.program.modules.base import ProgramModuleObj, needs_admin, main_call
 from esp.utils.web       import render_to_response
-from django.db.models.query     import Q
-from django.db.models    import Sum
-from esp.users.models    import User, ESPUser
-from esp.accounting.models import Transfer
 from esp.accounting.controllers import ProgramAccountingController, IndividualAccountingController
-from esp.middleware      import ESPError
 from argcache            import cache_function
 
 class CreditCardViewer(ProgramModuleObj):

--- a/esp/esp/program/modules/handlers/creditcardviewer.py
+++ b/esp/esp/program/modules/handlers/creditcardviewer.py
@@ -44,11 +44,11 @@ from esp.accounting.controllers import ProgramAccountingController, IndividualAc
 from esp.middleware      import ESPError
 from argcache            import cache_function
 
-class CreditCardViewer_Cybersource(ProgramModuleObj):
+class CreditCardViewer(ProgramModuleObj):
     @classmethod
     def module_properties(cls):
         return {
-            "admin_title": "Credit Card View Module (Cybersource)",
+            "admin_title": "Credit Card View Module",
             "link_title": "View Credit Card Transactions",
             "module_type": "manage",
             "seq": 10000
@@ -56,7 +56,7 @@ class CreditCardViewer_Cybersource(ProgramModuleObj):
 
     @main_call
     @needs_admin
-    def viewpay_cybersource(self, request, tl, one, two, module, extra, prog):
+    def viewpay(self, request, tl, one, two, module, extra, prog):
         pac = ProgramAccountingController(prog)
         student_list = list(pac.all_students())
         payment_table = []
@@ -76,7 +76,7 @@ class CreditCardViewer_Cybersource(ProgramModuleObj):
             'total_payment': total_payment,
         }
 
-        return render_to_response(self.baseDir() + 'viewpay_cybersource.html', request, context)
+        return render_to_response(self.baseDir() + 'viewpay.html', request, context)
 
     @staticmethod
     @cache_function

--- a/esp/esp/program/modules/handlers/creditcardviewer.py
+++ b/esp/esp/program/modules/handlers/creditcardviewer.py
@@ -35,7 +35,6 @@ Learning Unlimited, Inc.
 from esp.program.modules.base import ProgramModuleObj, needs_teacher, needs_student, needs_admin, usercheck_usetl, meets_deadline, main_call, aux_call
 from esp.program.modules import module_ext
 from esp.utils.web       import render_to_response
-from datetime            import datetime
 from django.db.models.query     import Q
 from django.db.models    import Sum
 from esp.users.models    import User, ESPUser

--- a/esp/esp/program/modules/migrations/0019_auto_20200503_1046.py
+++ b/esp/esp/program/modules/migrations/0019_auto_20200503_1046.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import esp.program.modules.base
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('modules', '0018_studentonsite'),
+    ]
+
+    operations = [
+        migrations.RenameModel('CreditCardViewer_Cybersource', 'CreditCardViewer')
+    ]

--- a/esp/esp/program/modules/migrations/0020_auto_20200503_1046.py
+++ b/esp/esp/program/modules/migrations/0020_auto_20200503_1046.py
@@ -8,7 +8,7 @@ import esp.program.modules.base
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('modules', '0018_studentonsite'),
+        ('modules', '0019_auto_20200502_1251'),
     ]
 
     operations = [

--- a/esp/templates/program/modules/creditcardviewer/viewpay.html
+++ b/esp/templates/program/modules/creditcardviewer/viewpay.html
@@ -36,7 +36,7 @@
 </ul>
 
 <div id="program_form">
-<table>
+<table width="100%">
 
 <tr>
 <th>
@@ -47,15 +47,15 @@ Payments:
 </th>
 </tr>
 {% for payment in payment_table %}
-<tr>
+<tr{% if not forloop.last %} style="border-bottom: 1px dashed #699;"{% endif %}>
 <td>
-<b>{{ payment.0.get_full_name }}</b> (ID: {{ payment.0.id }}) <br />
+<b><a href="/manage/userview?username={{ payment.0.username}}">{{ payment.0.get_full_name }}</a></b> (ID: {{ payment.0.id }}) <br />
 ${{ payment.2 }} billed; ${{ payment.3 }} owed
 </td>
 <td>
-<ul>
+<ul style="margin: 0px;">
 {% for transfer in payment.1 %}
-<li>${{ transfer.amount|floatformat:2 }} - {{ transfer.line_item.text }}
+<li>${{ transfer.amount|floatformat:2 }} - {{ transfer.line_item.text }}{% if transfer.transaction_id %} (CC Transaction ID: {{ transfer.transaction_id }}){% endif %}
 </div></li> <!-- div.( doc.getDoctypeStr ) -->
 {% endfor %}
 </ul>


### PR DESCRIPTION
This removes all mentions of "Cybersource" from the credit card viewpay module (including renaming the module and all files). I also added the credit card transaction IDs when payments were made by credit card, cleaned up the table a little bit, and linked to the userview page for each student.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/1328 and fixes https://github.com/learning-unlimited/ESP-Website/issues/1329.

![image](https://user-images.githubusercontent.com/7232514/80919538-19432980-8d30-11ea-9e79-ec57e68b9606.png)