### PR TITLE
Attendance-over-time chart

### DIFF
--- a/esp/esp/program/modules/handlers/bigboardmodule.py
+++ b/esp/esp/program/modules/handlers/bigboardmodule.py
@@ -62,8 +62,8 @@ class BigBoardModule(ProgramModuleObj):
         numbers = [(desc, num) for desc, num in numbers if num]
 
         timess = [
-            ("completed the medical form", [(1, time) for time in self.times_medical(prog)]),
-            ("signed up for classes", [(1, time) for time in self.times_classes(prog)]),
+            ("completed the medical form", [(1, time) for time in self.times_medical(prog)], True),
+            ("signed up for classes", [(1, time) for time in self.times_classes(prog)], True),
         ]
 
         timess_data, start = self.make_graph_data(timess, 4, 0, 5)
@@ -240,12 +240,12 @@ class BigBoardModule(ProgramModuleObj):
         return sorted(ssi_times_dict.itervalues())
 
     @staticmethod
-    def chunk_times(times, start, end, delta=datetime.timedelta(0, 3600)):
+    def chunk_times(times, start, end, delta=datetime.timedelta(0, 3600), cumulative = True):
         """Given a list of times, return hourly summaries.
 
         `times` should be a list of tuples, sorted by time, containing some metric (duration, capacity, etc.) and datetime.datetime objects
-        `start` and `end` should be datetimes; the chunks will be for hours
-        between them, inclusive.
+        `start` and `end` should be datetimes; the chunks will be for hours between them, inclusive.
+        `cumulative` should be a boolean determining whether counts should be summed cumulatively for conseculative hours or if they should only be summed within individual hours
         Returns a list of integers, each of which is the number of times that
         precede the given hour.
         """
@@ -266,13 +266,15 @@ class BigBoardModule(ProgramModuleObj):
                 # times preceding it for the previous hour.
                 chunks.append(float(count))
                 start += delta
+                if not cumulative:
+                    count = 0
         return chunks
 
     @staticmethod
     def make_graph_data(timess, drop_beg = 0, drop_end = 0, cutoff = 1):
         """Given a list of time series, return graph data series.
 
-        `timess` should be a list of pairs (description, sorted tuples of metrics and datetime.datetime objects).
+        `timess` should be a list of tuples (description, sorted tuples of metrics and datetime.datetime objects, whether counts should be cumulative).
         `drop_beg` should be a number of items to drop from the beginning of each list
         `drop_end` should be a number of items to drop from the end of each list
         `cutoff` should be the minimum number of items that must exist in a time series
@@ -280,22 +282,22 @@ class BigBoardModule(ProgramModuleObj):
         Returns a dict of cleaned time series and the start time for graphing
         """
         #Remove any time series without at least 'cutoff' times
-        timess = [(desc, times) for desc, times in timess if len(times) >= cutoff]
+        timess = [(desc, times, cumulative) for desc, times, cumulative in timess if len(times) >= cutoff]
         # Drop the first and last times if specified
         # Then round start down and end up to the nearest day.
         if not timess:
             graph_data = []
             start = None
         else:
-            start = min([times[drop_beg:(len(times)-drop_end)][0][1] for desc, times in timess])
+            start = min([times[drop_beg:(len(times)-drop_end)][0][1] for desc, times, cumulative in timess])
             start = start.replace(hour=0, minute=0, second=0, microsecond=0)
-            end = max([times[drop_beg:(len(times)-drop_end)][-1][1] for desc, times in timess])
+            end = max([times[drop_beg:(len(times)-drop_end)][-1][1] for desc, times, cumulative in timess])
             end = end.replace(hour=0, minute=0, second=0, microsecond=0)
             end += datetime.timedelta(1)
             end = min(end, datetime.datetime.now())
             graph_data = [{"description": desc,
-                           "data": BigBoardModule.chunk_times(times, start, end)}
-                          for desc, times in timess]
+                           "data": BigBoardModule.chunk_times(times, start, end, cumulative = cumulative)}
+                          for desc, times, cumulative in timess]
         return graph_data, start
 
     # runs in 9ms, so don't bother caching

--- a/esp/esp/program/modules/handlers/onsiteattendance.py
+++ b/esp/esp/program/modules/handlers/onsiteattendance.py
@@ -161,7 +161,6 @@ class OnSiteAttendance(ProgramModuleObj):
             # For classes that are multiple hours, we want to count a student for
             # each hour starting from when they are marked and ending at the end of the class
             # Also, for multi-week programs (e.g. Sprout), we want to adjust the start and end times based on the attendance sr
