### PR TITLE
New user list filters

### DIFF
--- a/esp/esp/program/modules/handlers/commmodule.py
+++ b/esp/esp/program/modules/handlers/commmodule.py
@@ -33,6 +33,7 @@ Learning Unlimited, Inc.
   Email: web-team@learningu.org
 """
 from esp.program.modules.base import ProgramModuleObj, needs_student, needs_admin, main_call, aux_call
+from esp.program.modules.handlers.listgenmodule import ListGenModule
 from esp.utils.web import render_to_response
 from esp.dbmail.models import MessageRequest
 from esp.users.models   import ESPUser, PersistentQueryFilter
@@ -235,25 +236,7 @@ class CommModule(ProgramModuleObj):
         #   If list information was submitted, continue to prepare a message
         if request.method == 'POST':
             #   Turn multi-valued QueryDict into standard dictionary
-            data = {}
-            for key in request.POST:
-                #   Some keys have list values
-                if key in ['regtypes', 'teaching_times', 'teacher_events', 'class_times']:
-                    data[key] = request.POST.getlist(key)
-                elif key == 'target_user':
-                    if request.POST['target_user']:
-                        student_search_form = StudentSearchForm(request.POST)
-                        if student_search_form.is_valid():
-                            student = student_search_form.cleaned_data['target_user']
-                            #   Check that this is a student user
-                            if student.isStudent():
-                                data[key] = student
-                            else:
-                                data[key] = "invalid"
-                    elif request.POST['target_user_raw']:
-                        data[key] = "invalid"
-                else:
-                    data[key] = request.POST[key]
+            data = ListGenModule.processPost(request)
 
             ##  Handle normal list selecting submissions
             if ('base_list' in data and 'recipient_type' in data) or ('combo_base_list' in data):

--- a/esp/esp/program/modules/handlers/commmodule.py
+++ b/esp/esp/program/modules/handlers/commmodule.py
@@ -249,9 +249,10 @@ class CommModule(ProgramModuleObj):
                             if student.isStudent():
                                 data[key] = student
                             else:
-                                context['student_in_class_message'] = '%s %s is not a student' % (
-                                    student.first_name, student.last_name)
+                                data[key] = "invalid"
                             student_search_form = StudentSearchForm(initial={'target_user': student.id})
+                    elif request.POST['target_user_raw']:
+                        data[key] = "invalid"
                 else:
                     data[key] = request.POST[key]
 
@@ -289,8 +290,6 @@ class CommModule(ProgramModuleObj):
             else:
                 raise ESPError('What do I do without knowing what kind of users to look for?', log=True)
         else:
-            if 'user' in request.GET:
-                target_id = request.GET['user']
             student_search_form = StudentSearchForm()
 
         context['student_search_form'] = student_search_form

--- a/esp/esp/program/modules/handlers/commmodule.py
+++ b/esp/esp/program/modules/handlers/commmodule.py
@@ -250,7 +250,6 @@ class CommModule(ProgramModuleObj):
                                 data[key] = student
                             else:
                                 data[key] = "invalid"
-                            student_search_form = StudentSearchForm(initial={'target_user': student.id})
                     elif request.POST['target_user_raw']:
                         data[key] = "invalid"
                 else:

--- a/esp/esp/program/modules/handlers/grouptextmodule.py
+++ b/esp/esp/program/modules/handlers/grouptextmodule.py
@@ -125,7 +125,6 @@ class GroupTextModule(ProgramModuleObj):
                                 data[key] = student
                             else:
                                 data[key] = "invalid"
-                            student_search_form = StudentSearchForm(initial={'target_user': student.id})
                     elif request.POST['target_user_raw']:
                         data[key] = "invalid"
                 else:

--- a/esp/esp/program/modules/handlers/grouptextmodule.py
+++ b/esp/esp/program/modules/handlers/grouptextmodule.py
@@ -124,9 +124,10 @@ class GroupTextModule(ProgramModuleObj):
                             if student.isStudent():
                                 data[key] = student
                             else:
-                                context['student_in_class_message'] = '%s %s is not a student' % (
-                                student.first_name, student.last_name)
+                                data[key] = "invalid"
                             student_search_form = StudentSearchForm(initial={'target_user': student.id})
+                    elif request.POST['target_user_raw']:
+                        data[key] = "invalid"
                 else:
                     data[key] = request.POST[key]
             filterObj = UserSearchController().filter_from_postdata(prog, data)

--- a/esp/esp/program/modules/handlers/grouptextmodule.py
+++ b/esp/esp/program/modules/handlers/grouptextmodule.py
@@ -33,6 +33,7 @@ Learning Unlimited, Inc.
   Email: web-team@learningu.org
 """
 from esp.program.modules.base import ProgramModuleObj, needs_student, needs_admin, main_call, aux_call
