### PR TITLE
Fix class and section status inconsistencies

### DIFF
--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -1210,7 +1210,8 @@ class ClassSection(models.Model):
     def friendly_times_with_date(self, raw=False):
         return self.friendly_times(raw=raw, include_date=True)
 
-    def isAccepted(self): return self.status == ACCEPTED
+    def isAccepted(self): return self.status > 0
+    def isHidden(self): return self.status == HIDDEN
     def isReviewed(self): return self.status != UNREVIEWED
     def isRejected(self): return self.status == REJECTED
     def isCancelled(self): return self.status == CANCELLED
@@ -1776,6 +1777,7 @@ class ClassSubject(models.Model, CustomFormsLinkModel):
         return False
 
     def isAccepted(self): return self.status > 0
+    def isHidden(self): return self.status == HIDDEN
     def isReviewed(self): return self.status != UNREVIEWED
     def isRejected(self): return self.status == REJECTED
     def isCancelled(self): return self.status == CANCELLED

--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -95,7 +95,7 @@ class TeacherClassRegModule(ProgramModuleObj):
 
     def noclasses(self):
         """ Returns true of there are no classes in this program """
-        return len(self.clslist(get_current_request().user)) < 1
+        return not self.clslist(get_current_request().user).exists()
 
     def isCompleted(self):
         return not self.noclasses()
@@ -215,8 +215,7 @@ class TeacherClassRegModule(ProgramModuleObj):
         return any(map(self.reg_is_open, self.reg_is_open_methods.keys()))
 
     def clslist(self, user):
-        return [cls for cls in user.getTaughtClasses()
-                if cls.parent_program_id == self.program.id ]
+        return user.getTaughtClasses(program = self.program, include_rejected = True)
 
     @aux_call
     @needs_teacher

