### PR TITLE
Re-render class changes grid when settings are changed

### DIFF
--- a/esp/public/media/default_styles/onsite_ajax_status.css
+++ b/esp/public/media/default_styles/onsite_ajax_status.css
@@ -147,7 +147,7 @@ table.narrow {
     border: 1px solid #666666;
 }
 
-.section_hidden, .section_search_hidden, .section_category_hidden, .section_conflict_hidden {
+.section_hidden, .section_search_hidden, .section_conflict_hidden {
     visibility: hidden;
     height: 0px;
     border: 0px;
@@ -156,7 +156,7 @@ table.narrow {
     overflow: hidden;
 }
 .section_hidden > input, .section_search_hidden > input,
-.section_category_hidden > input, .section_conflict_hidden > input {
+.section_conflict_hidden > input {
     display: none;
 }
 

--- a/esp/public/media/scripts/onsite/ajax_status.js
+++ b/esp/public/media/scripts/onsite/ajax_status.js
@@ -866,6 +866,9 @@ function render_table(display_mode, student_id)
         filtered_sections = filtered_sections.filter(sec_id => !(data.sections[sec_id].registration_status != 0));
     }
     
+    //exclude classes in hidden categories
+    filtered_sections = filtered_sections.filter(sec_id => settings.categories_to_display[data.classes[data.sections[sec_id].class_id].category__id]);
+    
     for (var sec_id of filtered_sections)
     {
         var row = 0;
@@ -1018,7 +1021,6 @@ function render_table(display_mode, student_id)
         update_checkboxes();
     }
     update_search_filter();
-    update_category_filters(); // show/hide classes by category
 }
     
 function render_status_table()
@@ -1036,26 +1038,6 @@ function render_classchange_table(student_id)
 
 }
 
-function update_category_filters()
-{   
-    $j(".section").removeClass("section_category_hidden");
-    for (var id_str in data.categories)
-    {
-        var id = parseInt(id_str);
-
-        if (!settings.categories_to_display[id])
-        {
-            //  console.log("Hiding category .section_category_" + id);
-            $j(".section_category_" + id).not(".student_enrolled").addClass("section_category_hidden");
-        }
-    }
-    if (!settings.categories_to_display[open_class_category.id])
-    {
-        console.log("Hiding walk-ins");
-        $j(".section_category_" + open_class_category.id).not(".student_enrolled").addClass("section_category_hidden");
-    }
-}
-
 function toggle_categories() {
     var showAll = $j(this).prop("id") == "category_show_all";
 
@@ -1066,7 +1048,7 @@ function toggle_categories() {
     $j("#category_list :checkbox").not(".category_selector")
                                   .not("#category_select_" + open_class_category.id)
                                   .prop('checked', showAll);
-    update_category_filters();
+    render_table();
 
 }
 
@@ -1095,7 +1077,7 @@ function render_category_options()
         new_checkbox.change(function (event) {
             var target_id = extract_category_id(event.target.id);
             settings.categories_to_display[target_id] = !settings.categories_to_display[target_id];
-            update_category_filters();
+            render_table();
         });
 
         new_li.append(new_checkbox);


### PR DESCRIPTION
Instead of using CSS classes to hide sections based on the settings on the class changes grid page (e.g. hide full classes or displayed categories), we now filter out those classes and re-render the entire table each time a setting is changed. We were already re-rendering the entire table each time but just adding CSS classes, so this shouldn't have any real speed impact. In fact, I filtered the full list of sections to only those with actual timeslot assignments outside of `render_table()`, so, if anything, there should now be a small speed boost each time we re-render the classes table.

I also sorted the list of sections in descending order of section length (again, outside of `render_table()`), such that we insert the longest sections first, then fill in the empty spaces with the shorter classes. This should help reduce empty spaces in the table.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/2946.