### PR TITLE
Fix file upload URLs in custom forms

### DIFF
--- a/esp/esp/customforms/forms.py
+++ b/esp/esp/customforms/forms.py
@@ -2,7 +2,20 @@ from django.forms.fields import Select
 from django import forms
 from collections import OrderedDict
 from localflavor.us.forms import USStateField, USStateSelect
+from django.utils.html import conditional_escape
 
+class CustomFileWidget(forms.ClearableFileInput):
+    """
+    Custom widget for the 'File' field to fix the URL.
+    """
+    def get_template_substitution_values(self, value):
+        """
+        Return value-related substitutions.
+        """
+        return {
+            'initial': conditional_escape(value.url.split("/")[-1]),
+            'initial_url': conditional_escape("/" + value.url.split("/public/")[1])
+        }
 
 class NameWidget(forms.MultiWidget):
     """

--- a/esp/esp/customforms/linkfields.py
+++ b/esp/esp/customforms/linkfields.py
@@ -2,7 +2,7 @@ from django import forms
 from django.forms.models import fields_for_model
 from django.apps import apps
 from localflavor.us.forms import USStateField, USPhoneNumberField, USStateSelect
-from esp.customforms.forms import NameField, AddressField
+from esp.customforms.forms import NameField, AddressField, CustomFileWidget
 from esp.utils.forms import DummyField
 
 generic_fields = {
@@ -17,7 +17,7 @@ generic_fields = {
     'numeric': {'typeMap': forms.IntegerField, 'attrs': {'widget': forms.TextInput,}, 'widget_attrs': {'class': 'digits '},},
     'date': {'typeMap': forms.DateField,'attrs': {'widget': forms.DateInput,}, 'widget_attrs': {'class': 'ddate ', 'format': '%m-%d-%Y'},},
     'time': {'typeMap': forms.TimeField, 'attrs': {'widget': forms.TimeInput,}, 'widget_attrs': {'class': 'time '},},
-    'file': {'typeMap': forms.FileField, 'attrs': {'widget': forms.ClearableFileInput,}, 'widget_attrs': {'class': 'file'},},
+    'file': {'typeMap': forms.FileField, 'attrs': {'widget': CustomFileWidget,}, 'widget_attrs': {'class': 'file'},},
     'phone': {'typeMap': USPhoneNumberField, 'attrs': {'widget': forms.TextInput,}, 'widget_attrs': {'class': 'USPhone '}},
     'email': {'typeMap': forms.EmailField, 'attrs': {'max_length': 30, 'widget': forms.TextInput,}, 'widget_attrs': {'class': 'email '}},
     'state': {'typeMap': USStateField, 'attrs': {'widget': USStateSelect}, 'widget_attrs': {'class': ''}},

--- a/esp/public/media/scripts/customforms_response.js
+++ b/esp/public/media/scripts/customforms_response.js
@@ -57,8 +57,12 @@ $j(document).ready(function() {
 function file_link_formatter(cellvalue, options, rowObject)
 {
     var url_path = cellvalue.split("media/uploaded/")[1];
-    var url_dir = cellvalue.split("/");
-    return "<a href=\"/media/uploaded/" + url_path +  "\">" + url_dir[url_dir.length - 1] + "</a>";
+    if (url_path) {
+        var url_dir = url_path.split("/");
+        return "<a href=\"/media/uploaded/" + url_dir.slice(0, url_dir.length - 1).join("/") + "/" + encodeURIComponent(url_dir[url_dir.length - 1]) +  "\">" + url_dir[url_dir.length - 1] + "</a>";
+    } else {
+        return ""
+    }
 }
 
 var createGrid=function(form_data){


### PR DESCRIPTION
I fixed two things here:

1. When a teacher or student submitted the custom form with an uploaded file, they could then go back and see the uploaded file. However, for some strange reason, it linked to the full server path of the file, not the relative site path. I've created a widget override to fix this (and also cleaned up the displayed text for the link) ([extended widget class is here](https://docs.djangoproject.com/en/1.8/_modules/django/forms/widgets/#ClearableFileInput)).
2. When an admin viewed the responses to a custom form, the URLs for uploaded files weren't encoded at all, so weird characters would cause the links to be broken (e.g. "#"). I've made it such that the URLs are now encoded, while the displayed text is unencoded.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/2983.