### PR TITLE
Add terms of service links to all themes

### DIFF
--- a/esp/esp/themes/theme_data/bigpicture/templates/users/loginbox_content.html
+++ b/esp/esp/themes/theme_data/bigpicture/templates/users/loginbox_content.html
@@ -16,7 +16,7 @@
           <li><a href="/myesp/passwd/">Change Password</a></li>
           <li><a href="/myesp/profile/">Profile</a></li>
           <li><a href="/myesp/loginhelp.html">Help</a></li>
-          <li><a href="https://www.learningu.org/about/">Terms of Service</a></li>
+          <li><a href="https://www.learningu.org/about/tos/">Terms of Service</a></li>
         </ul>
       </span>
     </form>
@@ -37,7 +37,7 @@
           <li><a href="/myesp/register">Register</a></li>
           <li><a href="/myesp/passwdrecover/">Forgot Password</a></li>
           <li><a href="/myesp/loginhelp.html">Help</a></li>
-          <li><a href="https://www.learningu.org/about/">Terms of Service</a></li>
+          <li><a href="https://www.learningu.org/about/tos/">Terms of Service</a></li>
         </ul>
       </span>
 

--- a/esp/esp/themes/theme_data/bigpicture/templates/users/loginbox_content.html
+++ b/esp/esp/themes/theme_data/bigpicture/templates/users/loginbox_content.html
@@ -16,6 +16,7 @@
           <li><a href="/myesp/passwd/">Change Password</a></li>
           <li><a href="/myesp/profile/">Profile</a></li>
           <li><a href="/myesp/loginhelp.html">Help</a></li>
+          <li><a href="https://www.learningu.org/about/">Terms of Service</a></li>
         </ul>
       </span>
     </form>
@@ -36,6 +37,7 @@
           <li><a href="/myesp/register">Register</a></li>
           <li><a href="/myesp/passwdrecover/">Forgot Password</a></li>
           <li><a href="/myesp/loginhelp.html">Help</a></li>
+          <li><a href="https://www.learningu.org/about/">Terms of Service</a></li>
         </ul>
       </span>
 

--- a/esp/esp/themes/theme_data/bigpicture/templates/users/loginbox_content.html
+++ b/esp/esp/themes/theme_data/bigpicture/templates/users/loginbox_content.html
@@ -16,7 +16,7 @@
           <li><a href="/myesp/passwd/">Change Password</a></li>
           <li><a href="/myesp/profile/">Profile</a></li>
           <li><a href="/myesp/loginhelp.html">Help</a></li>
-          <li><a href="https://www.learningu.org/about/tos/">Terms of Service</a></li>
+          <li><a href="https://www.learningu.org/about/tos/" target="_blank">Terms of Service</a></li>
         </ul>
       </span>
     </form>
@@ -37,7 +37,7 @@
           <li><a href="/myesp/register">Register</a></li>
           <li><a href="/myesp/passwdrecover/">Forgot Password</a></li>
           <li><a href="/myesp/loginhelp.html">Help</a></li>
-          <li><a href="https://www.learningu.org/about/tos/">Terms of Service</a></li>
+          <li><a href="https://www.learningu.org/about/tos/" target="_blank">Terms of Service</a></li>
         </ul>
       </span>
 

--- a/esp/esp/themes/theme_data/circles/templates/users/loginbox_content.html
+++ b/esp/esp/themes/theme_data/circles/templates/users/loginbox_content.html
@@ -18,6 +18,8 @@
        <br /><a href="/myesp/switchback/">Unmorph to <script type="text/javascript">document.write(esp_user.cur_retTitle);</script></a><br /><div id="unmorph_text"></div>
     </div>
     <a href="/myesp/signout/">Logout</a>
+    <br/>
+    <a href="https://www.learningu.org/about/">Terms of Service</a>
   </p>
 </div>
 </div>
@@ -43,6 +45,9 @@
         <td colspan="3"><div class="divformcol1"><a href="/myesp/loginhelp.html">Login Help</a>
         <span style="padding-left: 25px;">
         <a href="/myesp/register">Register</a></span></div></td>
+      </tr>
+      <tr>
+        <td colspan="3"><div class="divformcol1"><a href="https://www.learningu.org/about/">Terms of Service</a></div></td>
       </tr>
     </table>
   </form>

