### PR TITLE
Ajax scheduler availability override improvements

### DIFF
--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/ApiClient.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/ApiClient.js
@@ -51,11 +51,12 @@ function ApiClient() {
      * @param section_id: The ID of the section to schedule
      * @param timeslot_ids: A list of ids of all timeslots the class should be scheduled during.
      * @param room_id: The id of the room.
+     * @param override: Should teacher availability be overriden?
      * @param callback: If successful, this function will be called. Takes no params.
      * @param errorReporter: If server reports an error, this function will be called.
      *                       Takes one param msg with an error message.
      */
-    this.schedule_section = function(section_id, timeslot_ids, room_id, callback, errorReporter){
+    this.schedule_section = function(section_id, timeslot_ids, room_id, override, callback, errorReporter){
         assignments = timeslot_ids.map(function(id) {
             return id + "," + room_id;
         }).join("\n");
@@ -65,7 +66,7 @@ function ApiClient() {
             csrfmiddlewaretoken: csrf_token(),
             cls: section_id,
             block_room_assignments: assignments,
-            override: $j("input#schedule-override").prop('checked')
+            override: override
         };
         return this.send_request(req, callback, errorReporter);
     };

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/SectionInfoPanel.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/SectionInfoPanel.js
@@ -10,6 +10,7 @@ function SectionInfoPanel(el, sections, togglePanel, sectionCommentDialog) {
     this.togglePanel = togglePanel; // The panel that should be hidden when the info panel is shown
     this.sections = sections;
     this.sectionCommentDialog = sectionCommentDialog;
+    this.override = false;
 
     /**
      * Hide the panel and show togglePanel if it exists.
@@ -70,6 +71,18 @@ function SectionInfoPanel(el, sections, togglePanel, sectionCommentDialog) {
             }.bind(this)
         );
         toolbar.append(commentButton);
+
+        var overrideCheckbox = $j("<input id='schedule-override' type='checkbox'></input>");
+        overrideCheckbox.prop('checked', this.override)
+            .change(function(box) {
+                var override = $j(box.target).prop("checked");
+                // Reload the section to update the availability
+                this.sections.unselectSection(override = override);
+                this.sections.selectSection(section);
+            }.bind(this)
+        );
+        toolbar.append(overrideCheckbox);
+        toolbar.append($j("<label for='schedule-override'>Override availability</label>"));
 
         var baseURL = this.sections.getBaseUrlString();
         var autoschedulerLink = "";

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/SectionInfoPanel.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/SectionInfoPanel.js
@@ -77,7 +77,7 @@ function SectionInfoPanel(el, sections, togglePanel, sectionCommentDialog) {
             .change(function(box) {
                 var override = $j(box.target).prop("checked");
                 // Reload the section to update the availability
-                this.sections.unselectSection(override = override);
+                this.sections.unselectSection(override);
                 this.sections.selectSection(section);
             }.bind(this)
         );

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
@@ -245,8 +245,9 @@ function Sections(sections_data, section_details_data, teacher_data, scheduleAss
     /**
      * Unselect the cells associated with the currently selected section, hide the section info
      * panel, and unhighlight the available cells to place the section.
+     * @param override: What should the availability override status be?
      */
-    this.unselectSection = function() {
+    this.unselectSection = function(override = false) {
         if(!this.selectedSection) {
             return;
         }
@@ -262,6 +263,7 @@ function Sections(sections_data, section_details_data, teacher_data, scheduleAss
 
         this.selectedSection = null;
         this.matrix.sectionInfoPanel.hide();
+        this.matrix.sectionInfoPanel.override = override;
         this.matrix.unhighlightTimeslots(this.availableTimeslots);
 
     };
@@ -280,7 +282,7 @@ function Sections(sections_data, section_details_data, teacher_data, scheduleAss
     this.getAvailableTimeslots = function(section) {
         var availableTimeslots = [];
         var already_teaching = [];
-        if($j("input#schedule-override").prop('checked')){
+        if(this.matrix.sectionInfoPanel.override){
             $j.each(this.matrix.timeslots.timeslots, function(index, timeslot) {
                 availableTimeslots.push(timeslot.id);
             }.bind(this));
@@ -344,6 +346,7 @@ function Sections(sections_data, section_details_data, teacher_data, scheduleAss
         var old_assignment = this.scheduleAssignments[section.id];
         var schedule_timeslots = this.matrix.timeslots.
             get_timeslots_to_schedule_section(section, first_timeslot_id);
+        var override = this.matrix.sectionInfoPanel.override;
 
         // Make sure the assignment is valid
         if (!this.matrix.validateAssignment(section, room_id, schedule_timeslots).valid){
@@ -363,6 +366,7 @@ function Sections(sections_data, section_details_data, teacher_data, scheduleAss
             section.id,
             schedule_timeslots,
             room_id,
+            override,
             function() {},
             // If there's an error, reschedule the section in its old location
             function(msg) {
@@ -373,6 +377,8 @@ function Sections(sections_data, section_details_data, teacher_data, scheduleAss
                 console.log(msg);
             }.bind(this)
         );
+        // Reset the availability override
+        this.matrix.sectionInfoPanel.override = false;
     }
 
 

--- a/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
+++ b/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
@@ -142,10 +142,6 @@
                         <label for="section-filter-resources-text"><b>Resource(s)</b></label><br />
                         <input id="section-filter-resources-text"></input>
                     </div>
-                    <div id="schedule-override-wrapper">
-                        <input id="schedule-override" type="checkbox"></input>
-                        <label for="schedule-override">Override teacher availability</label>
-                    </div>
                   </form>
                 </div>
                 <div id="filters2">


### PR DESCRIPTION
This improves the ajax scheduler availability override from https://github.com/learning-unlimited/ESP-Website/pull/2859 in a few ways:

1. The checkbox is reset whenever the selected section is scheduled/unselected or another section is selected. This is to prevent abuse of the override option, such that it must be selected EACH time an admin wants to use it.
2. I moved the override checkbox from the class filters tab to the section info panel. It didn't really belong in the class filters tab, and this spot makes more sense since the option is now section-specific.
3. Upon checking/unchecking the checkbox, the availability for the selected section is automatically updated. Before, the change would only take effect after selecting a new (or the same) section.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3034.

Note: https://github.com/learning-unlimited/ESP-Website/issues/3034 also suggested changing the color/styling scheme for the availability, but I think that these changes have actually made this much less of a concern since the change in availability happens immediately and the setting is reset every time a section is scheduled. If there are suggestions about a better styling scheme for the scheduler as a whole, that should be filed as a new issue.