### PR TITLE
Update teacher onsite seq

### DIFF
--- a/esp/esp/program/modules/handlers/teacheronsite.py
+++ b/esp/esp/program/modules/handlers/teacheronsite.py
@@ -45,7 +45,7 @@ class TeacherOnsite(ProgramModuleObj, CoreModule):
             "link_title": "Teacher Onsite",
             "admin_title": "Teacher Onsite Webapp",
             "module_type": "teach",
-            "seq": -9999,
+            "seq": 9999,
             "choosable": 1
             }
 

--- a/esp/esp/program/modules/migrations/0022_change_teacheronsite_seq.py
+++ b/esp/esp/program/modules/migrations/0022_change_teacheronsite_seq.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+def set_my_defaults(apps, schema_editor):
+    ProgramModule = apps.get_model('program', 'ProgramModule')
+    pm = ProgramModule.objects.get_or_create(handler="TeacherOnsite")[0]
+    pm.seq = 9999
+    pm.save()
+
+def reverse_func(apps, schema_editor):
+    ProgramModule = apps.get_model('program', 'ProgramModule')
+    pm = ProgramModule.objects.get_or_create(handler="TeacherOnsite")[0]
+    pm.seq = -9999
+    pm.save()
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('modules', '0021_onsiteattendance_onsitecheckoutmodule_studentacknowledgementmodule_teacheronsite'),
+    ]
+
+    operations = [
+        migrations.RunPython(set_my_defaults, reverse_func),
+    ]

--- a/esp/esp/program/modules/migrations/0022_change_teacheronsite_seq.py
+++ b/esp/esp/program/modules/migrations/0022_change_teacheronsite_seq.py
@@ -1,27 +1,27 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import migrations, models
+from django.db import migrations
 
 def set_my_defaults(apps, schema_editor):
     ProgramModule = apps.get_model('program', 'ProgramModule')
-    pm = ProgramModule.objects.get_or_create(handler="TeacherOnsite")[0]
-    pm.seq = 9999
-    pm.save()
-    ProgramModuleObj = apps.get_model('modules', 'ProgramModuleObj')
-    for pmo in ProgramModuleObj.objects.filter(module=pm):
-        pmo.seq = 9999
-        pmo.save()
+    for pm in ProgramModule.objects.filter(handler="TeacherOnsite"):
+        pm.seq = 9999
+        pm.save()
+        ProgramModuleObj = apps.get_model('modules', 'ProgramModuleObj')
+        for pmo in ProgramModuleObj.objects.filter(module=pm):
+            pmo.seq = 9999
+            pmo.save()
 
 def reverse_func(apps, schema_editor):
     ProgramModule = apps.get_model('program', 'ProgramModule')
-    pm = ProgramModule.objects.get_or_create(handler="TeacherOnsite")[0]
-    pm.seq = -9999
-    pm.save()
-    ProgramModuleObj = apps.get_model('modules', 'ProgramModuleObj')
-    for pmo in ProgramModuleObj.objects.filter(module=pm):
-        pmo.seq = -9999
-        pmo.save()
+    for pm in ProgramModule.objects.filter(handler="TeacherOnsite"):
+        pm.seq = -9999
+        pm.save()
+        ProgramModuleObj = apps.get_model('modules', 'ProgramModuleObj')
+        for pmo in ProgramModuleObj.objects.filter(module=pm):
+            pmo.seq = -9999
+            pmo.save()
 
 class Migration(migrations.Migration):
 

--- a/esp/esp/program/modules/migrations/0022_change_teacheronsite_seq.py
+++ b/esp/esp/program/modules/migrations/0022_change_teacheronsite_seq.py
@@ -8,12 +8,20 @@ def set_my_defaults(apps, schema_editor):
     pm = ProgramModule.objects.get_or_create(handler="TeacherOnsite")[0]
     pm.seq = 9999
     pm.save()
+    ProgramModuleObj = apps.get_model('modules', 'ProgramModuleObj')
+    for pmo in ProgramModuleObj.objects.filter(module=pm):
+        pmo.seq = 9999
+        pmo.save()
 
 def reverse_func(apps, schema_editor):
     ProgramModule = apps.get_model('program', 'ProgramModule')
     pm = ProgramModule.objects.get_or_create(handler="TeacherOnsite")[0]
     pm.seq = -9999
     pm.save()
+    ProgramModuleObj = apps.get_model('modules', 'ProgramModuleObj')
+    for pmo in ProgramModuleObj.objects.filter(module=pm):
+        pmo.seq = -9999
+        pmo.save()
 
 class Migration(migrations.Migration):
 


### PR DESCRIPTION
This updates the seq value for the teacher onsite module (and any related teacher onsite module objects in case any have been created). Since these are values in the database (not just the handler), I had to make a custom migration to handle the db changes.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3041.