### PR TITLE
Add autorefresh button to scheduling checks page

### DIFF
--- a/esp/public/media/default_styles/scheduling_checks.css
+++ b/esp/public/media/default_styles/scheduling_checks.css
@@ -113,3 +113,14 @@ table {
 .alittlepspace {
 	padding-top: 8px;
 }
+
+input[name="refresh_interval"] {
+    width: 40px;
+    float: right;
+    margin-right: 10px;
+}
+
+button[name="refresh"] {
+    float: right;
+    margin-right: 10px;
+}

--- a/esp/public/media/scripts/program/modules/scheduling_checks.jsx
+++ b/esp/public/media/scripts/program/modules/scheduling_checks.jsx
@@ -1,3 +1,40 @@
+var auto_running = false;
+var myInterval;
+
+$j(function(){
+    function refreshAll() {
+        if (auto_running) {
+            console.log("boop");
+            $j("button.refresh-button").click();
+            // Allow for updating fresh interval while the refresh is already running
+            myInterval = setTimeout(refreshAll, $j("[name=refresh_interval]").val() * 1000);
+        }
+    }
+    $j("[name=refresh]").click(function() {
+        if (auto_running) {
+            auto_running = false;
+            // Change button class and text
+            $j(this).addClass("btn-success");
+            $j(this).removeClass("btn-danger");
+            $j(this).html("Start Auto Refresh");
+            
+            // Stop autorefreshing
+            console.log("autorefresh stopping");
+            clearTimeout(myInterval);
+        } else {
+            auto_running = true;
+            // Change button class and text
+            $j(this).addClass("btn-danger");
+            $j(this).removeClass("btn-success");
+            $j(this).html("Stop Auto Refresh");
+            
+            // Start autorefreshing
+            console.log("autorefresh starting");
+            refreshAll()
+        }
+    });
+});
+
 /**
  * List of scheduling checks.
  *

--- a/esp/public/media/scripts/program/modules/scheduling_checks.jsx
+++ b/esp/public/media/scripts/program/modules/scheduling_checks.jsx
@@ -4,7 +4,6 @@ var myInterval;
 $j(function(){
     function refreshAll() {
         if (auto_running) {
-            console.log("boop");
             $j("button.refresh-button").click();
             // Allow for updating fresh interval while the refresh is already running
             myInterval = setTimeout(refreshAll, $j("[name=refresh_interval]").val() * 1000);
@@ -19,7 +18,6 @@ $j(function(){
             $j(this).html("Start Auto Refresh");
             
             // Stop autorefreshing
-            console.log("autorefresh stopping");
             clearTimeout(myInterval);
         } else {
             auto_running = true;
@@ -29,7 +27,6 @@ $j(function(){
             $j(this).html("Stop Auto Refresh");
             
             // Start autorefreshing
-            console.log("autorefresh starting");
             refreshAll()
         }
     });

--- a/esp/templates/program/modules/schedulingcheckmodule/output.html
+++ b/esp/templates/program/modules/schedulingcheckmodule/output.html
@@ -38,6 +38,7 @@ function updateDocs(docs) {
     <p>Clicking "Include unreviewed classes" will show all classes in the diagnostic.</p>
     <br></div>
 <a class="btn move_left" href="scheduling_checks{% if unreviewed %}">Exclude{% else %}?unreviewed">Include{% endif %} unreviewed classes</a>
+<button class="btn btn-success" name="refresh">Start Auto Refresh</button><input type="number" min="5" name="refresh_interval" title="(Refresh interval in seconds)" value=30>
 
 <div id="scheduling-check-wrapper" />
 <script type="text/jsx">


### PR DESCRIPTION
This adds a button to the scheduling checks page that, when clicked, causes all of the checks to refresh at some interval that is specified by the user (default is 30 seconds). When you click the button again, the refreshing stops.

![image](https://user-images.githubusercontent.com/7232514/101926698-26af7480-3b99-11eb-97cf-324f6539fdd8.png)

![image](https://user-images.githubusercontent.com/7232514/101926838-58284000-3b99-11eb-9c96-fa7f9aee40ea.png)
(My dev server was turned off when I took these screenshots, hence the failed loading)

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3175.