### PR TITLE
Add filter for class registrations to UserSearchController

### DIFF
--- a/esp/esp/program/modules/handlers/commmodule.py
+++ b/esp/esp/program/modules/handlers/commmodule.py
@@ -235,7 +235,11 @@ class CommModule(ProgramModuleObj):
             #   Turn multi-valued QueryDict into standard dictionary
             data = {}
             for key in request.POST:
-                data[key] = request.POST[key]
+                #   Some keys have list values
+                if key in ['regtypes']:
+                    data[key] = request.POST.getlist(key)
+                else:
+                    data[key] = request.POST[key]
 
             ##  Handle normal list selecting submissions
             if ('base_list' in data and 'recipient_type' in data) or ('combo_base_list' in data):

--- a/esp/esp/program/modules/handlers/grouptextmodule.py
+++ b/esp/esp/program/modules/handlers/grouptextmodule.py
@@ -110,7 +110,11 @@ class GroupTextModule(ProgramModuleObj):
         if request.method == "POST":
             data = {}
             for key in request.POST:
-                data[key] = request.POST[key]
+                #   Some keys have list values
+                if key in ['regtypes']:
+                    data[key] = request.POST.getlist(key)
+                else:
+                    data[key] = request.POST[key]
             filterObj = UserSearchController().filter_from_postdata(prog, data)
 
             context['filterid'] = filterObj.id

--- a/esp/esp/program/modules/handlers/listgenmodule.py
+++ b/esp/esp/program/modules/handlers/listgenmodule.py
@@ -366,7 +366,11 @@ class ListGenModule(ProgramModuleObj):
             #   Turn multi-valued QueryDict into standard dictionary
             data = {}
             for key in request.POST:
-                data[key] = request.POST[key]
+                #   Some keys have list values
+                if key in ['regtypes']:
+                    data[key] = request.POST.getlist(key)
+                else:
+                    data[key] = request.POST[key]
             filterObj = usc.filter_from_postdata(prog, data)
 
             #   Display list generation options

--- a/esp/esp/users/controllers/usersearch.py
+++ b/esp/esp/users/controllers/usersearch.py
@@ -35,8 +35,9 @@ from collections import defaultdict
 from esp.users.models import ESPUser, ZipCode, PersistentQueryFilter, Record
 from esp.middleware import ESPError
 from esp.utils.web import render_to_response
-from esp.program.models import Program
+from esp.program.models import Program, RegistrationType, StudentRegistration
 from esp.dbmail.models import MessageRequest
+from esp.utils.query_utils import nest_Q
 
 from django.db.models import Count
 from django.db.models.query import Q
@@ -89,6 +90,20 @@ class UserSearchController(object):
         else:
 
             ##  Select users based on all other criteria that was entered
+            if criteria.get('clsid', '').strip():
+                clsid = []
+                for digit in criteria['clsid'].split(','):
+                    try:
+                        clsid.append(int(digit))
+                    except:
+                        raise ESPError('Class id invalid, please enter a comma-separated list of numbers.', log=False)
+                if 'regtypes' in criteria:
+                    student_verbs = criteria['regtypes']
+                else:
+                    student_verbs = ['Enrolled']
+                Q_include &= Q(studentregistration__section__parent_class__id__in=clsid,
+                               studentregistration__relationship__name__in=student_verbs) & nest_Q(StudentRegistration.is_valid_qobject(), 'studentregistration')
+                
             if 'group' in criteria and criteria['group'] != "":
                 group = criteria['group']
                 #Can't just filter by group because we are already filtering by group with user_type above. - willgearty, 2016-11-23
@@ -365,6 +380,7 @@ class UserSearchController(object):
             target_path = '/manage/%s/commpanel' % program.getUrlBase()
         context['action_path'] = target_path
         context['groups'] = Group.objects.all()
+        context['regtypes'] = RegistrationType.objects.all().order_by("name")
 
         return context
 

--- a/esp/esp/users/controllers/usersearch.py
+++ b/esp/esp/users/controllers/usersearch.py
@@ -103,7 +103,7 @@ class UserSearchController(object):
                     student_verbs = ['Enrolled']
                 Q_include &= Q(studentregistration__section__parent_class__id__in=clsid,
                                studentregistration__relationship__name__in=student_verbs) & nest_Q(StudentRegistration.is_valid_qobject(), 'studentregistration')
-                
+
             if 'group' in criteria and criteria['group'] != "":
                 group = criteria['group']
                 #Can't just filter by group because we are already filtering by group with user_type above. - willgearty, 2016-11-23

