### PR TITLE
Fix nametag textFit

### DIFF
--- a/esp/templates/program/modules/nametagmodule/ids.html
+++ b/esp/templates/program/modules/nametagmodule/ids.html
@@ -33,7 +33,7 @@ body { font-family: georgia;
 .singleid .url { font-size: 10pt; }
 .singleid .title { font-weight: bolder; font-size: 15pt;}
 .singleid .programtitle { font-weight: bolder; font-size: 19pt;}
-.singleid .name  { font-weight: bolder; font-size: 20pt; }
+.singleid .name  { font-weight: bolder; font-size: 20pt; height: 1in }
 .singleid .studentid { font-size: 10pt; font-weight: normal; }
 .firstspace { height: 5pt; }
 .numlabel { text-align: center; vertical-align: center;


### PR DESCRIPTION
This just adds a `height` css attribute to the name field so that `textFit` knows how much space it is allowed to expand the text within (within the font size limits).

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3043.