### PR TITLE
Upgrade numpy to 1.16.6

### DIFF
--- a/esp/esp/program/controllers/classchange.py
+++ b/esp/esp/program/controllers/classchange.py
@@ -463,7 +463,7 @@ class ClassChangeController(object):
         except IndexError:
             pass
 
-        self.student_not_checked_in[numpy.transpose(numpy.nonzero(True-self.enroll_orig.any(axis=(1,2))))] = True
+        self.student_not_checked_in[numpy.transpose(numpy.nonzero(~(self.enroll_orig.any(axis=(1,2)))))] = True
 
         #   Populate request matrix
         request_regs = StudentRegistration.objects.filter(self.Q_REQ).values_list('user__id', 'section__id', 'section__meeting_times__id').distinct()
@@ -518,7 +518,7 @@ class ClassChangeController(object):
             self.section_capacities[sec_ind] += numpy.count_nonzero(sec_enroll_orig * any_overlapping_requests)
             # Commit to enrolling students into this section if they were
             # originally in it and they didn't request any overlapping classes
-            self.enroll_final[numpy.transpose(numpy.nonzero(sec_enroll_orig * (True - any_overlapping_requests))), sec_ind, self.section_schedules[sec_ind,:]] = True
+            self.enroll_final[numpy.transpose(numpy.nonzero(sec_enroll_orig * ~(any_overlapping_requests))), sec_ind, self.section_schedules[sec_ind,:]] = True
             self.section_scores[sec_ind] = -self.section_capacities[sec_ind]
             self.section_scores[sec_ind] += numpy.count_nonzero(self.request[:, sec_ind, :].any(axis=1)) # number who want to switch in
         self.section_capacities_orig = numpy.copy(self.section_capacities)
@@ -563,11 +563,11 @@ class ClassChangeController(object):
 
         #   Filter students by who has all of the section's timeslots available
         for [ts_ind,] in timeslots:
-            possible_students *= (True - self.enroll_final[:, :, ts_ind].any(axis=1))
+            possible_students *= ~(self.enroll_final[:, :, ts_ind].any(axis=1))
 
         #   Filter students by who is not already registered for a different section of the class
         for sec_index in numpy.nonzero(self.same_subject[:, si])[0]:
-            possible_students *= (True - self.enroll_final[:, sec_index, :].any(axis=1))
+            possible_students *= ~(self.enroll_final[:, sec_index, :].any(axis=1))
 
         #   Filter students by lunch constraint - if class overlaps with lunch period, student must have 1 additional free spot
         #   NOTE: Currently only works with 2 lunch periods per day
@@ -577,7 +577,7 @@ class ClassChangeController(object):
                 for j in range(self.lunch_timeslots.shape[1]):
                     timeslot_index = self.timeslot_indices[self.lunch_timeslots[lunch_day, j]]
                     if timeslot_index != ts_ind:
-                        possible_students *= (True - self.student_schedules[:, timeslot_index])
+                        possible_students *= ~(self.student_schedules[:, timeslot_index])
 
         candidate_students = numpy.nonzero(possible_students)[0]
         num_spaces = self.section_capacities[si]
@@ -621,7 +621,7 @@ class ClassChangeController(object):
                 # 1-dimensional matrix of whether students are free during the
                 # times of this class section in the enrollment we've computed
                 # so far
-                no_enroll_final = True - self.enroll_final[:,:,self.section_schedules[sec_ind,:]].any(axis=(1,2))
+                no_enroll_final = ~(self.enroll_final[:,:,self.section_schedules[sec_ind,:]].any(axis=(1,2)))
                 # Find students that were originally enrolled in this class and
                 # did not get any classes overlapping it in the enrollment
                 # we've computed so far
@@ -692,8 +692,8 @@ class ClassChangeController(object):
         """ Store lottery assignments in the database once they have been computed.
             This is a fairly time consuming step compared to computing the assignments. """
 
-        assignments = numpy.transpose(numpy.nonzero((self.enroll_final * (True - self.enroll_orig)).any(axis=2)))
-        removals = numpy.transpose(numpy.nonzero((self.enroll_orig * (True - self.enroll_final)).any(axis=2)))
+        assignments = numpy.transpose(numpy.nonzero((self.enroll_final * ~(self.enroll_orig)).any(axis=2)))
+        removals = numpy.transpose(numpy.nonzero((self.enroll_orig * ~(self.enroll_final)).any(axis=2)))
         relationship, created = RegistrationType.objects.get_or_create(name='Enrolled')
 
         for (student_ind,section_ind) in removals:
@@ -741,5 +741,5 @@ class ClassChangeController(object):
         self.extra_headers['Reply-To'] = self.from_email
         for [student_ind] in numpy.transpose(numpy.nonzero(self.changed)):
             self.send_student_email(student_ind, changed = True, for_real = for_real, f = f)
-        for [student_ind] in numpy.transpose(numpy.nonzero(True-self.changed)):
+        for [student_ind] in numpy.transpose(numpy.nonzero(~(self.changed))):
             self.send_student_email(student_ind, changed = False, for_real = for_real, f = f)