+from esp.program.modules.handlers.listgenmodule import ListGenModule
 from esp.utils.web import render_to_response
 from esp.users.models   import ESPUser, PersistentQueryFilter, ContactInfo
 from esp.users.controllers.usersearch import UserSearchController
@@ -110,25 +111,7 @@ class GroupTextModule(ProgramModuleObj):
         context['program'] = prog
 
         if request.method == "POST":
-            data = {}
-            for key in request.POST:
-                #   Some keys have list values
-                if key in ['regtypes', 'teaching_times', 'teacher_events', 'class_times']:
-                    data[key] = request.POST.getlist(key)
-                elif key == 'target_user':
-                    if request.POST['target_user']:
-                        student_search_form = StudentSearchForm(request.POST)
-                        if student_search_form.is_valid():
-                            student = student_search_form.cleaned_data['target_user']
-                            #   Check that this is a student user
-                            if student.isStudent():
-                                data[key] = student
-                            else:
-                                data[key] = "invalid"
-                    elif request.POST['target_user_raw']:
-                        data[key] = "invalid"
-                else:
-                    data[key] = request.POST[key]
+            data = ListGenModule.processPost(request)
             filterObj = UserSearchController().filter_from_postdata(prog, data)
 
             context['filterid'] = filterObj.id

--- a/esp/esp/program/modules/handlers/listgenmodule.py
+++ b/esp/esp/program/modules/handlers/listgenmodule.py
@@ -398,7 +398,6 @@ class ListGenModule(ProgramModuleObj):
                                 data[key] = student
                             else:
                                 data[key] = "invalid"
-                            student_search_form = StudentSearchForm(initial={'target_user': student.id})
                     elif request.POST['target_user_raw']:
                         data[key] = "invalid"
                 else:

--- a/esp/esp/program/modules/handlers/listgenmodule.py
+++ b/esp/esp/program/modules/handlers/listgenmodule.py
@@ -397,9 +397,10 @@ class ListGenModule(ProgramModuleObj):
                             if student.isStudent():
                                 data[key] = student
                             else:
-                                context['student_in_class_message'] = '%s %s is not a student' % (
-                                student.first_name, student.last_name)
+                                data[key] = "invalid"
                             student_search_form = StudentSearchForm(initial={'target_user': student.id})
+                    elif request.POST['target_user_raw']:
+                        data[key] = "invalid"
                 else:
                     data[key] = request.POST[key]
             filterObj = usc.filter_from_postdata(prog, data)

--- a/esp/esp/users/controllers/usersearch.py
+++ b/esp/esp/users/controllers/usersearch.py
@@ -46,8 +46,6 @@ from django.contrib.auth.models import Group
 
 import collections
 import re
-import operator
-
 
 class UserSearchController(object):
 

--- a/esp/esp/users/controllers/usersearch.py
+++ b/esp/esp/users/controllers/usersearch.py
@@ -35,7 +35,7 @@ from collections import defaultdict
 from esp.users.models import ESPUser, ZipCode, PersistentQueryFilter, Record
 from esp.middleware import ESPError
 from esp.utils.web import render_to_response
-from esp.program.models import Program, RegistrationType, StudentRegistration, ClassSubject
+from esp.program.models import Program, RegistrationType, StudentRegistration
 from esp.dbmail.models import MessageRequest
 from esp.utils.query_utils import nest_Q
 from esp.cal.models import EventType

--- a/esp/esp/users/controllers/usersearch.py
+++ b/esp/esp/users/controllers/usersearch.py
@@ -109,7 +109,6 @@ class UserSearchController(object):
 
             if 'class_times' in criteria:
                 class_times = criteria['class_times']
-                print(class_times)
                 if 'regtypes' in criteria:
                     student_verbs = criteria['regtypes']
                 else:

