### PR TITLE
Check for guardian info before providing it in AUL

### DIFF
--- a/esp/esp/program/modules/handlers/listgenmodule.py
+++ b/esp/esp/program/modules/handlers/listgenmodule.py
@@ -132,15 +132,18 @@ class UserAttributeGetter(object):
 
     def get_guardian_email(self):
         if self.profile.student_info:
-            return self.profile.contact_guardian.email
+            if self.profile.contact_guardian:
+                return self.profile.contact_guardian.email
 
     def get_guardian_name(self):
         if self.profile.student_info:
-            return self.profile.contact_guardian.name
+            if self.profile.contact_guardian:
+                return self.profile.contact_guardian.name
 
     def get_guardian_cellphone(self):
         if self.profile.student_info:
-            return self.profile.contact_guardian.phone_cell
+            if self.profile.contact_guardian:
+                return self.profile.contact_guardian.phone_cell
 
     def get_accountdate(self):
         return self.user.date_joined.strftime("%m/%d/%Y")


### PR DESCRIPTION
Fixes #2972 to check that a student has guardian info provided before returning the guardian name, cell phone, or email in the AUL.

Note that I was only able to replicate the original issue on dev3 (tried Yale, cloud, my devserver as well), but the dev3 logs said "AttributeError: 'NoneType' object has no attribute 'phone_cell'" and putting dev3 on this branch fixed the AUL generation (for all students in database).