### PR TITLE
Fix profile form when morphed as a teacher

### DIFF
--- a/esp/esp/users/forms/user_profile.py
+++ b/esp/esp/users/forms/user_profile.py
@@ -63,13 +63,17 @@ class UserContactForm(FormUnrestrictedOtherUser, FormWithTagInitialValues):
             del self.fields['receive_txt_message']
         if self.user.isTeacher() and not Tag.getBooleanTag('teacher_address_required', default = False):
             self.fields['address_street'].required = False
-            self.fields['address_street'].widget.attrs['class'] = self.fields['address_street'].widget.attrs['class'].replace('required', '')
+            if 'class' in self.fields['address_street'].widget.attrs and self.fields['address_street'].widget.attrs['class']:
+                self.fields['address_street'].widget.attrs['class'] = self.fields['address_street'].widget.attrs['class'].replace('required', '')
             self.fields['address_city'].required = False
-            self.fields['address_city'].widget.attrs['class'] = self.fields['address_city'].widget.attrs['class'].replace('required', '')
+            if 'class' in self.fields['address_city'].widget.attrs and self.fields['address_city'].widget.attrs['class']:
+                self.fields['address_city'].widget.attrs['class'] = self.fields['address_city'].widget.attrs['class'].replace('required', '')
             self.fields['address_state'].required = False
-            self.fields['address_state'].widget.attrs['class'] = self.fields['address_state'].widget.attrs['class'].replace('required', '')
+            if 'class' in self.fields['address_state'].widget.attrs and self.fields['address_state'].widget.attrs['class']:
+                self.fields['address_state'].widget.attrs['class'] = self.fields['address_state'].widget.attrs['class'].replace('required', '')
             self.fields['address_zip'].required = False
-            self.fields['address_zip'].widget.attrs['class'] = self.fields['address_zip'].widget.attrs['class'].replace('required', '')
+            if 'class' in self.fields['address_zip'].widget.attrs and self.fields['address_zip'].widget.attrs['class']:
+                self.fields['address_zip'].widget.attrs['class'] = self.fields['address_zip'].widget.attrs['class'].replace('required', '')
 
     def clean(self):
         super(UserContactForm, self).clean()


### PR DESCRIPTION
I'm not actually sure what the root cause of this error is. It appears that when you are morphed, all of the fields of the form are no longer required AND the `widget.attrs['class']` field becomes `None` instead of a string, which caused the error when we called `.replace()` on that. To get around that, we just do some brute force checking before accessing the field. The fix implemented here should be agnostic to django version (so should be fine to cherry pick to SR12), but in the future, we can probably just get rid of all of this code that fixes the required fields because the django bug is fixed now that we are on django 1.11.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3107.