### PR TITLE
Filter listgen fields based on recipient type

### DIFF
--- a/esp/esp/program/modules/handlers/listgenmodule.py
+++ b/esp/esp/program/modules/handlers/listgenmodule.py
@@ -44,47 +44,51 @@ from django import forms
 class UserAttributeGetter(object):
     @staticmethod
     def getFunctions():
-        """ Enter labels for available fields here; they are sorted alphabetically by key """
-        labels = {  '01_id': 'ID',
-                    '02_username': 'Username',
-                    '03_fullname': 'Full Name',
-                    '04_firstname': 'First Name',
-                    '05_lastname': 'Last Name',
-                    '06_email': 'E-mail',
-                    '07_cellphone': 'Cell Phone',
-                    '08_textmsg': 'Text Msg?',
-                    '09_address': 'Address',
-                    '10_tshirt_size': 'T-Shirt Size',
-                    '11_dob': 'Date of Birth',
-                    '12_gender': 'Gender',
-                    '13_gradyear': 'Grad Year',
-                    '14_school': 'School',
-                    '15_affiliation': 'Affiliation',
-                    '16_major': 'Major',
-                    '17_studentrep': 'Student Rep?',
-                    '18_heard_about': 'Heard about Splash from',
-                    '19_accountdate': 'Created Date',
-                    '20_first_regdate': 'Initial Registration Date',
-                    '21_last_regdate': 'Most Recent Registration Date',
-                    '22_lottery_ticket_id': 'Student Lottery Ticket ID',
-                    '23_classhours': 'Num Class Hrs',
-                    '24_transportation': 'Plan to Get to Splash',
-                    '25_guardian_name': 'Guardian Name',
-                    '26_guardian_email': 'Guardian E-mail',
-                    '27_guardian_cellphone': 'Guardian Cell Phone',
+        """ Enter labels for available fields here; they are sorted alphabetically by key
+            The values should be dictionaries with at least "label" and "usertype" keys.
+            The value for the "label" key will be the text shown in the form.
+            The value for the "usertype" key should be a set of user types that the field is releveant for.
+            Use 'any' to show the field for all user types (all fields will be shown for combo lists, as well) """
+        fields = {  '01_id': {'label': 'ID', 'usertype': {'any'}},
+                    '02_username': {'label': 'Username', 'usertype': {'any'}},
+                    '03_fullname': {'label': 'Full Name', 'usertype': {'any'}},
+                    '04_firstname': {'label': 'First Name', 'usertype': {'any'}},
+                    '05_lastname': {'label': 'Last Name', 'usertype': {'any'}},
+                    '06_email': {'label': 'E-mail', 'usertype': {'any'}},
+                    '07_cellphone': {'label': 'Cell Phone', 'usertype': {'any'}},
+                    '08_textmsg': {'label': 'Text Msg?', 'usertype': {'any'}},
+                    '09_address': {'label': 'Address', 'usertype': {'any'}},
+                    '10_tshirt_size': {'label': 'T-Shirt Size', 'usertype': {'teacher', 'student'}},
+                    '11_dob': {'label': 'Date of Birth', 'usertype': {'student'}},
+                    '12_gender': {'label': 'Gender', 'usertype': {'student'}},
+                    '13_gradyear': {'label': 'Grad Year', 'usertype': {'teacher', 'student'}},
+                    '14_school': {'label': 'School', 'usertype': {'teacher', 'student'}},
+                    '15_affiliation': {'label': 'Affiliation', 'usertype': {'teacher'}},
+                    '16_major': {'label': 'Major', 'usertype': {'teacher'}},
+                    '17_studentrep': {'label': 'Student Rep?', 'usertype': {'student'}},
+                    '18_heard_about': {'label': 'Heard about Splash from', 'usertype': {'student'}},
+                    '19_accountdate': {'label': 'Created Date', 'usertype': {'any'}},
+                    '20_first_regdate': {'label': 'Initial Registration Date', 'usertype': {'student'}},
+                    '21_last_regdate': {'label': 'Most Recent Registration Date', 'usertype': {'student'}},
+                    '22_lottery_ticket_id': {'label': 'Student Lottery Ticket ID', 'usertype': {'student'}},
+                    '23_classhours': {'label': 'Num Class Hrs', 'usertype': {'student'}},
+                    '24_transportation': {'label': 'Plan to Get to Splash', 'usertype': {'student'}},
+                    '25_guardian_name': {'label': 'Guardian Name', 'usertype': {'student'}},
+                    '26_guardian_email': {'label': 'Guardian E-mail', 'usertype': {'student'}},
+                    '27_guardian_cellphone': {'label': 'Guardian Cell Phone', 'usertype': {'student'}},
                  }
 
-        last_label_index = len(labels)
+        last_field_index = len(fields)
         for i in range(3):#replace 3 with call to get_max_applications + fix that method
-            key = str(last_label_index + i + 1) + '_class_application_' + str(i+1)
-            labels[key] = 'Class Application ' + str(i+1)
+            key = str(last_field_index + i + 1) + '_class_application_' + str(i+1)
+            fields[key] = {'label': 'Class Application ' + str(i+1), 'usertype': {'student'}}
         result = {}
         for item in dir(UserAttributeGetter):
             label_map = {}
-            for x in labels.keys():
+            for x in fields.keys():
                 label_map[x[3:]] = x
             if item.startswith('get_') and item[4:] in label_map:
-                result[label_map[item[4:]]] = labels[label_map[item[4:]]]
+                result[label_map[item[4:]]] = fields[label_map[item[4:]]]
 
         return result
 
@@ -256,12 +260,22 @@ class UserAttributeGetter(object):
 
 
 class ListGenForm(forms.Form):
-    attr_choices = choices=UserAttributeGetter.getFunctions().items()
+    attr_choices = UserAttributeGetter.getFunctions().items()
     attr_choices.sort(key=lambda x: x[0])
 
-    fields = forms.MultipleChoiceField(choices=attr_choices, initial=['id','fullname','address','cellphone','school'], widget=forms.CheckboxSelectMultiple)
-    split_by = forms.ChoiceField(choices=[('', '')] + attr_choices, required=False)
+    fields = forms.MultipleChoiceField(choices=[(choice[0], choice[1]['label']) for choice in attr_choices], widget=forms.CheckboxSelectMultiple)
+    split_by = forms.ChoiceField(choices=[('', '')] + [(choice[0], choice[1]['label']) for choice in attr_choices], required=False)
     output_type = forms.ChoiceField(choices=(('csv', 'CSV format'), ('html', 'HTML format')), initial='html')
+
+    def __init__(self, *args, **kwargs):
+        usertype = kwargs.pop('usertype', 'any')
+        super(ListGenForm, self).__init__(*args, **kwargs)
+        #   If we have a specific recipient user type,
+        #   filter to only the fields that are relevant to that user type
+        if usertype != 'combo':
+            self.fields['fields'].choices = [(choice[0], choice[1]['label']) for choice in self.attr_choices if len({'any', usertype}.intersection(choice[1]['usertype'])) > 0]
+            self.fields['split_by'].choices = [('', '')] + [(choice[0], choice[1]['label']) for choice in self.attr_choices if len({'any', usertype}.intersection(choice[1]['usertype'])) > 0]
+        self.fields['fields'].initial = ['02_username','04_firstname','05_lastname','06_email']
 
 class ListGenModule(ProgramModuleObj):
     """ While far from complete, this will allow you to just generate a simple list of users matching a criteria (criteria very similar to the communications panel)."""
@@ -297,10 +311,10 @@ class ListGenModule(ProgramModuleObj):
                 split_by = form.cleaned_data['split_by']
 
                 labels_dict = UserAttributeGetter.getFunctions()
-                fields = [labels_dict[f] for f in form.cleaned_data['fields']]
+                fields = [labels_dict[f]['label'] for f in form.cleaned_data['fields']]
                 #   If a split field is specified, make sure we fetch its data
-                if split_by and labels_dict[split_by] not in fields:
-                    fields.append(labels_dict[split_by])
+                if split_by and labels_dict[split_by]['label'] not in fields:
+                    fields.append(labels_dict[split_by]['label'])
                 output_type = form.cleaned_data['output_type']
 
                 users = list(ESPUser.objects.filter(filterObj.get_Q()).filter(is_active=True).distinct())
@@ -312,7 +326,7 @@ class ListGenModule(ProgramModuleObj):
                     #   Add information for split lists if desired
                     if split_by:
                         if ua.get(split_by) not in lists_indices:
-                            lists.append({'key': labels_dict[split_by], 'value': ua.get(split_by), 'users': []})
+                            lists.append({'key': labels_dict[split_by]['label'], 'value': ua.get(split_by), 'users': []})
                             lists_indices[ua.get(split_by)] = len(lists) - 1
                         lists[lists_indices[ua.get(split_by)]]['users'].append(u)
 
@@ -345,8 +359,8 @@ class ListGenModule(ProgramModuleObj):
                 }
                 return render_to_response(self.baseDir()+'options.html', request, context)
         else:
