### PR TITLE
Add grant amount/percent fields to finaid approval form

### DIFF
--- a/esp/esp/accounting/models.py
+++ b/esp/esp/accounting/models.py
@@ -141,8 +141,8 @@ class LineItemOptions(models.Model):
 
 class FinancialAidGrant(models.Model):
     request = AjaxForeignKey(FinancialAidRequest)
-    amount_max_dec = models.DecimalField(max_digits=9, decimal_places=2, blank=True, null=True, help_text='Enter a number here to grant a dollar value of financial aid.  The grant will cover this amount or the full cost of the program, whichever is less.')
-    percent = models.PositiveIntegerField(blank=True, null=True, help_text='Enter an integer between 0 and 100 here to grant a certain percentage discount to the program after the above dollar credit is applied.  0 means no additional discount, 100 means no payment required.')
+    amount_max_dec = models.DecimalField(max_digits=9, decimal_places=2, blank=True, null=True, help_text='Enter a number here to grant a dollar value of financial aid.  The grant will cover this amount or the full cost, whichever is less.')
+    percent = models.PositiveIntegerField(blank=True, null=True, help_text='Enter an integer between 0 and 100 here to grant a certain percentage discount after the above dollar credit is applied.  0 means no additional discount, 100 means no payment required.')
     timestamp = models.DateTimeField(auto_now=True)
     finalized = models.BooleanField(default=False, editable=False)
 

--- a/esp/esp/program/modules/handlers/finaidapprovemodule.py
+++ b/esp/esp/program/modules/handlers/finaidapprovemodule.py
@@ -81,7 +81,7 @@ class FinAidApproveModule(ProgramModuleObj):
             userchecklist = request.POST.getlist("user")
             approve_blanks = request.POST.get('approve_blanks', False)
             amount_max_dec = request.POST.get('amount_max_dec', None)
-            percent = request.POST.get('percent', 100)
+            percent = request.POST.get('percent', None)
 
             def is_blank(x):
                 return x is None or x == ""

--- a/esp/esp/program/modules/handlers/finaidapprovemodule.py
+++ b/esp/esp/program/modules/handlers/finaidapprovemodule.py
@@ -36,6 +36,7 @@ Learning Unlimited, Inc.
 from esp.program.modules.base import ProgramModuleObj, needs_admin, main_call
 from esp.utils.web import render_to_response
 from esp.program.models import FinancialAidRequest
+from esp.accounting.models import FinancialAidGrant
 
 
 class FinAidApproveModule(ProgramModuleObj):
@@ -57,9 +58,10 @@ class FinAidApproveModule(ProgramModuleObj):
     @needs_admin
     def finaidapprove(self, request, tl, one, two, module, extra, prog):
         context = {}
-        message = ""
         users_approved = []
         users_error = []
+        context['amount_max_dec_help_text'] = FinancialAidGrant._meta.get_field('amount_max_dec').help_text
+        context['percent_help_text'] = FinancialAidGrant._meta.get_field('percent').help_text
 
         # The following code was copied and modified from finaid_approve.py in useful_scripts
 
@@ -70,16 +72,16 @@ class FinAidApproveModule(ProgramModuleObj):
         # populate the query set cache (whereas if we used .exists() or .count(), they
         # wouldn't, and the later iteration would hit the database again)
         if len(reqs) == 0:
-            message = "No requests found."
-            context["error"] = message
+            context["error"] = "No requests found."
             return render_to_response(self.baseDir()+'finaid.html', request, context)
 
         if request.method == 'POST':
             context['POST'] = True
-
             # ITERATE & APPROVE REQUESTS
             userchecklist = request.POST.getlist("user")
-            approve_blanks = request.POST.get('approve_blanks', False);
+            approve_blanks = request.POST.get('approve_blanks', False)
+            amount_max_dec = request.POST.get('amount_max_dec', None)
+            percent = request.POST.get('percent', 100)
 
             def is_blank(x):
                 return x is None or x == ""
@@ -96,7 +98,7 @@ class FinAidApproveModule(ProgramModuleObj):
                     continue
 
                 try:
-                    req.approve(dollar_amount = None, discount_percent=100)
+                    req.approve(dollar_amount = amount_max_dec, discount_percent = percent)
                     users_approved.append(req.user.name())
                 except:
                     users_error.append(req.user.name())

--- a/esp/templates/program/modules/finaidapprovemodule/finaid.html
+++ b/esp/templates/program/modules/finaidapprovemodule/finaid.html
@@ -81,10 +81,10 @@ function toggle(source) {
     </div>
 
     <label for="amount_max_dec">{{ amount_max_dec_help_text }}</label>
-    <input name="amount_max_dec" type="number" min="0.00" step="0.01" max="2500" value="0.00">
+    <input name="amount_max_dec" type="number" min="0.00" step="0.01" max="2500" value="0.00" required>
     <br />
     <label for="amount_max_dec">{{ percent_help_text }}</label>
-    <input name="percent" type="number" min="0" step="1" max="100" value="100">
+    <input name="percent" type="number" min="0" step="1" max="100" value="100" required>
     <br />
     <input type="submit" value="Approve Requests" class="btn btn-primary" >
     <input type="checkbox" id="approve_blanks_checkbox" name="approve_blanks" checked> Approve blank requests?

--- a/esp/templates/program/modules/finaidapprovemodule/finaid.html
+++ b/esp/templates/program/modules/finaidapprovemodule/finaid.html
@@ -80,8 +80,14 @@ function toggle(source) {
       </table>
     </div>
 
+    <label for="amount_max_dec">{{ amount_max_dec_help_text }}</label>
+    <input name="amount_max_dec" type="number" min="0.00" step="0.01" max="2500" value="0.00">
+    <br />
+    <label for="amount_max_dec">{{ percent_help_text }}</label>
+    <input name="percent" type="number" min="0" step="1" max="100" value="100">
+    <br />
     <input type="submit" value="Approve Requests" class="btn btn-primary" >
-    <input type="checkbox" id="approve_blanks_checkbox" name="approve_blanks" value=True> Approve blank requests?
+    <input type="checkbox" id="approve_blanks_checkbox" name="approve_blanks" checked> Approve blank requests?
   </form>
 
   {% if error %}
@@ -93,7 +99,7 @@ function toggle(source) {
   <h4>
     {{ users_approved|join:", " }}
   </h4>
-  {% else %}
+  {% elif POST %}
   <h3 style="padding-top: 10px;"> 0 New Approvals </h3>
   {% endif %}
 


### PR DESCRIPTION
This adds two new fields to the financial aid request approval form to allow admins to customize the amount of financial aid to grant (as a decimal amount and/or percent amount).

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3102.

![image](https://user-images.githubusercontent.com/7232514/94214756-0e845f00-fea0-11ea-9e70-440e9b18f76f.png)