--- a/esp/esp/themes/theme_data/circles/templates/users/loginbox_content.html
+++ b/esp/esp/themes/theme_data/circles/templates/users/loginbox_content.html
@@ -19,7 +19,7 @@
     </div>
     <a href="/myesp/signout/">Logout</a>
     <br/>
-    <a href="https://www.learningu.org/about/">Terms of Service</a>
+    <a href="https://www.learningu.org/about/tos/">Terms of Service</a>
   </p>
 </div>
 </div>
@@ -47,7 +47,7 @@
         <a href="/myesp/register">Register</a></span></div></td>
       </tr>
       <tr>
-        <td colspan="3"><div class="divformcol1"><a href="https://www.learningu.org/about/">Terms of Service</a></div></td>
+        <td colspan="3"><div class="divformcol1"><a href="https://www.learningu.org/about/tos/">Terms of Service</a></div></td>
       </tr>
     </table>
   </form>

--- a/esp/esp/themes/theme_data/circles/templates/users/loginbox_content.html
+++ b/esp/esp/themes/theme_data/circles/templates/users/loginbox_content.html
@@ -19,7 +19,7 @@
     </div>
     <a href="/myesp/signout/">Logout</a>
     <br/>
-    <a href="https://www.learningu.org/about/tos/">Terms of Service</a>
+    <a href="https://www.learningu.org/about/tos/" target="_blank">Terms of Service</a>
   </p>
 </div>
 </div>
@@ -47,7 +47,7 @@
         <a href="/myesp/register">Register</a></span></div></td>
       </tr>
       <tr>
-        <td colspan="3"><div class="divformcol1"><a href="https://www.learningu.org/about/tos/">Terms of Service</a></div></td>
+        <td colspan="3"><div class="divformcol1"><a href="https://www.learningu.org/about/tos/" target="_blank">Terms of Service</a></div></td>
       </tr>
     </table>
   </form>

