### PR TITLE
Add dummy data for survey questions that need it

### DIFF
--- a/esp/esp/program/modules/handlers/surveymanagement.py
+++ b/esp/esp/program/modules/handlers/surveymanagement.py
@@ -63,6 +63,11 @@ class SurveyManagement(ProgramModuleObj):
     @needs_admin
     def survey_manage(self, request, tl, one, two, module, extra, prog):
         context = {'program': prog}
+        # Make some dummy data for survey questions that need it
+        classes = [ClassSubject(id = i, title="Test %s" %i, parent_program = prog, category = prog.class_categories.all()[0],
+                   grade_min = prog.grade_min, grade_max = prog.grade_max) for i in range(1,4)]
+        context['classes'] = classes
+        context['section'] = ClassSection(parent_class=classes[0])
         context['question_types'] = json.dumps({str(qt.id): qt.param_names for qt in QuestionType.objects.all()})
         if request.GET:
             obj = request.GET.get("obj", None)
@@ -160,11 +165,6 @@ class SurveyManagement(ProgramModuleObj):
             context['import_survey_form'] = SurveyImportForm(cur_prog = prog)
         context['surveys'] = Survey.objects.filter(program = prog)
         context['questions'] = Question.objects.filter(survey__program = prog).order_by('survey__category', 'survey', 'per_class', 'seq')
-        # Make some dummy data for survey questions that need it
-        classes = [ClassSubject(id = i, title="Test %s" %i, parent_program = prog, category = prog.class_categories.all()[0],
-                   grade_min = prog.grade_min, grade_max = prog.grade_max) for i in range(1,4)]
-        context['classes'] = classes
-        context['section'] = ClassSection(parent_class=classes[0])
 
         return render_to_response('program/modules/surveymanagement/manage.html', request, context)
 

--- a/esp/esp/program/modules/handlers/surveymanagement.py
+++ b/esp/esp/program/modules/handlers/surveymanagement.py
@@ -34,6 +34,7 @@ Learning Unlimited, Inc.
 """
 from esp.program.modules.base import ProgramModuleObj, needs_teacher, needs_student, needs_admin, usercheck_usetl, meets_deadline, meets_grade, main_call, aux_call
 from esp.program.modules import module_ext
+from esp.program.models import ClassSubject, ClassSection
 from esp.utils.web import render_to_response
 from esp.users.models    import ESPUser
 from django.db.models.query   import Q
@@ -159,6 +160,11 @@ class SurveyManagement(ProgramModuleObj):
             context['import_survey_form'] = SurveyImportForm(cur_prog = prog)
         context['surveys'] = Survey.objects.filter(program = prog)
         context['questions'] = Question.objects.filter(survey__program = prog).order_by('survey__category', 'survey', 'per_class', 'seq')
+        # Make some dummy data for survey questions that need it
+        classes = [ClassSubject(id = i, title="Test %s" %i, parent_program = prog, category = prog.class_categories.all()[0],
+                   grade_min = prog.grade_min, grade_max = prog.grade_max) for i in range(1,4)]
+        context['classes'] = classes
+        context['section'] = ClassSection(parent_class=classes[0])
 
         return render_to_response('program/modules/surveymanagement/manage.html', request, context)
 

--- a/esp/templates/program/modules/surveymanagement/import.html
+++ b/esp/templates/program/modules/surveymanagement/import.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block content %}
-
+{% load survey %}
 <h1>Survey Management for {{ program.niceName }}</h1>
 
 <h2>Confirm Survey Import</h2>
@@ -62,7 +62,7 @@ You have chosen to import {{ survey.name }} ({{ survey.category }}) from {{ surv
     {% for question in questions %}
         <tr>
             <td class="underline">{{ question.seq }}</td>
-            <td class="underline" colspan="4">{{ question.render }}</td>
+            <td class="underline" colspan="4">{% if question.per_class %}{{ question.render|substitute:section }}{% else %}{{ question.render|uselist:classes }}{% endif %}</td>
             <td class="underline" align="center"><input type="checkbox" name="to_import" value="{{ question.id }}" onclick=toggle(this) checked></td>
         </tr>
     {% endfor %}

--- a/esp/templates/program/modules/surveymanagement/manage.html
+++ b/esp/templates/program/modules/surveymanagement/manage.html
@@ -17,6 +17,7 @@
 {% endblock %}
 
 {% block content %}
+{% load survey %}
 <h1>Survey Management for {{ program.niceName }}</h1>
 
 <p>
@@ -160,7 +161,7 @@ Each step below is a form that you can expand or contract by clicking on the hea
             {% endifchanged %}
             <tr>
                 <td class="underline">{{ question.seq }}</td>
-                <td class="underline" colspan="3">{{ question.render }}</td>
+                <td class="underline" colspan="3">{% if question.per_class %}{{ question.render|substitute:section }}{% else %}{{ question.render|uselist:classes }}{% endif %}</td>
                 <td class="underline">
                     <a href="/manage/{{ program.url }}/surveys/manage?obj=question&op=edit&id={{ question.id }}">[Edit]</a>
                     <a href="/manage/{{ program.url }}/surveys/manage?obj=question&op=delete&id={{ question.id }}">[Delete]</a>

--- a/esp/templates/survey/questions/favorite_class.html
+++ b/esp/templates/survey/questions/favorite_class.html
@@ -5,7 +5,7 @@
     <td>
     <div style = "text-align: left; font-weight: bold;"> {{ name }} </div>
     {% templatetag openblock %} for l in lst {% templatetag closeblock %}
-    <div style="text-align: left; padding-left:2em; text-indent:-2em;"> <input type="checkbox" name="question_{{ id }}" value="{% templatetag openvariable %} l.id {% templatetag closevariable %}" />{% templatetag openvariable %} l.emailcode {% templatetag closevariable %}: {% templatetag openvariable %} l.title {% templatetag closevariable %}<br /> </div>
+    <div style="text-align: left; padding-left:2em; text-indent:-2em;"> <input type="checkbox" name="question_{{ id }}" value="{% templatetag openvariable %} l.id {% templatetag closevariable %}" /> {% templatetag openvariable %} l.emailcode {% templatetag closevariable %}: {% templatetag openvariable %} l.title {% templatetag closevariable %}<br /> </div>
         {% templatetag openblock %} endfor {% templatetag closeblock %}
     </td>
 </tr>


### PR DESCRIPTION
I added some dummy classes and a dummy section for the context of the survey questions when they are rendered on the survey management pages. This was specifically aimed at the favorite classes survey question type, but this copies how survey questions are rendered in the actual survey, so it should catch any other edge cases (apparently you can include django template tags for the fields of the section in a survey question if it is a per-class question?).

Fixes https://github.com/learning-unlimited/ESP-Website/issues/2985.