### PR TITLE
Fix table overflow and add links to userview on attendance page

### DIFF
--- a/esp/templates/program/modules/onsiteattendance/attendance.html
+++ b/esp/templates/program/modules/onsiteattendance/attendance.html
@@ -6,6 +6,12 @@
     {{ block.super }}
     <link rel="stylesheet" href="/media/styles/forms.css" type="text/css" />
     <link rel="stylesheet" href="/media/styles/expand_display.css" type="text/css" />
+    <style>
+    table.sortable {
+        table-layout: fixed;
+        overflow-wrap: break-word;
+    }
+    </style>
 {% endblock %}
 
 {% block xtrajs %}
@@ -101,7 +107,7 @@ or select a timeslot from the dropdown below to see attendance stats:
     <th class="small">{{ forloop.counter }}</th>
     <td>{{ student.first_name }}</td>
     <td>{{ student.last_name }}</td>
-    <td>{{ student.username }}</td>
+    <td><a href="/manage/userview?username={{ student.username|urlencode }}">{{ student.username }}</a></td>
     <td>{{ student.id }}</td>
     <td>{{ student|getGradeForProg:program.id }}</td>
     <td>{{ student.getLastProfile.student_info.getSchool }}</td>
@@ -145,20 +151,20 @@ or select a timeslot from the dropdown below to see attendance stats:
 <table class="sortable" width="100%">
 <tr>
     <th width="5%">#</th>
-    <th width="10%">First Name</th>
-    <th width="10%">Last Name</th>
+    <th width="15%">First Name</th>
+    <th width="15%">Last Name</th>
     <th width="15%">Username</th>
     <th width="10%">ID #</th>
     <th width="10%">Grade</th>
-    <th width="20%">School</th>
-    <th width="20%">Enrolled Class</th>
+    <th width="15%">School</th>
+    <th width="15%">Enrolled Class</th>
 </tr>
 {% for student in not_attending %}
 <tr>
     <th class="small">{{ forloop.counter }}</th>
     <td>{{ student.first_name }}</td>
     <td>{{ student.last_name }}</td>
-    <td>{{ student.username }}</td>
+    <td><a href="/manage/userview?username={{ student.username|urlencode }}">{{ student.username }}</a></td>
     <td>{{ student.id }}</td>
     <td>{{ student|getGradeForProg:program.id }}</td>
     <td>{{ student.getLastProfile.student_info.getSchool }}</td>
@@ -217,7 +223,7 @@ or select a timeslot from the dropdown below to see attendance stats:
     <th class="small">{{ forloop.counter }}</th>
     <td>{{ student.first_name }}</td>
     <td>{{ student.last_name }}</td>
-    <td>{{ student.username }}</td>
+    <td><a href="/manage/userview?username={{ student.username|urlencode }}">{{ student.username }}</a></td>
     <td>{{ student.id }}</td>
     <td>{{ student|getGradeForProg:program.id }}</td>
     <td>{{ student.getLastProfile.student_info.getSchool }}</td>
@@ -273,7 +279,7 @@ or select a timeslot from the dropdown below to see attendance stats:
     <th class="small">{{ forloop.counter }}</th>
     <td>{{ section.emailcode }}</td>
     <td>{{ section.title }}</td>
-    <td>{{ section.parent_class.pretty_teachers }}</td>
+    <td>{% for teacher in section.parent_class.get_teachers %}<a href="/manage/userview?username={{ teacher.username|urlencode }}">{{ teacher.nonblank_name }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}</td>
     <td>{{ section.friendly_times_with_date|join:", " }}</td>
     <td>{{ section.num_students }}</td>
 </tr>


### PR DESCRIPTION
This fixes the potential overflow problem that the tables on the attendance page could encounter. I also added some links to the userview page (#1374).

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3031.