### PR TITLE
Updated format on the Theme Select Page

### DIFF
--- a/esp/templates/themes/selector.html
+++ b/esp/templates/themes/selector.html
@@ -6,7 +6,7 @@
 
 <h2>Current theme: {{ theme_name }} </h2>
 
-<div class="span5 offset2 well" style="margin-left: 0px;"></div>
+<div class="span5 offset2 well" style="margin-left: 0px;">
     <center>
     
     <form method="post" action="/themes/select/">
@@ -25,7 +25,7 @@
     <p>A new theme will be displayed initially without any customization, but you can apply saved customizations in the theme editor.</p>
 </div>
 
-<div class="span5 offset2 well" style="margin-left: 0px;"></div>
+<div class="span5 offset2 well" style="margin-left: 0px;">
     <center>
     <form method="post" action="/themes/select/">
     <input name="action" type="hidden" value="clear" />

--- a/esp/templates/themes/selector.html
+++ b/esp/templates/themes/selector.html
@@ -6,7 +6,7 @@
 
 <h2>Current theme: {{ theme_name }} </h2>
 
-<div class="span5 offset2 well">
+<div class="span5 offset2 well" style="margin-left: 0px;"></div>
     <center>
     
     <form method="post" action="/themes/select/">
@@ -25,7 +25,7 @@
     <p>A new theme will be displayed initially without any customization, but you can apply saved customizations in the theme editor.</p>
 </div>
 
-<div class="span5 offset2 well">
+<div class="span5 offset2 well" style="margin-left: 0px;"></div>
     <center>
     <form method="post" action="/themes/select/">
     <input name="action" type="hidden" value="clear" />


### PR DESCRIPTION
Fixes #3024 This is a really small fix. The issue only referenced the page /themes/select so I just reduced the left side margin so it sits flush with the grey column to the left of it. By doing this, it matches the /themes page. Please let me know if you want me to update the format in a different way. 