### PR TITLE
Add student and teacher links to surveys

### DIFF
--- a/esp/esp/program/modules/handlers/studentsurveymodule.py
+++ b/esp/esp/program/modules/handlers/studentsurveymodule.py
@@ -32,17 +32,12 @@ Learning Unlimited, Inc.
   Phone: 617-379-0178
   Email: web-team@learningu.org
 """
-from esp.program.modules.base import ProgramModuleObj, needs_teacher, needs_student, needs_admin, usercheck_usetl, meets_deadline, meets_grade, main_call
-from esp.program.modules import module_ext
+from esp.program.modules.base import ProgramModuleObj, needs_student, meets_deadline, meets_grade, main_call
 from esp.tagdict.models import Tag
-from esp.utils.web import render_to_response
 from esp.users.models    import ESPUser
 from django.db.models.query   import Q
-from esp.middleware     import ESPError
-from esp.survey.models  import QuestionType, Question, Answer, SurveyResponse, Survey
-from esp.survey.views   import survey_view, survey_review, survey_graphical, survey_review_single
+from esp.survey.views   import survey_view
 
-import operator
 import datetime
 
 class StudentSurveyModule(ProgramModuleObj):
@@ -76,6 +71,7 @@ class StudentSurveyModule(ProgramModuleObj):
 
     @main_call
     @needs_student
+    @meets_grade
     @meets_deadline('/Survey')
     def survey(self, request, tl, one, two, module, extra, prog):
         return survey_view(request, tl, one, two)

--- a/esp/esp/program/modules/handlers/studentsurveymodule.py
+++ b/esp/esp/program/modules/handlers/studentsurveymodule.py
@@ -1,0 +1,87 @@
+
+__author__    = "Individual contributors (see AUTHORS file)"
+__date__      = "$DATE$"
+__rev__       = "$REV$"
+__license__   = "AGPL v.3"
+__copyright__ = """
+This file is part of the ESP Web Site
+Copyright (c) 2007 by the individual contributors
+  (see AUTHORS file)
+
+The ESP Web Site is free software; you can redistribute it and/or
+modify it under the terms of the GNU Affero General Public License
+as published by the Free Software Foundation; either version 3
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public
+License along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+Contact information:
+MIT Educational Studies Program
+  84 Massachusetts Ave W20-467, Cambridge, MA 02139
+  Phone: 617-253-4882
+  Email: esp-webmasters@mit.edu
+Learning Unlimited, Inc.
+  527 Franklin St, Cambridge, MA 02139
+  Phone: 617-379-0178
+  Email: web-team@learningu.org
+"""
+from esp.program.modules.base import ProgramModuleObj, needs_teacher, needs_student, needs_admin, usercheck_usetl, meets_deadline, meets_grade, main_call
+from esp.program.modules import module_ext
+from esp.tagdict.models import Tag
+from esp.utils.web import render_to_response
+from esp.users.models    import ESPUser
+from django.db.models.query   import Q
+from esp.middleware     import ESPError
+from esp.survey.models  import QuestionType, Question, Answer, SurveyResponse, Survey
+from esp.survey.views   import survey_view, survey_review, survey_graphical, survey_review_single
+
+import operator
+import datetime
+
+class StudentSurveyModule(ProgramModuleObj):
+    """ A module for people to take surveys. """
+
+    @classmethod
+    def module_properties(cls):
+        return [ {
+            "admin_title": "Student Surveys",
+            "link_title": "Student Surveys",
+            "module_type": "learn",
+            "seq": 9999,
+            "choosable": 1,
+        } ]
+
+    def students(self, QObject = False):
+        event="student_survey"
+        program=self.program
+
+        if QObject:
+            return {'student_survey': Q(record__program=program) & Q(record__event=event)}
+        return {'student_survey': ESPUser.objects.filter(record__program=program, record__event=event).distinct()}
+
+    def studentDesc(self):
+        return {'student_survey': """Students who filled out the survey"""}
+
+    def isStep(self):
+        return (Tag.getBooleanTag('student_survey_isstep', program=self.program, default=False) and
+                self.program.getTimeSlots()[0].start < datetime.datetime.now() and
+                self.program.getSurveys().filter(category = "learn").exists())
+
+    @main_call
+    @needs_student
+    @meets_deadline('/Survey')
+    def survey(self, request, tl, one, two, module, extra, prog):
+        return survey_view(request, tl, one, two)
+
+    surveys = survey
+
+    class Meta:
+        proxy = True
+        app_label = 'modules'

--- a/esp/esp/program/modules/handlers/surveymanagement.py
+++ b/esp/esp/program/modules/handlers/surveymanagement.py
@@ -166,7 +166,14 @@ class SurveyManagement(ProgramModuleObj):
     @needs_admin
     def surveys(self, request, tl, one, two, module, extra, prog):
         if extra is None or extra == '':
-            return render_to_response('program/modules/surveymanagement/main.html', request, {'program': prog, 'surveys': prog.getSurveys()})
+            surveys = prog.getSurveys()
+            counts = {}
+            for s in surveys:
+                if s.category not in counts:
+                    counts[s.category] = 1
+                else:
+                    counts[s.category] += 1
+            return render_to_response('program/modules/surveymanagement/main.html', request, {'program': prog, 'surveys': surveys, 'counts': counts})
         elif extra == 'manage':
             return self.survey_manage(request, tl, one, two, module, extra, prog)
         elif extra == 'review':

--- a/esp/esp/program/modules/handlers/surveymodule.py
+++ b/esp/esp/program/modules/handlers/surveymodule.py
@@ -34,6 +34,7 @@ Learning Unlimited, Inc.
 """
 from esp.program.modules.base import ProgramModuleObj, needs_teacher, needs_student, needs_admin, usercheck_usetl, meets_deadline, meets_grade, main_call
 from esp.program.modules import module_ext
