### PR TITLE
Fix grade range popup

### DIFF
--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -808,10 +808,7 @@ class TeacherClassRegModule(ProgramModuleObj):
         context['formset'] = resource_formset
         context['resource_types'] = self.program.getResourceTypes(include_classroom=True)
         context['classroom_form_advisories'] = 'classroom_form_advisories'
-        if self.program.grade_max - self.program.grade_min >= 4:
-            context['grade_range_popup'] = Tag.getBooleanTag('grade_range_popup', self.program, default=True)
-        else:
-            context['grade_range_popup'] = False
+        context['grade_range_popup'] = Tag.getBooleanTag('grade_range_popup', self.program, default=True)
 
         if newclass is None:
             context['addoredit'] = 'Add'

--- a/esp/esp/program/modules/tests/teacherclassregmodule.py
+++ b/esp/esp/program/modules/tests/teacherclassregmodule.py
@@ -91,20 +91,10 @@ class TeacherClassRegTest(ProgramFrameworkTest):
 
         # Try editing the class
         response = self.client.get('%smakeaclass' % self.program.get_teach_url())
-        self.assertTrue("grade_range_popup" in response.content)
+        self.assertTrue("check_grade_range" in response.content)
 
         # Add a tag that specifically removes this functionality
         Tag.setTag('grade_range_popup', self.program, 'False')
-
-        # Try editing the class
-        response = self.client.get('%smakeaclass' % self.program.get_teach_url())
-        self.assertTrue(not "grade_range_popup" in response.content)
-
-        # Change the grade range of the program and reset the tag
-        self.program.grade_min = 7
-        self.program.grade_max = 8
-        self.program.save()
-        Tag.setTag('grade_range_popup', self.program, 'True')
 
         # Try editing the class
         response = self.client.get('%smakeaclass' % self.program.get_teach_url())

--- a/esp/public/media/scripts/program/modules/teacherclassregmodule.js
+++ b/esp/public/media/scripts/program/modules/teacherclassregmodule.js
@@ -1,7 +1,9 @@
-function check_grade_range(form, grade_min, grade_max)
+function check_grade_range(form)
 {
     console.log("Checking!");
-    if ($j(form).find('#id_grade_min').val() == grade_min && $j(form).find('#id_grade_max').val() == grade_max)
+    var grade_max = $j(form).find('#id_grade_max').val();
+    var grade_min = $j(form).find('#id_grade_min').val();
+    if (grade_max - grade_min >= 4)
     {
         return confirm("Are you sure you want your class to have grade range "+grade_min+"-"+grade_max+"? \
 Managing a class with grade range "+grade_min+"-"+grade_max+" can be more difficult due to the \
@@ -40,16 +42,3 @@ function setup_autocomplete()
 	}
     });
 }
-$j(document).ready(function() {
-	$j("#clsform").submit(function() {
-		$j(this).submit(function() {
-		    return false;
-		});
-
-		if($j(this).hasClass("grade_range_popup")) {
-			return check_grade_range($j(this), $j(this).attr("grademin"), $j(this).attr("grademax"));
-		} else {
-			return true;
-		}
-	});
-});

--- a/esp/templates/program/modules/teacherclassregmodule/classedit.html
+++ b/esp/templates/program/modules/teacherclassregmodule/classedit.html
@@ -42,7 +42,7 @@
 {% endif %}
 
 <div id="program_form">
-<form action="{{request.path}}" id="clsform" name="clsform" method="post" class="form-inline" {% if grade_range_popup %}class="grade_range_popup" grademin="{{ program.grade_min }}" grademax="{{ program.grade_max }}"{% endif %}>
+<form action="{{request.path}}" id="clsform" name="clsform" method="post" class="form-inline"{% if grade_range_popup %} onSubmit="check_grade_range(this)"{% endif %}">
 
 {% if form.errors %}
 <p align="center">


### PR DESCRIPTION
Man, there were a whole bunch of bugs going on here:

1. We didn't successfully add the class to the form, so the check was never triggered on form submit.
2. Even if it had worked at some point, we didn't actually check that the selected grade range was 4 or more, just that the selected grade range matched the max and min grades of the program (eww).
3. And even if all of that had worked, the form wouldn't submit after you clicked the "OK" button on the popup.

So this fixes all of that.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3045.