--- a/esp/esp/users/controllers/usersearch.py
+++ b/esp/esp/users/controllers/usersearch.py
@@ -231,7 +231,9 @@ class UserSearchController(object):
 
             if 'target_user' in criteria:
                 student_id = criteria['target_user']
-                if student_id:
+                if student_id == "invalid":
+                    raise ESPError('Please select a valid student whose teachers to email.', log=False)
+                else:
                     sections = [sr.section for sr in StudentRegistration.valid_objects().filter(user_id=student_id, relationship__name="Enrolled", section__parent_class__parent_program=program)]
                     if len(sections):
                         teacher_filter = Q(classsubject__sections__in=sections)

--- a/esp/esp/users/controllers/usersearch.py
+++ b/esp/esp/users/controllers/usersearch.py
@@ -109,25 +109,23 @@ class UserSearchController(object):
 
             if 'class_times' in criteria:
                 class_times = criteria['class_times']
+                print(class_times)
                 if 'regtypes' in criteria:
                     student_verbs = criteria['regtypes']
                 else:
                     student_verbs = ['Enrolled']
-                times_filter = reduce(operator.or_, (Q(studentregistration__section__meeting_times__in=time, studentregistration__relationship__name__in=student_verbs)
-                                                     & nest_Q(StudentRegistration.is_valid_qobject(), 'studentregistration') for time in class_times))
-                Q_include &= times_filter
+                Q_include &= Q(studentregistration__section__meeting_times__id__in=class_times, studentregistration__relationship__name__in=student_verbs) \
+                             & nest_Q(StudentRegistration.is_valid_qobject(), 'studentregistration')
                 self.updated = True
 
             if 'teaching_times' in criteria:
                 teaching_times = criteria['teaching_times']
-                times_filter = reduce(operator.or_, (Q(classsubject__sections__meeting_times__in=time) for time in teaching_times))
-                Q_include &= times_filter
+                Q_include &= Q(classsubject__sections__meeting_times__id__in=teaching_times)
                 self.updated = True
 
             if 'teacher_events' in criteria:
                 teacher_events = criteria['teacher_events']
-                events_filter = reduce(operator.or_, (Q(useravailability__event=event) for event in teacher_events))
-                Q_include &= events_filter
+                Q_include &= Q(useravailability__event__id__in=teacher_events)
                 self.updated = True
 
             if 'group' in criteria and criteria['group'] != "":

--- a/esp/esp/users/controllers/usersearch.py
+++ b/esp/esp/users/controllers/usersearch.py
@@ -35,9 +35,10 @@ from collections import defaultdict
 from esp.users.models import ESPUser, ZipCode, PersistentQueryFilter, Record
 from esp.middleware import ESPError
 from esp.utils.web import render_to_response
-from esp.program.models import Program, RegistrationType, StudentRegistration
+from esp.program.models import Program, RegistrationType, StudentRegistration, ClassSubject
 from esp.dbmail.models import MessageRequest
 from esp.utils.query_utils import nest_Q
+from esp.cal.models import EventType
 
 from django.db.models import Count
 from django.db.models.query import Q
@@ -45,6 +46,8 @@ from django.contrib.auth.models import Group
 
 import collections
 import re
+import operator
+
 
 class UserSearchController(object):
 
@@ -54,10 +57,10 @@ class UserSearchController(object):
     def __init__(self, *args, **kwargs):
         self.updated = False
 
-    def filter_from_criteria(self, base_list, criteria):
-        return base_list.filter(self.query_from_criteria('any', criteria)).distinct()
+    def filter_from_criteria(self, base_list, criteria, program=None):
+        return base_list.filter(self.query_from_criteria('any', criteria, program)).distinct()
 
-    def query_from_criteria(self, user_type, criteria):
+    def query_from_criteria(self, user_type, criteria, program=None):
 
         """ Get the "base list" consisting of all the users of a specific type. """
         if user_type.lower() == 'any':
@@ -103,6 +106,29 @@ class UserSearchController(object):
                     student_verbs = ['Enrolled']
                 Q_include &= Q(studentregistration__section__parent_class__id__in=clsid,
                                studentregistration__relationship__name__in=student_verbs) & nest_Q(StudentRegistration.is_valid_qobject(), 'studentregistration')
