### PR TITLE
Add links to comm panel, AUL, and group text module on /classsearch

### DIFF
--- a/esp/esp/program/admin.py
+++ b/esp/esp/program/admin.py
@@ -192,7 +192,7 @@ admin_site.register(VolunteerOffer, VolunteerOfferAdmin)
 ## class_.py
 
 class Admin_RegistrationType(admin.ModelAdmin):
-    list_display = ('name', 'category', )
+    list_display = ('name', 'category', 'displayName', 'description', )
 admin_site.register(RegistrationType, Admin_RegistrationType)
 
 def expire_student_registrations(modeladmin, request, queryset):

--- a/esp/esp/program/migrations/0017_regtype_defaults.py
+++ b/esp/esp/program/migrations/0017_regtype_defaults.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+def set_my_defaults(apps, schema_editor):
+    defaults_dict = {
+                        "Enrolled": {"dn": "Enrolled in Class", "des": "Student is currently enrolled in this class"},
+                        "Attended": {"dn": "Attended Class", "des": "Student attended this class"},
+                        "Accepted": {"dn": "Application Accepted", "des": "Student's application for this class was accepted"},
+                        "Request": {"dn": "Class Change Request", "des": "Student made a class change request for this class"},
+                        "Interested": {"dn": "Interested in Class", "des": "For old lottery registration, a student would be interested in being placed into this class, but it isn't their first choice"},
+                        "SurveyCompleted": {"dn": "Completed Class Survey", "des": "Student filled out the survey for this class"},
+                        "Onsite/Webapp": {"dn": "Enrolled Using Webapp", "des": "Student used the onsite webapp to enroll in this class"},
+                        "OnSite/ChangedClasses": {"dn": "Enrolled at Onsite", "des": "Student enrolled in this class at onsite registration"},
+                        "OnSite/AttendedClass": {"dn": "Enrolled via Attendance", "des": "Student was enrolled in this class because they attended it"},
+                    }
+    RegistrationType = apps.get_model('program', 'RegistrationType')
+    for rt in RegistrationType.objects.all():
+        if "Priority/" in rt.name:
+            prior_num = int(rt.name.split("Priority/")[1])
+            if rt.displayName is None or rt.displayName == u"":
+                rt.displayName = "Priority %i" % prior_num
+            if rt.description is None or rt.description == u"":
+                rt.description = "Student marked this class as their #%i priority in the two-phase class lottery" % prior_num
+        if rt.name in defaults_dict.keys():
+            if rt.displayName is None or rt.displayName == u"":
+                rt.displayName = defaults_dict[rt.name]["dn"]
+            if rt.description is None or rt.description == u"":
+                rt.description = defaults_dict[rt.name]["des"]
+        rt.save()
+
+def reverse_func(apps, schema_editor):
+    return
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('program', '0016_auto_20200531_1357'),
+    ]
+
+    operations = [
+        migrations.RunPython(set_my_defaults, reverse_func),
+    ]

--- a/esp/esp/program/modules/handlers/classsearchmodule.py
+++ b/esp/esp/program/modules/handlers/classsearchmodule.py
@@ -156,6 +156,6 @@ class ClassSearchModule(ProgramModuleObj):
             context['queryset'] = queryset
             context['IDs'] = [cls.id for cls in queryset]
             context['flag_types'] = self.program.flag_types.all()
-            context['regtypes'] = RegistrationType.objects.all().order_by("name")
+            context['regtypes'] = sorted(RegistrationType.objects.all(), key=lambda a: str(a))
         return render_to_response(self.baseDir()+'class_search.html',
                                   request, context)

--- a/esp/esp/program/modules/handlers/classsearchmodule.py
+++ b/esp/esp/program/modules/handlers/classsearchmodule.py
@@ -6,6 +6,7 @@ from django.http import HttpResponseRedirect
 from django.db.models.query import Q
 
 from esp.program.modules.base import ProgramModuleObj, main_call, needs_admin
+from esp.program.models import RegistrationType
 from esp.program.models.class_ import ClassSubject, STATUS_CHOICES
 from esp.program.models.flags import ClassFlagType
 from esp.resources.models import Resource, ResourceType, ResourceRequest
