### PR TITLE
Separate webapp tags

### DIFF
--- a/docs/admin/program_modules.rst
+++ b/docs/admin/program_modules.rst
@@ -366,7 +366,7 @@ For class changes on the student webapp, students are allowed by default to enro
 - 'switch_lag_class_attendance': Set this tag to the amount of minutes into a class at which you'd like to start using class attendance numbers if available (instead of enrollment or program attendance). This many minutes into a class block, if at least 1 student has been marked attending that class, students will be able to class change based on class attendance numbers. If blank, class attendance numbers will not be used.
 Note that if both tags are set, the hierarchy is that class attendance will be used if available; program attendance will be used if class attendance is not available; enrollment will be used if program attendance is not available. 
 
-There's one last tag that may be useful, 'webapp_isstep', which you can set to "True" if you want to list the webapp as a step in student registration (in the checkboxes). Otherwise it won't be shown and you'll need to direct your students to the URL(s) some other way.
+There's one last tag that may be useful, 'student_webapp_isstep', which you can set to "True" if you want to list the webapp as a step in student registration (in the checkboxes). Otherwise it won't be shown and you'll need to direct your students to the URL(s) some other way.
 
 Views provided
 ~~~~~~~~~~~~~~
@@ -493,7 +493,7 @@ The basic functionality of the teacher webapp should work as soon as the module 
 
 Note that you do not need to do any of this again if you've already done this for the student webapp.
 
-There's one last tag that may be useful, 'webapp_isstep', which you can set to "True" if you want to list the webapp as a step in teacher registration (in the checkboxes). Otherwise it won't be shown and you'll need to direct your teacher to the URL(s) some other way.
+There's one last tag that may be useful, 'teacher_webapp_isstep', which you can set to "True" if you want to list the webapp as a step in teacher registration (in the checkboxes). Otherwise it won't be shown and you'll need to direct your teacher to the URL(s) some other way.
 
 Views provided
 ~~~~~~~~~~~~~~

--- a/esp/esp/program/modules/handlers/studentonsite.py
+++ b/esp/esp/program/modules/handlers/studentonsite.py
@@ -200,7 +200,7 @@ class StudentOnsite(ProgramModuleObj, CoreModule):
         return context
 
     def isStep(self):
-        return Tag.getBooleanTag('student_webapp_isstep', default=False)
+        return Tag.getBooleanTag('student_webapp_isstep', program=self.program, default=False)
 
     class Meta:
         proxy = True

--- a/esp/esp/program/modules/handlers/studentonsite.py
+++ b/esp/esp/program/modules/handlers/studentonsite.py
@@ -200,7 +200,7 @@ class StudentOnsite(ProgramModuleObj, CoreModule):
         return context
 
     def isStep(self):
-        return Tag.getBooleanTag('webapp_isstep', default=False)
+        return Tag.getBooleanTag('student_webapp_isstep', default=False)
 
     class Meta:
         proxy = True

--- a/esp/esp/program/modules/handlers/teacheronsite.py
+++ b/esp/esp/program/modules/handlers/teacheronsite.py
@@ -180,7 +180,7 @@ class TeacherOnsite(ProgramModuleObj, CoreModule):
         return context
 
     def isStep(self):
-        return Tag.getBooleanTag('webapp_isstep', default=False)
+        return Tag.getBooleanTag('teacher_webapp_isstep', default=False)
 
     class Meta:
         proxy = True

--- a/esp/esp/program/modules/handlers/teacheronsite.py
+++ b/esp/esp/program/modules/handlers/teacheronsite.py
@@ -180,7 +180,7 @@ class TeacherOnsite(ProgramModuleObj, CoreModule):
         return context
 
     def isStep(self):
-        return Tag.getBooleanTag('teacher_webapp_isstep', default=False)
+        return Tag.getBooleanTag('teacher_webapp_isstep', program=self.program, default=False)
 
     class Meta:
         proxy = True

--- a/esp/esp/tagdict/__init__.py
+++ b/esp/esp/tagdict/__init__.py
@@ -65,7 +65,6 @@ all_global_tags = {
     'random_constraints': (False, 'Constraints for /random in a JSON dictionary (e.g. {"bad_program_names": ["Delve", "SATPrep", "9001", "Test"], "bad_titles": ["Lunch Period"]})', '{}', 'manage', True),
     'admin_home_page': (False, 'The page to which admins get redirected after logging in (can be a relative or absolute page)', None, 'manage', True),
     'default_restypes': (False, 'A JSON list of the resource types (by name) to create when making a new program', None, 'manage', True),
-    'webapp_isstep': (True, 'Should the student and teacher onsite webapps be shown as steps in student and teacher registration respectively?', False, 'learn', True),
     'google_cloud_api_key': (False, 'An API key for use with the Google Cloud Platform. Used for the student and teacher onsite webapps.', '', 'manage', True),
     'shirt_types': (False, 'Comma-separated list of shirt type options', 'Straight cut, Fitted cut', 'manage', True),
 }
@@ -133,6 +132,8 @@ all_program_tags = {
     'volunteer_help_text_comments': (False, 'If set, overrides the help text for the comments field for the volunteer form', None, 'volunteer', True),
     'volunteer_require_auth': (True, 'Do volunteers need to have accounts before signing up? (If not, one will be created when they sign up)', False, 'volunteer', True),
     'program_center': (False, 'The geographic center for a program, following the form {lat: 37.427490, lng: -122.170267}. Used for the teacher and student onsite webapps.', '{lat: 37.427490, lng: -122.170267}', 'manage', True),
+    'student_webapp_isstep': (True, 'Should the student onsite webapp be shown as a step in student registration?', False, 'learn', True),
+    'teacher_webapp_isstep': (True, 'Should the teacher onsite webapp be shown as a step in teacher registration?', False, 'teach', True),
     'switch_time_program_attendance': (False, 'At what time should the student onsite webapp use program attendance if available (instead of enrollment) to determine if a class is full? If blank, program attendance numbers will not be used. Format: HH:MM where HH is in 24 hour time.', None, 'learn', True),
     'switch_lag_class_attendance': (False, 'How many minutes into a class should the student onsite webapp use class attendance numbers if available (instead of enrollment or program attendance) to determine if a class is full? If blank, class attendance numbers will not be used.', None, 'learn', True),
     'student_lottery_group_max': (False, 'What is the maximum number of students that can be in the same lottery group? (set to 1 to not allow groups)', '4', 'learn', True),


### PR DESCRIPTION
This splits the `webapp_isstep` tag into two tags `student_webapp_isstep` and `teacher_webapp_isstep` which are used for their respective registration modules.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3074 (in combination with the recent changes in https://github.com/learning-unlimited/ESP-Website/pull/3071)