### PR TITLE
Clean up onsite attendance UI

### DIFF
--- a/esp/templates/program/modules/onsiteattendance/attendance.html
+++ b/esp/templates/program/modules/onsiteattendance/attendance.html
@@ -5,6 +5,12 @@
 {% block stylesheets %}
     {{ block.super }}
     <link rel="stylesheet" href="/media/styles/forms.css" type="text/css" />
+    <link rel="stylesheet" href="/media/styles/expand_display.css" type="text/css" />
+{% endblock %}
+
+{% block xtrajs %}
+    {{ block.super }}
+    <script src="/media/scripts/sorttable.js"></script>
 {% endblock %}
 
 {% block content %}
@@ -24,7 +30,8 @@ Here is an attendance summary for {{ timeslot }}. Here you can see attendance st
 {% if timeslot %}
 If you are looking for a different timeslot, you can select it from the dropdown below:
 {% else %}
-Please select a timeslot from the dropdown below:
+<a class="btn" href="/onsite/{{ one }}/{{ two }}/section_attendance/{{ timeslot.id }}">See or record section attendance</a><br /><br />
+or select a timeslot from the dropdown below to see attendance stats:
 {% endif %}
 </p>
 </center>
@@ -53,9 +60,9 @@ Please select a timeslot from the dropdown below:
         </p>
         <input name="when" type="date" value="{{ when|date:'Y-m-d' }}" style="width:auto;"><input type="submit" value="Change Date">
     </form>
-    {% endif %}
     <br />
     <a class="btn" href="/onsite/{{ one }}/{{ two }}/section_attendance/{{ timeslot.id }}">See or record section attendance{% if timeslot %} for this timeslot{% endif %}</a>
+    {% endif %}
     <br /><br />
 </center>
 
@@ -74,10 +81,12 @@ Please select a timeslot from the dropdown below:
 </tr>
 </table>
 <br />
-<table>
-<tr>
-    <th colspan="6">Students Checked In Between {{ timeslot.start_w_buffer|date:"g:i A" }} and {{ timeslot.end|date:"g:i A" }}{% if when != timeslot.end %} on {{ when|date:'n/j/Y' }}{% endif %}</th>
-</tr>
+
+<button class="dsphead">
+    <b>Students Checked In Between {{ timeslot.start_w_buffer|date:"g:i A" }} and {{ timeslot.end|date:"g:i A" }}{% if when != timeslot.end %} on {{ when|date:'n/j/Y' }}{% endif %}</b> (click to expand/collapse)
+</button>
+<div class="dspcont">
+<table class="sortable">
 <tr>
     <th width="5%">#</th>
     <th width="30%">Student Name</th>
@@ -101,6 +110,7 @@ Please select a timeslot from the dropdown below:
 </tr>
 {% endfor %}
 </table>
+
 <table width="100%" style="border: none;">
     {% if program|hasModule:"ListGenModule" %}
         <td width="33%" align="center">
@@ -124,11 +134,13 @@ Please select a timeslot from the dropdown below:
         </td>
     {% endif %}
 </table>
-<br />
-<table>
-<tr>
-    <th colspan="7">Students Checked In Before {{ timeslot.end|date:"g:i A" }} But Not Attending Class During This Timeslot{% if when != timeslot.end %} on {{ when|date:'n/j/Y' }}{% endif %}</th>
-</tr>
+</div>
+
+<button class="dsphead">
+    <b>Students Checked In Before {{ timeslot.end|date:"g:i A" }} But Not Attending Class During This Timeslot{% if when != timeslot.end %} on {{ when|date:'n/j/Y' }}{% endif %}</b> (click to expand/collapse)
+</button>
+<div class="dspcont">
+<table class="sortable">
 <tr>
     <th width="5%">#</th>
     <th width="20%">Student Name</th>
@@ -154,6 +166,7 @@ Please select a timeslot from the dropdown below:
 </tr>
 {% endfor %}
 </table>
+
 <table width="100%" style="border: none;">
     {% if program|hasModule:"ListGenModule" %}
         <td width="33%" align="center">
@@ -177,11 +190,13 @@ Please select a timeslot from the dropdown below:
         </td>
     {% endif %}
 </table>
