### PR TITLE
Fix asterisks when address not required

### DIFF
--- a/esp/esp/users/forms/user_profile.py
+++ b/esp/esp/users/forms/user_profile.py
@@ -63,9 +63,13 @@ class UserContactForm(FormUnrestrictedOtherUser, FormWithTagInitialValues):
             del self.fields['receive_txt_message']
         if self.user.isTeacher() and not Tag.getBooleanTag('teacher_address_required', default = False):
             self.fields['address_street'].required = False
+            self.fields['address_street'].widget.attrs['class'] = ""
             self.fields['address_city'].required = False
+            self.fields['address_city'].widget.attrs['class'] = ""
             self.fields['address_state'].required = False
+            self.fields['address_state'].widget.attrs['class'] = ""
             self.fields['address_zip'].required = False
+            self.fields['address_zip'].widget.attrs['class'] = ""
 
     def clean(self):
         super(UserContactForm, self).clean()

--- a/esp/esp/users/forms/user_profile.py
+++ b/esp/esp/users/forms/user_profile.py
@@ -63,13 +63,13 @@ class UserContactForm(FormUnrestrictedOtherUser, FormWithTagInitialValues):
             del self.fields['receive_txt_message']
         if self.user.isTeacher() and not Tag.getBooleanTag('teacher_address_required', default = False):
             self.fields['address_street'].required = False
-            self.fields['address_street'].widget.attrs['class'] = ""
+            self.fields['address_street'].widget.attrs['class'] = self.fields['address_street'].widget.attrs['class'].replace('required', '')
             self.fields['address_city'].required = False
-            self.fields['address_city'].widget.attrs['class'] = ""
+            self.fields['address_city'].widget.attrs['class'] = self.fields['address_city'].widget.attrs['class'].replace('required', '')
             self.fields['address_state'].required = False
-            self.fields['address_state'].widget.attrs['class'] = ""
+            self.fields['address_state'].widget.attrs['class'] = self.fields['address_state'].widget.attrs['class'].replace('required', '')
             self.fields['address_zip'].required = False
-            self.fields['address_zip'].widget.attrs['class'] = ""
+            self.fields['address_zip'].widget.attrs['class'] = self.fields['address_zip'].widget.attrs['class'].replace('required', '')
 
     def clean(self):
         super(UserContactForm, self).clean()


### PR DESCRIPTION
This manually removes the "required" CSS class from the address fields when they aren't required (due to the `teacher_address_required` tag being `False`). This removes the asterisks from the labels in the form. This is all necessary due to a django bug reported in https://github.com/learning-unlimited/ESP-Website/issues/2435.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/2952.