+from esp.tagdict.models import Tag
 from esp.utils.web import render_to_response
 from esp.users.models    import ESPUser
 from django.db.models.query   import Q
@@ -42,6 +43,7 @@ from esp.survey.models  import QuestionType, Question, Answer, SurveyResponse, S
 from esp.survey.views   import survey_view, survey_review, survey_graphical, survey_review_single
 
 import operator
+import datetime
 
 class SurveyModule(ProgramModuleObj):
     """ A module for people to take surveys. """
@@ -85,7 +87,7 @@ class SurveyModule(ProgramModuleObj):
         return {'teacher_survey': """Teachers who filled out the survey"""}
 
     def isStep(self):
-        return False
+        return Tag.getBooleanTag('survey_isstep', program=self.program, default=False) and self.program.getTimeSlots()[0].start < datetime.datetime.now()
 
     @main_call
     @usercheck_usetl

--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -86,6 +86,8 @@ class TeacherClassRegModule(ProgramModuleObj):
         context['can_create_class'] = self.class_reg_is_open()
         context['can_create_open_class'] = self.open_class_reg_is_open()
         context['can_req_cancel'] = self.deadline_met('/Classes/CancelReq')
+        context['survey_results'] = (self.program.getSurveys().filter(category = "learn", questions__per_class=True).exists() and
+                                     self.program.getTimeSlots()[0].start < datetime.datetime.now())
         context['crmi'] = self.crmi
         context['clslist'] = self.clslist(get_current_request().user)
         context['friendly_times_with_date'] = Tag.getBooleanTag('friendly_times_with_date', self.program, False)