-<br />
-<table>
-<tr>
-    <th colspan="8">Students Attending Classes In Which They Weren't Originally Enrolled During This Timeslot{% if when != timeslot.end %} on {{ when|date:'n/j/Y' }}{% endif %}</th>
-</tr>
+</div>
+
+<button class="dsphead">
+    <b>Students Attending Classes In Which They Weren't Originally Enrolled During This Timeslot{% if when != timeslot.end %} on {{ when|date:'n/j/Y' }}{% endif %}</b> (click to expand/collapse)
+</button>
+<div class="dspcont">
+<table class="sortable">
 <tr>
     <th width="5%">#</th>
     <th width="15%">Student Name</th>
@@ -232,11 +247,13 @@ Please select a timeslot from the dropdown below:
         </td>
     {% endif %}
 </table>
-<br />
-<table>
-<tr>
-    <th colspan="6">Sections During This Timeslot with No Attendance Recorded{% if when != timeslot.end %} on {{ when|date:'n/j/Y' }}{% endif %}</th>
-</tr>
+</div>
+
+<button class="dsphead">
+    <b>Sections During This Timeslot with No Attendance Recorded{% if when != timeslot.end %} on {{ when|date:'n/j/Y' }}{% endif %}</b> (click to expand/collapse)
+</button>
+<div class="dspcont">
+<table class="sortable">
 <tr>
     <th width="5%">#</th>
     <th width="10%">Email Code</th>
@@ -283,12 +300,14 @@ Please select a timeslot from the dropdown below:
         </td>
     {% endif %}
 </table>
+</div>
 </center>
+
+<script type="text/javascript" src="/media/scripts/expand_display.js"></script>
 {% endif %}
 
 </div>
 
 {% include "program/modules/onsitecore/returnlink.html" %}
-
 
 {% endblock %}

--- a/esp/templates/program/modules/onsiteattendance/attendance.html
+++ b/esp/templates/program/modules/onsiteattendance/attendance.html
@@ -22,7 +22,7 @@
 
 {% if timeslot %}
 <p>
-Here is an attendance summary for {{ timeslot }}. Here you can see attendance statistics and details for students that have been checked in during this timeslot, students that are not attending class, and students that are attending classes they were not originally enrolled in.
+Here is an attendance summary for {{ timeslot }}. Here you can see attendance statistics and details for students that have been checked in during this timeslot, students that are not attending class, students that are attending classes they were not originally enrolled in, and sections that have not recorded attendance. All tables are sortable by any of their columns by clicking on the column headers.
 </p>
 {% endif %}
 <center>
@@ -30,7 +30,7 @@ Here is an attendance summary for {{ timeslot }}. Here you can see attendance st
 {% if timeslot %}
 If you are looking for a different timeslot, you can select it from the dropdown below:
 {% else %}
-<a class="btn" href="/onsite/{{ one }}/{{ two }}/section_attendance/{{ timeslot.id }}">See or record section attendance</a><br /><br />
+<a class="btn" href="/onsite/{{ one }}/{{ two }}/section_attendance/">See or record section attendance</a><br /><br />
 or select a timeslot from the dropdown below to see attendance stats:
 {% endif %}
 </p>
@@ -55,7 +55,7 @@ or select a timeslot from the dropdown below to see attendance stats:
     <!--Could possibly hide this with a tag-->
     <form action="/onsite/{{ one }}/{{ two }}/attendance/{{ timeslot.id }}" method="get">
         <p>
-        If this timeslot is for reccuring classes, select the preferred date here:<br />
+        If this timeslot is for recurring classes, select the preferred date here:<br />
         (the <a href="/onsite/{{ one }}/{{ two }}/attendance/{{ timeslot.id }}">default</a> is the date associated with the timeslot)
         </p>
         <input name="when" type="date" value="{{ when|date:'Y-m-d' }}" style="width:auto;"><input type="submit" value="Change Date">
@@ -86,19 +86,21 @@ or select a timeslot from the dropdown below to see attendance stats:
     <b>Students Checked In Between {{ timeslot.start_w_buffer|date:"g:i A" }} and {{ timeslot.end|date:"g:i A" }}{% if when != timeslot.end %} on {{ when|date:'n/j/Y' }}{% endif %}</b> (click to expand/collapse)
 </button>
 <div class="dspcont">
-<table class="sortable">
+<table class="sortable" width="100%">
 <tr>
     <th width="5%">#</th>