-            #   Otherwise, show a blank form
-            form = ListGenForm()
+            #   Otherwise, show a blank form with the fields filtered by recipient_type
+            form = ListGenForm(usertype=request.POST.get('recipient_type', 'combo').lower())
             context = {
                 'form': form,
                 'filterid': filterObj.id,
@@ -377,8 +391,9 @@ class ListGenModule(ProgramModuleObj):
                     data[key] = request.POST[key]
             filterObj = usc.filter_from_postdata(prog, data)
 
-            #   Display list generation options
-            form = ListGenForm()
+            #   Display list generation options filtered by recipient type
+            #   If there is no receipient_type, we submitted a combo list
+            form = ListGenForm(usertype=request.POST.get('recipient_type', 'combo').lower())
             context.update({
                 'form': form,
                 'filterid': filterObj.id,

--- a/esp/public/media/scripts/commpanel.js
+++ b/esp/public/media/scripts/commpanel.js
@@ -64,24 +64,16 @@ function submit_prev_selection()
 
 function prepare_accordion(accordion_id, rb_selected)
 {
+    $j("#" + accordion_id).children(".ui-accordion-header:not(.any)").hide();
+    
     //  Show school/grade options for students, graduation year options for teachers
     if (rb_selected.toLowerCase().substr(0, 7) == "student")
     {
-        $j("#" + accordion_id).children(".ui-accordion-header").eq(7).show();
-        $j("#" + accordion_id).children(".ui-accordion-header").eq(8).show();
-        $j("#" + accordion_id).children(".ui-accordion-header").eq(9).hide();
+        $j("#" + accordion_id).children(".ui-accordion-header.student").show();
     }
     else if (rb_selected.toLowerCase().substr(0, 7) == "teacher")
     {
-        $j("#" + accordion_id).children(".ui-accordion-header").eq(7).hide();
-        $j("#" + accordion_id).children(".ui-accordion-header").eq(8).hide();
-        $j("#" + accordion_id).children(".ui-accordion-header").eq(9).show();
-    }
-    else
-    {
-        $j("#" + accordion_id).children(".ui-accordion-header").eq(7).hide();
-        $j("#" + accordion_id).children(".ui-accordion-header").eq(8).hide();
-        $j("#" + accordion_id).children(".ui-accordion-header").eq(9).hide();
+        $j("#" + accordion_id).children(".ui-accordion-header.teacher").show();
     }
 }
 
@@ -151,8 +143,8 @@ function initialize()
     $j("#filter_accordion").accordion({
         heightStyle: "content",
         collapsible: true,
+        active: false,
     });
-    $j("#filter_accordion").accordion("option", "active", false);
 
     //  Handle changes in the recipient type
     recipient_type_change = function () {
@@ -310,7 +302,7 @@ function initialize()
     $j("#prev_select_done").click(submit_prev_selection);
 
     //  Populate fields with GET parameters
-    var items = location.search.substr(1).split("&");
+    var items = location.search.substr(1).split("&").filter(Boolean);
     for (var index = 0; index < items.length; index++) {
         var key_val = items[index].split("=");
         $j("[name=" + key_val[0] + "]").val(key_val[1].split(",")).change();

--- a/esp/templates/program/modules/listgenmodule/options.html
+++ b/esp/templates/program/modules/listgenmodule/options.html
@@ -5,6 +5,8 @@
 {% block content %}
 <style type="text/css">
 .nocheckmark { border: 1px solid black; }
+#id_fields { list-style: none; margin: 0px; }
+input[name="fields"] { margin: 0px 3px 0px 0px; }
 </style>
 <br />
 <br />

--- a/esp/templates/users/usersearch/list_selector.html
+++ b/esp/templates/users/usersearch/list_selector.html
@@ -72,53 +72,53 @@
             <div class="step_instructions step_highlight">Currently selected: <span id="filter_current_list"></span></div>
             <div id="filter_accordion">
 
-                <h4><a href="#">User ID</a></h4>
+                <h4 class="any"><a href="#">User ID</a></h4>
                 <div>Enter ID number: <input type="text" size="6" name="userid" id="userid" /> <br />
                 <small>(Can be a comma-separated list)</small></div>
 
-                <h4><a href="#">User name</a></h4>
+                <h4 class="any"><a href="#">User name</a></h4>
                 <div>Enter a username: <input type="text" size="30" name="username" id="username" autocomplete="new-username" /> <br />
                 <small>(Supports regular expressions)</small></div>
 
-                <h4><a href="#">Last name</a></h4>
+                <h4 class="any"><a href="#">Last name</a></h4>
                 <div>Enter a portion of the last name: <input type="text" size="30" name="last_name" id="last_name" /> <br />
                 <small>(Supports regular expressions)</small></div>
 
-                <h4><a href="#">First name</a></h4>
+                <h4 class="any"><a href="#">First name</a></h4>
                 <div>Enter a portion of the first name: <input type="text" size="30" name="first_name" id="first_name" /> <br />
                 <small>(Supports regular expressions)</small></div>
 
-                <h4><a href="#">Email address</a></h4>
+                <h4 class="any"><a href="#">Email address</a></h4>
                 <div>Enter a portion of the email address: <input type="text" size="30" name="email" id="email" /> <br />
                 <small>(Supports regular expressions)</small></div>
 
-                <h4><a href="#">Zip Code</a></h4>
+                <h4 class="any"><a href="#">Zip Code</a></h4>
                 <div>
                     Center of region: <input type="text" size="5" name="zipcode" value="02139" /> <br />
                     Minimum distance: <input type="text" size="4" name="zipdistance_exclude" value="" /> miles <br />
                     Maximum distance: <input type="text" size="4" name="zipdistance" value="" /> miles
                 </div>
 
-                <h4><a href="#">States</a></h4>
+                <h4 class="any"><a href="#">States</a></h4>
                 <div>Enter a list of states: <input type="text" size="18" name="states" value="" /> <br />
                 <small>Example: MA,CT,NY</small></div>
 
-                <h4><a href="#">School</a></h4>
+                <h4 class="student"><a href="#">School</a></h4>
                 <div>Enter a portion of the school name: <input type="text" size="30" name="school" value="" /></div>
 
-                <h4><a href="#">Grade</a></h4>
+                <h4 class="student"><a href="#">Grade</a></h4>
                 <div>
                 Min Grade: <input type="text" size="3" name="grade_min" value="" /><br />
                 Max Grade: <input type="text" size="3" name="grade_max" value="" />
                 </div>
 
-                <h4><a href="#">Graduation Year</a></h4>
+                <h4 class="teacher"><a href="#">Graduation Year</a></h4>
                 <div>
                 Min: <input type="text" size="3" name="gradyear_min" value="" /> <br />
                 Max: <input type="text" size="3" name="gradyear_max" value="" />
                 </div>
 
-                <h4><a href="#">User Group</a></h4>
+                <h4 class="any"><a href="#">User Group</a></h4>
                 <div><select name="group" id="user-search-group">
                     {% for group in groups %}
                     <option value="{{ group.id }}">{{ group.name }}</option>
@@ -126,7 +126,7 @@
                     <option value="" selected hidden></option>
                 </select></div>
 
-                <h4><a href="#">Class Registrations</a></h4>
+                <h4 class="student"><a href="#">Class Registrations</a></h4>
                 <div>Enter class ID number: <input type="text" size="6" name="clsid" id="clsid" /> <br />
                 <small>(Can be a comma-separated list)</small> <br /><br />
                 Select registration type(s): <select name="regtypes" id="regtypes" multiple>


### PR DESCRIPTION
This filters the vast list of available fields in the list gen module to only those that are relevant based on the recipient type. In the case of a combo list, we still show all of the fields in the form.

While I was at it, I also cleaned up the way we were hiding some of the user filters in the user search modules, fixed a couple of bugs (there were supposed to be initial values for the list gen fields form, the filters were all supposed to be collapsed at initialization, and there was a string handling error when there were no GET parameters in the URL), and cleaned up the styling of the list gen fields form.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/2348.