@@ -155,5 +156,6 @@ class ClassSearchModule(ProgramModuleObj):
             context['queryset'] = queryset
             context['IDs'] = [cls.id for cls in queryset]
             context['flag_types'] = self.program.flag_types.all()
+            context['regtypes'] = RegistrationType.objects.all().order_by("name")
         return render_to_response(self.baseDir()+'class_search.html',
                                   request, context)

--- a/esp/public/media/scripts/commpanel.js
+++ b/esp/public/media/scripts/commpanel.js
@@ -312,8 +312,8 @@ function initialize()
     //  Populate fields with GET parameters
     var items = location.search.substr(1).split("&");
     for (var index = 0; index < items.length; index++) {
-          var tmp = items[index].split("=");
-          $j("[name="+tmp[0]+"]").val(tmp[1]);
+        var tmp = items[index].split("=");
+        $j("[name="+tmp[0]+"]").val(tmp[1]).change();
     }
 }
 

--- a/esp/public/media/scripts/commpanel.js
+++ b/esp/public/media/scripts/commpanel.js
@@ -312,8 +312,8 @@ function initialize()
     //  Populate fields with GET parameters
     var items = location.search.substr(1).split("&");
     for (var index = 0; index < items.length; index++) {
-        var tmp = items[index].split("=");
-        $j("[name="+tmp[0]+"]").val(tmp[1]).change();
+        var key_val = items[index].split("=");
+        $j("[name=" + key_val[0] + "]").val(key_val[1].split(",")).change();
     }
 }
 

