### PR TITLE
Send email when financial aid request is approved

### DIFF
--- a/esp/esp/accounting/admin.py
+++ b/esp/esp/accounting/admin.py
@@ -75,6 +75,7 @@ def finalize_finaid_grants(modeladmin, request, queryset):
         grant.finalize()
 class FinancialAidGrantAdmin(admin.ModelAdmin):
     list_display = ['id', 'request', 'user', 'program', 'finalized', 'amount_max_dec', 'percent']
+    readonly_fields=('finalized',)
     list_filter = ['request__program']
     search_fields = default_user_search('request__user')
     actions = [ finalize_finaid_grants, ]

--- a/esp/esp/accounting/migrations/0012_auto_20200812_1128.py
+++ b/esp/esp/accounting/migrations/0012_auto_20200812_1128.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounting', '0011_auto_20200614_1216'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='financialaidgrant',
+            name='finalized',
+            field=models.BooleanField(default=False, editable=False),
+        ),
+    ]

--- a/esp/esp/accounting/models.py
+++ b/esp/esp/accounting/models.py
@@ -144,7 +144,7 @@ class FinancialAidGrant(models.Model):
     amount_max_dec = models.DecimalField(max_digits=9, decimal_places=2, blank=True, null=True, help_text='Enter a number here to grant a dollar value of financial aid.  The grant will cover this amount or the full cost of the program, whichever is less.')
     percent = models.PositiveIntegerField(blank=True, null=True, help_text='Enter an integer between 0 and 100 here to grant a certain percentage discount to the program after the above dollar credit is applied.  0 means no additional discount, 100 means no payment required.')
     timestamp = models.DateTimeField(auto_now=True)
-    finalized = models.BooleanField(default=False)
+    finalized = models.BooleanField(default=False, editable=False)
 
     @property
     def amount_max(self):

--- a/esp/esp/program/admin.py
+++ b/esp/esp/program/admin.py
@@ -98,11 +98,15 @@ class FinancialAidGrantInline(admin.TabularInline):
     max_num = 1
     verbose_name_plural = 'Financial aid grant - enter 100 in "Percent" field to waive entire cost'
 
+def approve_finaid_requests(modeladmin, request, queryset):
+    for req in queryset:
+        req.approve()
 class FinancialAidRequestAdmin(admin.ModelAdmin):
     list_display = ('user', 'approved', 'reduced_lunch', 'program', 'household_income', 'extra_explaination')
     search_fields = default_user_search() + ['id', 'program__url']
     list_filter = ['program']
     inlines = [FinancialAidGrantInline,]
+    actions = [ approve_finaid_requests, ]
 admin_site.register(FinancialAidRequest, FinancialAidRequestAdmin)
 
 class Admin_SplashInfo(admin.ModelAdmin):

--- a/esp/esp/program/admin.py
+++ b/esp/esp/program/admin.py
@@ -98,15 +98,34 @@ class FinancialAidGrantInline(admin.TabularInline):
     max_num = 1
     verbose_name_plural = 'Financial aid grant - enter 100 in "Percent" field to waive entire cost'
 
-def approve_finaid_requests(modeladmin, request, queryset):
-    for req in queryset:
-        req.approve()
 class FinancialAidRequestAdmin(admin.ModelAdmin):
     list_display = ('user', 'approved', 'reduced_lunch', 'program', 'household_income', 'extra_explaination')
     search_fields = default_user_search() + ['id', 'program__url']
     list_filter = ['program']
     inlines = [FinancialAidGrantInline,]
-    actions = [ approve_finaid_requests, ]
+    actions = ['approve', ]
+
+    def save_related(self, request, form, formsets, change):
+        form.save_m2m()
+        obj = form.instance
+        # get the financial aid grant formset
+        formset = formsets[0]
+        # if we want to delete or change an existing grant, just save like normal
+        if formset[0].cleaned_data.get('DELETE') or obj.approved:
+            self.save_formset(request, form, formset, change=change)
+        else:
+            # if we want to add a grant, use approve() instead
+            instance = formset.save(commit=False)[0]
+            obj.approve(instance.amount_max_dec, instance.percent)
+            formset.save_m2m()
+            self.message_user(request, "Request successfully approved.")
+
+    def approve(self, request, queryset):
+        num_approved = len([req for req in queryset if not req.approved])
+        for req in queryset:
+            req.approve()
+        self.message_user(request, "%s request(s) successfully approved." % num_approved)
+    approve.short_description = "Approve selected financial aid requests for 100%%"
 admin_site.register(FinancialAidRequest, FinancialAidRequestAdmin)
 
 class Admin_SplashInfo(admin.ModelAdmin):

