### PR TITLE
Add functionality to manage.py update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,6 @@ finish:
 	@echo "Updating the site; if this fails for any reason, fix it up and (re-)run 'make finish'."
 	esp/update_deps.sh
 	sudo -u www-data esp/manage.py update
-	@# Clear memcache
-	@# TODO(benkraft): do this in manage.py update
-	echo flush_all | nc localhost 11211
-	sudo -u www-data touch esp.wsgi
 	@echo "Done! Go test some things."
 
 .PHONY: pre src finish

--- a/esp/esp/utils/management/commands/update.py
+++ b/esp/esp/utils/management/commands/update.py
@@ -35,6 +35,8 @@ Learning Unlimited, Inc.
 
 from django.core.management import call_command
 from django.core.management.base import NoArgsCommand
+from django.conf import settings
+import os
 
 class Command(NoArgsCommand):
     """Update the site.
@@ -44,6 +46,8 @@ class Command(NoArgsCommand):
     - Install initial data (happens automatically after running migrations).
     - Collect static files.
     - Recompile the theme.
+    - Clear memcache
+    - Touch esp.wsgi.
     """
     def handle_noargs(self, **options):
         default_options = {
@@ -51,6 +55,7 @@ class Command(NoArgsCommand):
             'interactive': False,
             'merge': True,
             'delete_ghosts': True,
+            'clear': True,
         }
         default_options.update(options)
         options = default_options
@@ -58,3 +63,7 @@ class Command(NoArgsCommand):
         call_command('migrate', **options)
         call_command('collectstatic', **options)
         call_command('recompile_theme', **options)
+        os.system('echo flush_all | nc localhost 11211')
+        root = os.path.dirname(os.path.abspath(settings.BASE_DIR))
+        file = os.path.join(root, 'esp.wsgi')
+        os.system('touch ' + file)


### PR DESCRIPTION
This modifies manage.py update to do a few new things (most of which we previously had to do separately):

1. Instead of only collecting new static files, we now clear all of the old static files and then recollect all of the static files. This is important for when dependencies change (and it doesn't take that long, so it's nice to always ensure the static files are up-to-date). This fixes https://github.com/learning-unlimited/ESP-Website/issues/2955 and fixes https://github.com/learning-unlimited/ESP-Website/issues/2948.
2. Clear memcache. We previously did this in the Makefile for when we upgraded sites, but it's another quick thing that we can move to `update`.
3. Touch `esp.wsgi`. Especially relevant for updating sites, but also relevant for dev servers. No longer will we need to touch `esp.wsgi` separately after running `manage.py update`! Fixes #1599.

I then removed these commands from the Makefile, since we don't need to do them separately anymore.