### PR TITLE
Make survey review pdf up to date with html version

### DIFF
--- a/esp/templates/survey/answers.tex
+++ b/esp/templates/survey/answers.tex
@@ -5,24 +5,65 @@
 {% if q.question.question_type.is_countable %}
     \begin{minipage}[b]{3in}
         \vspace*{0.1in}
-        {{ q.question.name|texescape }}: \\
-        (Numerical responses) \vspace*{0.5in}
-
+        \textbf{ {{ q.question.name|texescape }}:} \\
+        (Numerical responses)
+        \vspace*{0.1in}
+        
         \textbf{Number of responses:} {{ q.answers|length }}/{{ num_participants }} \\
         {% if q.question.question_type.is_numeric %}
             \textbf{Average:} {{ q.answers|unpack_answers|average }} \\
-            \textbf{Std. deviation:} {{ q.answers|unpack_answers|stdev }} \\ ~\\
-            \textbf{Global average:} {{ q.question.global_average }}
+            \textbf{Std. deviation:} {{ q.answers|unpack_answers|stdev }} \\
+            {% if q.question.per_class %}\textbf{Global average:} {{ q.question.global_average }}
+            {% endif %}
+            {% comment %}Creates a key that provides details about the Histogram Labeling{% endcomment %}
+            \vspace*{0.1in}
+            \textbf{Response Labels:} \\
+            {% with q.question.get_params as params %}
+                {% if not params.list|length_is:0 %}
+                \begin{itemize2}
+                {% for label in params.list %}
+                    \item \textbf{ {{ forloop.counter }}:} {{ label|texescape }}
+                {% endfor %}
+                \end{itemize2}
+                {% endif %}
+                {% if params.lower_text or params.upper_text or params.middle_text %}
+                    \begin{enumerate}
+                    {% if params.lower_text %}
+                    \item [1] {{ params.lower_text|texescape }}
+                    {% endif %}
+                    {% if params.middle_text %}
+                        {% if not params.number_of_ratings|divisibleby:"2" %}
+                            \item [{{ params.number_of_ratings|midValue }}] {{ params.middle_text|texescape }}
+                        {% endif %}
+                    {% endif %}
+                    {% if params.upper_text %}
+                        \item [{{ params.number_of_ratings }}] {{ params.upper_text|texescape }}
+                    {% endif %}
+                \end{enumerate}
+                {% endif %}
+            {% endwith %}
         {% endif %}
     \end{minipage} & 
     {% if not q.answers|length_is:0 %}
-        {% if q.question.question_type.is_numeric and q.question.get_params.number_of_ratings %}
-            {% with "format=tex&max="|concat:q.question.get_params.number_of_ratings as args %}
-                {{ q.answers|unpack_answers|histogram:args|safe }}
-            {% endwith %}
-        {% else %}
-            {{ q.answers|unpack_answers|histogram:"format=tex"|safe }}
-        {% endif %}
+        {% with q.question.get_params as params %}
+            {% if q.question.question_type.is_numeric and params.number_of_ratings %}
+                {% comment %}Labeled Numeric Rating and Numeric Rating{% endcomment %}
+                {% with "format=tex&max="|concat:params.number_of_ratings as args %}
+                    {{ q.answers|unpack_answers|histogram:args|safe }}
+                {% endwith %}
+            {% elif q.question.question_type.name == "Yes-No Response" %}
+                {% with "format=tex&opts=Yes|No" as args %}
+                    {{ q.answers|unpack_answers|histogram:args|safe }}
+                {% endwith %}
+            {% else %}
+                {% comment %}Checkboxes and Multiple Choice{% endcomment %}
+                {% with params.list|join:"|" as opts %}
+                    {% with "format=tex&opts="|concat:opts as args %}
+                        {{ q.answers|unpack_answers|histogram:args|safe }}
+                    {% endwith %}
+                {% endwith %}
+            {% endif %}
+        {% endwith %}
     {% else %} There are no responses to this question.
     {% endif %}
     \vspace*{0.1in}
@@ -30,8 +71,9 @@
 {% else %}
     \begin{minipage}{3in}
         \vspace*{0.1in}
-        {{ q.question.name|texescape }} \vspace*{0.5in}
-
+        \textbf{ {{ q.question.name|texescape }} }
+        \vspace*{0.1in}
+        
         \textbf{Number of responses:} {{ q.answers|length }}/{{ num_participants }} \\
     \end{minipage} &
     \begin{minipage}{3in}
@@ -46,16 +88,17 @@
         \end{enumerate}
         \vspace*{0.1in}
     {% else %}
-        {% if not q.answers|length_is:0 %}
-        \vspace*{0.1in} Responses include: \\ 
-        \small
-        \begin{itemize2}
-        {% for a in q.answers|unpack_answers %}{% if not a|length_is:0 %}\item {{ a|texescape }}
-        {% endif %}{% endfor %}
-        \end{itemize2}
+        {% if not q.answers|drop_empty_answers|length_is:0 %}
+            \vspace*{0.1in}
+            \textbf{Responses include:} \\ 
+            \small
+            \begin{itemize2}
+            {% for ans in q.answers|drop_empty_answers %}
+                \item {{ ans.answer|texescape }}
+            {% endfor %}
+            \end{itemize2}
         {% else %}
-        \vspace*{0.5in}
-        There are no responses to this question.
+            There are no responses to this question.
         {% endif %}
         \vspace*{0.1in}
     {% endifequal %}

--- a/esp/templates/survey/review.tex
+++ b/esp/templates/survey/review.tex
@@ -17,7 +17,7 @@
     \begin{center}
     \begin{longtable}{|p{0.48\linewidth}|p{0.48\linewidth}|} \hline
     \multicolumn{2}{|C{\linewidth}|}{\cellcolor{esphead} ~ } \\
-    \multicolumn{2}{|C{\linewidth}|}{\cellcolor{esphead} \Large {Responses for {{ s.name }}} } \\ 
+    \multicolumn{2}{|C{\linewidth}|}{\cellcolor{esphead} \Large {Responses for {{ s.name|texescape }}} } \\ 
     \multicolumn{2}{|C{\linewidth}|}{\cellcolor{esphead} ~ } \\\hline
     {% for q in s.display_data.questions %}
         {% with s.num_participants as num_participants %}


### PR DESCRIPTION
This implements the changes from https://github.com/learning-unlimited/ESP-Website/pull/2943 and https://github.com/learning-unlimited/ESP-Website/pull/3053 to make the pdf version of the survey review page up-to-date with the HTML version. I also fixed a bug that could occur due to not escaping the survey name and I tweaked some spacing.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/2950