--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -52,6 +52,7 @@ from django.db.models import Q
 from django.db.models.query import QuerySet
 from django.db.models.signals import m2m_changed
 from django.dispatch import receiver
+from django.template.loader import render_to_string
 from django.utils import timezone
 from django.utils.safestring import mark_safe
 
@@ -59,6 +60,7 @@ from argcache import cache_function, cache_function_for, wildcard
 from esp.cal.models import Event
 from esp.customforms.linkfields import CustomFormsLinkModel
 from esp.db.fields import AjaxForeignKey
+from esp.dbmail.models import send_mail
 from esp.middleware import ESPError, AjaxError
 from esp.tagdict.models import Tag
 from esp.users.models import ContactInfo, StudentInfo, TeacherInfo, EducatorInfo, GuardianInfo, ESPUser, Record
@@ -1629,6 +1631,31 @@ class FinancialAidRequest(models.Model):
             string = u"Finished: [" + string + u"]"
 
         return string
+
+    def approve(self, dollar_amount = None, discount_percent = 100):
+        from esp.accounting.models import FinancialAidGrant
+        if not self.approved:
+            if any([dollar_amount, discount_percent]):
+                # create financial aid grant
+                f = FinancialAidGrant(request = self, amount_max_dec = dollar_amount, percent = discount_percent)
+                # finalize the grant (creates the accounting transfer)
+                f.finalize()
+                # mark request as done
+                self.done = True
+                self.save()
+                # send email to student
+                email_from = '%s Registration System <server@%s>' % (self.program.program_type, settings.EMAIL_HOST_SENDER)
+                email_to = ['%s <%s>' % (self.user.name(), self.user.email)]
+                subj = 'Financial Aid Approved for %s for %s' % (self.user.name(), self.program.niceName())
+                email_context = {'student': self.user,
+                                 'program': self.program,
+                                 'grant': f,
+                                 'curtime': datetime.now(),
+                                 'DEFAULT_HOST': settings.DEFAULT_HOST}
+                email_contents = render_to_string('program/modules/finaidapprovemodule/approval_email.txt', email_context)
+                send_mail(subj, email_contents, email_from, email_to)
+            else:
+                raise ESPError('Need to supply at least one of dollar_amount and discount_percent', log=True) 
 
 """ Functions for scheduling constraints
     I'm sorry that these are in the same __init__.py file;

--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -1655,7 +1655,7 @@ class FinancialAidRequest(models.Model):
                 email_contents = render_to_string('program/modules/finaidapprovemodule/approval_email.txt', email_context)
                 send_mail(subj, email_contents, email_from, email_to)
             else:
-                raise ESPError('Need to supply at least one of dollar_amount and discount_percent', log=True) 
+                raise ESPError('Need to supply at least one of dollar_amount and discount_percent', log=True)
 
 """ Functions for scheduling constraints
     I'm sorry that these are in the same __init__.py file;

--- a/esp/esp/program/modules/handlers/finaidapprovemodule.py
+++ b/esp/esp/program/modules/handlers/finaidapprovemodule.py
@@ -36,7 +36,6 @@ Learning Unlimited, Inc.
 from esp.program.modules.base import ProgramModuleObj, needs_admin, main_call
 from esp.utils.web import render_to_response
 from esp.program.models import FinancialAidRequest
-from esp.accounting.models import FinancialAidGrant
 
 
 class FinAidApproveModule(ProgramModuleObj):

--- a/esp/esp/program/modules/handlers/finaidapprovemodule.py
+++ b/esp/esp/program/modules/handlers/finaidapprovemodule.py
@@ -97,10 +97,7 @@ class FinAidApproveModule(ProgramModuleObj):
                     continue
 
                 try:
