### PR TITLE
Add missing method to creditcardmodule

### DIFF
--- a/esp/esp/program/modules/handlers/creditcardmodule_stripe.py
+++ b/esp/esp/program/modules/handlers/creditcardmodule_stripe.py
@@ -82,6 +82,11 @@ class CreditCardModule_Stripe(ProgramModuleObj):
     def get_setting(self, name, default=None):
         return self.apply_settings().get(name, default)
 
+    def line_item_type(self):
+        pac = ProgramAccountingController(self.program)
+        (donate_type, created) = pac.get_lineitemtypes().get_or_create(program=self.program, text=self.get_setting('donation_text'))
+        return donate_type
+
     def isCompleted(self):
         """ Whether the user has paid for this program or its parent program. """
         return IndividualAccountingController(self.program, get_current_request().user).has_paid()


### PR DESCRIPTION
Unfortunately it looks like #1528 had a missing method, breaking the credit card payment. I added it here and tested that it fixes the problem.

The error, reported by Yale, was:

File "/lu/sites/yale/esp/esp/program/modules/handlers/creditcardmodule_stripe.py", line 224, in charge_payment

AttributeError: 'CreditCardModule_Stripe' object has no attribute 'line_item_type'