-    <th width="30%">Student Name</th>
-    <th width="15%">Student Username</th>
-    <th width="10%">Student ID #</th>
-    <th width="10%">Student Grade</th>
+    <th width="15%">First Name</th>
+    <th width="15%">Last Name</th>
+    <th width="15%">Username</th>
+    <th width="10%">ID #</th>
+    <th width="10%">Grade</th>
     <th width="20%">School</th>
 </tr>
 {% for student in checked_in_ts %}
 <tr>
     <th class="small">{{ forloop.counter }}</th>
-    <td>{{ student.name }}</td>
+    <td>{{ student.first_name }}</td>
+    <td>{{ student.last_name }}</td>
     <td>{{ student.username }}</td>
     <td>{{ student.id }}</td>
     <td>{{ student|getGradeForProg:program.id }}</td>
@@ -106,7 +108,7 @@ or select a timeslot from the dropdown below to see attendance stats:
 </tr>
 {% empty %}
 <tr>
-    <td colspan="6" align="center">No students checked in during this timeslot</td>
+    <td colspan="7" align="center">No students checked in during this timeslot</td>
 </tr>
 {% endfor %}
 </table>
@@ -140,20 +142,22 @@ or select a timeslot from the dropdown below to see attendance stats:
     <b>Students Checked In Before {{ timeslot.end|date:"g:i A" }} But Not Attending Class During This Timeslot{% if when != timeslot.end %} on {{ when|date:'n/j/Y' }}{% endif %}</b> (click to expand/collapse)
 </button>
 <div class="dspcont">
-<table class="sortable">
+<table class="sortable" width="100%">
 <tr>
     <th width="5%">#</th>
-    <th width="20%">Student Name</th>
-    <th width="15%">Student Username</th>
-    <th width="10%">Student ID #</th>
-    <th width="10%">Student Grade</th>
+    <th width="10%">First Name</th>
+    <th width="10%">Last Name</th>
+    <th width="15%">Username</th>
+    <th width="10%">ID #</th>
+    <th width="10%">Grade</th>
     <th width="20%">School</th>
     <th width="20%">Enrolled Class</th>
 </tr>
 {% for student in not_attending %}
 <tr>
     <th class="small">{{ forloop.counter }}</th>
-    <td>{{ student.name }}</td>
+    <td>{{ student.first_name }}</td>
+    <td>{{ student.last_name }}</td>
     <td>{{ student.username }}</td>
     <td>{{ student.id }}</td>
     <td>{{ student|getGradeForProg:program.id }}</td>
@@ -162,7 +166,7 @@ or select a timeslot from the dropdown below to see attendance stats:
 </tr>
 {% empty %}
 <tr>
-    <td colspan="7" align="center">No students checked in but not attending class</td>
+    <td colspan="8" align="center">No students checked in but not attending class</td>
 </tr>
 {% endfor %}
 </table>
@@ -196,13 +200,14 @@ or select a timeslot from the dropdown below to see attendance stats:
     <b>Students Attending Classes In Which They Weren't Originally Enrolled During This Timeslot{% if when != timeslot.end %} on {{ when|date:'n/j/Y' }}{% endif %}</b> (click to expand/collapse)
 </button>
 <div class="dspcont">
-<table class="sortable">
+<table class="sortable" width="100%">
 <tr>
     <th width="5%">#</th>
-    <th width="15%">Student Name</th>
-    <th width="15%">Student Username</th>
-    <th width="10%">Student ID #</th>
-    <th width="10%">Student Grade</th>
+    <th width="10%">First Name</th>
+    <th width="10%">Last Name</th>
+    <th width="15%">Username</th>
+    <th width="10%">ID #</th>
+    <th width="10%">Grade</th>
     <th width="15%">School</th>
     <th width="15%">Attended Class</th>
     <th width="15%">Enrolled Class</th>
@@ -210,7 +215,8 @@ or select a timeslot from the dropdown below to see attendance stats:
 {% for student in onsite %}
 <tr>
     <th class="small">{{ forloop.counter }}</th>
-    <td>{{ student.name }}</td>
+    <td>{{ student.first_name }}</td>
+    <td>{{ student.last_name }}</td>
     <td>{{ student.username }}</td>
     <td>{{ student.id }}</td>
     <td>{{ student|getGradeForProg:program.id }}</td>
@@ -220,7 +226,7 @@ or select a timeslot from the dropdown below to see attendance stats:
 </tr>
 {% empty %}
 <tr>