--- a/esp/esp/program/modules/handlers/teachersurveymodule.py
+++ b/esp/esp/program/modules/handlers/teachersurveymodule.py
@@ -32,17 +32,12 @@ Learning Unlimited, Inc.
   Phone: 617-379-0178
   Email: web-team@learningu.org
 """
-from esp.program.modules.base import ProgramModuleObj, needs_teacher, needs_student, needs_admin, usercheck_usetl, meets_deadline, meets_grade, main_call
-from esp.program.modules import module_ext
+from esp.program.modules.base import ProgramModuleObj, needs_teacher, meets_deadline, main_call
 from esp.tagdict.models import Tag
-from esp.utils.web import render_to_response
 from esp.users.models    import ESPUser
 from django.db.models.query   import Q
-from esp.middleware     import ESPError
-from esp.survey.models  import QuestionType, Question, Answer, SurveyResponse, Survey
 from esp.survey.views   import survey_view, survey_review, survey_graphical, survey_review_single
 
-import operator
 import datetime
 
 class TeacherSurveyModule(ProgramModuleObj):
@@ -75,7 +70,7 @@ class TeacherSurveyModule(ProgramModuleObj):
                 self.program.getSurveys().filter(category__in = ["learn","teach"]).exists())
 
     @main_call
-    @usercheck_usetl
+    @needs_teacher
     @meets_deadline('/Survey')
     def survey(self, request, tl, one, two, module, extra, prog):
         if extra is None or extra == '':

--- a/esp/esp/program/modules/handlers/teachersurveymodule.py
+++ b/esp/esp/program/modules/handlers/teachersurveymodule.py
@@ -45,32 +45,18 @@ from esp.survey.views   import survey_view, survey_review, survey_graphical, sur
 import operator
 import datetime
 
-class SurveyModule(ProgramModuleObj):
+class TeacherSurveyModule(ProgramModuleObj):
     """ A module for people to take surveys. """
 
     @classmethod
     def module_properties(cls):
         return [ {
-            "admin_title": "Student Surveys",
-            "link_title": "Surveys",
-            "module_type": "learn",
-            "seq": 20,
-            "choosable": 1,
-        }, {
             "admin_title": "Teacher Surveys",
-            "link_title": "Survey",
+            "link_title": "Teacher Surveys",
             "module_type": "teach",
-            "seq": 15,
+            "seq": 9999,
             "choosable": 1,
         } ]
-
-    def students(self, QObject = False):
-        event="student_survey"
-        program=self.program
-
-        if QObject:
-            return {'student_survey': Q(record__program=program) & Q(record__event=event)}
-        return {'student_survey': ESPUser.objects.filter(record__program=program, record__event=event).distinct()}
 
     def teachers(self, QObject = False):
         event="teacher_survey"
@@ -80,14 +66,13 @@ class SurveyModule(ProgramModuleObj):
             return {'teacher_survey': Q(record__program=program) & Q(record__event=event)}
         return {'teacher_survey': ESPUser.objects.filter(record__program=program, record__event=event).distinct()}
 
-    def studentDesc(self):
-        return {'student_survey': """Students who filled out the survey"""}
-
     def teacherDesc(self):
         return {'teacher_survey': """Teachers who filled out the survey"""}
 
     def isStep(self):
-        return Tag.getBooleanTag('survey_isstep', program=self.program, default=False) and self.program.getTimeSlots()[0].start < datetime.datetime.now()
+        return (Tag.getBooleanTag('teacher_survey_isstep', program=self.program, default=False) and
+                self.program.getTimeSlots()[0].start < datetime.datetime.now() and
+                self.program.getSurveys().filter(category__in = ["learn","teach"]).exists())
 
     @main_call
     @usercheck_usetl

--- a/esp/esp/program/modules/migrations/0023_auto_20200730_2006.py
+++ b/esp/esp/program/modules/migrations/0023_auto_20200730_2006.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 from django.db import migrations
 
 def set_my_defaults(apps, schema_editor):
-    Program = apps.get_model('program', 'Program')
     ProgramModule = apps.get_model('program', 'ProgramModule')
     old_pms = ProgramModule.objects.filter(handler="SurveyModule")
     for pm in old_pms:
@@ -24,7 +23,6 @@ def set_my_defaults(apps, schema_editor):
         pmo.save()
 
 def reverse_func(apps, schema_editor):
-    Program = apps.get_model('program', 'Program')
     ProgramModule = apps.get_model('program', 'ProgramModule')
     new_pm1 = ProgramModule.objects.get(handler="StudentSurveyModule")
     new_pm2 = ProgramModule.objects.get(handler="TeacherSurveyModule")

--- a/esp/esp/program/modules/migrations/0023_auto_20200730_2006.py
+++ b/esp/esp/program/modules/migrations/0023_auto_20200730_2006.py
@@ -6,26 +6,31 @@ from django.db import migrations
 def set_my_defaults(apps, schema_editor):
     ProgramModule = apps.get_model('program', 'ProgramModule')
     old_pms = ProgramModule.objects.filter(handler="SurveyModule")
-    for pm in old_pms:
-        if pm.module_type == "teach":
-            pm.handler = "TeacherSurveyModule"
-            pm.link_title = "Teacher Surveys"
-        else:
-            pm.handler = "StudentSurveyModule"
-            pm.link_title = "Student Surveys"
-        pm.seq = 9999
-        pm.save()
-    new_pm1 = ProgramModule.objects.get(handler="StudentSurveyModule")
-    new_pm2 = ProgramModule.objects.get(handler="TeacherSurveyModule")
-    ProgramModuleObj = apps.get_model('modules', 'ProgramModuleObj')
-    for pmo in ProgramModuleObj.objects.filter(module__in=[new_pm1, new_pm2]):
-        pmo.seq = 9999
-        pmo.save()
+    if old_pms.exists():
+        for pm in old_pms:
+            if pm.module_type == "teach":
+                pm.handler = "TeacherSurveyModule"
+                pm.link_title = "Teacher Surveys"
+            else:
+                pm.handler = "StudentSurveyModule"
+                pm.link_title = "Student Surveys"
+            pm.seq = 9999
+            pm.save()
+        new_pm1 = ProgramModule.objects.get(handler="StudentSurveyModule")
+        new_pm2 = ProgramModule.objects.get(handler="TeacherSurveyModule")
+        ProgramModuleObj = apps.get_model('modules', 'ProgramModuleObj')
+        for pmo in ProgramModuleObj.objects.filter(module__in=[new_pm1, new_pm2]):
+            pmo.seq = 9999
+            pmo.save()
 
 def reverse_func(apps, schema_editor):
     ProgramModule = apps.get_model('program', 'ProgramModule')
-    new_pm1 = ProgramModule.objects.get(handler="StudentSurveyModule")
-    new_pm2 = ProgramModule.objects.get(handler="TeacherSurveyModule")
+    pms = ProgramModule.objects.filter(handler="StudentSurveyModule")
+    if pms.count() == 1:
+        new_pm1 = pms[0] if pms.count() == 1 else None
+    pms = ProgramModule.objects.filter(handler="TeacherSurveyModule")
+    if pms.count() == 1:
+        new_pm2 = pms[0] if pms.count() == 1 else None
     for pm in [new_pm1, new_pm2]:
         pm.handler = "SurveyModule"
         pm.link_title = "Surveys"

--- a/esp/esp/program/modules/migrations/0023_auto_20200730_2006.py
+++ b/esp/esp/program/modules/migrations/0023_auto_20200730_2006.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+def set_my_defaults(apps, schema_editor):
+    Program = apps.get_model('program', 'Program')
+    ProgramModule = apps.get_model('program', 'ProgramModule')
+    old_pms = ProgramModule.objects.filter(handler="SurveyModule")
+    for pm in old_pms:
+        if pm.module_type == "teach":
+            pm.handler = "TeacherSurveyModule"
+            pm.link_title = "Teacher Surveys"
+        else:
+            pm.handler = "StudentSurveyModule"
+            pm.link_title = "Student Surveys"
+        pm.seq = 9999
+        pm.save()
+    new_pm1 = ProgramModule.objects.get(handler="StudentSurveyModule")
+    new_pm2 = ProgramModule.objects.get(handler="TeacherSurveyModule")
+    ProgramModuleObj = apps.get_model('modules', 'ProgramModuleObj')
+    for pmo in ProgramModuleObj.objects.filter(module__in=[new_pm1, new_pm2]):
+        pmo.seq = 9999
+        pmo.save()
+
+def reverse_func(apps, schema_editor):
+    Program = apps.get_model('program', 'Program')
+    ProgramModule = apps.get_model('program', 'ProgramModule')
+    new_pm1 = ProgramModule.objects.get(handler="StudentSurveyModule")
+    new_pm2 = ProgramModule.objects.get(handler="TeacherSurveyModule")
+    for pm in [new_pm1, new_pm2]:
+        pm.handler = "SurveyModule"
+        pm.link_title = "Surveys"
+        if "Teacher" in pm.admin_title:
+            pm.seq = 15
+        else:
+            pm.seq = 20
+        pm.save()
+    old_pms = ProgramModule.objects.filter(handler="SurveyModule")
+    ProgramModuleObj = apps.get_model('modules', 'ProgramModuleObj')
+    for pmo in ProgramModuleObj.objects.filter(module__in=old_pms):
+        if pmo.module.module_type == "learn":
+            pmo.seq = 20
+        else:
+            pmo.seq = 15
+        pmo.save()
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('modules', '0022_change_teacheronsite_seq'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='StudentSurveyModule',
+            fields=[
+            ],
+            options={
+                'proxy': True,
+            },
+            bases=('modules.programmoduleobj',),
+        ),
+        migrations.CreateModel(
+            name='TeacherSurveyModule',
+            fields=[
+            ],
+            options={
+                'proxy': True,
+            },
+            bases=('modules.programmoduleobj',),
+        ),
+        migrations.RunPython(set_my_defaults, reverse_func),
+        migrations.DeleteModel(
+            name='SurveyModule',
+        ),
+    ]

--- a/esp/esp/program/templatetags/class_render_row.py
+++ b/esp/esp/program/templatetags/class_render_row.py
@@ -10,12 +10,13 @@ register = template.Library()
 
 
 @cache_inclusion_tag(register, 'inclusion/program/class_teacher_list_row.html')
-def render_class_teacher_list_row(cls, can_req_cancel):
+def render_class_teacher_list_row(cls, can_req_cancel, survey_results):
     """Render a class for the teacher list of classes in teacherreg."""
     return {'cls': cls,
             'program': cls.parent_program,
             'crmi': cls.parent_program.classregmoduleinfo,
             'can_req_cancel': can_req_cancel,
+            'survey_results': survey_results,
             'friendly_times_with_date': Tag.getBooleanTag(
                 'friendly_times_with_date', cls.parent_program, False),
             'email_host_sender': settings.EMAIL_HOST_SENDER

--- a/esp/esp/survey/views.py
+++ b/esp/esp/survey/views.py
@@ -83,7 +83,7 @@ def survey_view(request, tl, program, instance, template = 'survey/survey.html',
         event = "student_survey"
     else:
         event = "teacher_survey"
-        student_results = prog.getSurveys().filter(category = "learn").exists()
+        student_results = prog.getSurveys().filter(category = "learn", questions__per_class=True).exists()
 
     surveys = prog.getSurveys().filter(category = tl).select_related()
 
@@ -101,7 +101,7 @@ def survey_view(request, tl, program, instance, template = 'survey/survey.html',
         else:
             raise ESPError("Sorry, no such survey exists for this program!", log=False)
     elif len(surveys) > 1:
-        return render_to_response('survey/choose_survey.html', request, { 'surveys': surveys, 'error': request.POST }) # if request.POST, then we shouldn't have more than one survey any more...
+        return render_to_response('survey/choose_survey.html', request, { 'surveys': surveys, 'student_results': student_results, 'error': request.POST }) # if request.POST, then we shouldn't have more than one survey any more...
     else:
         survey = surveys[0]
 

--- a/esp/esp/survey/views.py
+++ b/esp/esp/survey/views.py
@@ -66,6 +66,7 @@ def survey_view(request, tl, program, instance, template = 'survey/survey.html',
     user = request.user
     view_list = True
 
+    context['tl'] = tl
     if tl in ['teach', 'learn']:
         filters = [x.strip() for x in Tag.getProgramTag('survey_' + {'learn': "student", 'teach': "teacher"}[tl] + '_filter', prog, default = {'learn': "classreg", 'teach': "class_submitted"}[tl]).split(",") if x.strip()]
         if len(filters) > 0:
@@ -77,13 +78,16 @@ def survey_view(request, tl, program, instance, template = 'survey/survey.html',
                 descs = prog.getListDescriptions()
                 raise ESPError('Only ' + " or ".join([descs[filter].lower() for filter in filters if filter in descs]) + ' may participate in this survey.  Please contact the directors directly if you have additional feedback.', log=False)
 
+    student_results = False
     if tl == 'learn':
         event = "student_survey"
     else:
         event = "teacher_survey"
+        student_results = prog.getSurveys().filter(category = "learn").exists()
 
     surveys = prog.getSurveys().filter(category = tl).select_related()
 
+    context['survey_id'] = request.GET.get('survey_id', None)
     if 'survey_id' in request.GET:
         try:
             s_id = int( request.GET['survey_id'] )
@@ -92,12 +96,14 @@ def survey_view(request, tl, program, instance, template = 'survey/survey.html',
             pass
 
     if len(surveys) < 1:
-        raise ESPError("Sorry, no such survey exists for this program!", log=False)
-
-    if len(surveys) > 1:
+        if student_results:
+            survey = None
+        else:
+            raise ESPError("Sorry, no such survey exists for this program!", log=False)
+    elif len(surveys) > 1:
         return render_to_response('survey/choose_survey.html', request, { 'surveys': surveys, 'error': request.POST }) # if request.POST, then we shouldn't have more than one survey any more...
-
-    survey = surveys[0]
+    else:
+        survey = surveys[0]
 
     # Section-specific survey
     section = None
@@ -152,7 +158,7 @@ def survey_view(request, tl, program, instance, template = 'survey/survey.html',
                 view_list = False
 
     sections = []
-    if view_list:
+    if view_list and survey:
         completed_sections = ClassSection.objects.filter(parent_class__parent_program=prog, studentregistration__user=user, studentregistration__relationship__name="SurveyCompleted")
         if tl == 'learn':
             # Get a student's enrolled sections
@@ -185,7 +191,8 @@ def survey_view(request, tl, program, instance, template = 'survey/survey.html',
         'completed': completed,
         'classes': classes,
         'section_surveys': section_surveys,
-        'general_survey': general_survey
+        'general_survey': general_survey,
+        'student_results': student_results
         })
     return render_to_response(template, request, context)
 

--- a/esp/esp/tagdict/__init__.py
+++ b/esp/esp/tagdict/__init__.py
@@ -136,7 +136,8 @@ all_program_tags = {
     'switch_time_program_attendance': (False, 'At what time should the student onsite webapp use program attendance if available (instead of enrollment) to determine if a class is full? If blank, program attendance numbers will not be used. Format: HH:MM where HH is in 24 hour time.', None, 'learn', True),
     'switch_lag_class_attendance': (False, 'How many minutes into a class should the student onsite webapp use class attendance numbers if available (instead of enrollment or program attendance) to determine if a class is full? If blank, class attendance numbers will not be used.', None, 'learn', True),
     'student_lottery_group_max': (False, 'What is the maximum number of students that can be in the same lottery group? (set to 1 to not allow groups)', '4', 'learn', True),
-    'survey_isstep': (True, 'Should the student and teacher surveys be shown as steps in student and teacher registration respectively once the event has started?', False, 'manage', True),
+    'student_survey_isstep': (True, 'Should the student survey be shown as a step in student registration once the event has started?', False, 'learn', True),
+    'teacher_survey_isstep': (True, 'Should the teacher survey be shown as a step in teacher registration once the event has started?', False, 'teach', True),
 }
 
 # Dictionary of categories that tags fall into (for grouping on the tag settings page)

--- a/esp/esp/tagdict/__init__.py
+++ b/esp/esp/tagdict/__init__.py
@@ -65,7 +65,7 @@ all_global_tags = {
     'random_constraints': (False, 'Constraints for /random in a JSON dictionary (e.g. {"bad_program_names": ["Delve", "SATPrep", "9001", "Test"], "bad_titles": ["Lunch Period"]})', '{}', 'manage', True),
     'admin_home_page': (False, 'The page to which admins get redirected after logging in (can be a relative or absolute page)', None, 'manage', True),
     'default_restypes': (False, 'A JSON list of the resource types (by name) to create when making a new program', None, 'manage', True),
-    'webapp_isstep': (True, 'Should the student and teacher onsite webapps be shown as steps in student and teacher registration respectively?', False, 'learn', True),
+    'webapp_isstep': (True, 'Should the student and teacher onsite webapps be shown as steps in student and teacher registration respectively?', False, 'manage', True),
     'google_cloud_api_key': (False, 'An API key for use with the Google Cloud Platform. Used for the student and teacher onsite webapps.', '', 'manage', True),
     'shirt_types': (False, 'Comma-separated list of shirt type options', 'Straight cut, Fitted cut', 'manage', True),
 }
@@ -136,7 +136,7 @@ all_program_tags = {
     'switch_time_program_attendance': (False, 'At what time should the student onsite webapp use program attendance if available (instead of enrollment) to determine if a class is full? If blank, program attendance numbers will not be used. Format: HH:MM where HH is in 24 hour time.', None, 'learn', True),
     'switch_lag_class_attendance': (False, 'How many minutes into a class should the student onsite webapp use class attendance numbers if available (instead of enrollment or program attendance) to determine if a class is full? If blank, class attendance numbers will not be used.', None, 'learn', True),
     'student_lottery_group_max': (False, 'What is the maximum number of students that can be in the same lottery group? (set to 1 to not allow groups)', '4', 'learn', True),
-    'survey_isstep': (True, 'Should the student and teacher surveys be shown as steps in student and teacher registration respectively once the event has started?', False, 'learn', True),
+    'survey_isstep': (True, 'Should the student and teacher surveys be shown as steps in student and teacher registration respectively once the event has started?', False, 'manage', True),
 }
 
 # Dictionary of categories that tags fall into (for grouping on the tag settings page)

--- a/esp/esp/tagdict/__init__.py
+++ b/esp/esp/tagdict/__init__.py
@@ -136,6 +136,7 @@ all_program_tags = {
     'switch_time_program_attendance': (False, 'At what time should the student onsite webapp use program attendance if available (instead of enrollment) to determine if a class is full? If blank, program attendance numbers will not be used. Format: HH:MM where HH is in 24 hour time.', None, 'learn', True),
     'switch_lag_class_attendance': (False, 'How many minutes into a class should the student onsite webapp use class attendance numbers if available (instead of enrollment or program attendance) to determine if a class is full? If blank, class attendance numbers will not be used.', None, 'learn', True),
     'student_lottery_group_max': (False, 'What is the maximum number of students that can be in the same lottery group? (set to 1 to not allow groups)', '4', 'learn', True),
+    'survey_isstep': (True, 'Should the student and teacher surveys be shown as steps in student and teacher registration respectively once the event has started?', False, 'learn', True),
 }
 
 # Dictionary of categories that tags fall into (for grouping on the tag settings page)

--- a/esp/templates/inclusion/program/class_teacher_list_row.html
+++ b/esp/templates/inclusion/program/class_teacher_list_row.html
@@ -1,4 +1,4 @@
-{# expects program, class, can_req_cancel, and crmi (ClassRegModuleInfo) #}
+{# expects program, class, can_req_cancel, survey_results, and crmi (ClassRegModuleInfo) #}
 
 <tr{% if not cls.isReviewed %} style="color: gray"{% endif %}{% if cls.isRejected or cls.isCancelled %} style="color: red"{% endif %}>
   <td class="clsleft classname bordertop2" colspan="3">
@@ -78,6 +78,13 @@ Popup div for class cancellation request
        title="Email Class' Students" class="abutton">
       Email Students
     </a>
+    {% if survey_results %}
+    <br /><br />
+    <a href="/teach/{{ program.getUrlBase }}/survey/review?classsubject_id={{ cls.id }}"
+       title="Review Results from Student Survey" class="abutton">
+      Student Survey Results
+    </a>
+    {% endif %}
     {% endif %}
   {% endblock %}
   </td>

--- a/esp/templates/program/modules/studentregcore/returnlink.html
+++ b/esp/templates/program/modules/studentregcore/returnlink.html
@@ -1,0 +1,9 @@
+</br></br><p>
+{% if prog %}
+<a class="btn btn-primary" href="/learn/{{ prog.getUrlBase }}/studentreg">Return to the main student registration page</a>
+{% else %}
+{% if program %}
+<a class="btn btn-primary" href="/learn/{{ program.getUrlBase }}/studentreg">Return to the main student registration page</a>
+{% endif %}
+{% endif %}
+</p>

--- a/esp/templates/program/modules/surveymanagement/main.html
+++ b/esp/templates/program/modules/surveymanagement/main.html
@@ -16,16 +16,24 @@ Surveys for students and teachers can be associated with {{ program.program_type
 <h3>Possibilities</h3>
 <ul>
 <li><a href="/manage/{{ program.getUrlBase }}/surveys/manage" title="Create">Create a new survey</a></li>
-<li><a href="/manage/{{ program.getUrlBase }}/surveys/review" title="Review">Review survey results</a></li>
-<li><a href="/manage/{{ program.getUrlBase }}/surveys/review_pdf" title="Review PDF">Review survey results (PDF format)</a></li>
-<li><a href="/manage/{{ program.getUrlBase }}/surveys/dump" title="Dump XLS">Export survey results (XLS format)</a></li>
+<li><a href="/manage/{{ program.getUrlBase }}/surveys/review" title="Review">Review all survey results</a></li>
+<li><a href="/manage/{{ program.getUrlBase }}/surveys/review_pdf" title="Review PDF">Review all survey results (PDF format)</a></li>
+<li><a href="/manage/{{ program.getUrlBase }}/surveys/dump" title="Dump XLS">Export all survey results (XLS format)</a></li>
 <li><a href="/manage/{{ program.getUrlBase }}/surveys/top_classes" title="Top Classes">List the favorite classes</a></li>
 </ul>
 
 <h3>Existing Surveys</h3>
 <ul>
-{% for s in program.getSurveys %}
+{% for s in surveys %}
     <li><a href="/manage/{{ program.getUrlBase }}/surveys/manage?obj=survey&op=edit&id={{ s.id }}">{{ s.name }}</a> (click to edit)
+    <ul>
+    {% if s.category == "teach" %}
+        <li><a href="/teach/{{ program.getUrlBase }}/survey{% if counts.teach > 1 %}?survey_id={{ s.id }}{% endif %}">Link for teachers</a></li>
+    {% elif s.category == "learn" %}
+        <li><a href="/learn/{{ program.getUrlBase }}/survey{% if counts.learn > 1 %}?survey_id={{ s.id }}{% endif %}">Link for students</a></li>
+        <li><a href="/teach/{{ program.getUrlBase }}/survey/review{% if counts.learn > 1 %}?survey_id={{ s.id }}{% endif %}">Link for teachers to review results</a></li>
+    {% endif %}
+    </ul>
 {% endfor %}
 </ul>
 

--- a/esp/templates/program/modules/teacherclassregmodule/listclasses.html
+++ b/esp/templates/program/modules/teacherclassregmodule/listclasses.html
@@ -98,7 +98,7 @@ If you have any questions regarding the program, <br /> please email the
   {% endif %}
   {% load class_render_row %}
   {% for cls in clslist %}
-    {% render_class_teacher_list_row cls can_req_cancel %}
+    {% render_class_teacher_list_row cls can_req_cancel survey_results %}
   {% endfor %}
 
    {% if can_create %}

--- a/esp/templates/survey/choose_survey.html
+++ b/esp/templates/survey/choose_survey.html
@@ -22,4 +22,8 @@
 {% endfor %}
 </ul>
 
+{% if student_results %}
+<p class="message">Alternatively, you can view the results of the student survey(s) for your class(es) by <a href="{{ request.path }}/review">going here</a>.
+{% endif %}
+
 {% endblock %}

--- a/esp/templates/survey/survey.html
+++ b/esp/templates/survey/survey.html
@@ -17,4 +17,10 @@
 
 {% include "survey/survey_form.html" %}
 
+{% if tl == "teach" %}
+    {% include "program/modules/teacherregcore/returnlink.html" %}
+{% elif tl == "learn" %}
+    {% include "program/modules/studentregcore/returnlink.html" %}
+{% endif %}
+
 {% endblock %}

--- a/esp/templates/survey/survey_form.html
+++ b/esp/templates/survey/survey_form.html
@@ -22,19 +22,23 @@
                 {% for sec in sections %}
                 <tr>
                     <td class="underline" align="center">{{ sec }}</td>
-                    <td class="underline" align="center">{% if not sec.started %}<span style="color: grey">Not available</span>{% elif sec.completed %}<span style="color: green">Completed</span>{% else %}<a class="btn fancybutton no-dec" href="{{ request.path }}?sec={{ sec.id }}">Take Survey</a>{% endif %}</td>
+                    <td class="underline" align="center">{% if not sec.started %}<span style="color: grey">Not available</span>{% elif sec.completed %}<span style="color: green">Completed</span>{% else %}<a class="btn fancybutton no-dec" href="{{ request.path }}?{% if survey_id %}survey_id={{ survey_id }}&{% endif %}sec={{ sec.id }}">Take Survey</a>{% endif %}</td>
                 </tr>
                 {% endfor %}
             {% endif %}
             {% if general_survey %}
                 <tr>
                     <td class="underline" align="center">General Program Survey</td>
-                    <td class="underline" align="center">{% if not general_available %}<span style="color: grey">Not available</span>{% elif general_done %}<span style="color: green">Completed</span>{% else %}<a class="btn fancybutton no-dec" href="{{ request.path }}?general">Take Survey</a>{% endif %}</td>
+                    <td class="underline" align="center">{% if not general_available %}<span style="color: grey">Not available</span>{% elif general_done %}<span style="color: green">Completed</span>{% else %}<a class="btn fancybutton no-dec" href="{{ request.path }}?{% if survey_id %}survey_id={{ survey_id }}&{% endif %}general">Take Survey</a>{% endif %}</td>
                 </tr>
             {% endif %}
         </table>
+        <br><br>
     {% else %}
         <p class="message">This survey does not have any questions.</p>
+    {% endif %}
+    {% if student_results %}
+        <p class="message">You can view the results of the student survey(s) for your class(es) by <a href="{{ request.path }}/review">going here</a>.
     {% endif %}
 {% else %}
     <form method="post" action="{{ request.get_full_path }}">


### PR DESCRIPTION
I added links to the student and teacher surveys (and the teacher survey review page) to the survey management page (if there are multiple surveys for a single category, we specify the survey ID for each link). I also changed the `isStep` behavior for the survey module such that it will be included in the registration steps if 1) the `survey_isstep` tag is set to True and 2) the first class block of the program has started.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3035.