### PR TITLE
Indicate which scheduling checks have content

### DIFF
--- a/esp/public/media/default_styles/scheduling_checks.css
+++ b/esp/public/media/default_styles/scheduling_checks.css
@@ -14,11 +14,13 @@ th { cursor: pointer; }
 }
 
 .scheduling-check.no-items {
-    background-color: rgba(3, 121, 0, 0.23);
+    background-color: rgb(197 224 196);
 }
 
 .scheduling-check-title {
-     width: 100%;
+     width: 320px;
+	 margin-left: 0px;
+	 margin-right: auto;
      text-align: center;
 }
 
@@ -38,10 +40,6 @@ th { cursor: pointer; }
      float: right;
 }
 
-.placeholder {
-     text-align: center;
-}
-
 .rowGreyed {
 color: lightgray;
 }
@@ -58,30 +56,24 @@ color: lightgray;
   margin: 10px;
   font-style: italic;
 }
-.load_ready{
-    background-color: rgba(3, 121, 0, 0.23);
+
+.placeholder {
+    text-align: center;
     border-radius: 3px;
-	width: 200px;
-	text-align: center;
-	margin-left: 120px;
+	width: 240px;
+	margin-left: 40px;
 	margin-right: auto;
+}
+
+.load_ready{
+    background-color: rgb(197 224 196);
 }
 
 .load_yellow{
     background-color: yellow;
-    border-radius: 3px;
-	width: 200px;
-	text-align: center;
-	margin-left: 140px;
-	margin-right: auto;
 }
 .load_fail{
     background-color: red;
-    border-radius: 3px;
-	width: 200px;
-	text-align: center;
-	margin-left: 140px;
-	margin-right: auto;
 }
 .move_left{
     margin-left: 10px;
@@ -108,7 +100,7 @@ thead {
     color: #fff;
 }
 table {
-    width: 100%
+    width: 100%;
     border-spacing: 1;
     border-collapse: collapse;
     background: white;

--- a/esp/public/media/default_styles/scheduling_checks.css
+++ b/esp/public/media/default_styles/scheduling_checks.css
@@ -9,6 +9,14 @@ th { cursor: pointer; }
      border-radius: 4px;
 }
 
+.scheduling-check.items {
+    background-color: yellow;
+}
+
+.scheduling-check.no-items {
+    background-color: rgba(3, 121, 0, 0.23);
+}
+
 .scheduling-check-title {
      width: 100%;
      text-align: center;
@@ -17,6 +25,7 @@ th { cursor: pointer; }
 .scheduling-check-title span {
      font-weight: bold;
      font-size: 14px;
+     cursor: pointer;
 }
 
 .reset-button {

--- a/esp/public/media/scripts/program/modules/scheduling_checks.jsx
+++ b/esp/public/media/scripts/program/modules/scheduling_checks.jsx
@@ -175,13 +175,12 @@ var SchedulingCheck = React.createClass({
         {table}
       </div>;
     }
-    console.log(this.state.has_items);
     return <div className={`scheduling-check ${this.state.has_items ? "items" : this.state.data ? "no-items" : "loading"}`}>
+      <ScheduleButton onClick={this.handleClick} />
+      <RefreshButton onClick={this.loadData} />
+      <ResetButton onClick={this.resetTable} />
       <div className="scheduling-check-title">
         <span onClick={this.handleClick}>{this.props.title}</span>
-        <ScheduleButton onClick={this.handleClick} />
-        <RefreshButton onClick={this.loadData} />
-        <ResetButton onClick={this.resetTable} />
       </div>
       <div className="scheduling-check-body">
         {body}

--- a/esp/public/media/scripts/program/modules/scheduling_checks.jsx
+++ b/esp/public/media/scripts/program/modules/scheduling_checks.jsx
@@ -96,12 +96,15 @@ var SchedulingCheck = React.createClass({
   loadData: function () {
     // remove any existing data, so we see a loading thing again
     this.setState({data: undefined});
+    this.setState({has_items: false});
     this.setState({timestamp: "loading"});
 
     $j.get("scheduling_checks/" + this.props.slug)
     .done(function (data) {
+      data_parse = JSON.parse(data); // Might not work on old browsers
       this.setState({
-        data: data,
+        data: data_parse,
+        has_items: (data_parse.body && data_parse.body.length > 0),
         failed: false,
         timestamp: this.timestamp(),
       });
@@ -138,7 +141,7 @@ var SchedulingCheck = React.createClass({
     }else if (!this.state.data) {
       body = <div className="placeholder load_yellow">loading...</div>;
     } else {
-      var data = JSON.parse(this.state.data); // Might not work on old browsers
+      var data = this.state.data;
       var table;
       if (data.headings.length == 0) {
         table = <SelectTable rows = {data.body} header = {false} 
@@ -172,8 +175,8 @@ var SchedulingCheck = React.createClass({
         {table}
       </div>;
     }
-
-    return <div className="scheduling-check">
+    console.log(this.state.has_items);
+    return <div className={`scheduling-check ${this.state.has_items ? "items" : this.state.data ? "no-items" : "loading"}`}>
       <div className="scheduling-check-title">
         <span onClick={this.handleClick}>{this.props.title}</span>
         <ScheduleButton onClick={this.handleClick} />

--- a/esp/public/media/scripts/program/modules/scheduling_checks.jsx
+++ b/esp/public/media/scripts/program/modules/scheduling_checks.jsx
@@ -101,7 +101,7 @@ var SchedulingCheck = React.createClass({
 
     $j.get("scheduling_checks/" + this.props.slug)
     .done(function (data) {
-      data_parse = JSON.parse(data); // Might not work on old browsers
+      var data_parse = JSON.parse(data);
       this.setState({
         data: data_parse,
         has_items: (data_parse.body && data_parse.body.length > 0),


### PR DESCRIPTION
This colors each of the scheduling checks based on whether the checks has returned any content (yellow) or not (green) (or white if it's still loading). The color change occurs as soon as the check has been run (thanks to https://github.com/learning-unlimited/ESP-Website/pull/3000). I also fixed the alignment of the "loading/loaded" text with the title of each check. I'm happy to change the color of the ones with content, but I was a little concerned that big red blocks all over the page might be a little ugly (although I suppose I could play around with the alpha to get a more subdued red).

![image](https://user-images.githubusercontent.com/7232514/89848564-0b315000-db4c-11ea-81b6-128f7c36b933.png)

Fixes https://github.com/learning-unlimited/ESP-Website/issues/1583.