### PR TITLE
Update tags dev docs

### DIFF
--- a/docs/dev/tags.rst
+++ b/docs/dev/tags.rst
@@ -7,9 +7,12 @@ To create a *global tag* (one applies to all programs), add a new line to the gl
 file https://github.com/learning-unlimited/ESP-Website/blob/main/esp/esp/tagdict/__init__.py.
 To create a *program-specific tag*, add the new tag's name to the program tag dictionary ``all_program_tags`` in the same file as above.
 
-The format for tags in both dictionaries is ``'tag_name': (is the tag boolean?, 'some help text for admins')``, where the first
+The format for tags in both dictionaries is ``'tag_name': (is the tag boolean?, 'some help text for admins', default value, category, show on tag settings page?)``. The first
 variable in the tuple determines whether the tag is meant to contain only a boolean value (if so, set the first variable to ``True``)
-or other data (set it to ``False``).
+or other data (set it to ``False``). The second variable is a string of help text that will be displayed for admins. The
+third variable is the default value of the tag (type matters). The fourth variable is a string identifying the category of the tag, which is one of
+``teach``, ``learn``, ``manage``, ``onsite``, ``volunteer``, or ``theme``. These categories are defined in the ``tag_categories`` dictionary in the same file above.
+Finally, the fifth variable is a boolean identifying whether the tag should be shown on the tag settings page (``True`` for shown or ``False`` for not shown).
 
 In order to make use of your new tag, find the file(s) where you want to use the tag's data, and make sure to include the
 line ``from esp.tagdict.models import Tag``.
@@ -24,4 +27,3 @@ Program tags can be used with ``Tag.getProgramTag('tag_name', program)`` or by p
 * You may want to implement checks against the validity of the tag's data.
   For instance, it is helpful to send a descriptive error message to an admin who's trying access invalid tag data (unfortunately, there
   is not currently an easy way to notify an admin immediately when an invalid tag is set in the admin panel).
-* Please also add a description of your tag to the `LU Wiki page on Tags <https://wiki.learningu.org/Customize_behavior_with_Tags>`_.


### PR DESCRIPTION
This updates the dev docs for tags to reflect the changes in https://github.com/learning-unlimited/ESP-Website/pull/2916.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/2969.