-            sec = sr.section
             start_time = sr.start_date.replace(minute = 0, second = 0, microsecond = 0)
             end_time = sr.section.end_time().end.replace(
                 year = sr.start_date.year, month = sr.start_date.month, day = sr.start_date.day,

--- a/esp/esp/program/modules/handlers/studentregphasezeromanage.py
+++ b/esp/esp/program/modules/handlers/studentregphasezeromanage.py
@@ -140,7 +140,7 @@ class StudentRegPhaseZeroManage(ProgramModuleObj):
         context['grade_caps'] = sorted(prog.grade_caps().iteritems())
 
         recs = PhaseZeroRecord.objects.filter(program=prog).order_by('time')
-        timess = [("number of lottery students", [(rec.user.count(), rec.time) for rec in recs])]
+        timess = [("number of lottery students", [(rec.user.count(), rec.time) for rec in recs], True)]
         timess_data, start = BigBoardModule.make_graph_data(timess)
         context["left_axis_data"] = [{"axis_name": "#", "series_data": timess_data}]
         context["first_hour"] = start

--- a/esp/esp/program/modules/handlers/teacherbigboardmodule.py
+++ b/esp/esp/program/modules/handlers/teacherbigboardmodule.py
@@ -76,10 +76,10 @@ class TeacherBigBoardModule(ProgramModuleObj):
             start = self.mindate
         else:
             timess = [
-                ("number of registered classes", [(1, time) for time in self.reg_classes(prog)]),
-                ("number of approved classes", [(1, time) for time in self.reg_classes(prog, True)]),
-                ("number of teachers registered", [(1, time) for time in self.teach_times(prog)]),
-                ("number of teachers approved", [(1, time) for time in self.teach_times(prog, True)]),
+                ("number of registered classes", [(1, time) for time in self.reg_classes(prog)], True),
+                ("number of approved classes", [(1, time) for time in self.reg_classes(prog, True)], True),
+                ("number of teachers registered", [(1, time) for time in self.teach_times(prog)], True),
+                ("number of teachers approved", [(1, time) for time in self.teach_times(prog, True)], True),
             ]
 
             timess_data, start = BigBoardModule.make_graph_data(timess)
@@ -88,14 +88,14 @@ class TeacherBigBoardModule(ProgramModuleObj):
             class_hours_approved, student_hours_approved = self.get_hours(prog, approved = True)
 
             class_hourss = [
-                ("number of registered class-hours", class_hours),
-                ("number of approved class-hours", class_hours_approved),
+                ("number of registered class-hours", class_hours, True),
+                ("number of approved class-hours", class_hours_approved, True),
             ]
             class_hourss_data, _ = BigBoardModule.make_graph_data(class_hourss)
 
             student_hourss = [
-                ("number of registered class-student-hours", student_hours),
-                ("number of approved class-student-hours", student_hours_approved),
+                ("number of registered class-student-hours", student_hours, True),
+                ("number of approved class-student-hours", student_hours_approved, True),
             ]
             student_hourss_data, _ = BigBoardModule.make_graph_data(student_hourss)
 

--- a/esp/templates/program/modules/onsiteattendance/attendance.html
+++ b/esp/templates/program/modules/onsiteattendance/attendance.html
@@ -11,12 +11,21 @@
         table-layout: fixed;
         overflow-wrap: break-word;
     }
+    #highcharts-placeholder {
+        width: 100%;
+        height: 250px;
+    }
     </style>
 {% endblock %}
 
 {% block xtrajs %}
     {{ block.super }}
     <script src="/media/scripts/sorttable.js"></script>
+    {% if not timeslot %}
+        <script type="text/javascript" src="//code.highcharts.com/highcharts.js"></script>
+        <script type="text/javascript" src="//code.highcharts.com/highcharts-more.js"></script>
+        <script type="text/javascript" src="//code.highcharts.com/modules/no-data-to-display.js"></script>
+    {% endif %}
 {% endblock %}
 
 {% block content %}
@@ -68,6 +77,8 @@ or select a timeslot from the dropdown below to see attendance stats:
     </form>
     <br />
     <a class="btn" href="/onsite/{{ one }}/{{ two }}/section_attendance/{{ timeslot.id }}">See or record section attendance{% if timeslot %} for this timeslot{% endif %}</a>
+    {% else %}
+        {% include "program/modules/bigboardmodule/bigboard_graph.html" %}
     {% endif %}
     <br /><br />
 </center>


### PR DESCRIPTION
This adds a plot of program and class attendance over time (by the hour) to the onsite attendance landing page. I've tested it with multi-hour classes and multi-week programs and it seems to work properly.

![image](https://user-images.githubusercontent.com/7232514/103370218-d9d10680-4a91-11eb-9382-dcd5254f351b.png)

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3177.