--- a/esp/esp/program/controllers/lottery.py
+++ b/esp/esp/program/controllers/lottery.py
@@ -393,11 +393,11 @@ class LotteryAssignmentController(object):
 
         #   Filter students by who has all of the section's timeslots available
         for i in range(timeslots.shape[0]):
-            possible_students *= (True - self.student_schedules[:, timeslots[i]])
+            possible_students *= ~(self.student_schedules[:, timeslots[i]])
 
         #   Filter students by who is not already registered for a different section of the class
         for sec_index in numpy.nonzero(self.section_overlap[:, si])[0]:
-            possible_students *= (True - self.student_sections[:, sec_index])
+            possible_students *= ~(self.student_sections[:, sec_index])
 
         #   Filter students by lunch constraint - if class overlaps with lunch period, student must have 1 additional free spot
         #   NOTE: Currently only works with 2 lunch periods per day
@@ -407,7 +407,7 @@ class LotteryAssignmentController(object):
                 for j in range(self.lunch_timeslots.shape[1]):
                     timeslot_index = self.timeslot_indices[self.lunch_timeslots[lunch_day, j]]
                     if timeslot_index != timeslots[i]:
-                        possible_students *= (True - self.student_schedules[:, timeslot_index])
+                        possible_students *= ~(self.student_schedules[:, timeslot_index])
 
         candidate_students = numpy.nonzero(possible_students)[0]
         if candidate_students.shape[0] <= num_spaces:

--- a/esp/esp/program/controllers/studentregsanity.py
+++ b/esp/esp/program/controllers/studentregsanity.py
@@ -32,9 +32,6 @@ Learning Unlimited, Inc.
   Email: web-team@learningu.org
 """
 
-import numpy
-import numpy.random
-
 from datetime import date, datetime
 import logging
 logger = logging.getLogger(__name__)

--- a/esp/esp/program/modules/handlers/lotteryfrontendmodule.py
+++ b/esp/esp/program/modules/handlers/lotteryfrontendmodule.py
@@ -6,7 +6,6 @@ from esp.program.controllers.lottery import LotteryAssignmentController, Lottery
 from esp.utils.web import render_to_response
 from esp.users.models import ESPUser
 from esp.utils.decorators import json_response
-import numpy
 
 class LotteryFrontendModule(ProgramModuleObj):
 

--- a/esp/esp/program/modules/handlers/schedulingcheckmodule.py
+++ b/esp/esp/program/modules/handlers/schedulingcheckmodule.py
@@ -123,7 +123,6 @@ class SchedulingCheckRunner:
           self.d_grades = []
 
      def _getLunchByDay(self):
-        import numpy
         #   Get IDs of timeslots allocated to lunch by day
         #   (note: requires that this is constant across days)
         lunch_timeslots = Event.objects.filter(meeting_times__parent_class__parent_program=self.p, meeting_times__parent_class__category__category='Lunch').order_by('start').distinct()

--- a/esp/requirements.txt
+++ b/esp/requirements.txt
@@ -21,7 +21,7 @@ docutils==0.12 # Needed for django.contrib.admindocs
 flake8==2.5.0 # Required for linter
 ipython==3.2.1 # Used for shell_plus
 Markdown==2.3.1 # Used in QSD
-numpy==1.16.5 # Used mainly in the lottery and class change controller
+numpy==1.16.6 # Used mainly in the lottery and class change controller
 pillow==6.2.2 # Required for ImageField, which we use in teacher bios
 psycopg2==2.8.6 # Talks to postgres
 pycurl==7.19.5.1 # Used only in mailing labels and a formstack script which I think is outdated

--- a/esp/requirements.txt
+++ b/esp/requirements.txt
@@ -21,7 +21,7 @@ docutils==0.12 # Needed for django.contrib.admindocs
 flake8==2.5.0 # Required for linter
 ipython==3.2.1 # Used for shell_plus
 Markdown==2.3.1 # Used in QSD
-numpy==1.7.1 # Used mainly in the lottery and class change controller
+numpy==1.16.5 # Used mainly in the lottery and class change controller
 pillow==6.2.2 # Required for ImageField, which we use in teacher bios
 psycopg2==2.8.6 # Talks to postgres
 pycurl==7.19.5.1 # Used only in mailing labels and a formstack script which I think is outdated


### PR DESCRIPTION
This upgrades numpy to v. 1.16.6, which is the latest version to support python 2.7. I went through the [release notes](https://numpy.org/doc/stable/release.html) for all of the releases between 1.7 and 1.16.6 to check for any glaring deprecations (we only use a handful of numpy functions almost exclusively in the class change and lottery controllers). None of the functions we currently use have been deprecated or changed in breaking ways. The only breaking change was that boolean subtraction (eww) was deprecated (good riddance). If I understand the way we were using it correctly, we just want the element-wise opposites of the boolean values in the vectors, so `~` should do the trick provided [the values are always boolean](https://stackoverflow.com/questions/13728708/inverting-a-numpy-boolean-array-using). All of the lottery tests run fine, so I think everything should be okay?

I also removed some extraneous imports of numpy where it was never used.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/2403.