### PR TITLE
Encode all classes spreadsheet text to ascii

### DIFF
--- a/esp/esp/program/modules/handlers/programprintables.py
+++ b/esp/esp/program/modules/handlers/programprintables.py
@@ -1494,7 +1494,6 @@ class ProgramPrintables(ProgramModuleObj):
                 write_cvs.writerow(csv_headings)
 
                 for cls in ClassSubject.objects.filter(parent_program=prog):
-                    fields = []
                     write_cvs.writerow([_encode_ascii(converter.fieldvalue(cls,f)) for f in selected_fields])
 
                 response['Content-Disposition'] = 'attachment; filename=all_classes.csv'

--- a/esp/esp/program/modules/handlers/programprintables.py
+++ b/esp/esp/program/modules/handlers/programprintables.py
@@ -47,6 +47,7 @@ from esp.cal.models import Event
 from esp.middleware import ESPError
 from esp.utils.query_utils import nest_Q
 from esp.program.models import VolunteerOffer
+from esp.survey.views import _encode_ascii
 
 from django import forms
 from django.conf import settings
@@ -1489,11 +1490,12 @@ class ProgramPrintables(ProgramModuleObj):
                 response = HttpResponse(content_type="text/csv")
                 write_cvs = csv.writer(response)
                 selected_fields = form.cleaned_data['subject_fields']
-                csv_headings = [converter.field_dict[fieldname] for fieldname in selected_fields]
+                csv_headings = [_encode_ascii(converter.field_dict[fieldname]) for fieldname in selected_fields]
                 write_cvs.writerow(csv_headings)
 
                 for cls in ClassSubject.objects.filter(parent_program=prog):
-                    write_cvs.writerow([converter.fieldvalue(cls,f) for f in selected_fields])
+                    fields = []
+                    write_cvs.writerow([_encode_ascii(converter.fieldvalue(cls,f)) for f in selected_fields])
 
                 response['Content-Disposition'] = 'attachment; filename=all_classes.csv'
                 return response


### PR DESCRIPTION
We now encode all of the text for the all classes spreadsheet to ascii in case there are any special characters that we can't write to a csv.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3033.