--- a/esp/esp/themes/theme_data/fruitsalad/templates/main.html
+++ b/esp/esp/themes/theme_data/fruitsalad/templates/main.html
@@ -240,7 +240,7 @@ var currentPrograms = [
     <div id="footer">
       &copy; {{ theme.full_group_name }}, {{ theme.mtime.year }}
       <br />
-      <a href="https://www.learningu.org/about/">Terms of Service</a>
+      <a href="https://www.learningu.org/about/tos/">Terms of Service</a>
     </div>
   </div>
 </div>

--- a/esp/esp/themes/theme_data/fruitsalad/templates/main.html
+++ b/esp/esp/themes/theme_data/fruitsalad/templates/main.html
@@ -240,7 +240,7 @@ var currentPrograms = [
     <div id="footer">
       &copy; {{ theme.full_group_name }}, {{ theme.mtime.year }}
       <br />
-      <a href="https://www.learningu.org/about/tos/">Terms of Service</a>
+      <a href="https://www.learningu.org/about/tos/" target="_blank">Terms of Service</a>
     </div>
   </div>
 </div>

--- a/esp/esp/themes/theme_data/fruitsalad/templates/main.html
+++ b/esp/esp/themes/theme_data/fruitsalad/templates/main.html
@@ -239,6 +239,8 @@ var currentPrograms = [
     </div>
     <div id="footer">
       &copy; {{ theme.full_group_name }}, {{ theme.mtime.year }}
+      <br />
+      <a href="https://www.learningu.org/about/">Terms of Service</a>
     </div>
   </div>
 </div>

--- a/esp/templates/registration/newuser.html
+++ b/esp/templates/registration/newuser.html
@@ -42,6 +42,8 @@
   To do almost anything with us, you first need to register
   an account with us. After you register account, you will be allowed to register
   for programs, sign up for classes, among other things.
+  By creating an account, you agree to the <a href="https://www.learningu.org/about/">terms of service</a>
+  set forth by Learning Unlimited, the umbrella organization of which we are a member.
 </p>
 {% if settings.USE_MAILMAN %}
 <p>

--- a/esp/templates/registration/newuser.html
+++ b/esp/templates/registration/newuser.html
@@ -42,7 +42,7 @@
   To do almost anything with us, you first need to register
   an account with us. After you register account, you will be allowed to register
   for programs, sign up for classes, among other things.
-  By creating an account, you agree to the <a href="https://www.learningu.org/about/tos/">terms of service</a>
+  By creating an account, you agree to the <a href="https://www.learningu.org/about/tos/" target="_blank">terms of service</a>
   set forth by Learning Unlimited, the umbrella organization of which we are a member.
 </p>
 {% if settings.USE_MAILMAN %}

--- a/esp/templates/registration/newuser.html
+++ b/esp/templates/registration/newuser.html
@@ -42,7 +42,7 @@
   To do almost anything with us, you first need to register
   an account with us. After you register account, you will be allowed to register
   for programs, sign up for classes, among other things.
-  By creating an account, you agree to the <a href="https://www.learningu.org/about/">terms of service</a>
+  By creating an account, you agree to the <a href="https://www.learningu.org/about/tos/">terms of service</a>
   set forth by Learning Unlimited, the umbrella organization of which we are a member.
 </p>
 {% if settings.USE_MAILMAN %}

--- a/esp/templates/users/loginbox_content.html
+++ b/esp/templates/users/loginbox_content.html
@@ -24,6 +24,7 @@
             <li><a href="/myesp/passwd/">Change Password</a></li>
             <li><a href="/myesp/profile/">Profile</a></li>
             <li><a href="/myesp/loginhelp.html">Help</a></li>
+            <li><a href="https://www.learningu.org/about/">Terms of Service</a></li>
           </ul>
         </span>
 
@@ -50,6 +51,7 @@
           <li><a href="/myesp/register">Register</a></li>
           <li><a href="/myesp/passwdrecover/">Forgot Password</a></li>
           <li><a href="/myesp/loginhelp.html">Help</a></li>
+          <li><a href="https://www.learningu.org/about/">Terms of Service</a></li>
         </ul>
       </span>
 

--- a/esp/templates/users/loginbox_content.html
+++ b/esp/templates/users/loginbox_content.html
@@ -24,7 +24,7 @@
             <li><a href="/myesp/passwd/">Change Password</a></li>
             <li><a href="/myesp/profile/">Profile</a></li>
             <li><a href="/myesp/loginhelp.html">Help</a></li>
-            <li><a href="https://www.learningu.org/about/">Terms of Service</a></li>
+            <li><a href="https://www.learningu.org/about/tos/">Terms of Service</a></li>
           </ul>
         </span>
 
@@ -51,7 +51,7 @@
           <li><a href="/myesp/register">Register</a></li>
           <li><a href="/myesp/passwdrecover/">Forgot Password</a></li>
           <li><a href="/myesp/loginhelp.html">Help</a></li>
-          <li><a href="https://www.learningu.org/about/">Terms of Service</a></li>
+          <li><a href="https://www.learningu.org/about/tos/">Terms of Service</a></li>
         </ul>
       </span>
 

--- a/esp/templates/users/loginbox_content.html
+++ b/esp/templates/users/loginbox_content.html
@@ -24,7 +24,7 @@
             <li><a href="/myesp/passwd/">Change Password</a></li>
             <li><a href="/myesp/profile/">Profile</a></li>
             <li><a href="/myesp/loginhelp.html">Help</a></li>
-            <li><a href="https://www.learningu.org/about/tos/">Terms of Service</a></li>
+            <li><a href="https://www.learningu.org/about/tos/" target="_blank">Terms of Service</a></li>
           </ul>
         </span>
 
@@ -51,7 +51,7 @@
           <li><a href="/myesp/register">Register</a></li>
           <li><a href="/myesp/passwdrecover/">Forgot Password</a></li>
           <li><a href="/myesp/loginhelp.html">Help</a></li>
-          <li><a href="https://www.learningu.org/about/tos/">Terms of Service</a></li>
+          <li><a href="https://www.learningu.org/about/tos/" target="_blank">Terms of Service</a></li>
         </ul>
       </span>
 


### PR DESCRIPTION
Fixes #2995. Adds a link to terms of service on the account creation page, as well as somewhere on each theme that is accessible whether logged in or out. 

For barebones, bigpicture, and floaty, the link is in the dropdown next to login/logout.
For fruitsalad, the link is in the footer next to the copyright. 
For circles, the link is in the login box under the register/help or under the logout.