### PR TITLE
Use webapp isfull conditions for grid based class changes

### DIFF
--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -1139,13 +1139,13 @@ class ClassSection(models.Model):
                 pass
 
         # Mode 1: Base "fullness" on class attendance numbers if:
-        # 1) using webapp, 2) 'switch_lag_class_attendance' tag is set properly
+        # 1) using webapp/grid based class changes, 2) 'switch_lag_class_attendance' tag is set properly
         # 3) it is currently past the class start time + however many minutes specified in tag
         # 4) at least one student has been marked as attending the class
         if webapp and switch_lag and now >= (self.start_time_prefetchable() + timedelta(minutes=switch_lag)) and self.count_attending_students() >= 1:
             num_students = self.count_attending_students()
         # Mode 2: Base "fullness" on program attendance numbers if:
-        # 1) using webapp, 2) 'switch_time_program_attendance' tag is set properly
+        # 1) using webapp/grid based class changes, 2) 'switch_time_program_attendance' tag is set properly
         # 3) it is currently past the time specified in tag
         # 4) at least five students have been marked as attending the program (to account for test users)
         elif webapp and switch_time and now >= switch_time and self.parent_program.currentlyCheckedInStudents().count() >= 5:

--- a/esp/esp/program/modules/handlers/onsiteclasslist.py
+++ b/esp/esp/program/modules/handlers/onsiteclasslist.py
@@ -203,12 +203,10 @@ class OnSiteClassList(ProgramModuleObj):
     @aux_call
     @needs_onsite
     def full_status(self, request, tl, one, two, module, extra, prog):
-        print("full status python function")
         resp = HttpResponse(content_type='application/json')
         data = [[section.id, section.isFull(webapp=True)] for section in
                      ClassSection.objects.filter(status__gt=0, parent_class__status__gt=0,
                                                  parent_class__parent_program=prog)]
-        print(data)
         json.dump(data, resp)
         return resp
 


### PR DESCRIPTION
FIxes #2997. 

In the student webapp, a student can change into classes that aren't full, where full can be defined by enrollment numbers, program attendance numbers, or class attendance numbers, depending on a few tag settings. This PR makes it so that if a student can class change through the webapp, the admin can class change them without needing to override class capacity.

Things that have changed:
- shading is red for the webapp version of isFull, not based on enrollment numbers
- checkbox to switch a student is greyed out for webapp version of isFull
- show/hide full classes uses webapp version of isFull
- can class change without overriding status as long as the class isnt full by webapp version of isFull
