### PR TITLE
Fix some survey bugs

### DIFF
--- a/esp/esp/program/modules/forms/surveys.py
+++ b/esp/esp/program/modules/forms/surveys.py
@@ -48,9 +48,9 @@ class QuestionForm(forms.ModelForm):
         }
 
 class SurveyImportForm(forms.Form):
-    survey = forms.ModelChoiceField(queryset=None)
+    survey_id = forms.ModelChoiceField(queryset=None, label = "Survey")
 
     def __init__(self, *args, **kwargs):
         cur_prog = kwargs.pop('cur_prog', None)
         super(SurveyImportForm, self).__init__(*args, **kwargs)
-        self.fields['survey'].queryset = Survey.objects.exclude(program=cur_prog)
+        self.fields['survey_id'].queryset = Survey.objects.exclude(program=cur_prog)

--- a/esp/esp/program/modules/handlers/surveymanagement.py
+++ b/esp/esp/program/modules/handlers/surveymanagement.py
@@ -66,7 +66,7 @@ class SurveyManagement(ProgramModuleObj):
         if request.GET:
             obj = request.GET.get("obj", None)
             op = request.GET.get("op", None)
-            id = request.GET.get("id", None) or request.POST.get("survey", None) or request.POST.get("survey_id", None) or request.POST.get("question_id", None)
+            id = request.GET.get("id", None) or request.POST.get("survey_id", None) or request.POST.get("question_id", None)
             if obj == "survey":
                 context['open_section'] = 'survey'
                 survey = None

--- a/esp/templates/program/modules/surveymanagement/import.html
+++ b/esp/templates/program/modules/surveymanagement/import.html
@@ -21,7 +21,7 @@ You have chosen to import {{ survey.name }} ({{ survey.category }}) from {{ surv
 <div id="program_form">
 <form method="post" action="/manage/{{ program.url }}/surveys/manage?obj=survey&op=import">
 <input type="hidden" name="import_confirm" value="yes" />
-<input type="hidden" name="survey" value="{{ survey.id }}" />
+<input type="hidden" name="survey_id" value="{{ survey.id }}" />
 <table align="center" cellpadding="0" cellspacing="0" width="100%">
     <tr><th colspan="6">Questions for {{ survey.name }} ({{ survey.category }})</th></tr>
     <tr>


### PR DESCRIPTION
This fixes some survey bugs that arose when I implemented https://github.com/learning-unlimited/ESP-Website/commit/c8510c252336934d2296b0e1ded877f9ca36943b. While this change fixed the survey import feature, it ending up breaking the other parts of survey management. I reverted that change, made sure the two new bugs were fixed, then made a better fix for the survey import bug.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3059 and fixes https://github.com/learning-unlimited/ESP-Website/issues/3062