### PR TITLE
Fix big board lottery preferences count

### DIFF
--- a/esp/esp/program/modules/handlers/bigboardmodule.py
+++ b/esp/esp/program/modules/handlers/bigboardmodule.py
@@ -149,6 +149,8 @@ class BigBoardModule(ProgramModuleObj):
     @cache_function_for(105)
     def num_prefs(self, prog):
         num_srs = StudentRegistration.valid_objects().filter(
+            Q(relationship__name='Interested') |
+            Q(relationship__name__contains='Priority/'),
             section__parent_class__parent_program=prog).count()
         return num_srs + self.num_ssis(prog)
 


### PR DESCRIPTION
Before, we were counting all valid (unexpired) student registrations (oops). Now, we only count student registrations created by the class lottery or two-phase lottery modules.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3148.