### PR TITLE
Clean up directory and always check for views

### DIFF
--- a/esp/public/media/default_styles/management.css
+++ b/esp/public/media/default_styles/management.css
@@ -1,3 +1,7 @@
+div .module_group {
+    margin-bottom: 10px;
+}
+
 div .module_group_body {
     padding-left: 10px;
     padding-right: 10px;
@@ -8,19 +12,27 @@ div .module_group_body ul {
     margin-top: 0px;
 }
 
-div .module_group_header {
-    width: 90%;
+div .module_group_header, div .module_group_header_half {
+    width: calc(100% - 20px);
     background-color: #f3ecc4;
     font-size: 0.95em;
     font-weight: bold;
     padding: 5px;
+    margin-left: 5px;
+    margin-right: 5px;
     margin-bottom: 8px;
     box-shadow: 3px 3px 5px #CCCCCC;
 }
 
+div .button_wrapper {
+    width: 100%;
+    padding: 0px;
+    margin: 0px;
+}
+
 div .module_link_large {
-    width: 200px;
-    margin: 8px;
+    width: calc(50% - 20px);
+    margin: 10px;
     padding: 6px;
     text-align: center;
     float: left;
@@ -41,4 +53,9 @@ div .module_group_expandable + .module_group_body {
 
 .expand_collapse_text {
     font-weight: normal;
+}
+
+.helpbox {
+    margin-right: 0px;
+    width: inherit;
 }

--- a/esp/templates/program/modules/admincore/directory.html
+++ b/esp/templates/program/modules/admincore/directory.html
@@ -47,27 +47,29 @@ Welcome to the administrative home page for {{ program.niceName }}.  This page l
     <div class="module_group_header">
         Configure Your Program
     </div>
-    <div class="module_group_body">
-        <div style="display: inline-block;">
+    <div style="display: inline-block;" class="button_wrapper">
+        {% if manage_resources %}
         <a href="/manage/{{ program.getUrlBase }}/resources"><button type="button" class="module_link_large btn btn-default btn-lg">
             <div class="module_link_main">Resources</div>
             <div class="module_link_caption">timeslots, classrooms</div>
         </button></a>
+        {% endif %}
+        {% if manage_deadlines %}
         <a href="/manage/{{ program.getUrlBase }}/deadlines"><button type="button" class="module_link_large btn btn-default btn-lg">
             <div class="module_link_main">Deadlines</div>
             <div class="module_link_caption">open/close registration</div>
         </button></a>
-        </div>
-        <div style="display: inline-block;">
+        {% endif %}
+    </div>
+    <div class="module_group_body">
         <ul>
             {% if manage_teacher_events %}<li><a href="/manage/{{ program.getUrlBase }}/teacher_events">Teacher Training and Interviews</a>: Teachers signed up for each slot</li>{% endif %}
             {% if manage_lunch_constraints %}<li><a href="/manage/{{ program.getUrlBase }}/lunch_constraints">Lunch Constraints</a>: Rules for your students' schedules</li>{% endif %}
             {% if manage_registrationtype_management %}<li><a href="/manage/{{ program.getUrlBase }}/registrationtype_management">Student Registration Types</a>: What students see on their schedule after a lottery</li>{% endif %}
-            <li><a href="/manage/{{ program.getUrlBase }}/surveys">View and Manage Surveys</a></li>
-            <li><a href="/manage/{{ program.getUrlBase }}/settings/">Modify Settings for This Program</a>: Emails, program caps and modules, class categories, and flag types</li>
-            <li><a href="/manage/{{ program.getUrlBase }}/tags">Modify Tag Settings for This Program</a>: Generic miscellaneous settings, for experts only</li>
+            {% if manage_surveys %}<li><a href="/manage/{{ program.getUrlBase }}/surveys">View and Manage Surveys</a>: Create new surveys, edit existing surveys, and review survey results</li>{% endif %}
+            {% if manage_settings %}<li><a href="/manage/{{ program.getUrlBase }}/settings/">Modify Settings for This Program</a>: Emails, program caps and modules, class categories, and flag types</li>{% endif %}
+            {% if manage_tags %}<li><a href="/manage/{{ program.getUrlBase }}/tags">Modify Tag Settings for This Program</a>: Generic miscellaneous settings, for experts only</li>{% endif %}
         </ul>
-        </div>
     </div>
 </div>
 
@@ -75,17 +77,19 @@ Welcome to the administrative home page for {{ program.niceName }}.  This page l
     <div class="module_group_header">
         Coordinate with Participants
     </div>
-    <div class="module_group_body">
-    <div style="display: inline-block;">
+    <div style="display: inline-block;" class="button_wrapper">
+        {% if manage_commpanel %}
         <a href="/manage/{{ program.getUrlBase }}/commpanel"><button type="button" class="module_link_large btn btn-default btn-lg">
             <div class="module_link_main">Email</div>
             <div class="module_link_caption">communications panel</div>
         </button></a>
+        {% endif %}
+        {% if manage_admin_morph %}
         <a href="/manage/{{ program.getUrlBase }}/admin_morph"><button type="button" class="module_link_large btn btn-default btn-lg">
             <div class="module_link_main">Morph into User</div>
             <div class="module_link_caption">&nbsp;</div>
         </button></a>
-    </div>
+        {% endif %}
     </div>
 </div>
 
@@ -93,59 +97,63 @@ Welcome to the administrative home page for {{ program.niceName }}.  This page l
     <div class="module_group_header">
         Manage Logistics
     </div>
-    <div class="module_group_body">
-        <div style="display: inline-block;">
+    <div style="display: inline-block;" class="button_wrapper">
+        {% if manage_dashboard %}
         <a href="/manage/{{ program.getUrlBase }}/dashboard"><button type="button" class="module_link_large btn btn-default btn-lg">
             <div class="module_link_main">Dashboard</div>
             <div class="module_link_caption">review classes and stats</div>
         </button></a>
+        {% endif %}
+        {% if manage_ajax_scheduling %}
         <a href="/manage/{{ program.getUrlBase }}/ajax_scheduling"><button type="button" class="module_link_large btn btn-default btn-lg">
             <div class="module_link_main">Scheduling</div>
             <div class="module_link_caption">assign rooms and times</div>
         </button></a>
-        </div>
-        <div style="display: inline-block;">
+        {% endif %}
+        {% if manage_get_materials %}
         <a href="/manage/{{ program.getUrlBase }}/get_materials"><button type="button" class="module_link_large btn btn-default btn-lg">
             <div class="module_link_main">Documents</div>
             <div class="module_link_caption">upload and view files</div>
         </button></a>
+        {% endif %}
+        {% if manage_volunteering %}
         <a href="/manage/{{ program.getUrlBase }}/volunteering"><button type="button" class="module_link_large btn btn-default btn-lg">
             <div class="module_link_main">Volunteers</div>
             <div class="module_link_caption">create shifts, view signups</div>
         </button></a>
-        </div>
+        {% endif %}
     </div>
 </div>
-<table width="95%">
+<table width="100%">
 <tr>
 <td width="50%">
 <div class="module_group" id="module_group_4">
-    <div class="module_group_header">
+    <div class="module_group_header_half">
         Quick Links
     </div>
     <div class="module_group_body">
     <ul>
-        <li><a href="/learn/{{ program.getUrlBase }}/catalog">Catalog</a></li>
-        <li><a href="/learn/{{ program.getUrlBase }}/studentreg">Student Reg</a></li>
-        <li><a href="/teach/{{ program.getUrlBase }}/teacherreg">Teacher Reg</a></li>
-        <li><a href="/volunteer/{{ program.getUrlBase }}/signup">Volunteer Reg</a></li>
-        <li><a href="/onsite/{{ program.getUrlBase }}/main">Onsite</a></li>
+        {% if learn_catalog %}<li><a href="/learn/{{ program.getUrlBase }}/catalog">Catalog</a></li>{% endif %}
+        {% if learn_studentreg %}<li><a href="/learn/{{ program.getUrlBase }}/studentreg">Student Reg</a></li>{% endif %}
+        {% if teach_teacherreg %}<li><a href="/teach/{{ program.getUrlBase }}/teacherreg">Teacher Reg</a></li>{% endif %}
+        {% if volunteer_signup %}<li><a href="/volunteer/{{ program.getUrlBase }}/signup">Volunteer Reg</a></li>{% endif %}
+        {% if onsite_main %}<li><a href="/onsite/{{ program.getUrlBase }}/main">Onsite</a></li>{% endif %}
     </ul>
     </div>
 </div>
 </td>
 <td width="50%">
 <div class="module_group" id="module_group_5">
-    <div class="module_group_header">
+    <div class="module_group_header_half">
         Generate Printables
     </div>
     <div class="module_group_body">
     <ul>
-        <li><a href="/manage/{{ program.getUrlBase }}/catalog">PDF Catalog</a></li>
-        <li><a href="/manage/{{ program.getUrlBase }}/studentschedules">Student Schedules</a></li>
-        <li><a href="/manage/{{ program.getUrlBase }}/selectidoptions">Nametags</a></li>
-        <li><a href="/manage/{{ program.getUrlBase }}/selectList">Arbitrary User List</a></li>
-        <li><a href="/manage/{{ program.getUrlBase }}/printoptions">All Printables</a></li>
+        {% if manage_catalog %}<li><a href="/manage/{{ program.getUrlBase }}/catalog">PDF Catalog</a></li>{% endif %}
+        {% if manage_studentschedules %}<li><a href="/manage/{{ program.getUrlBase }}/studentschedules">Student Schedules</a></li>{% endif %}
+        {% if manage_selectidoptions %}<li><a href="/manage/{{ program.getUrlBase }}/selectidoptions">Nametags</a></li>{% endif %}
+        {% if manage_selectList %}<li><a href="/manage/{{ program.getUrlBase }}/selectList">Arbitrary User List</a></li>{% endif %}
+        {% if manage_printoptions %}<li><a href="/manage/{{ program.getUrlBase }}/printoptions">All Printables</a></li>{% endif %}
     </ul>
     </div>
 </div>
@@ -154,10 +162,10 @@ Welcome to the administrative home page for {{ program.niceName }}.  This page l
 </table>
 
 <div class="module_group_header">Additional Modules</div>
-<div id="additional_modules">
+<div id="additional_modules" class="module_group_body">
 <table border="0" width="100%">
 <tr>
- <td width="40%">
+ <td width="50%">
 <ul>
 {% for module in modules %}
 {% if module.isStep %}


### PR DESCRIPTION
This started out as a quick fix for the survey management link appearing even when the module wasn't enabled (https://github.com/learning-unlimited/ESP-Website/issues/3063), but then I decided to broaden the scope to verifying that the views were valid for every single link on the directory. While I was at it, I cleaned up the visual appearance a little bit to make the single-column/two-column approach more consistent.

![image](https://user-images.githubusercontent.com/7232514/90339785-bca30c00-dfb8-11ea-8d47-8bf7b323905c.png)

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3063.