### PR TITLE
Add flushcache option for fab manage

### DIFF
--- a/esp/esp/utils/management/commands/flushcache.py
+++ b/esp/esp/utils/management/commands/flushcache.py
@@ -1,0 +1,18 @@
+from django.conf import settings
+from django.core.cache import cache
+from django.core.management.base import NoArgsCommand
+
+import logging
+logger = logging.getLogger(__name__)
+import os
+
+class Command(NoArgsCommand):
+    """
+    This clears the cache just like /manage/flushcache
+    """
+    def handle_noargs(self, **options):
+        _cache = cache
+        while hasattr(_cache, "_wrapped_cache"):
+            _cache = _cache._wrapped_cache
+        if hasattr(_cache, "clear"):
+            _cache.clear()

--- a/esp/esp/utils/management/commands/flushcache.py
+++ b/esp/esp/utils/management/commands/flushcache.py
@@ -1,10 +1,5 @@
-from django.conf import settings
 from django.core.cache import cache
 from django.core.management.base import NoArgsCommand
-
-import logging
-logger = logging.getLogger(__name__)
-import os
 
 class Command(NoArgsCommand):
     """

--- a/esp/esp/utils/management/commands/update.py
+++ b/esp/esp/utils/management/commands/update.py
@@ -36,7 +36,6 @@ Learning Unlimited, Inc.
 from django.core.management import call_command
 from django.core.management.base import NoArgsCommand
 from django.conf import settings
-import os
 
 class Command(NoArgsCommand):
     """Update the site.
@@ -62,4 +61,4 @@ class Command(NoArgsCommand):
         call_command('migrate', **options)
         call_command('collectstatic', **options)
         call_command('recompile_theme', **options)
-        os.system('echo flush_all | nc localhost 11211')
+        call_command('flushcache', **options)


### PR DESCRIPTION
This adds a new option for `fab manage` that allows developers to flush the cache (just like on /manage/flushcache) from the shell. Since this is a more thorough cache flush than the flush we were doing before, I've also included this in the `fab manage:update` command.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/1952.