+
+            if 'class_times' in criteria:
+                class_times = criteria['class_times']
+                if 'regtypes' in criteria:
+                    student_verbs = criteria['regtypes']
+                else:
+                    student_verbs = ['Enrolled']
+                times_filter = reduce(operator.or_, (Q(studentregistration__section__meeting_times__in=time, studentregistration__relationship__name__in=student_verbs)
+                                                     & nest_Q(StudentRegistration.is_valid_qobject(), 'studentregistration') for time in class_times))
+                Q_include &= times_filter
+                self.updated = True
+
+            if 'teaching_times' in criteria:
+                teaching_times = criteria['teaching_times']
+                times_filter = reduce(operator.or_, (Q(classsubject__sections__meeting_times__in=time) for time in teaching_times))
+                Q_include &= times_filter
+                self.updated = True
+
+            if 'teacher_events' in criteria:
+                teacher_events = criteria['teacher_events']
+                events_filter = reduce(operator.or_, (Q(useravailability__event=event) for event in teacher_events))
+                Q_include &= events_filter
+                self.updated = True
 
             if 'group' in criteria and criteria['group'] != "":
                 group = criteria['group']
@@ -184,6 +210,36 @@ class UserSearchController(object):
                 Q_include &= Q(registrationprofile__teacher_info__graduation_year__in = map(str, possible_gradyears), registrationprofile__most_recent_profile=True)
                 self.updated = True
 
+            if 'hours_min' in criteria or 'hours_max' in criteria:
+                current_Q = Q_base & (Q_include & ~Q_exclude)
+                user_hours = {user.id: (sum([section.meeting_times.count() for section in user.getEnrolledSections(program)])) for user in ESPUser.objects.filter(current_Q)}
+                exclude_user_list = []
+                if 'hours_min' in criteria:
+                    hours_min = criteria['hours_min']
+                    if hours_min:
+                        for user, hours in user_hours.items():
+                            if hours < int(hours_min):
+                                exclude_user_list.append(user)
+                if 'hours_max' in criteria:
+                    hours_max = criteria['hours_max']
+                    if hours_max:
+                        for user, hours in user_hours.items():
+                            if hours > int(hours_max):
+                                exclude_user_list.append(user)
+                Q_exclude &= Q(id__in=exclude_user_list)
+                self.updated = True
+
+            if 'target_user' in criteria:
+                student_id = criteria['target_user']
+                if student_id:
+                    sections = [sr.section for sr in StudentRegistration.valid_objects().filter(user_id=student_id, relationship__name="Enrolled", section__parent_class__parent_program=program)]
+                    if len(sections):
+                        teacher_filter = Q(classsubject__sections__in=sections)
+                    else:
+                        teacher_filter = Q(classsubject__sections__in=sections)
+                    Q_include &= teacher_filter
+                    self.updated = True
+
         return Q_base & (Q_include & ~Q_exclude)
 
     def query_from_postdata(self, program, data):
@@ -217,7 +273,7 @@ class UserSearchController(object):
                     recipient_type = 'any'
 
             #   Get the user-specific part of the query (e.g. ID, name, school)
-            q_extra = self.query_from_criteria(recipient_type, data)
+            q_extra = self.query_from_criteria(recipient_type, data, program)
 
         ##  Handle "combination list" submissions
         elif 'combo_base_list' in data:
@@ -295,7 +351,7 @@ class UserSearchController(object):
                         q_program = q_program | ~qobject
 
             #   Get the user-specific part of the query (e.g. ID, name, school)
-            q_extra = self.query_from_criteria(recipient_type, data)
+            q_extra = self.query_from_criteria(recipient_type, data, program)
 
         qobject = (q_extra & q_program & Q(is_active=True))
 
@@ -381,6 +437,8 @@ class UserSearchController(object):
         context['action_path'] = target_path
         context['groups'] = Group.objects.all()
         context['regtypes'] = RegistrationType.objects.all().order_by("name")
+        context['class_times'] = program.getTimeSlots(types = [EventType.get_from_desc('Class Time Block')]).order_by('start')
+        context['teacher_events'] = program.getTimeSlots(types = [EventType.get_from_desc('Teacher Training'), EventType.get_from_desc('Teacher Interview')]).order_by('start')
 
         return context
 

