### PR TITLE
Check for payment, not amount due, on extracosts/donation

### DIFF
--- a/esp/esp/program/modules/handlers/donationmodule.py
+++ b/esp/esp/program/modules/handlers/donationmodule.py
@@ -176,7 +176,7 @@ class DonationModule(ProgramModuleObj):
         # credit card payment has occured. For now, just do the same thing we
         # do in other accounting modules, and don't allow changes after payment
         # has occured.
-        if iac.amount_due() <= 0:
+        if iac.has_paid():
             raise ESPError("You've already paid for this program.  Please make any further changes onsite so that we can charge or refund you properly.", log=False)
 
         form = None

--- a/esp/esp/program/modules/handlers/studentextracosts.py
+++ b/esp/esp/program/modules/handlers/studentextracosts.py
@@ -81,10 +81,6 @@ class StudentExtraCosts(ProgramModuleObj):
         super(StudentExtraCosts, self).__init__(*args, **kwargs)
         self.event = "extra_costs_done"
 
-    def have_paid(self):
-        iac = IndividualAccountingController(self.program, get_current_request().user)
-        return (iac.amount_due() <= 0)
-
     def studentDesc(self):
         """ Return a description for each line item type that students can be filtered by. """
         student_desc = {}
@@ -136,11 +132,11 @@ class StudentExtraCosts(ProgramModuleObj):
         This module should ultimately deal with things like optional lab fees, etc.
         Right now it doesn't.
         """
-        if self.have_paid():
+        iac = IndividualAccountingController(self.program, get_current_request().user)
+        if iac.has_paid():
             raise ESPError("You've already paid for this program.  Please make any further changes onsite so that we can charge or refund you properly.", log=False)
 
         #   Determine which line item types we will be asking about
-        iac = IndividualAccountingController(self.program, get_current_request().user)
         costs_list = iac.get_lineitemtypes(optional_only=True).filter(max_quantity__lte=1, lineitemoptions__isnull=True)
         multicosts_list = iac.get_lineitemtypes(optional_only=True).filter(max_quantity__gt=1, lineitemoptions__isnull=True)
         multiselect_list = iac.get_lineitemtypes(optional_only=True).filter(lineitemoptions__isnull=False)

--- a/esp/esp/program/modules/handlers/studentregcore.py
+++ b/esp/esp/program/modules/handlers/studentregcore.py
@@ -67,7 +67,7 @@ class StudentRegCore(ProgramModuleObj, CoreModule):
     def have_paid(self, user):
         """ Whether the user has paid for this program.  """
         iac = IndividualAccountingController(self.program, user)
-        return (iac.amount_due() <= 0)
+        return (iac.has_paid())
     have_paid.depend_on_row('accounting.Transfer', lambda transfer: {'user': transfer.user})
     have_paid.depend_on_row('program.SplashInfo', lambda splashinfo: {'user': splashinfo.student})
     have_paid.depend_on_row('accounting.FinancialAidGrant', lambda grant: {'user': grant.request.user})


### PR DESCRIPTION
Fixes #1315. 

On the extra costs/ donation modules, it used to say "whoop you've already paid" even if a program was free or if fin aid was granted because it was checking that the amount due was <=0. Now I switch to checking whether there is any credit card payment instead.

The [has_paid function](https://github.com/learning-unlimited/ESP-Website/blob/43dc04958b5bfa9518ec69b7b6b3b98b8831b803/esp/esp/accounting/controllers.py#L564) in the iac already is based on amount_paid, which sums the credit card transfers, so I switched to using that and got rid of the have_paid functions to reduce code duplication, except in the case where it adds caching.