### PR TITLE
Catch students with invalid grades in phase zero

### DIFF
--- a/esp/templates/program/modules/studentregphasezero/status.html
+++ b/esp/templates/program/modules/studentregphasezero/status.html
@@ -75,6 +75,7 @@ td {
 <center>
 <hr>
 {% if error %}<p><font color="red">{{ error }}</font></p>{% endif %}
+{% if invalid_grades %}<p><font color="red">The following students have invalid grades:</br>{% for student in invalid_grades %}{{ student }}</br>{% endfor %}</font></p>{% endif %}
 {% autoescape off %}
 {% if lottery_messages %}<p><font color="blue">{{ lottery_messages|join:"<br/>" }}</font></p>{% endif %}
 {% endautoescape %}


### PR DESCRIPTION
The phase zero management page would break when a student somehow hadn't filled out their profile. This fixes this and also alerts the admins to which students have invalid grades.

![image](https://user-images.githubusercontent.com/7232514/96946201-4bdf0b00-14a5-11eb-9586-058b2adc5977.png)

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3135.