-                    f = FinancialAidGrant(request = req, percent = 100, finalized = True)
-                    f.save()
-                    req.done = True
-                    req.save()
+                    req.approve(dollar_amount = None, discount_percent=100)
                     users_approved.append(req.user.name())
                 except:
                     users_error.append(req.user.name())

--- a/esp/esp/program/modules/handlers/financialaidappmodule.py
+++ b/esp/esp/program/modules/handlers/financialaidappmodule.py
@@ -41,7 +41,6 @@ from django.db.models.query       import Q
 from django.template.loader import get_template
 from django.utils.decorators import method_decorator
 from esp.program.models  import FinancialAidRequest
-from esp.accounting.controllers import IndividualAccountingController
 from esp.tagdict.models import Tag
 from django.conf import settings
 from esp.middleware.threadlocalrequest import get_current_request

--- a/esp/esp/program/modules/handlers/financialaidappmodule.py
+++ b/esp/esp/program/modules/handlers/financialaidappmodule.py
@@ -123,17 +123,11 @@ class FinancialAidAppModule(ProgramModuleObj):
 
                 app.save()
 
-                # Automatically accept apps for people with subsidized lunches
-                # Send an email announcing the application either way
+                # Send an email announcing the application
                 date_str = str(datetime.now())
                 iac = IndividualAccountingController(self.program, request.user)
-                if app.reduced_lunch:
-                    iac.grant_full_financial_aid()
-                    subj_str = '%s %s received Financial Aid for %s' % (request.user.first_name, request.user.last_name, prog.niceName())
-                    msg_str = "\n%s %s received Financial Aid for %s on %s, for stating that they receive a free or reduced-price lunch."
-                else:
-                    subj_str = '%s %s applied for Financial Aid for %s' % (request.user.first_name, request.user.last_name, prog.niceName())
-                    msg_str = "\n%s %s applied for Financial Aid for %s on %s, but did not state that they receive a free or reduced-price lunch."
+                subj_str = '%s %s applied for Financial Aid for %s' % (request.user.first_name, request.user.last_name, prog.niceName())
+                msg_str = "\n%s %s applied for Financial Aid for %s on %s."
                 send_mail(subj_str, (msg_str +
                 """
 
@@ -172,7 +166,9 @@ This request can be (re)viewed at:
     str(app.id)),
                             settings.SERVER_EMAIL,
                             [ prog.getDirectorConfidentialEmail() ] )
-
+                # Automatically accept apps for people with subsidized lunches
+                if app.reduced_lunch:
+                    app.approve()
                 return self.goToCore(tl)
 
         else:

--- a/esp/esp/program/modules/handlers/financialaidappmodule.py
+++ b/esp/esp/program/modules/handlers/financialaidappmodule.py
@@ -125,7 +125,6 @@ class FinancialAidAppModule(ProgramModuleObj):
 
                 # Send an email announcing the application
                 date_str = str(datetime.now())
-                iac = IndividualAccountingController(self.program, request.user)
                 subj_str = '%s %s applied for Financial Aid for %s' % (request.user.first_name, request.user.last_name, prog.niceName())
                 msg_str = "\n%s %s applied for Financial Aid for %s on %s."
                 send_mail(subj_str, (msg_str +

--- a/esp/templates/program/modules/finaidapprovemodule/approval_email.txt
+++ b/esp/templates/program/modules/finaidapprovemodule/approval_email.txt
@@ -1,0 +1,10 @@
+Hi {{ student.name }},
+
+On {{ curtime|date:"l M d Y" }} at {{ curtime|date:"h:i A" }}, your financial aid request for {{ program.niceName }} was approved by a program administrator.
+
+Your financial aid grant provides {% if grant.amount_max_dec %}${{ grant.amount_max_dec }} of direct financial aid{% endif %}{% if grant.amount_max_dec and grant.percent %} plus {% endif %}{% if grant.percent %}{{ grant.percent }}% of any {% if grant.amount_max_dec %}remaining {% endif %}costs for the program{% endif %}.
+
+{% if note %}Additional comments: {{ note }}{% endif %}
+
+- {{ program.program_type }} Registration System
+  Contact the directors: {{ program.director_email }}


### PR DESCRIPTION
When a financial aid request is approved (whether it be automatically in the financial aid app, through the financial aid approval module, or through the admin panel [this is new]), we now send a brief email to the student telling them that their request was approved.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/2482.