### PR TITLE
Fix /manageclass duration error message

### DIFF
--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -1022,7 +1022,7 @@ class Program(models.Model, CustomFormsLinkModel):
                     else:
                         rounded_seconds = durationSeconds
                     if (max_seconds is None) or (durationSeconds <= max_seconds):
-                        durationDict[(Decimal(durationSeconds) / 3600)] = \
+                        durationDict[(Decimal(durationSeconds) / 3600).quantize(Decimal('.01'))] = \
                                         str(rounded_seconds / 3600) + ':' + \
                                         str(int(round((rounded_seconds / 60.0) % 60))).rjust(2,'0')
 


### PR DESCRIPTION
This fixes the error message shown when a class has a duration that is exactly some number of hours. `getDurations()` is only ever used in the manageclass form and the teacher registration forms, and I checked both and there are no errors and both are able to modify the field without any problems.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3127.