### PR TITLE
Make clicking class title more obvious on /missingteachers

### DIFF
--- a/esp/public/media/default_styles/missingteachers.css
+++ b/esp/public/media/default_styles/missingteachers.css
@@ -1,0 +1,111 @@
+#shortcuts-box {
+    position: fixed;
+    right: 10px;
+    top: 10px;
+    width: 200px;
+    border: 1px solid gray;
+    padding: 5px;
+    z-index: 100;
+    background-color: white;
+    opacity: 0.75;
+    transition: opacity 0.25s ease;
+}
+
+#shortcuts-box:hover {
+    opacity: 1;
+}
+
+#shortcuts-box input{
+    width: 190px;
+}
+
+.section-first-row {
+    border-top: 4px solid #ccc;
+}
+
+.section-code {
+    background-color: #c6def7;
+    background: linear-gradient(to bottom, white, #c6def7);
+}
+
+.not-checked-in a {
+    font-weight: bold;
+}
+
+.checked-in {
+    text-decoration: line-through;
+}
+
+.selected .checkin + span:after {
+    content: "◀"; font-weight: bold;
+}
+
+.selected .not-checked-in, .selected .checkin-column, .selected .phone, .selected .text-teacher {
+    background-color: #FFFF00;
+}
+
+.checkin-column {
+    min-width: 90px;
+}
+
+input.found {
+    background-color: #AAFFAA;
+}
+
+input.not-found {
+    background-color: #FFAAAA;
+}
+
+.section-detail-td {
+    background-color: #c6def7;
+    padding: 0px !important;
+}
+
+.section-detail {
+    display: inline-block;
+    border-width: 0;
+    margin: 0px;
+    width: 100%;
+}
+
+.section-detail-header {
+    background-color: #c6def7;
+    font-size: 1.2em;
+    width: calc(100% - 8px);
+    cursor: pointer;
+    padding: 4px;
+    border-bottom: 2px solid grey;
+}
+
+.section-detail-header:not(.active):after {
+    content: '\002B';
+    color: black;
+    font-weight: bold;
+    float: right;
+}
+
+.section-detail-header.active:after {
+    content: '\2212';
+    color: black;
+    font-weight: bold;
+    float: right;
+}
+
+.flag-name-list {
+    display: inline-block;
+    width: 470px;
+    vertical-align: middle;
+}
+
+.section-detail-include {
+    background-color: white;
+}
+
+.add-flag, .add-assignment {
+    margin-left: 4px;
+    margin-right: 4px;
+}
+
+.add-assignment {
+    margin-bottom: 4px;
+}

--- a/esp/public/media/scripts/onsite/teacher_checkin.js
+++ b/esp/public/media/scripts/onsite/teacher_checkin.js
@@ -19,6 +19,7 @@ $j(function(){
     $j(".phone").map(changeHyphens);
 
     $j('.section-detail-header').click(function () {
+        $j(this).toggleClass('active');
         var info = $j(this).siblings('.section-detail-info');
         var class_id = info.attr('data-class-id');
 

--- a/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
+++ b/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
@@ -7,90 +7,7 @@
     <link rel='stylesheet' type='text/css' href='/media/styles/forms.css' />
     <link rel='stylesheet' type='text/css' href='/media/styles/flags.css' />
     <link rel='stylesheet' type='text/css' href='/media/styles/assignments.css' />
-    <style type="text/css">
-        #shortcuts-box {
-            position: fixed;
-            right: 10px;
-            top: 10px;
-            width: 200px;
-            border: 1px solid gray;
-            padding: 5px;
-            z-index: 100;
-            background-color: white;
-            opacity: 0.75;
-            transition: opacity 0.25s ease;
-        }
-        #shortcuts-box:hover {
-            opacity: 1;
-        }
-        #shortcuts-box input{
-            width: 190px;
-        }
-
-        .section-first-row {
-            border-top: 4px solid #ccc;
-        }
-
-        .section-code {
-            background-color: #c6def7;
-            background: linear-gradient(to bottom, white, #c6def7);
-        }
-
-        .not-checked-in a {
-            font-weight: bold;
-        }
-
-        .checked-in {
-            text-decoration: line-through;
-        }
-
-        .selected .checkin + span:after {
-            content: "◀"; font-weight: bold;
-        }
-
-        .selected .not-checked-in, .selected .checkin-column, .selected .phone, .selected .text-teacher {
-            background-color: #FFFF00;
-        }
-
-        .checkin-column {
-            min-width: 90px;
-        }
-
-        input.found {
-            background-color: #AAFFAA;
-        }
-
-        input.not-found {
-            background-color: #FFAAAA;
-        }
-
-        .section-detail-td {
-            background-color: #c6def7;
-        }
-
-        .section-detail {
-            display: inline-block;
-            border-width: 0;
-            margin: 0px;
-            width: 100%;
-        }
-
-        .section-detail-header {
-            background-color: #c6def7;
-            font-size: 1.2em;
-            width: 100%;
-        }
-
-        .flag-name-list {
-            display: inline-block;
-            width: 470px;
-            vertical-align: middle;
-        }
-
-        .section-detail-include {
-            background-color: white;
-        }
-    </style>
+    <link rel='stylesheet' type='text/css' href='/media/styles/missingteachers.css' />
 {% endblock %}
 
 {% block javascript %}
@@ -292,7 +209,7 @@
     {% endfor %}
     <td colspan="6" class="section-detail-td">
         <div class="section-detail fqr-class">
-            <div class="section-detail-header">
+            <div class="section-detail-header" title="Click to toggle class details">
                 {{section.title}}
                 (<a href="{{section.get_absolute_url|urlencode}}">manage</a> | <a href="{{section.get_edit_absolute_url|urlencode}}">edit</a>)
             </div>
@@ -302,6 +219,7 @@
                         {% include "program/modules/classflagmodule/flag_name.html" %}
                     {% endfor %}
                 </div>
+                <br />
                 <button class="add-flag btn">add flag</button>
             {% endif %}
             <div class="assignment-name-list fqr-class-assignments">


### PR DESCRIPTION
I added some visual indicators to make it more obvious that you can click a class title on the teacher checkin page to see the class details:

- Hover text (reads "Click to toggle class details")
- Cursor changes to a pointer when hovering
- +/- to show expanded state
- Bottom border to make it feel like a unique element on the page

![image](https://user-images.githubusercontent.com/7232514/89715600-58ef6200-d96c-11ea-807b-0f176706b4ab.png)

I also pulled the CSS out of the template into a separate CSS file for easier editing in the future.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3026.