--- a/esp/esp/program/views.py
+++ b/esp/esp/program/views.py
@@ -393,7 +393,7 @@ def userview(request):
 
     context = {
         'user': user,
-        'taught_classes' : user.getTaughtClasses().order_by('parent_program', 'id'),
+        'taught_classes' : user.getTaughtClasses(include_rejected = True).order_by('parent_program', 'id'),
         'enrolled_classes' : user.getEnrolledSections().order_by('parent_class__parent_program', 'id'),
         'taken_classes' : user.getSections().order_by('parent_class__parent_program', 'id'),
         'teacherbio': teacherbio,

--- a/esp/templates/inclusion/program/class_teacher_list_row.html
+++ b/esp/templates/inclusion/program/class_teacher_list_row.html
@@ -57,11 +57,15 @@ Popup div for class cancellation request
 
 <tr>
   <td class="clsleft" colspan="5">
-    <b>Directors' review status</b>: {% if cls.isReviewed %}{% if cls.isAccepted %}
-    <span style="font-weight: bold; color: #0C0;">Accepted</span>
-    {% else %}
-    <span style="font-weight: bold; color: #C00;">Rejected</span>
-    {% endif %}
+    <b>Directors' review status</b>:
+    {% if cls.isReviewed %}
+        {% if cls.isAccepted %}
+        <span style="font-weight: bold; color: #0C0;">Accepted{% if cls.isHidden %} (Hidden){% endif %}</span>
+        {% elif cls.isCancelled %}
+        <span style="font-weight: bold; color: #C00;">Cancelled</span>
+        {% else %}
+        <span style="font-weight: bold; color: #C00;">Rejected</span>
+        {% endif %}
     {% else %}
     <span style="font-weight: bold; color: #00C;">Unreviewed</span>
     {% endif %}
@@ -115,11 +119,15 @@ Popup div for class cancellation request
 {% for sec in cls.sections.all %}
 <tr>
   <td class="clsleft" valign="top"><i>Section {{ sec.index }}</i> <br />
-    Status: {% if sec.isReviewed %}{% if sec.isAccepted %}
-    <span style="font-weight: bold; color: #0C0;">Accepted</span>
-    {% else %}
-    <span style="font-weight: bold; color: #C00;">Rejected</span>
-    {% endif %}
+    Status:
+    {% if sec.isReviewed %}
+        {% if sec.isAccepted %}
+        <span style="font-weight: bold; color: #0C0;">Accepted{% if sec.isHidden %} (Hidden){% endif %}</span>
+        {% elif sec.isCancelled %}
+        <span style="font-weight: bold; color: #C00;">Cancelled</span>
+        {% else %}
+        <span style="font-weight: bold; color: #C00;">Rejected</span>
+        {% endif %}
     {% else %}
     <span style="font-weight: bold; color: #00C;">Unreviewed</span>
     {% endif %}

--- a/esp/templates/program/modules/adminclass/manageclass.html
+++ b/esp/templates/program/modules/adminclass/manageclass.html
@@ -131,7 +131,7 @@
 <br />
 
 <p>
-Please use the form below to alter {{ class.title }}.  Note that changes made to the class will propagate to each of the sections, but you can later change each section independently.
+Please use the form below to alter {{ class.title }}.  Note that changes made to the class will propagate to each of the sections (except the class status will not override a section's review status if it is already changed), but you can later change each section independently.
 </p>
 
 <form name="classmanage" action="{{ request.path }}?action=modify" method="POST">

--- a/esp/templates/program/modules/adminclass/manageclass_class_info.html
+++ b/esp/templates/program/modules/adminclass/manageclass_class_info.html
@@ -11,13 +11,17 @@
 </tr>
 <tr>
     <th class="smaller">Reviewing Status:<br />
-        (Unreviewed, Accepted, or Rejected)
+        (Unreviewed, Accepted, Cancelled, or Rejected)
     </th>
-    <td>{% if class.isReviewed %}{% if class.isAccepted %}
-        <span class="class-status" style="font-weight: bold; color: #0C0;">Accepted</span>
-        {% else %}
-        <span class="class-status" style="font-weight: bold; color: #C00;">Rejected</span>
-        {% endif %}
+    <td>
+        {% if class.isReviewed %}
+            {% if class.isAccepted %}
+            <span class="class-status" style="font-weight: bold; color: #0C0;">Accepted{% if class.isHidden %} (Hidden){% endif %}</span>
+            {% elif class.isCancelled %}
+            <span class="class-status" style="font-weight: bold; color: #C00;">Cancelled</span>
+            {% else %}
+            <span class="class-status" style="font-weight: bold; color: #C00;">Rejected</span>
+            {% endif %}
         {% else %}
         <span class="class-status" style="font-weight: bold; color: #00C;">Unreviewed<span class="manage-approve-link"> (<a href="/manage/{{ program.getUrlBase }}/approveclass/{{ class.id }}">Approve Now</a>)</span></span>
         {% endif %}

--- a/esp/templates/users/userview_class_entry.html
+++ b/esp/templates/users/userview_class_entry.html
@@ -1,8 +1,10 @@
 <li>
 <span style="color: {% if not class.isReviewed %}gray{% else %}{% if class.isRejected or class.isCancelled %}red{% else %}black{% endif %}{% endif %}">
-{% if not class.isReviewed %}(Unreviewed){% endif %}
-{% if class.isRejected %}(Rejected){% endif %}
-{% if class.isCancelled %}(Cancelled){% endif %}
+{% if not class.isReviewed %}(Unreviewed)
+{% elif class.isHidden %}(Hidden)
+{% elif class.isRejected %}(Rejected)
+{% elif class.isCancelled %}(Cancelled)
+{% endif %}
 </span>
 <a href="{{class.parent_program.get_learn_url}}catalog#class_{{class.id}}"  style="color: #000000">{{class.emailcode}}: {{ class.title }}</a>
 (<a href="{{ class.get_absolute_url|urlencode }}">manage</a> | <a href="{{ class.get_edit_absolute_url|urlencode }}">edit</a>)
@@ -13,12 +15,14 @@
     <br />
     {{ sec.emailcode }} ({{ sec.num_students }}/{{ sec.capacity }}): 
     <span style="color: {% if not sec.isReviewed %}gray{% else %}{% if sec.isRejected or sec.isCancelled %}red{% else %}black{% endif %}{% endif %}">
-    {% if sec.isRejected or sec.isCancelled %}
+    {% if sec.isRejected %}
+        Rejected
+    {% elif sec.isCancelled %}
         Cancelled
     {% elif sec.friendly_times|length_is:0 %}
         Not scheduled
     {% else %}
-        {% for time in sec.friendly_times %}{{ time }}{% if not forloop.last %}, {% endif %}{% endfor %} in {% for room in sec.prettyrooms %}{{ room }}{% if not forloop.last %} and{% endif %}{% endfor %}
+        {% if sec.isHidden %}(Hidden) {% endif %}{% for time in sec.friendly_times %}{{ time }}{% if not forloop.last %}, {% endif %}{% endfor %} in {% for room in sec.prettyrooms %}{{ room }}{% if not forloop.last %} and{% endif %}{% endfor %}
     {% endif %}
     </span>
 {% endfor %}


### PR DESCRIPTION
This fixes a few separate issues, some of which were reported:

1. Previously we had changed `isAccepted` for classes to also return `True` if the class was "accepted but hidden. I've copied this behavior over to sections.
2. We weren't including rejected classes on the teacher registration and userview pages.
3. We weren't distinguishing between "Cancelled" and "Rejected" status on the teacher registration and userview pages.
4. We weren't identifying "accepted but hidden" classes or sections as "hidden" on the teacher registration and userview pages.

It's certainly possible there are other places we repeat numbers 2 through 3, so please let me know if anything comes to mind during review!

Fixes https://github.com/learning-unlimited/ESP-Website/issues/2992 and fixes https://github.com/learning-unlimited/ESP-Website/issues/3003.