### PR TITLE
Upgrade pillow to latest that supports python 2.7 (6.2.2)

### DIFF
--- a/esp/requirements.txt
+++ b/esp/requirements.txt
@@ -22,7 +22,7 @@ flake8==2.5.0 # Required for linter
 ipython==3.2.1 # Used for shell_plus
 Markdown==2.3.1 # Used in QSD
 numpy==1.7.1 # Used mainly in the lottery and class change controller
-pillow==3.3.3 # Required for ImageField, which we use in teacher bios
+pillow==6.2.2 # Required for ImageField, which we use in teacher bios
 psycopg2==2.6.1 # Talks to postgres
 pycurl==7.19.5.1 # Used only in mailing labels and a formstack script which I think is outdated
 pydns==2.3.6 # Used for validating email addresses; imports as "DNS", not "pydns"


### PR DESCRIPTION
We can't fix all of the vulnerabilities of pillow (https://github.com/learning-unlimited/ESP-Website/issues/2820) because we can't upgrade to the latest version, since it only supports python 3. For the meantime, we might as well fix some vulnerabilities by upgrading a few versions. I tested the teacher biography module (the only place we use pillow) and it still works fine.