--- a/esp/public/media/scripts/commpanel.js
+++ b/esp/public/media/scripts/commpanel.js
@@ -106,7 +106,7 @@ function clear_filters(form_name)
 {
     //  Remove any existing data in the "user filtering options" part of a comm panel form
     var form = $j("#"+form_name)[0];
-    field_names = ["userid", "username", "first_name", "last_name", "email", "zipcode", "zipdistance", "zipdistance_exclude", "states", "school", "grade_min", "grade_max", "gradyear_min", "gradyear_max", "group", "clsid", "regtypes"];
+    field_names = ["userid", "username", "first_name", "last_name", "email", "zipcode", "zipdistance", "zipdistance_exclude", "states", "school", "grade_min", "grade_max", "gradyear_min", "gradyear_max", "group", "clsid", "regtypes", "hours_min", "hours_max", "teaching_times", "teacher_events", "class_times", "target_user"];
     for (var i = 0; i < field_names.length; i++)
     {
         var form_field = $j(form).find(':input[name=' + field_names[i] + ']')[0];

--- a/esp/templates/users/usersearch/list_selector.html
+++ b/esp/templates/users/usersearch/list_selector.html
@@ -1,3 +1,9 @@
+<script>
+$j(document).ready(function() {
+    $j("#id_target_user").removeClass("span6");
+});
+</script>
+
 <div id="list_descriptions" class="commpanel_hidden">
 {% for kv in lists.items %}{% for item in kv.1 %}
 <div id="list_description_{{ item.name }}">{{ item.description }}</div>
@@ -129,11 +135,44 @@
                 <h4 class="student"><a href="#">Class Registrations</a></h4>
                 <div>Enter class ID number: <input type="text" size="6" name="clsid" id="clsid" /> <br />
                 <small>(Can be a comma-separated list)</small> <br /><br />
+                Select class time(s): <select name="class_times" id="class_times" multiple>
+                    {% for class_time in class_times %}
+                    <option value="{{ class_time.id }}">{{ class_time }}</option>
+                    {% endfor %}
+                </select><br /><br />
+                <small>(Can enter either class ID(s) or class time(s) or both)</small><br /><br />
                 Select registration type(s): <select name="regtypes" id="regtypes" multiple>
                     {% for regtype in regtypes %}
                     <option {% if regtype.description %}title="{{ regtype.description }}" {% endif %}value="{{ regtype.name }}"{% if regtype.name == "Enrolled" %} selected{% endif %}>{{ regtype }}</option>
                     {% endfor %}
                 </select></div>
+
+                <h4 class="teacher"><a href="#">Teaching Times</a></h4>
+                <div>Select timeslot(s): <select name="teaching_times" id="teaching_times" multiple>
+                    {% for teaching_time in class_times %}
+                    <option  value="{{ teaching_time.id }}">{{ teaching_time }}</option>
+                    {% endfor %}
+                </select></div>
+
+                <h4 class="teacher"><a href="#">Teacher Events</a></h4>
+                <div>Select timeslot(s): <select name="teacher_events" id="teacher_events" multiple>
+                    {% for event in teacher_events %}
+                    <option value="{{ event.id }}">{{ event }}</option>
+                    {% endfor %}
+                </select></div>
+
+                <h4 class="student"><a href="#">Number of enrolled class blocks</a></h4>
+                <div>
+                Min number: <input type="text" size="3" name="hours_min" value="" /><br />
+                Max number: <input type="text" size="3" name="hours_max" value="" />
+                </div>
+
+                <h4 class="teacher"><a href="#">Student enrolled in class</a></h4>
+                <div>
+                <form id="student_in_class" name="student_in_class" method="POST" action="{{ request.path }}">
+                    {{ student_search_form }}
+                </form>
+                </div>
 
             </div>
 
@@ -269,11 +308,44 @@
                 <h4><a href="#">Class Registrations</a></h4>
                 <div>Enter class ID number: <input type="text" size="6" name="clsid" id="clsid" /> <br />
                 <small>(Can be a comma-separated list)</small> <br /><br />
+                Select class time(s): <select name="class_times" id="class_times" multiple>
+                    {% for class_time in class_times %}
+                    <option value="{{ class_time.id }}">{{ class_time }}</option>
+                    {% endfor %}
+                </select><br /><br />
+                <small>(Can enter either class ID(s) or class time(s) or both)</small><br /><br />
                 Select registration type(s): <select name="regtypes" id="regtypes" multiple>
                     {% for regtype in regtypes %}
                     <option {% if regtype.description %}title="{{ regtype.description }}" {% endif %}value="{{ regtype.name }}"{% if regtype.name == "Enrolled" %} selected{% endif %}>{{ regtype }}</option>
                     {% endfor %}
                 </select></div>
+
+                <h4 class="teacher"><a href="#">Teaching Times</a></h4>
+                <div>Select timeslot(s): <select name="teaching_times" id="teaching_times" multiple>
+                    {% for teaching_time in class_times %}
+                    <option value="{{ teaching_time.id }}">{{ teaching_time }}</option>
+                    {% endfor %}
+                </select></div>
+
+                <h4 class="teacher"><a href="#">Teacher Events</a></h4>
+                <div>Select timeslot(s): <select name="teacher_events" id="teacher_events" multiple>
+                    {% for event in teacher_events %}
+                    <option value="{{ event.id }}">{{ event }}</option>
+                    {% endfor %}
+                </select></div>
+
+                <h4 class="student"><a href="#">Number of enrolled class blocks</a></h4>
+                <div>
+                Min number: <input type="text" size="3" name="hours_min" value="" /><br />
+                Max number: <input type="text" size="3" name="hours_max" value="" />
+                </div>
+
+                <h4 class="teacher"><a href="#">Student enrolled in class</a></h4>
+                <div>
+                <form id="student_in_class" name="student_in_class" method="POST" action="{{ request.path }}">
+                    {{ student_search_form }}
+                </form>
+                </div>
 
             </div>
 

--- a/esp/templates/users/usersearch/list_selector.html
+++ b/esp/templates/users/usersearch/list_selector.html
@@ -98,7 +98,7 @@ $j(document).ready(function() {
                 <div>Enter a portion of the email address: <input type="text" size="30" name="email" id="email" /> <br />
                 <small>(Supports regular expressions)</small></div>
 
-                <h4 class="any"><a href="#">Zip Code</a></h4>
+                <h4 class="any"><a href="#">Zip code</a></h4>
                 <div>
                     Center of region: <input type="text" size="5" name="zipcode" value="02139" /> <br />
                     Minimum distance: <input type="text" size="4" name="zipdistance_exclude" value="" /> miles <br />
@@ -118,13 +118,13 @@ $j(document).ready(function() {
                 Max Grade: <input type="text" size="3" name="grade_max" value="" />
                 </div>
 
-                <h4 class="teacher"><a href="#">Graduation Year</a></h4>
+                <h4 class="teacher"><a href="#">Graduation year</a></h4>
                 <div>
                 Min: <input type="text" size="3" name="gradyear_min" value="" /> <br />
                 Max: <input type="text" size="3" name="gradyear_max" value="" />
                 </div>
 
-                <h4 class="any"><a href="#">User Group</a></h4>
+                <h4 class="any"><a href="#">User group</a></h4>
                 <div><select name="group" id="user-search-group">
                     {% for group in groups %}
                     <option value="{{ group.id }}">{{ group.name }}</option>
@@ -132,7 +132,7 @@ $j(document).ready(function() {
                     <option value="" selected hidden></option>
                 </select></div>
 
-                <h4 class="student"><a href="#">Class Registrations</a></h4>
+                <h4 class="student"><a href="#">Class registrations</a></h4>
                 <div>Enter class ID number: <input type="text" size="6" name="clsid" id="clsid" /> <br />
                 <small>(Can be a comma-separated list)</small> <br /><br />
                 Select class time(s): <select name="class_times" id="class_times" multiple>
@@ -147,14 +147,14 @@ $j(document).ready(function() {
                     {% endfor %}
                 </select></div>
 
-                <h4 class="teacher"><a href="#">Teaching Times</a></h4>
+                <h4 class="teacher"><a href="#">Teaching times</a></h4>
                 <div>Select timeslot(s): <select name="teaching_times" id="teaching_times" multiple>
                     {% for teaching_time in class_times %}
                     <option  value="{{ teaching_time.id }}">{{ teaching_time }}</option>
                     {% endfor %}
                 </select></div>
 
-                <h4 class="teacher"><a href="#">Teacher Events</a></h4>
+                <h4 class="teacher"><a href="#">Teacher events</a></h4>
                 <div>Select timeslot(s): <select name="teacher_events" id="teacher_events" multiple>
                     {% for event in teacher_events %}
                     <option value="{{ event.id }}">{{ event }}</option>
@@ -271,7 +271,7 @@ $j(document).ready(function() {
                 <div>Enter a portion of the email address: <input type="text" size="30" name="email" id="email" /> <br />
                 <small>(Supports regular expressions)</small></div>
 
-                <h4><a href="#">Zip Code</a></h4>
+                <h4><a href="#">Zip code</a></h4>
                 <div>
                     Center of region: <input type="text" size="5" name="zipcode" value="02139" /> <br />
                     Minimum distance: <input type="text" size="4" name="zipdistance_exclude" value="" /> miles <br />
@@ -291,13 +291,13 @@ $j(document).ready(function() {
                 Max Grade: <input type="text" size="3" name="grade_max" value="" />
                 </div>
 
-                <h4><a href="#">Graduation Year</a></h4>
+                <h4><a href="#">Graduation year</a></h4>
                 <div>
                 Min: <input type="text" size="3" name="gradyear_min" value="" /> <br />
                 Max: <input type="text" size="3" name="gradyear_max" value="" />
                 </div>
 
-                <h4><a href="#">User Group</a></h4>
+                <h4><a href="#">User group</a></h4>
                 <div><select name="group" id="user-search-group">
                     {% for group in groups %}
                     <option value="{{ group.id }}">{{ group.name }}</option>
@@ -305,7 +305,7 @@ $j(document).ready(function() {
                     <option value="" selected hidden></option>
                 </select></div>
 
-                <h4><a href="#">Class Registrations</a></h4>
+                <h4><a href="#">Class registrations</a></h4>
                 <div>Enter class ID number: <input type="text" size="6" name="clsid" id="clsid" /> <br />
                 <small>(Can be a comma-separated list)</small> <br /><br />
                 Select class time(s): <select name="class_times" id="class_times" multiple>
@@ -320,14 +320,14 @@ $j(document).ready(function() {
                     {% endfor %}
                 </select></div>
 
-                <h4 class="teacher"><a href="#">Teaching Times</a></h4>
+                <h4 class="teacher"><a href="#">Teaching times</a></h4>
                 <div>Select timeslot(s): <select name="teaching_times" id="teaching_times" multiple>
                     {% for teaching_time in class_times %}
                     <option value="{{ teaching_time.id }}">{{ teaching_time }}</option>
                     {% endfor %}
                 </select></div>
 
-                <h4 class="teacher"><a href="#">Teacher Events</a></h4>
+                <h4 class="teacher"><a href="#">Teacher events</a></h4>
                 <div>Select timeslot(s): <select name="teacher_events" id="teacher_events" multiple>
                     {% for event in teacher_events %}
                     <option value="{{ event.id }}">{{ event }}</option>

--- a/esp/templates/users/usersearch/list_selector.html
+++ b/esp/templates/users/usersearch/list_selector.html
@@ -167,7 +167,7 @@ $j(document).ready(function() {
                 Max number: <input type="text" size="3" name="hours_max" value="" />
                 </div>
 
-                <h4 class="teacher"><a href="#">Student enrolled in class</a></h4>
+                <h4 class="teacher"><a href="#">Teachers of a student</a></h4>
                 <div>
                 <form id="student_in_class" name="student_in_class" method="POST" action="{{ request.path }}">
                     {{ student_search_form }}
@@ -340,7 +340,7 @@ $j(document).ready(function() {
                 Max number: <input type="text" size="3" name="hours_max" value="" />
                 </div>
 
-                <h4 class="teacher"><a href="#">Student enrolled in class</a></h4>
+                <h4 class="teacher"><a href="#">Teachers of a student</a></h4>
                 <div>
                 <form id="student_in_class" name="student_in_class" method="POST" action="{{ request.path }}">
                     {{ student_search_form }}


### PR DESCRIPTION
Fixes #46 and fixes #2376. 

This creates user list (list gen, comm panel, and group text) filters for:
- number of class hours of a student
- class times of a student
- teaching times of a teacher
- training/interview times of a teacher
- teachers of a particular student

Since you can now select teaching times of a teacher, this also solves the "filter for second day teachers" because you can select all the relevant time blocks for the 2nd day. 

Note that I did not test the group text panel as I don't have it set up, but it is the same as the comm panel and list gen, both of which I did test.