### PR TITLE
Fullwidth fix

### DIFF
--- a/esp/public/media/default_styles/survey_manage.css
+++ b/esp/public/media/default_styles/survey_manage.css
@@ -1,7 +1,3 @@
-.fullwidth {
-    width: 100%
-}
-
 .selector {
     border-bottom: solid 5px #ccc;
 }

--- a/esp/public/media/theme_editor/less/main.less
+++ b/esp/public/media/theme_editor/less/main.less
@@ -9,3 +9,6 @@ input[type="radio"] + label, input[type="checkbox"] + label {
     display: inline;
 }
 
+.fullwidth { 
+    width: 100%;
+}

--- a/esp/templates/program/modules/studentregtwophase/studentregtwophase.html
+++ b/esp/templates/program/modules/studentregtwophase/studentregtwophase.html
@@ -95,7 +95,7 @@ recommend you have at least {{num_star}} classes starred for every priority slot
 </p>
 {% end_inline_program_qsd_block %}
 <div id="program_form">
-<table cellpadding="3" style="width:100%;" class="fullwidth">
+<table cellpadding="3" class="fullwidth">
 <tr>
     <th colspan="3">
     Classes for {{request.user.first_name}} {{request.user.last_name}} - ID: {{request.user.id}}

--- a/esp/templates/program/modules/teacherpreviewmodule/preview.html
+++ b/esp/templates/program/modules/teacherpreviewmodule/preview.html
@@ -8,7 +8,7 @@
 {% render_inline_program_qsd program "teach:teacherpreview" %}
 
 <div id="catalog">
-  <table align="center" cellpadding="0" cellspacing="0" class="fullwidth" style="width: 100%; text-align: center">
+  <table align="center" cellpadding="0" cellspacing="0" class="fullwidth" style="text-align: center">
     <tr>
         <th align="center"><h2>Classes Already Registered</h2></th>
     </tr>


### PR DESCRIPTION
This adds CSS for all themes for the "fullwidth" class (this was previously only included in the fruitsalad theme but the class is used in lots of places). I then removed any fixes that had been implemented for one-off instances.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3178. 