-    <td colspan="8" align="center">No students attending students in which they weren't enrolled</td>
+    <td colspan="9" align="center">No students attending students in which they weren't enrolled</td>
 </tr>
 {% endfor %}
 </table>

--- a/esp/templates/program/modules/teacherclassregmodule/section_attendance.html
+++ b/esp/templates/program/modules/teacherclassregmodule/section_attendance.html
@@ -40,6 +40,7 @@
             }
         });
     </script>
+    <script src="/media/scripts/sorttable.js"></script>
     {% endif %}
 {% endblock %}
 
@@ -48,7 +49,7 @@
 
 {% if tl == "onsite" %}
 <br />
-<a class="btn" style="float: left" href="/onsite/{{ one }}/{{ two }}/attendance/">&lt;&lt;Back to Program Attendance</a>
+<a class="btn" style="float: left" href="/onsite/{{ one }}/{{ two }}/attendance/{{ timeslot.id }}">&lt;&lt;Back to Attendance Overview</a>
 <select name="tsid" onchange="location.href='/onsite/{{ one }}/{{ two }}/section_attendance/'+$j(this).children('option:selected').val()" style="width: 200px; float: right;">
     <option disabled{% if not timeslot %} selected="selected"{% endif %}>
         (Select a timeslot)
@@ -66,7 +67,7 @@
 
 <p>
 {% if section %}
-Here is an attendance sheet for your section's students. Here you can see which students have checked in and submit attendance for your section. This section is scheduled for {{ section.friendly_times_with_date|join:", " }}. If you are looking for a different section, you can select it from the dropdown below.
+Here is an attendance sheet for your section's students. Here you can see which students have checked in and submit attendance for your section. This section is scheduled for {{ section.friendly_times_with_date|join:", " }}. If you are looking for a different section, you can select it from the dropdown below. You can sort the students by any column by clicking on the column header.
 {% elif tl == "onsite" and not timeslot %}
 Please select a timeslot above.
 {% else %}
@@ -95,86 +96,93 @@ Please select a section from the dropdown below.
 <form action="{{ request.get_full_path }}" method="post">
 <input type="hidden" name="submitted">
 <table align="center" width="100%">
-<thead>
 <tr>
-    <th colspan="7" align="center">
+    <th align="center">
         Mark attendance for students enrolled in this section:
     </th>
 </tr>
 <tr>
-    <th width="5%">#</th>
-    <th width="30%">Student Name</th>
-    <th width="12.5%">Student ID #</th>
-    <th width="12.5%">Student Grade</th>
-    <th width="20%">School</th>
-    <th width="10%">Checked In?</th>
-    <th width="10%">Attending Section?</th>
-</tr>
-</thead>
-<tbody>
-{% for student in section.enrolled_list %}
-    <tr>
-        <th class="small">{{ forloop.counter }}</th>
-        <td>{{ student.name }}</td>
-        <td>{{ student.id }}</td>
-        <td>{{ student|getGradeForProg:program.id }}</td>
-        <td>{{ student.getLastProfile.student_info.getSchool }}</td>
-        <td align="center"><input type="checkbox"{% if student.checked_in %} checked{% endif %} disabled></td>
-        <td align="center"><input name="attending" value="{{ student.id }}" type="checkbox"{% if student.attended %} checked{% endif %}></td>
-    </tr>
-{% empty %}
-<tr>
-    <td colspan="7" align="center">
-        No students enrolled in this section
+    <td style="padding: 0px;">
+        <table align="center" width="100%" class="sortable" style="border: none;">
+            <tr>
+                <th width="5%">#</th>
+                <th width="17.5%">First Name</th>
+                <th width="17.5%">Last Name</th>
+                <th width="10%">ID #</th>
+                <th width="10%">Grade</th>
+                <th width="20%">School</th>
+                <th width="10%">Checked In?</th>
+                <th width="10%">Attending Section?</th>
+            </tr>
+            {% for student in section.enrolled_list %}
+                <tr>
+                    <th class="small">{{ forloop.counter }}</th>
+                    <td>{{ student.first_name }}</td>
+                    <td>{{ student.last_name }}</td>
+                    <td>{{ student.id }}</td>
+                    <td>{{ student|getGradeForProg:program.id }}</td>
+                    <td>{{ student.getLastProfile.student_info.getSchool }}</td>
+                    <td align="center" sorttable_customkey="{% if student.checked_in %}2{% else %}1{% endif %}"><input type="checkbox"{% if student.checked_in %} checked{% endif %} disabled></td>
+                    <td align="center" sorttable_customkey="{% if student.attended %}2{% else %}1{% endif %}"><input name="attending" value="{{ student.id }}" type="checkbox"{% if student.attended %} checked{% endif %}></td>
+                </tr>
+            {% empty %}
+            <tr>
+                <td colspan="8" align="center">
+                    No students enrolled in this section
+                </td>
+            </tr>
+            {% endfor %}
+        </table>
     </td>
 </tr>
