### PR TITLE
Don't group timeslots on resources pages

### DIFF
--- a/esp/templates/program/modules/resourcemodule/classroom_import.html
+++ b/esp/templates/program/modules/resourcemodule/classroom_import.html
@@ -52,7 +52,7 @@ You have chosen to import the classrooms from {{ past_program.niceName }} to {{ 
             {{ c.name }}
         </td>
         <td class="underline">{{ c.num_students }}</td>
-        <td class="underline">{% for t in c.timegroup %}{{ t }}<br />{% endfor %}</td>
+        <td class="underline">{% for t in c.timeslots %}{{ t }}<br />{% endfor %}</td>
         {% if import_furnishings %}
         <td class="underline">
             <ol>

--- a/esp/templates/program/modules/resourcemodule/classrooms.html
+++ b/esp/templates/program/modules/resourcemodule/classrooms.html
@@ -73,7 +73,7 @@
                 <a href="/manage/{{ prog.url }}/resources/classroom?op=delete&id={{ c.id }}">[Delete]</a>
         </td>
         <td class="underline">{{ c.num_students }}</td>
-        <td class="underline">{% for t in c.timegroup %}{{ t }}<br />{% endfor %}</td>
+        <td class="underline">{% for t in c.timeslots %}{{ t }}<br />{% endfor %}</td>
         <td class="underline">
             <ol>
             {% for f in c.furnishings %}

--- a/esp/templates/program/modules/resourcemodule/equipment.html
+++ b/esp/templates/program/modules/resourcemodule/equipment.html
@@ -51,7 +51,7 @@
             <td class="underline">{{ r.num_items }}</td>
             <td class="underline">{{ r.res_type.name }}{% if r.res_type.hidden %} (Hidden){% endif %}</td>
             <td class="underline">{{ r.attribute_value }}</td>
-            <td class="underline">{% for t in r.timegroup %}{{ t }}<br />{% endfor %}</td>
+            <td class="underline">{% for t in r.timeslots %}{{ t }}<br />{% endfor %}</td>
         </tr>
     {% endfor %}
     </table></td></tr>

--- a/esp/templates/program/modules/resourcemodule/equipment_import.html
+++ b/esp/templates/program/modules/resourcemodule/equipment_import.html
@@ -48,7 +48,7 @@ You have chosen to import the floating resources from {{ past_program.niceName }
         <td class="underline">{{ r.name }}</td>
         <td class="underline">{{ r.res_type.name }}{% if r.res_type.hidden %} (Hidden){% endif %}</td>
         <td class="underline">{{ r.attribute_value }}</td>
-        <td class="underline">{% for t in r.timegroup %}{{ t }}<br />{% endfor %}</td>
+        <td class="underline">{% for t in r.timeslots %}{{ t }}<br />{% endfor %}</td>
         <td class="underline"><input type="checkbox" name="to_import" value="{{ r.old_id }}" checked></td>
     </tr>
     {% endfor %}


### PR DESCRIPTION
This ungroups the timeslots on the resources pages (specifically for classrooms and equipment/floating resources), so that it's clearer which timeslots (as the column heading says) are available for the resource.

Old: 
![image](https://user-images.githubusercontent.com/7232514/96944528-9b6f0800-14a0-11eb-8beb-77c2e5fefc66.png)
New:
![image](https://user-images.githubusercontent.com/7232514/96944471-78dcef00-14a0-11eb-8a07-dec1caf425b2.png)

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3136.