### PR TITLE
Attendance without form submission

### DIFF
--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -329,13 +329,13 @@ class TeacherClassRegModule(ProgramModuleObj):
         if 'student' in request.POST and 'secid' in request.POST:
             students = ESPUser.objects.filter(username=request.POST['student'])
             if not students.exists():
-                json_data['message'] = 'User not found!'
+                json_data['error'] = 'User with username %s not found!' % request.POST['student']
             else:
                 student = students[0]
                 json_data['name'] = student.name()
                 sections = ClassSection.objects.filter(id=request.POST['secid'])
                 if not sections.exists():
-                    json_data['message'] = 'Section not found!'
+                    json_data['error'] = 'Section with ID %s not found!' % request.POST['secid']
                 else:
                     section = sections[0]
                     json_data['secid'] = section.id

--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -305,6 +305,7 @@ class TeacherClassRegModule(ProgramModuleObj):
         return (section, not_found)
 
     @aux_call
+    @needs_teacher
     def ajaxstudentattendance(self, request, tl, one, two, module, extra, prog):
         """
         POST to this view to change the attendance status of a student for a given section.

--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -48,7 +48,7 @@ from esp.users.models            import User, ESPUser, Record, TeacherInfo
 from esp.resources.forms         import ResourceRequestFormSet
 from esp.mailman                 import add_list_members
 from django.conf                 import settings
-from django.http                 import HttpResponseRedirect
+from django.http                 import HttpResponse, HttpResponseRedirect
 from django.db                   import models
 from django.forms.utils          import ErrorDict
 from django.template.loader      import render_to_string
@@ -316,6 +316,77 @@ class TeacherClassRegModule(ProgramModuleObj):
                 student.attended = StudentRegistration.valid_objects().filter(user = student, section = section, relationship = attended).exists()
                 section.attended_list.append(student)
         return (section, not_found)
+
+    @aux_call
+    def ajaxstudentattendance(self, request, tl, one, two, module, extra, prog):
+        """
+        POST to this view to change the attendance status of a student for a given section.
+        POST data:
+          'student':              The teacher's username.
+          'section':              The section ID.
+          'undo' (optional):      If 'true', expires all attendance registrations
+                                  for the student for the section.
+                                  Otherwise, the student is marked as attending the section.
+          'enroll' (optional):    If 'false', does not enroll the student in the section.
+                                  Otherwise, enrolls the student if they are not already enrolled.
+          'unenroll' (optional):  If 'false', does not unenroll the student from conflicting sections.
+                                  Otherwise, unenrolls the student from conflicting sections.
+        """
+        json_data = {}
+        today_min = datetime.datetime.combine(datetime.date.today(), datetime.time.min)
+        today_max = datetime.datetime.combine(datetime.date.today(), datetime.time.max)
+        attended = RegistrationType.objects.get_or_create(name = 'Attended', category = "student")[0]
+        enrolled = RegistrationType.objects.get_or_create(name='Enrolled', category = "student")[0]
+        onsite = RegistrationType.objects.get_or_create(name='OnSite/AttendedClass', category = "student")[0]
+        if 'student' in request.POST and 'section' in request.POST:
+            students = ESPUser.objects.filter(username=request.POST['student'])
+            if not students.exists():
+                json_data['message'] = 'User not found!'
+            else:
+                student = students[0]
+                json_data['name'] = student.name()
+                sections = ClassSection.objects.filter(id=request.POST['section'])
+                if not sections.exists():
+                    json_data['message'] = 'Section not found!'
+                else:
+                    section = sections[0]
+                    json_data['section'] = section.id
+                    if request.POST.get('undo', 'false').lower() == 'true':
+                        #should we also delete the program attendance record?
+                        srs = StudentRegistration.valid_objects().filter(user = student, section = section, relationship = attended)
+                        if srs.exists():
+                            for sr in srs:
+                                sr.expire() #or delete??
+                            json_data['message'] = '%s is no longer marked as attending.' % student.name()
+                        else:
+                            json_data['message'] = '%s was not marked as attending.' % teacher.name()
+                    else:
+                        if not prog.isCheckedIn(student):
+                            rec = Record(user=student, program=prog, event='attended')
+                            rec.save()
+                        sr = StudentRegistration.objects.get_or_create(user = student, section = section, relationship = attended, start_date__range=(today_min, today_max))[0]
+                        sr.end_date = today_max
+                        sr.save()
+                        if student not in section.students():
+                            if request.POST.get('unenroll', 'true').lower() == 'true':
+                                sm = ScheduleMap(student, prog)
+                                for ts in [ts.id for ts in section.get_meeting_times()]:
+                                    if ts in sm.map and len(sm.map[ts]) > 0:
+                                        for sm_sec in sm.map[ts]:
+                                            sm_sec.unpreregister_student(student)
+                            if request.POST.get('enroll', 'true').lower() == 'true':
+                                for rt in [enrolled, onsite]:
+                                    srs = StudentRegistration.objects.filter(user = student, section = section, relationship = rt)
+                                    if srs.count() > 0:
+                                        sr = srs[0]
+                                        sr.unexpire()
+                                    else:
+                                        sr = StudentRegistration.objects.create(user = student, section = section, relationship = rt)
+                                    if rt.name=='OnSite/AttendedClass':
+                                        sr.end_date = today_max
+                                        sr.save()
+                        json_data['message'] = '%s is marked as attending.' % student.name()
+        return HttpResponse(json.dumps(json_data), content_type='text/json')
 
     @aux_call
     @needs_teacher

--- a/esp/public/media/scripts/program/modules/attendance.js
+++ b/esp/public/media/scripts/program/modules/attendance.js
@@ -29,7 +29,7 @@ Quagga.onDetected(function(result) {
 prog_url = $j('#attendancescript').data('prog_url');
 
 $j(function(){
-    function markAttendance(username, secid, callback, undo = false, errorCallback){
+    function markAttendance(username, secid, undo = false, callback, errorCallback){
         refresh_csrf_cookie();
         var data = {student: username, secid: secid, undo: undo, csrfmiddlewaretoken: csrf_token()};
         $j.post('/teach/' + prog_url + '/ajaxstudentattendance', data, "json").success(callback)
@@ -46,16 +46,18 @@ $j(function(){
         var $me = $j(this);
         var username = $me.data("username");
         var secid = $me.data("secid");
-        var $msg = $me.parents("td").children(".msg");
-        var $checkedin = $me.parents("tr").children("[name=checkedin]");
+        var $msg = $me.closest("td").find(".msg");
+        var $checkedin = $me.closest("tr").find("[name=checkedin]");
         $me.prop('disabled', true);
-        markAttendance(username, secid, function(response) {
+        markAttendance(username, secid, !checked, function(response) {
+            $me.closest("td").attr("sorttable_customkey", (checked) ? 2 : 1);
+            if (response.checkedin) {
+                $checkedin.prop("checked", true);
+                $checkedin.closest("td").attr("sorttable_customkey", 2);
+            }
             $msg.text(response.message);
             $me.prop('disabled', false);
-            console.log(response.checkedin);
-            if (response.checkedin)
-                $checkedin.prop("checked", true);
-        }, !checked);
+        });
         $msg.text('Updating attendance...');
     });
 });

--- a/esp/public/media/scripts/program/modules/attendance.js
+++ b/esp/public/media/scripts/program/modules/attendance.js
@@ -33,12 +33,7 @@ $j(function(){
         refresh_csrf_cookie();
         var data = {student: username, secid: secid, undo: undo, csrfmiddlewaretoken: csrf_token()};
         $j.post('/teach/' + prog_url + '/ajaxstudentattendance', data, "json").success(callback)
-        .error(function(){
-            alert("An error occurred while atempting to update attendance for" + username + ".");
-            if (errorCallback) {
-                errorCallback();
-            }
-        });
+        .error(errorCallback);
     }
 
     $j("[name=attending]").change(function(){
@@ -50,12 +45,23 @@ $j(function(){
         var $checkedin = $me.closest("tr").find("[name=checkedin]");
         $me.prop('disabled', true);
         markAttendance(username, secid, !checked, function(response) {
-            $me.closest("td").attr("sorttable_customkey", (checked) ? 2 : 1);
-            if (response.checkedin) {
-                $checkedin.prop("checked", true);
-                $checkedin.closest("td").attr("sorttable_customkey", 2);
+            if (response.error) {
+                alert(response.error);
+                $me.prop("checked", !checked);
+            } else {
+                $me.closest("td").attr("sorttable_customkey", (checked) ? 2 : 1);
+                if (response.checkedin) {
+                    $checkedin.prop("checked", true);
+                    $checkedin.closest("td").attr("sorttable_customkey", 2);
+                }
+                console.log(response.message);
             }
-            $msg.text(response.message);
+            $msg.text("");
+            $me.prop('disabled', false);
+        }, function(error) {
+            alert("An error (" + error.statusText + ") occurred while attempting to update attendance for " + username + ".");
+            $me.prop("checked", !checked);
+            $msg.text("");
             $me.prop('disabled', false);
         });
         $msg.text('Updating attendance...');

--- a/esp/public/media/scripts/program/modules/attendance.js
+++ b/esp/public/media/scripts/program/modules/attendance.js
@@ -1,0 +1,86 @@
+/*
+ * Javascript code for the attendance module
+*/
+
+var message = '';
+var lastResult = '';
+Quagga.onDetected(function(result) {
+    var code = result.codeResult.code;
+
+    if (lastResult !== code) {
+        beep();
+        lastResult = code;
+        var results = document.querySelector('textarea');
+        var codes = results.value.trim().split(/\s+/).filter(Boolean);
+        console.log(codes);
+        if (!codes.includes(code)) {
+            codes.push(code);
+            results.value = codes.join("\n");
+            message = code+' added to list';
+        } else {
+            message = code+' already in list';
+        }
+        $j('#scaninfo').show();
+        $j('#scaninfo').html(message);
+        setTimeout("$j('#scaninfo').fadeOut(); ", 4000);
+    }
+});
+
+prog_url = $j('#attendancescript').data('prog_url');
+
+$j(function(){
+    function markAttendance(username, section, callback, undo, errorCallback){
+        refresh_csrf_cookie();
+        var data = {student: username, section: section, csrfmiddlewaretoken: csrf_token()};
+        if(undo)
+            data.undo = true;
+        $j.post('/teach/' + prog_url + '/ajaxstudentattendance', data, "json").success(callback)
+        .error(function(){
+            alert("An error occurred while atempting to " + (undo?"un-check-in ":"check-in ") + username + ".");
+            if (errorCallback) {
+                errorCallback();
+            }
+        });
+    }
+
+    function undoAttendance(username, section, callback, errorCallback){
+        markAttendance(username, section, callback, true, errorCallback);
+    }
+
+    $j(".checkin:enabled").click(function(){
+        var username = this.id.replace("checkin_", "");
+        var $me = $j(this);
+        var section = $me.data("section");
+        var $td = $j(this.parentNode);
+        var $msg = $td.children('.message');
+        var $txtbtn = $j(this).closest('tr').find('.text');
+        markAttendance(username, section, function(response) {
+            // $msg.text(response.message);
+            // $td.prev().prop('class', 'checked-in');
+            // checkins.push({username: username, name: response.name, $td: $td});
+            $me.hide().prop('disabled', true);
+            // $txtbtn.prop('disabled', true);
+            // $txtbtn.attr("title","Teacher already checked-in");
+            // updateSelected(false);
+
+            // var $undoButton = $j(document.createElement('button'));
+            // $undoButton.prop('class', 'btn btn-default btn-mini undo-button');
+            // $undoButton.text('Undo');
+            // $undoButton.click(function () {
+                // undoLiveCheckIn(username);
+            // });
+            // $msg.append(' ', $undoButton);
+        });
+        $msg.text('Checking in...');
+    });
+
+    // $j(".uncheckin:enabled").click(function(){
+        // var username = this.id.replace("uncheckin_", "");
+        // var section = $j(this).data("section");
+        // undoAttendance(username, section, function(response) {
+            // alert(response.message);
+            // location.reload();
+        // });
+        // this.value += "...";
+    // });
+});

--- a/esp/templates/program/modules/teacherclassregmodule/section_attendance.html
+++ b/esp/templates/program/modules/teacherclassregmodule/section_attendance.html
@@ -96,8 +96,8 @@ Please select a section from the dropdown below.
                     <td>{{ student.id }}</td>
                     <td>{{ student|getGradeForProg:program.id }}</td>
                     <td>{{ student.getLastProfile.student_info.getSchool }}</td>
-                    <td name="checkedin" align="center" sorttable_customkey="{% if student.checked_in %}2{% else %}1{% endif %}">
-                        <input type="checkbox"{% if student.checked_in %} checked{% endif %} disabled>
+                    <td align="center" sorttable_customkey="{% if student.checked_in %}2{% else %}1{% endif %}">
+                        <input name="checkedin" type="checkbox"{% if student.checked_in %} checked{% endif %} disabled>
                     </td>
                     <td align="center" sorttable_customkey="{% if student.attended %}2{% else %}1{% endif %}">
                         <input name="attending" data-username="{{ student.username }}" data-secid="{{ section.id }}"
@@ -147,7 +147,7 @@ Please select a section from the dropdown below.
                     <td>{{ student|getGradeForProg:program.id }}</td>
                     <td>{{ student.getLastProfile.student_info.getSchool }}</td>
                     <td align="center" sorttable_customkey="{% if student.checked_in %}2{% else %}1{% endif %}">
-                        <input type="checkbox"{% if student.checked_in %} checked{% endif %} disabled>
+                        <input name="checkedin" type="checkbox"{% if student.checked_in %} checked{% endif %} disabled>
                     </td>
                     <td align="center" sorttable_customkey="{% if student.attended %}2{% else %}1{% endif %}">
                         <input name="attending" data-username="{{ student.username }}" data-secid="{{ section.id }}"

--- a/esp/templates/program/modules/teacherclassregmodule/section_attendance.html
+++ b/esp/templates/program/modules/teacherclassregmodule/section_attendance.html
@@ -15,31 +15,7 @@
     <script src="https://webrtc.github.io/adapter/adapter-latest.js" type="text/javascript"></script>
     <script src="https://cdn.jsdelivr.net/gh/serratus/quaggaJS@e96eb9f7888507689cf33f1e6ce325959dde314e/dist/quagga.min.js" type="text/javascript"></script>
     <script src="/media/scripts/barcodescanner.js" type="text/javascript"></script>
-    <script>
-        var message = '';
-        var lastResult = '';
-        Quagga.onDetected(function(result) {
-            var code = result.codeResult.code;
-
-            if (lastResult !== code) {
-                beep();
-                lastResult = code;
-                var results = document.querySelector('textarea');
-                var codes = results.value.trim().split(/\s+/).filter(Boolean);
-                console.log(codes);
-                if (!codes.includes(code)) {
-                    codes.push(code);
-                    results.value = codes.join("\n");
-                    message = code+' added to list';
-                } else {
-                    message = code+' already in list';
-                }
-                $j('#scaninfo').show();
-                $j('#scaninfo').html(message);
-                setTimeout("$j('#scaninfo').fadeOut(); ", 4000);
-            }
-        });
-    </script>
+    <script id="attendancescript" data-prog_url="{{ program.url }}" src="/media/scripts/program/modules/attendance.js" type="text/javascript"></script>
     <script src="/media/scripts/sorttable.js"></script>
     {% endif %}
 {% endblock %}
@@ -123,7 +99,13 @@ Please select a section from the dropdown below.
                     <td>{{ student|getGradeForProg:program.id }}</td>
                     <td>{{ student.getLastProfile.student_info.getSchool }}</td>
                     <td align="center" sorttable_customkey="{% if student.checked_in %}2{% else %}1{% endif %}"><input type="checkbox"{% if student.checked_in %} checked{% endif %} disabled></td>
-                    <td align="center" sorttable_customkey="{% if student.attended %}2{% else %}1{% endif %}"><input name="attending" value="{{ student.id }}" type="checkbox"{% if student.attended %} checked{% endif %}></td>
+                    <td align="center" sorttable_customkey="{% if student.attended %}2{% else %}1{% endif %}">
+                        {% if student.attended %}
+                            <input id="uncheckin_{{ student.username }}" data-section="{{ section.id }}" class="button uncheckin" type="button" value="Undo Check-In" />
+                        {% else %}
+                            <input id="checkin_{{ student.username }}" data-section="{{ section.id }}" class="button checkin" type="button" value="Check In"/><span />
+                        {% endif %}
+                    </td>
                 </tr>
             {% empty %}
             <tr>

--- a/esp/templates/program/modules/teacherclassregmodule/section_attendance.html
+++ b/esp/templates/program/modules/teacherclassregmodule/section_attendance.html
@@ -69,8 +69,6 @@ Please select a section from the dropdown below.
 
 {% if section %}
 <div id="program_form">
-<form action="{{ request.get_full_path }}" method="post">
-<input type="hidden" name="submitted">
 <table align="center" width="100%">
 <tr>
     <th align="center">
@@ -98,13 +96,13 @@ Please select a section from the dropdown below.
                     <td>{{ student.id }}</td>
                     <td>{{ student|getGradeForProg:program.id }}</td>
                     <td>{{ student.getLastProfile.student_info.getSchool }}</td>
-                    <td align="center" sorttable_customkey="{% if student.checked_in %}2{% else %}1{% endif %}"><input type="checkbox"{% if student.checked_in %} checked{% endif %} disabled></td>
+                    <td name="checkedin" align="center" sorttable_customkey="{% if student.checked_in %}2{% else %}1{% endif %}">
+                        <input type="checkbox"{% if student.checked_in %} checked{% endif %} disabled>
+                    </td>
                     <td align="center" sorttable_customkey="{% if student.attended %}2{% else %}1{% endif %}">
-                        {% if student.attended %}
-                            <input id="uncheckin_{{ student.username }}" data-section="{{ section.id }}" class="button uncheckin" type="button" value="Undo Check-In" />
-                        {% else %}
-                            <input id="checkin_{{ student.username }}" data-section="{{ section.id }}" class="button checkin" type="button" value="Check In"/><span />
-                        {% endif %}
+                        <input name="attending" data-username="{{ student.username }}" data-secid="{{ section.id }}"
+                        value="{{ student.id }}" type="checkbox"{% if student.attended %} checked{% endif %}>
+                        <br /><span class="msg"></span>
                     </td>
                 </tr>
             {% empty %}
@@ -148,8 +146,14 @@ Please select a section from the dropdown below.
                     <td>{{ student.id }}</td>
                     <td>{{ student|getGradeForProg:program.id }}</td>
                     <td>{{ student.getLastProfile.student_info.getSchool }}</td>
-                    <td align="center" sorttable_customkey="{% if student.checked_in %}2{% else %}1{% endif %}"><input type="checkbox"{% if student.checked_in %} checked{% endif %} disabled></td>
-                    <td align="center" sorttable_customkey="{% if student.attended %}2{% else %}1{% endif %}"><input name="attending" value="{{ student.id }}" type="checkbox"{% if student.attended %} checked{% endif %}></td>
+                    <td align="center" sorttable_customkey="{% if student.checked_in %}2{% else %}1{% endif %}">
+                        <input type="checkbox"{% if student.checked_in %} checked{% endif %} disabled>
+                    </td>
+                    <td align="center" sorttable_customkey="{% if student.attended %}2{% else %}1{% endif %}">
+                        <input name="attending" data-username="{{ student.username }}" data-secid="{{ section.id }}"
+                        value="{{ student.id }}" type="checkbox"{% if student.attended %} checked{% endif %}>
+                        <br /><span class="msg"></span>
+                    </td>
                 </tr>
             {% endfor %}
         </table>
@@ -159,6 +163,8 @@ Please select a section from the dropdown below.
 {% endif %}
 
 <br />
+<form action="{{ request.get_full_path }}" method="post">
+<input type="hidden" name="submitted">
 <table align="center" width="100%">
 <tr>
     <th align="center">


### PR DESCRIPTION
When a teacher or onsite user now checks off (or unchecks) a student as attending a class, it sends a POST request to the server and updates the attendance accordingly (similar to how the teacher checkin page works). This means that users no longer need to submit the page to save the attendance. It also means that multiple users can be marking attendance for the same class at the same time and there will be no conflicts.

One thing that bugs me a little is that the status messages are kinda long and obnoxious, but I can't really think of a different way to display them (I though about a whole separate column, but that might result in the other columns getting squished) nor can I think of much shorter status messages.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3004 and fixes https://github.com/learning-unlimited/ESP-Website/issues/3016.