### PR TITLE
Add tag to adjust date when grades increment

### DIFF
--- a/esp/esp/tagdict/__init__.py
+++ b/esp/esp/tagdict/__init__.py
@@ -450,7 +450,7 @@ all_global_tags = {
         'is_boolean': False,
         'help_text': 'When should students\' grades rollover/increment?',
         'default': datetime.date(datetime.date.today().year, 7, 31),
-        'category': 'manage',
+        'category': 'learn',
         'is_setting': True,
         'field': forms.DateField(widget=forms.SelectDateWidget(years=[datetime.date.today().year]))
     },

--- a/esp/esp/tagdict/__init__.py
+++ b/esp/esp/tagdict/__init__.py
@@ -2,6 +2,7 @@ from django import forms
 from django.forms import widgets
 from django.core.validators import RegexValidator
 from decimal import Decimal
+import datetime
 
 from esp.users.forms import _states
 
@@ -444,6 +445,14 @@ all_global_tags = {
         'default': 'Straight cut, Fitted cut',
         'category': 'manage',
         'is_setting': True,
+    },
+    'grade_increment_date': {
+        'is_boolean': False,
+        'help_text': 'When should students\' grades rollover/increment?',
+        'default': datetime.date(datetime.date.today().year, 7, 31),
+        'category': 'manage',
+        'is_setting': True,
+        'field': forms.DateField(widget=forms.SelectDateWidget(years=[datetime.date.today().year]))
     },
 }
 

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -902,12 +902,13 @@ are a teacher of the class"""
         if now is None:
             now = date.today()
         curyear = now.year
-        # Changed from 6/1 to 5/1 rollover so as not to affect start of Summer HSSP registration
-        # - Michael P 5/24/2010
-        # Changed from 5/1 to 7/31 rollover to as to neither affect registration starts nor occur prior to graduation.
-        # Adam S 8/1/2010
-        #if datetime(curyear, 6, 1) > now:
-        if date(curyear, 7, 31) > now:
+        try:
+            # An error here can cause a good chunk of the site to break,
+            # so we'll just catch this if it fails and fall back on the default
+            d = datetime.strptime(Tag.getTag('grade_increment_date'), '%Y-%m-%d').date().replace(year=curyear)
+        except:
+            d = date(curyear, 7, 31)
+        if d > now:
             schoolyear = curyear
         else:
             schoolyear = curyear + 1

--- a/esp/templates/program/modules/admincore/tags.html
+++ b/esp/templates/program/modules/admincore/tags.html
@@ -6,6 +6,11 @@
     {{ block.super }}
     <link rel="stylesheet" href="/media/styles/forms.css" type="text/css" />
     <link rel="stylesheet" href="/media/styles/expand_display.css" type="text/css" />
+    <style>
+        #id_grade_increment_date_year {
+            display: none;
+        }
+    </style>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
I added a new tag `grade_increment_date` that allows admins to adjust when student grades increment (default is July 31). This can be useful for chapters that have summer programs instead of always setting the `increment_default_grade_levels` tag. I've tested that dates before today maintain grades on the /userview page and dates after today result in grades - 1 on the /userview page, so it appears to be working.

![image](https://user-images.githubusercontent.com/7232514/97650161-172ffe00-1a27-11eb-8d97-4bd01f3068ef.png)

Fixes https://github.com/learning-unlimited/ESP-Website/issues/2392.