-{% endfor %}
 </table>
 
 {% if section.attended_list %}
 <br />
 <table align="center" width="100%">
-<thead>
 <tr>
-    <th colspan="7" align="center">
+    <th align="center">
         Mark attendance for students attending (but not enrolled in) this section:
     </th>
 </tr>
 <tr>
-    <th width="5%">#</th>
-    <th width="30%">Student Name</th>
-    <th width="12.5%">Student ID #</th>
-    <th width="12.5%">Student Grade</th>
-    <th width="20%">School</th>
-    <th width="10%">Checked In?</th>
-    <th width="10%">Attending Section?</th>
+    <td style="padding: 0px;">
+        <table align="center" width="100%" class="sortable" style="border: none;">
+            <tr>
+                <th width="5%">#</th>
+                <th width="17.5%">First Name</th>
+                <th width="17.5%">Last Name</th>
+                <th width="10%">ID #</th>
+                <th width="10%">Grade</th>
+                <th width="20%">School</th>
+                <th width="10%">Checked In?</th>
+                <th width="10%">Attending Section?</th>
+            </tr>
+            {% for student in section.attended_list %}
+                <tr>
+                    <th class="small">{{ forloop.counter }}</th>
+                    <td>{{ student.first_name }}</td>
+                    <td>{{ student.last_name }}</td>
+                    <td>{{ student.id }}</td>
+                    <td>{{ student|getGradeForProg:program.id }}</td>
+                    <td>{{ student.getLastProfile.student_info.getSchool }}</td>
+                    <td align="center" sorttable_customkey="{% if student.checked_in %}2{% else %}1{% endif %}"><input type="checkbox"{% if student.checked_in %} checked{% endif %} disabled></td>
+                    <td align="center" sorttable_customkey="{% if student.attended %}2{% else %}1{% endif %}"><input name="attending" value="{{ student.id }}" type="checkbox"{% if student.attended %} checked{% endif %}></td>
+                </tr>
+            {% endfor %}
+        </table>
+    </td>
 </tr>
-</thead>
-<tbody>
-{% for student in section.attended_list %}
-    <tr>
-        <th class="small">{{ forloop.counter }}</th>
-        <td>{{ student.name }}</td>
-        <td>{{ student.id }}</td>
-        <td>{{ student|getGradeForProg:program.id }}</td>
-        <td>{{ student.getLastProfile.student_info.getSchool }}</td>
-        <td align="center"><input type="checkbox"{% if student.checked_in %} checked{% endif %} disabled></td>
-        <td align="center"><input name="attending" value="{{ student.id }}" type="checkbox"{% if student.attended %} checked{% endif %}></td>
-    </tr>
-{% endfor %}
 </table>
 {% endif %}
 
 <br />
 <table align="center" width="100%">
-<thead>
 <tr>
     <th align="center">
         And/or enter any attending students (including unenrolled ones) here:
     </th>
 </tr>
-</thead>
-<tbody>
 <tr>
     <td align="center">
         <div class="controls">
@@ -201,7 +209,6 @@ Please select a section from the dropdown below.
         <br /><input type="checkbox" name="unenroll" checked> Unenroll them from their conflicting sections
     </td>
 </tr>
-</tbody>
 </table>
 <center>
 <br /><input type="Submit" class="fancybutton" value="Submit Attendance" />


### PR DESCRIPTION
This cleans up the onsite attendance UI in a number of ways:

1. This moves the "section attendance" button on the landing page to above the dropdown menu. I've also changed the text to make it clear that the two are an "either or" situation (before people were trying to use the dropdown and then immediately click the button).
2. Wrap the tables in collapsible divs. From my experience looking at this page for larger programs, these tables can be obnoxiously large, so now they are hidden by default and can be revealed when necessary.
3. Make the tables sortable, because why not?

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3007 and fixes https://github.com/learning-unlimited/ESP-Website/issues/3008.