--- a/esp/public/media/scripts/commpanel.js
+++ b/esp/public/media/scripts/commpanel.js
@@ -114,7 +114,7 @@ function clear_filters(form_name)
 {
     //  Remove any existing data in the "user filtering options" part of a comm panel form
     var form = $j("#"+form_name)[0];
-    field_names = ["userid", "username", "first_name", "last_name", "email", "zipcode", "zipdistance", "zipdistance_exclude", "states", "school", "grade_min", "grade_max", "gradyear_min", "gradyear_max", "group"];
+    field_names = ["userid", "username", "first_name", "last_name", "email", "zipcode", "zipdistance", "zipdistance_exclude", "states", "school", "grade_min", "grade_max", "gradyear_min", "gradyear_max", "group", "clsid", "regtypes"];
     for (var i = 0; i < field_names.length; i++)
     {
         var form_field = $j(form).find(':input[name=' + field_names[i] + ']')[0];

--- a/esp/templates/users/usersearch/list_selector.html
+++ b/esp/templates/users/usersearch/list_selector.html
@@ -73,19 +73,24 @@
             <div id="filter_accordion">
 
                 <h4><a href="#">User ID</a></h4>
-                <div>Enter an ID number: <input type="text" size="6" name="userid" id="userid" /></div>
+                <div>Enter ID number: <input type="text" size="6" name="userid" id="userid" /> <br />
+                <small>(Can be a comma-separated list)</small></div>
 
                 <h4><a href="#">User name</a></h4>
-                <div>Enter a username: <input type="text" size="30" name="username" id="username" autocomplete="new-username" /></div>
+                <div>Enter a username: <input type="text" size="30" name="username" id="username" autocomplete="new-username" /> <br />
+                <small>(Supports regular expressions)</small></div>
 
                 <h4><a href="#">Last name</a></h4>
-                <div>Enter a portion of the last name: <input type="text" size="30" name="last_name" id="last_name" /></div>
+                <div>Enter a portion of the last name: <input type="text" size="30" name="last_name" id="last_name" /> <br />
+                <small>(Supports regular expressions)</small></div>
 
                 <h4><a href="#">First name</a></h4>
-                <div>Enter a portion of the first name: <input type="text" size="30" name="first_name" id="first_name" /></div>
+                <div>Enter a portion of the first name: <input type="text" size="30" name="first_name" id="first_name" /> <br />
+                <small>(Supports regular expressions)</small></div>
 
                 <h4><a href="#">Email address</a></h4>
-                <div>Enter a portion of the email address: <input type="text" size="30" name="email" id="email" /></div>
+                <div>Enter a portion of the email address: <input type="text" size="30" name="email" id="email" /> <br />
+                <small>(Supports regular expressions)</small></div>
 
                 <h4><a href="#">Zip Code</a></h4>
                 <div>
@@ -117,6 +122,16 @@
                 <div><select name="group" id="user-search-group">
                     {% for group in groups %}
                     <option value="{{ group.id }}">{{ group.name }}</option>
+                    {% endfor %}
+                    <option value="" selected hidden></option>
+                </select></div>
+
+                <h4><a href="#">Class Registrations</a></h4>
+                <div>Enter class ID number: <input type="text" size="6" name="clsid" id="clsid" /> <br />
+                <small>(Can be a comma-separated list)</small> <br /><br />
+                Select registration type(s): <select name="regtypes" id="regtypes" multiple>
+                    {% for regtype in regtypes %}
+                    <option value="{{ regtype.name }}">{{ regtype }}</option>
                     {% endfor %}
                     <option value="" selected hidden></option>
                 </select></div>
@@ -199,19 +214,24 @@
             <div id="combo_filter_accordion">
 
                 <h4><a href="#">User ID</a></h4>
-                <div>Enter an ID number: <input type="text" size="6" name="userid" id="userid" /></div>
+                <div>Enter ID number: <input type="text" size="6" name="userid" id="userid" /> <br />
+                <small>(Can be a comma-separated list)</small></div>
 
                 <h4><a href="#">User name</a></h4>
-                <div>Enter a username: <input type="text" size="30" name="username" id="username" autocomplete="new-username" /></div>
+                <div>Enter a username: <input type="text" size="30" name="username" id="username" autocomplete="new-username" /> <br />
+                <small>(Supports regular expressions)</small></div>
 
                 <h4><a href="#">Last name</a></h4>
-                <div>Enter a portion of the last name: <input type="text" size="30" name="last_name" id="last_name" /></div>
+                <div>Enter a portion of the last name: <input type="text" size="30" name="last_name" id="last_name" /> <br />
+                <small>(Supports regular expressions)</small></div>
 
                 <h4><a href="#">First name</a></h4>
-                <div>Enter a portion of the first name: <input type="text" size="30" name="first_name" id="first_name" /></div>
+                <div>Enter a portion of the first name: <input type="text" size="30" name="first_name" id="first_name" /> <br />
+                <small>(Supports regular expressions)</small></div>
 
                 <h4><a href="#">Email address</a></h4>
-                <div>Enter a portion of the email address: <input type="text" size="30" name="email" id="email" /></div>
+                <div>Enter a portion of the email address: <input type="text" size="30" name="email" id="email" /> <br />
+                <small>(Supports regular expressions)</small></div>
 
                 <h4><a href="#">Zip Code</a></h4>
                 <div>
@@ -243,6 +263,16 @@
                 <div><select name="group" id="user-search-group">
                     {% for group in groups %}
                     <option value="{{ group.id }}">{{ group.name }}</option>
+                    {% endfor %}
+                    <option value="" selected hidden></option>
+                </select></div>
+
+                <h4><a href="#">Class Registrations</a></h4>
+                <div>Enter class ID number: <input type="text" size="6" name="clsid" id="clsid" /> <br />
+                <small>(Can be a comma-separated list)</small> <br /><br />
+                Select registration type(s): <select name="regtypes" id="regtypes" multiple>
+                    {% for regtype in regtypes %}
+                    <option value="{{ regtype.name }}">{{ regtype }}</option>
                     {% endfor %}
                     <option value="" selected hidden></option>
                 </select></div>


### PR DESCRIPTION
This adds a new filter to the comm panel, listgen module, and group text module that allows admins to filter to users with various student registrations for specified classes (e.g. students enrolled in a particular class; or students that attended one or more of a series of classes). The registration types select allows for multiple registration types to be selected, and the class ID field supports multiple classes separated by commas. This can also be used to get lists of or email/text the guardians or emergency contacts of students in various classes.

I also added some help text to some of the other fields.

![image](https://user-images.githubusercontent.com/7232514/82760396-e6cd9f00-9db8-11ea-905a-0780af52f0b0.png)

Fixes https://github.com/learning-unlimited/ESP-Website/issues/2678.