### PR TITLE
Fix flag active/inactive behavior

### DIFF
--- a/esp/esp/program/modules/handlers/teachercheckinmodule.py
+++ b/esp/esp/program/modules/handlers/teachercheckinmodule.py
@@ -325,8 +325,8 @@ class TeacherCheckinModule(ProgramModuleObj):
                     or sections_by_class[section.parent_class_id].begin_time > section.begin_time):
                 # Precompute some things and pack them on the section.
                 teacher_status = [teacher.id in arrived for teacher in section.teachers]
-                section.all_arrived = all(teacher_status)
-                section.any_arrived = any(teacher_status)
+                section.all_arrived = all(teacher_status) and section.teachers.count() > 0
+                section.any_arrived = any(teacher_status) and section.teachers.count() > 0
                 section.room = (section.prettyrooms() or [None])[0]
                 section.unique_resources = section.resourceassignments().order_by('assignment_group').distinct('assignment_group')
                 # section.teachers is a property, so we can't add extra

--- a/esp/public/media/scripts/onsite/teacher_checkin.js
+++ b/esp/public/media/scripts/onsite/teacher_checkin.js
@@ -8,6 +8,7 @@ $j(function(){
     var checkins = [];
 
     $j(".flag-detail").hide();
+    $j(".flag-header").removeClass("active");
     $j(".assignment-detail").hide();
 
     //Replace hyphens with non-breaking hyphens, to stop Chrome from breaking up phone numbers

--- a/esp/public/media/scripts/program/modules/flag-results-page.js
+++ b/esp/public/media/scripts/program/modules/flag-results-page.js
@@ -46,16 +46,19 @@ function emailTeachers (emailAddress, subject) {
 
 function showAll () {
     $j(".fqr-class-detail").show();
+    $j(".flag-header").addClass("active");
     $j(".flag-detail:not(.flag-extra)").show();
 }
 
 function showWithComments () {
     $j(".fqr-class-detail").show();
+    $j(".flag-header.flag-has-comment").addClass("active");
     $j(".flag-detail.flag-has-comment").show();
 }
 
 function hideAll () {
     $j(".fqr-class-detail").hide();
+    $j(".flag-header").removeClass("active");
     $j(".flag-detail").hide();
 }
 
@@ -88,5 +91,6 @@ function rejectAll (IDs) {
 
 $j(document).ready(function () {
     $j(".flag-detail").hide();
+    $j(".flag-header").removeClass("active");
     $j(".manage-approve-link").hide();
 });

--- a/esp/templates/program/modules/classflagmodule/flag_name.html
+++ b/esp/templates/program/modules/classflagmodule/flag_name.html
@@ -1,4 +1,4 @@
-<span class="flag-header"
+<span class="flag-header active{% if flag.comment %} flag-has-comment{% endif %}"
       id="fqr-flag-header-{{flag.id}}"
       style="background: {{flag.flag_type.getColor}};">
     <span class="flag-name"

--- a/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
+++ b/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
@@ -245,10 +245,10 @@
     {% endif %}
 {% endifchanged %}
 <tr class="section-first-row" data-sec-id="{{ section.emailcode }}">
-    <td rowspan="{{ section.teachers|length }}" class="section-code">
+    <td rowspan="{% if section.teachers %}{{ section.teachers|length }}{% else %}1{% endif %}" class="section-code">
         {{ section.parent_class.emailcode }}: {{ section.name }}
     </td>
-    <td class="room" rowspan="{{ section.teachers|length }}">
+    <td class="room" rowspan="{% if section.teachers %}{{ section.teachers|length }}{% else %}1{% endif %}">
         {% if start_time %}
             {{ section.room }}
         {% else %}
@@ -281,6 +281,12 @@
                    {% if teacher.id in arrived %} disabled title="Teacher already checked in"
                    {% elif not text_configured %} disabled title="Twilio texting settings are not configured"
                    {% elif teacher.phone == default_phone %} disabled title="No contact info"{% endif %}/>
+        </tr>
+        <tr data-sec-id="{{ section.emailcode }}">
+    {% empty %}
+        <td colspan="4">
+            No teachers for this class
+        </td>
         </tr>
         <tr data-sec-id="{{ section.emailcode }}">
     {% endfor %}


### PR DESCRIPTION
This fixes the behavior of flags on a number of pages:

1. Fixes the +/- behavior of flag name elements on the manage class page
2. Fixes the +/- behavior of flag name elements when clicking the "show all"/"show comments"/"hide all" links on /classsearch
3. Fixes the default +/- behavior of flag name elements when creating new flags on /missingteachers, /classsearch, and the manage class page

I also fixed a weird bug that occurred on the /missingteachers page when a section had no teachers (an unlikely but definitely possible edge case that I discovered while fixing these flag things).

Fixes https://github.com/learning-unlimited/ESP-Website/issues/2994.