--- a/esp/public/media/scripts/program/modules/classsearch.js
+++ b/esp/public/media/scripts/program/modules/classsearch.js
@@ -53,3 +53,17 @@ $j.initialize("input.qb-input", function() {
 $j(document).on('change', 'select.qb-input', function() {
     checkSelect(this);
 });
+
+//Update student links based on selected registrations
+$j(function () {
+    $j("#regtypes").change(function (){
+        // Get user-selected options
+        var regtypes = $j(this).val();
+        var clsids = $j("#student_links").data("clsids");
+        // Add reg types to all links
+        $j("#student_links .dropdown-menu a").each(function (){
+            var base_url = $j(this).attr('href').split('?')[0];
+            $j(this).attr('href', base_url + "?clsid=" + clsids + "&regtypes=" +regtypes.join())
+        });
+    });
+});

--- a/esp/templates/program/modules/classsearchmodule/class_search.html
+++ b/esp/templates/program/modules/classsearchmodule/class_search.html
@@ -7,6 +7,15 @@
     <link rel="stylesheet" type="text/css" href="/media/styles/forms.css"/>
     <link rel="stylesheet" type="text/css" href="/media/styles/flags.css"/>
     <link rel="stylesheet" type="text/css" href="/media/styles/query-builder.css"/>
+    <style>
+    .btn-group a {
+        color: #333333 !important;
+        text-decoration: none !important;
+    }
+    .dropdown-menu a:hover {
+        color: #ffffff !important;
+    }
+    </style>
 {% endblock %}
 
 {% block xtrajs %}
@@ -36,33 +45,72 @@ Your query returned {{queryset|length}} of {{program.classsubject_set.count}} cl
 </p>
 
 <div class="btn-group">
-    <button class="btn btn-approve" onclick="approveAll({{ IDs|escapejs }});">approve all</button>
-    <button class="btn btn-unreview" onclick="unreviewAll({{ IDs|escapejs }});">unreview all</button>
-    <button class="btn btn-reject" onclick="rejectAll({{ IDs|escapejs }});">reject all</button>
+    <button class="btn btn-approve" onclick="approveAll({{ IDs|escapejs }});">Approve All</button>
+    <button class="btn btn-unreview" onclick="unreviewAll({{ IDs|escapejs }});">Unreview All</button>
+    <button class="btn btn-reject" onclick="rejectAll({{ IDs|escapejs }});">Reject All</button>
 </div>
-</br>
-<div class="btn-group" style="z-index: 99; margin-right: 5px; float: left;">
-    <a class="btn" href="./coursecatalog?clsids={{ IDs|join:',' }}" target="_blank" title="Change sorting with the 'catalog_sort_fields' tag">course catalog</a>
+<div class="btn-toolbar">
+    <div class="btn-group" id="catalog_links">
+        <a class="btn" href="./coursecatalog?clsids={{ IDs|join:',' }}" target="_blank" title="Change sorting with the 'catalog_sort_fields' tag">Course Catalog</a>
+    </div>
+    <div class="btn-group" id="spreadsheet_links">
+        <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
+            Class Spreadsheets
+            <span class="caret"></span>
+        </a>
+        <ul class="dropdown-menu">
+            <li><a href="./classesbyid?clsids={{ IDs|join:',' }}" target="_blank">By ID</a></li>
+            <li><a href="./classesbytitle?clsids={{ IDs|join:',' }}" target="_blank">By Title</a></li>
+            <li><a href="./classesbytime?clsids={{ IDs|join:',' }}" target="_blank">By Time</a></li>
+        </ul>
+    </div>
+    <div class="btn-group" id="flag_printable_links">
+        <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
+            Class Flag Printables
+            <span class="caret"></span>
+        </a>
+        <ul class="dropdown-menu">
+            <li><a href="./classflagdetails?clsids={{ IDs|join:',' }}" target="_blank">Without Comments</a></li>
+            <li><a href="./classflagdetails?comments&clsids={{ IDs|join:',' }}" target="_blank">With Comments</a></li>
+        </ul>
+    </div>
 </div>
-<div class="btn-group">
-    <a class="btn" href="./classesbyid?clsids={{ IDs|join:',' }}" target="_blank">spreadsheet (by ID)</a>
-    <a class="btn" href="./classesbytitle?clsids={{ IDs|join:',' }}" target="_blank">spreadsheet (by title)</a>
-    <a class="btn" href="./classesbytime?clsids={{ IDs|join:',' }}" target="_blank">spreadsheet (by time)</a>
+<div class="btn-toolbar">
+    <div id="reg_types_div" class="btn-group">
+        Select student registration type(s):</br>
+        <select name="regtypes" id="regtypes" multiple>
+            {% for regtype in regtypes %}
+            <option value="{{ regtype.name }}"{% if regtype.name == "Enrolled" %} selected{% endif %}>{{ regtype }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="btn-group" id="student_links" data-clsids="{{ IDs|join:',' }}">
+        <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
+            Student Links
+            <span class="caret"></span>
+        </a>
+        <ul class="dropdown-menu">
+            <li><a href="./selectList?clsid={{ IDs|join:',' }}&regtypes=Enrolled" target="_blank">Get Student Information</a></li>
+            <li><a href="./commpanel?clsid={{ IDs|join:',' }}&regtypes=Enrolled" target="_blank">Email Students</a></li>
+            {% if program|hasModule:"GroupTextModule" %}
+            <li><a href="./grouptextpanel?clsid={{ IDs|join:',' }}&regtypes=Enrolled" target="_blank">Text Students</a></li>
+            {% endif %}
+        </ul>
+    </div>
+    <div class="btn-group" id="teacher_links">
+        <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
+            Teacher Links
+            <span class="caret"></span>
+        </a>
+        <ul class="dropdown-menu">
+            <li><a href="./selectList?recipient_type=Teacher&userid={% for cls in queryset %}{% for teacher in cls.teachers.all %}{{ teacher.id }}{% if not forloop.last %},{% endif %}{% endfor %}{% if cls.teachers.exists and not forloop.last %},{% endif %}{% endfor %}" target="_blank">Get Teacher Information</a></li>
+            <li><a href="./commpanel?recipient_type=Teacher&userid={% for cls in queryset %}{% for teacher in cls.teachers.all %}{{ teacher.id }}{% if not forloop.last %},{% endif %}{% endfor %}{% if cls.teachers.exists and not forloop.last %},{% endif %}{% endfor %}" target="_blank">Email Teachers</a></li>
+            {% if program|hasModule:"GroupTextModule" %}
+            <li><a href="./grouptextpanel?recipient_type=Teacher&userid={% for cls in queryset %}{% for teacher in cls.teachers.all %}{{ teacher.id }}{% if not forloop.last %},{% endif %}{% endfor %}{% if cls.teachers.exists and not forloop.last %},{% endif %}{% endfor %}" target="_blank">Text Teachers</a></li>
+            {% endif %}
+        </ul>
+    </div>
 </div>
-</br>
-<div class="btn-group">
-    <a class="btn" href="./classflagdetails?clsids={{ IDs|join:',' }}" target="_blank">class flags</a>
-    <a class="btn" href="./classflagdetails?comments&clsids={{ IDs|join:',' }}" target="_blank">class flags (with comments)</a>
-</div>
-</br>
-<div class="btn-group">
-    <a class="btn" href="./selectList?recipient_type=Teacher&userid={% for cls in queryset %}{% for teacher in cls.teachers.all %}{{ teacher.id }}{% if not forloop.last %},{% endif %}{% endfor %}{% if cls.teachers.exists and not forloop.last %},{% endif %}{% endfor %}" target="_blank">Get Teacher Information</a>
-    <a class="btn" href="./commpanel?recipient_type=Teacher&userid={% for cls in queryset %}{% for teacher in cls.teachers.all %}{{ teacher.id }}{% if not forloop.last %},{% endif %}{% endfor %}{% if cls.teachers.exists and not forloop.last %},{% endif %}{% endfor %}" target="_blank">Email Teachers</a>
-    {% if program|hasModule:"GroupTextModule" %}
-    <a class="btn" href="./grouptextpanel?recipient_type=Teacher&userid={% for cls in queryset %}{% for teacher in cls.teachers.all %}{{ teacher.id }}{% if not forloop.last %},{% endif %}{% endfor %}{% if cls.teachers.exists and not forloop.last %},{% endif %}{% endfor %}" target="_blank">Text Teachers</a>
-    {% endif %}
-</div>
-</br>
 
 <div class="flag-query-results" id="program_form">
     {% for class in queryset %}

--- a/esp/templates/program/modules/classsearchmodule/class_search.html
+++ b/esp/templates/program/modules/classsearchmodule/class_search.html
@@ -19,6 +19,7 @@
 {% endblock %}
 
 {% block content %}
+{% load modules %}
 
 <h1>Search Classes for {{ program.niceName }}</h1>
 
@@ -41,17 +42,25 @@ Your query returned {{queryset|length}} of {{program.classsubject_set.count}} cl
 </div>
 </br>
 <div class="btn-group" style="z-index: 99; margin-right: 5px; float: left;">
-    <a class="btn btn-approve" href="./coursecatalog?clsids={{ IDs|join:',' }}" target="_blank" title="Change sorting with the 'catalog_sort_fields' tag">course catalog</a>
+    <a class="btn" href="./coursecatalog?clsids={{ IDs|join:',' }}" target="_blank" title="Change sorting with the 'catalog_sort_fields' tag">course catalog</a>
 </div>
 <div class="btn-group">
-    <a class="btn btn-approve" href="./classesbyid?clsids={{ IDs|join:',' }}" target="_blank">spreadsheet (by ID)</a>
-    <a class="btn btn-unreview" href="./classesbytitle?clsids={{ IDs|join:',' }}" target="_blank">spreadsheet (by title)</a>
-    <a class="btn btn-reject" href="./classesbytime?clsids={{ IDs|join:',' }}" target="_blank">spreadsheet (by time)</a>
+    <a class="btn" href="./classesbyid?clsids={{ IDs|join:',' }}" target="_blank">spreadsheet (by ID)</a>
+    <a class="btn" href="./classesbytitle?clsids={{ IDs|join:',' }}" target="_blank">spreadsheet (by title)</a>
+    <a class="btn" href="./classesbytime?clsids={{ IDs|join:',' }}" target="_blank">spreadsheet (by time)</a>
 </div>
 </br>
 <div class="btn-group">
-    <a class="btn btn-approve" href="./classflagdetails?clsids={{ IDs|join:',' }}" target="_blank">class flags</a>
-    <a class="btn btn-unreview" href="./classflagdetails?comments&clsids={{ IDs|join:',' }}" target="_blank">class flags (with comments)</a>
+    <a class="btn" href="./classflagdetails?clsids={{ IDs|join:',' }}" target="_blank">class flags</a>
+    <a class="btn" href="./classflagdetails?comments&clsids={{ IDs|join:',' }}" target="_blank">class flags (with comments)</a>
+</div>
+</br>
+<div class="btn-group">
+    <a class="btn" href="./selectList?recipient_type=Teacher&userid={% for cls in queryset %}{% for teacher in cls.teachers.all %}{{ teacher.id }}{% if not forloop.last %},{% endif %}{% endfor %}{% if cls.teachers.exists and not forloop.last %},{% endif %}{% endfor %}" target="_blank">Get Teacher Information</a>
+    <a class="btn" href="./commpanel?recipient_type=Teacher&userid={% for cls in queryset %}{% for teacher in cls.teachers.all %}{{ teacher.id }}{% if not forloop.last %},{% endif %}{% endfor %}{% if cls.teachers.exists and not forloop.last %},{% endif %}{% endfor %}" target="_blank">Email Teachers</a>
+    {% if program|hasModule:"GroupTextModule" %}
+    <a class="btn" href="./grouptextpanel?recipient_type=Teacher&userid={% for cls in queryset %}{% for teacher in cls.teachers.all %}{{ teacher.id }}{% if not forloop.last %},{% endif %}{% endfor %}{% if cls.teachers.exists and not forloop.last %},{% endif %}{% endfor %}" target="_blank">Text Teachers</a>
+    {% endif %}
 </div>
 </br>
 

--- a/esp/templates/program/modules/classsearchmodule/class_search.html
+++ b/esp/templates/program/modules/classsearchmodule/class_search.html
@@ -80,7 +80,7 @@ Your query returned {{queryset|length}} of {{program.classsubject_set.count}} cl
         Select student registration type(s):</br>
         <select name="regtypes" id="regtypes" multiple>
             {% for regtype in regtypes %}
-            <option value="{{ regtype.name }}"{% if regtype.name == "Enrolled" %} selected{% endif %}>{{ regtype }}</option>
+            <option {% if regtype.description %}title="{{ regtype.description }}" {% endif %}value="{{ regtype.name }}"{% if regtype.name == "Enrolled" %} selected{% endif %}>{{ regtype }}</option>
             {% endfor %}
         </select>
     </div>

--- a/esp/templates/users/usersearch/list_selector.html
+++ b/esp/templates/users/usersearch/list_selector.html
@@ -131,9 +131,8 @@
                 <small>(Can be a comma-separated list)</small> <br /><br />
                 Select registration type(s): <select name="regtypes" id="regtypes" multiple>
                     {% for regtype in regtypes %}
-                    <option value="{{ regtype.name }}">{{ regtype }}</option>
+                    <option {% if regtype.description %}title="{{ regtype.description }}" {% endif %}value="{{ regtype.name }}"{% if regtype.name == "Enrolled" %} selected{% endif %}>{{ regtype }}</option>
                     {% endfor %}
-                    <option value="" selected hidden></option>
                 </select></div>
 
             </div>
@@ -272,9 +271,8 @@
                 <small>(Can be a comma-separated list)</small> <br /><br />
                 Select registration type(s): <select name="regtypes" id="regtypes" multiple>
                     {% for regtype in regtypes %}
-                    <option value="{{ regtype.name }}">{{ regtype }}</option>
+                    <option {% if regtype.description %}title="{{ regtype.description }}" {% endif %}value="{{ regtype.name }}"{% if regtype.name == "Enrolled" %} selected{% endif %}>{{ regtype }}</option>
                     {% endfor %}
-                    <option value="" selected hidden></option>
                 </select></div>
 
             </div>


### PR DESCRIPTION
I added links from /classsearch to the comm panel, arbitrary user list, and group text module such that you can use the /classsearch query to filter those three modules for the teachers of the classes (this populates the fields via the js in https://github.com/learning-unlimited/ESP-Website/pull/2868/commits/ff525daf72dc7c3bf345c2cfaa3a7800b1d1eb0e). Theoretically, this now makes it possible to put together an arbitrarily complex /classsearch query and then use the results of that to email the teachers (or get their info or text them).

I also removed some of the classes on the other buttons because the varied colors were getting to be a little overwhelming (h/t @kkbrum).

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3006.