### PR TITLE
Add isStep dependencies to some teacher and student modules

### DIFF
--- a/esp/esp/program/modules/handlers/availabilitymodule.py
+++ b/esp/esp/program/modules/handlers/availabilitymodule.py
@@ -228,6 +228,9 @@ class AvailabilityModule(ProgramModuleObj):
 
         return render_to_response(self.baseDir()+'availability_form.html', request, context)
 
+    def isStep(self):
+        return self.program.getTimeSlots(types=[self.event_type()]).exists()
+
     class Meta:
         proxy = True
         app_label = 'modules'

--- a/esp/esp/program/modules/handlers/formstackmedliabmodule.py
+++ b/esp/esp/program/modules/handlers/formstackmedliabmodule.py
@@ -190,6 +190,9 @@ class FormstackMedliabModule(ProgramModuleObj):
         return render_to_response(self.baseDir()+'medicalbypass.html',
                                   request, context)
 
+    def isStep(self):
+        return bool(Tag.getProgramTag("formstack_id", self.program) and Tag.getProgramTag("formstack_viewkey", self.program))
+
     class Meta:
         proxy = True
         app_label = 'modules'

--- a/esp/esp/program/modules/handlers/studentextracosts.py
+++ b/esp/esp/program/modules/handlers/studentextracosts.py
@@ -280,6 +280,10 @@ class StudentExtraCosts(ProgramModuleObj):
                                   request,
                                   { 'errors': not forms_all_valid, 'error_custom': error_custom, 'forms': forms, 'financial_aid': request.user.hasFinancialAid(prog), 'select_qty': len(multicosts_list) > 0 })
 
+    def isStep(self):
+        pac = ProgramAccountingController(self.program)
+        return pac.get_lineitemtypes(optional_only=True).exists()
+
     class Meta:
         proxy = True
         app_label = 'modules'

--- a/esp/esp/program/modules/handlers/studentjunctionappmodule.py
+++ b/esp/esp/program/modules/handlers/studentjunctionappmodule.py
@@ -132,6 +132,8 @@ class StudentJunctionAppModule(ProgramModuleObj):
 
         return render_to_response(self.baseDir()+'application.html', request, {'forms': forms, 'app': app})
 
+    def isStep(self):
+        return self.program.isUsingStudentApps()
 
     class Meta:
         proxy = True

--- a/esp/esp/program/modules/handlers/studentlunchselection.py
+++ b/esp/esp/program/modules/handlers/studentlunchselection.py
@@ -155,6 +155,9 @@ class StudentLunchSelection(ProgramModuleObj):
 
         return render_to_response(self.baseDir()+'select_lunch.html', request, context)
 
+    def isStep(self):
+        return Event.objects.filter(meeting_times__parent_class__parent_program=self.program, meeting_times__parent_class__category__category='Lunch').exists()
+
     class Meta:
         proxy = True
         app_label = 'modules'

--- a/esp/esp/program/modules/handlers/teachereventsmodule.py
+++ b/esp/esp/program/modules/handlers/teachereventsmodule.py
@@ -205,6 +205,9 @@ class TeacherEventsModule(ProgramModuleObj):
 
         return render_to_response( self.baseDir()+'teacher_events.html', request, context )
 
+    def isStep(self):
+        return Event.objects.filter(program=self.program, event_type__in=self.event_types().values()).exists()
+
     class Meta:
         proxy = True
         app_label = 'modules'

--- a/esp/esp/program/modules/handlers/teacherquizmodule.py
+++ b/esp/esp/program/modules/handlers/teacherquizmodule.py
@@ -153,6 +153,10 @@ class TeacherQuizModule(ProgramModuleObj):
 
         return render_to_response(self.baseDir()+'quiz.html', request, {'prog':prog, 'form': form})
 
+    def isStep(self):
+        custom_form_id = Tag.getProgramTag('quiz_form_id', self.program, None)
+        return custom_form_id and Form.objects.filter(id=int(custom_form_id)).exists()
+
     class Meta:
         proxy = True
         app_label = 'modules'


### PR DESCRIPTION
This adds custom `isStep` functions to a number of teacher and student modules that will effectively hide the modules in registration if they are not set up correctly. For example, if there are no lunch times set up, we shouldn't show the lunch selection module, even if it is enabled. I believe this should cover all of the modules where such a change would be appropriate (although I'd be happy to be proven wrong), except for two: the combined student and teacher custom form handler. As is, a single `isStep` can't be written for this handler since the two modules would be dependent on the existence of different tags. The handler will need to be split in a future PR (see https://github.com/learning-unlimited/ESP-Website/pull/2125).

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3114.