### PR TITLE
Add account management page

### DIFF
--- a/esp/esp/themes/theme_data/bigpicture/templates/users/loginbox_content.html
+++ b/esp/esp/themes/theme_data/bigpicture/templates/users/loginbox_content.html
@@ -13,8 +13,7 @@
           &#9662;
         </button>
         <ul class="dropdown-menu pull-right">
-          <li><a href="/myesp/passwd/">Change Password</a></li>
-          <li><a href="/myesp/profile/">Profile</a></li>
+          <li><a href="/myesp/accountmanage/">Manage Account</a></li>
           <li><a href="/myesp/loginhelp.html">Help</a></li>
           <li><a href="https://www.learningu.org/about/privacy/" target="_blank">Privacy Policy</a></li>
         </ul>

--- a/esp/esp/themes/theme_data/circles/templates/users/loginbox_content.html
+++ b/esp/esp/themes/theme_data/circles/templates/users/loginbox_content.html
@@ -17,6 +17,8 @@
     <div class="unmorph hidden">
        <br /><a href="/myesp/switchback/">Unmorph to <script type="text/javascript">document.write(esp_user.cur_retTitle);</script></a><br /><div id="unmorph_text"></div>
     </div>
+    <a href="/myesp/accountmanage/">Manage Account</a>
+    <br/>
     <a href="/myesp/signout/">Logout</a>
     <br/>
     <a href="https://www.learningu.org/about/privacy/" target="_blank">Privacy Policy</a>

--- a/esp/esp/themes/theme_data/fruitsalad/templates/main.html
+++ b/esp/esp/themes/theme_data/fruitsalad/templates/main.html
@@ -149,7 +149,7 @@ var currentPrograms = [
 </div>
 <div class="logged_in hidden">
   {% include "users/loginbox_userinfo.html" %}
-  <span class="accentcolor"><a href="/myesp/signout/">Logout</a> | <a href="/myesp/accountmanage.html">My Profile</a></span>
+  <span class="accentcolor"><a href="/myesp/signout/">Logout</a> | <a href="/myesp/accountmanage">Manage Account</a></span>
 </div>
 
 </div>

--- a/esp/esp/users/urls.py
+++ b/esp/esp/users/urls.py
@@ -38,6 +38,7 @@ urlpatterns += [
     url(r'^switchback/?$', myesp.myesp_switchback),
     url(r'^onsite/?$', myesp.myesp_onsite),
     url(r'^passwd/?$', myesp.myesp_passwd),
+    url(r'^accountmanage/?$', myesp.myesp_accountmanage),
     url(r'^profile/?$', myesp.edit_profile),
 ]
 

--- a/esp/esp/web/views/myesp.py
+++ b/esp/esp/web/views/myesp.py
@@ -72,6 +72,10 @@ def myesp_passwd(request):
                                                     'Success': False})
 
 @login_required
+def myesp_accountmanage(request):
+    return render_to_response('users/account_manage.html', request, {})
+
+@login_required
 def myesp_switchback(request):
     user = request.user
     user.updateOnsite(request)

--- a/esp/templates/users/account_manage.html
+++ b/esp/templates/users/account_manage.html
@@ -1,0 +1,34 @@
+{% extends "main.html" %}
+
+{% block title %}Change Account Password{% endblock %}
+
+{% block stylesheets %}
+{{ block.super }}
+<style>
+.nav a {
+    text-decoration: none !important;
+}
+.nav {
+    width: 50%;
+}
+</style>
+{% endblock %}
+
+{% block content %}
+<h1>Manage Your Account</h1>
+{% load render_qsd %}
+{% inline_qsd_block "contact_password_recovery_check" %}
+<p>You can do the following things with your account:</p>
+<center>
+<ul class="nav nav-tabs nav-stacked">
+<li><a href="/myesp/profile" title="Edit your profile">Edit your profile</a></li>
+<li><a href="/myesp/passwd" title="Change your password">Change your password</a></li>
+<li><a href="/myesp/disableaccount" title="Disable your account">Disable your account</a></li>
+</ul>
+</center>
+<p>Please note, if you disable your account, you will no longer receive email and/or mail notifications from us.</p>
+{% end_inline_qsd_block %}
+
+<p>By creating an account, you agreed to the <a href="https://www.learningu.org/about/tos/" target="_blank">terms of service</a>
+  set forth by Learning Unlimited, the umbrella organization of which we are a member.</p>
+{% endblock %}

--- a/esp/templates/users/loginbox_content.html
+++ b/esp/templates/users/loginbox_content.html
@@ -21,8 +21,7 @@
           </button>
 
           <ul class="dropdown-menu">
-            <li><a href="/myesp/passwd/">Change Password</a></li>
-            <li><a href="/myesp/profile/">Profile</a></li>
+            <li><a href="/myesp/accountmanage/">Manage Account</a></li>
             <li><a href="/myesp/loginhelp.html">Help</a></li>
             <li><a href="https://www.learningu.org/about/privacy/" target="_blank">Privacy Policy</a></li>
           </ul>


### PR DESCRIPTION
This adds a uniform account management page to all themes (previously only the fruitsalad theme alluded to a QSD page that didn't even exist by default). I've added a new view at /myesp/accountmanage with a QSD section and the privacy policy:

![image](https://user-images.githubusercontent.com/7232514/99020753-e40c6500-2524-11eb-8c5e-55bcc0f8d3eb.png)

I've also modified the login links for the various themes to link to this new page instead of the profile/password/etc pages.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/352 and fixes https://github.com/learning-unlimited/ESP-Website/issues/353