### PR TITLE
Add more multiprogram statistics queries

### DIFF
--- a/esp/esp/program/forms.py
+++ b/esp/esp/program/forms.py
@@ -180,6 +180,7 @@ class StatisticsQueryForm(forms.Form):
         ('hours', 'How many hours of class did the students take and when?'),
         ('student_reg', 'How many students registered?'),
         ('teacher_reg', 'How many teachers registered?'),
+        ('class_reg', 'How many classes were registered by teachers?'),
         #   (other queries here)
     )
 
@@ -238,8 +239,8 @@ class StatisticsQueryForm(forms.Form):
     program_instance_all = forms.BooleanField(required=False, initial=True, widget=forms.CheckboxInput(), label='Search All Instances?', help_text='Uncheck to select specific instances')
     program_instances = forms.MultipleChoiceField(required=False, choices=((None, ''),), widget=forms.SelectMultiple(), label='Instance(s) of Program')  #   Choices will be replaced by Ajax request if necessary
 
-    student_reg_types = forms.MultipleChoiceField(choices=student_reg_categories, widget=forms.SelectMultiple(), initial='classreg', label='Registration Categories')
-    teacher_reg_types = forms.MultipleChoiceField(choices=teacher_reg_categories, widget=forms.SelectMultiple(), initial='class_approved', label='Registration Categories')
+    student_reg_types = forms.MultipleChoiceField(required=False, choices=student_reg_categories, widget=forms.SelectMultiple(), label='Registration Categories', help_text='Leaving this blank will select all students')
+    teacher_reg_types = forms.MultipleChoiceField(required=False, choices=teacher_reg_categories, widget=forms.SelectMultiple(), label='Registration Categories', help_text='Leaving this blank will select all teachers')
 
     school_query_type = forms.ChoiceField(choices=(('all', 'Match any school'), ('name', 'Enter partial school name')), initial='all', widget=forms.RadioSelect(), label='School Query Type')
     school_name = forms.CharField(required=False, widget=forms.TextInput(), label='[Partial] School Name')
@@ -378,12 +379,15 @@ class StatisticsQueryForm(forms.Form):
         if 'query' not in data or data['query'] not in ['zipcodes', 'heardabout', 'schools']:
             self.hide_field('limit')
 
-        #   Hide fields that don't apply to teachers
-        if 'query' in data and data['query'] in ['teacher_reg']:
+        if 'query' in data and data['query'] in ['teacher_reg', 'class_reg']:
+            #   Hide fields that don't apply to teachers
             self.hide_field('student_reg_types')
+            self.disable_field('student_reg_types')
             self.hide_field('school_query_type')
         else:
+            #   Hide fields that don't apply to students
             self.hide_field('teacher_reg_types')
+            self.disable_field('teacher_reg_types')
 
     @staticmethod
     def get_multiselect_fields():

--- a/esp/esp/program/forms.py
+++ b/esp/esp/program/forms.py
@@ -239,8 +239,10 @@ class StatisticsQueryForm(forms.Form):
     program_instance_all = forms.BooleanField(required=False, initial=True, widget=forms.CheckboxInput(), label='Search All Instances?', help_text='Uncheck to select specific instances')
     program_instances = forms.MultipleChoiceField(required=False, choices=((None, ''),), widget=forms.SelectMultiple(), label='Instance(s) of Program')  #   Choices will be replaced by Ajax request if necessary
 
-    student_reg_types = forms.MultipleChoiceField(required=False, choices=student_reg_categories, widget=forms.SelectMultiple(), label='Registration Categories', help_text='Leaving this blank will select all students')
-    teacher_reg_types = forms.MultipleChoiceField(required=False, choices=teacher_reg_categories, widget=forms.SelectMultiple(), label='Registration Categories', help_text='Leaving this blank will select all teachers')
+    student_reg_type_all = forms.BooleanField(required=False, initial=True, widget=forms.CheckboxInput(), label='Search All Students?', help_text='Uncheck to select student registration type(s)')
+    student_reg_types = forms.MultipleChoiceField(required=False, choices=student_reg_categories, widget=forms.SelectMultiple(), label='Registration Categories')
+    teacher_reg_type_all = forms.BooleanField(required=False, initial=True, widget=forms.CheckboxInput(), label='Search All Teachers?', help_text='Uncheck to select teacher registration type(s)')
+    teacher_reg_types = forms.MultipleChoiceField(required=False, choices=teacher_reg_categories, widget=forms.SelectMultiple(), label='Registration Categories')
 
     school_query_type = forms.ChoiceField(choices=(('all', 'Match any school'), ('name', 'Enter partial school name')), initial='all', widget=forms.RadioSelect(), label='School Query Type')
     school_name = forms.CharField(required=False, widget=forms.TextInput(), label='[Partial] School Name')
@@ -382,12 +384,16 @@ class StatisticsQueryForm(forms.Form):
         if 'query' in data and data['query'] in ['teacher_reg', 'class_reg']:
             #   Hide fields that don't apply to teachers
             self.hide_field('student_reg_types')
-            self.disable_field('student_reg_types')
             self.hide_field('school_query_type')
+            self.hide_field('student_reg_type_all')
+            if 'teacher_reg_type_all' in data and data['teacher_reg_type_all']:
+                self.hide_field('teacher_reg_types')
         else:
             #   Hide fields that don't apply to students
             self.hide_field('teacher_reg_types')
-            self.disable_field('teacher_reg_types')
+            self.hide_field('teacher_reg_type_all')
+            if 'student_reg_type_all' in data and data['student_reg_type_all']:
+                self.hide_field('student_reg_types')
 
     @staticmethod
     def get_multiselect_fields():

--- a/esp/esp/program/forms.py
+++ b/esp/esp/program/forms.py
@@ -178,17 +178,27 @@ class StatisticsQueryForm(forms.Form):
         ('repeats', 'What other programs have the students attended?'),
         ('heardabout', 'How did the students hear about the program?'),
         ('hours', 'How many hours of class did the students take and when?'),
-        #   Not yet implemented
-        #   ('classes', 'What were the most and least popular classes?'),
+        ('student_reg', 'How many students registered?'),
+        ('teacher_reg', 'How many teachers registered?'),
         #   (other queries here)
     )
 
     #   Keys into the program.students() dictionary (and descriptions)
-    reg_categories = (
+    student_reg_categories = (
+        ('student_profile', 'Created a profile'),
         ('confirmed', 'Confirmed registration'),
         ('attended', 'Marked as attended on the Web site'),
         ('classreg', 'Registered for at least one class'),
         ('student_survey', 'Completed the online survey'),
+    )
+
+    #   Keys into the program.students() dictionary (and descriptions)
+    teacher_reg_categories = (
+        ('teacher_profile', 'Created a profile'),
+        ('class_proposed', 'Proposed a class'),
+        ('class_approved', 'Had a class approved'),
+        ('class_rejected', 'Had a class rejected'),
+        ('teacher_survey', 'Completed the online survey'),
     )
 
     @staticmethod
@@ -228,7 +238,8 @@ class StatisticsQueryForm(forms.Form):
     program_instance_all = forms.BooleanField(required=False, initial=True, widget=forms.CheckboxInput(), label='Search All Instances?', help_text='Uncheck to select specific instances')
     program_instances = forms.MultipleChoiceField(required=False, choices=((None, ''),), widget=forms.SelectMultiple(), label='Instance(s) of Program')  #   Choices will be replaced by Ajax request if necessary
 
-    reg_types = forms.MultipleChoiceField(choices=reg_categories, widget=forms.SelectMultiple(), initial=['classreg'], label='Registration Categories')
+    student_reg_types = forms.MultipleChoiceField(choices=student_reg_categories, widget=forms.SelectMultiple(), initial='classreg', label='Registration Categories')
+    teacher_reg_types = forms.MultipleChoiceField(choices=teacher_reg_categories, widget=forms.SelectMultiple(), initial='class_approved', label='Registration Categories')
 
     school_query_type = forms.ChoiceField(choices=(('all', 'Match any school'), ('name', 'Enter partial school name')), initial='all', widget=forms.RadioSelect(), label='School Query Type')
     school_name = forms.CharField(required=False, widget=forms.TextInput(), label='[Partial] School Name')
@@ -329,7 +340,6 @@ class StatisticsQueryForm(forms.Form):
             if hasattr(self, 'initial'):
                 data.update(self.initial)
 
-
         #   Program selection
         if 'program_type_all' in data and data['program_type_all']:
             self.hide_field('program_type')
@@ -367,6 +377,13 @@ class StatisticsQueryForm(forms.Form):
         #   Limit queries
         if 'query' not in data or data['query'] not in ['zipcodes', 'heardabout', 'schools']:
             self.hide_field('limit')
+
+        #   Hide fields that don't apply to teachers
+        if 'query' in data and data['query'] in ['teacher_reg']:
+            self.hide_field('student_reg_types')
+            self.hide_field('school_query_type')
+        else:
+            self.hide_field('teacher_reg_types')
 
     @staticmethod
     def get_multiselect_fields():

--- a/esp/esp/program/forms.py
+++ b/esp/esp/program/forms.py
@@ -224,15 +224,15 @@ class StatisticsQueryForm(forms.Form):
     limit = forms.IntegerField(required=False, min_value=0, widget=forms.TextInput(), help_text='Limit number of aggregate results to display (leave blank or enter 0 to display all results)')
 
     program_type_all = forms.BooleanField(required=False, initial=False, widget=forms.CheckboxInput(), label='Search All Programs?', help_text='Uncheck to select a program type')
-    program_type = forms.ChoiceField(required=False, choices=((None, ''),), widget=forms.Select(), help_text='Type of Program')
+    program_type = forms.ChoiceField(required=False, choices=((None, ''),), widget=forms.Select())
     program_instance_all = forms.BooleanField(required=False, initial=True, widget=forms.CheckboxInput(), label='Search All Instances?', help_text='Uncheck to select specific instances')
-    program_instances = forms.MultipleChoiceField(required=False, choices=((None, ''),), widget=forms.SelectMultiple(), label='Instance[s] of Program')  #   Choices will be replaced by Ajax request if necessary
+    program_instances = forms.MultipleChoiceField(required=False, choices=((None, ''),), widget=forms.SelectMultiple(), label='Instance(s) of Program')  #   Choices will be replaced by Ajax request if necessary
 
     reg_types = forms.MultipleChoiceField(choices=reg_categories, widget=forms.SelectMultiple(), initial=['classreg'], label='Registration Categories')
 
-    school_query_type = forms.ChoiceField(choices=(('all', 'Match any school'), ('name', 'Enter partial school name'), ('list', 'Select school[s] from list')), initial='all', widget=forms.RadioSelect(), label='School Query Type')
+    school_query_type = forms.ChoiceField(choices=(('all', 'Match any school'), ('name', 'Enter partial school name'), ('list', 'Select school(s) from list')), initial='all', widget=forms.RadioSelect(), label='School Query Type')
     school_name = forms.CharField(required=False, widget=forms.TextInput(), label='[Partial] School Name')
-    school_multisel = forms.MultipleChoiceField(required=False, choices=(), widget=forms.SelectMultiple(), label='School[s]', help_text='Hold down Ctrl to select more than one')
+    school_multisel = forms.MultipleChoiceField(required=False, choices=(), widget=forms.SelectMultiple(), label='School(s)', help_text='Hold down Ctrl to select more than one')
 
     zip_query_type = forms.ChoiceField(choices=(('all', 'Any Zip code'), ('exact', 'Exact match'), ('partial', 'Partial match'), ('distance', 'Distance from Zip code')), initial='all', widget=forms.RadioSelect(), label='Zip Code Query Type')
     zip_code = forms.CharField(required=False, widget=forms.TextInput())

--- a/esp/esp/program/forms.py
+++ b/esp/esp/program/forms.py
@@ -230,7 +230,7 @@ class StatisticsQueryForm(forms.Form):
 
     reg_types = forms.MultipleChoiceField(choices=reg_categories, widget=forms.SelectMultiple(), initial=['classreg'], label='Registration Categories')
 
-    school_query_type = forms.ChoiceField(choices=(('all', 'Match any school'), ('name', 'Enter partial school name'), ('list', 'Select school(s) from list')), initial='all', widget=forms.RadioSelect(), label='School Query Type')
+    school_query_type = forms.ChoiceField(choices=(('all', 'Match any school'), ('name', 'Enter partial school name')), initial='all', widget=forms.RadioSelect(), label='School Query Type')
     school_name = forms.CharField(required=False, widget=forms.TextInput(), label='[Partial] School Name')
     school_multisel = forms.MultipleChoiceField(required=False, choices=(), widget=forms.SelectMultiple(), label='School(s)', help_text='Hold down Ctrl to select more than one')
 
@@ -249,8 +249,10 @@ class StatisticsQueryForm(forms.Form):
         self.fields['program_type'].choices = StatisticsQueryForm.get_program_type_choices()
         self.fields['program_instances'].choices = StatisticsQueryForm.get_program_instance_choices(self.fields['program_type'].choices[0][0])
 
-        #   This will be done later if they ask
-        #   self.fields['school_multisel'].choices = StatisticsQueryForm.get_school_choices()
+        school_choices = StatisticsQueryForm.get_school_choices()
+        if len(school_choices) > 0:
+            self.fields['school_query_type'].choices.append(('list', 'Select school(s) from list'))
+            self.fields['school_multisel'].choices = school_choices
 
     def clean(self):
         """ Check that either 'All Programs' is selected or a program is selected   """

--- a/esp/esp/program/forms.py
+++ b/esp/esp/program/forms.py
@@ -234,9 +234,9 @@ class StatisticsQueryForm(forms.Form):
     query = forms.ChoiceField(choices=stats_questions, widget=forms.Select(), help_text='What question would you like to ask?')
     limit = forms.IntegerField(required=False, min_value=0, widget=forms.TextInput(), help_text='Limit number of aggregate results to display (leave blank or enter 0 to display all results)')
 
-    program_type_all = forms.BooleanField(required=False, initial=False, widget=forms.CheckboxInput(), label='Search All Programs?', help_text='Uncheck to select a program type')
+    program_type_all = forms.BooleanField(required=False, initial=False, widget=forms.CheckboxInput(), label='Search All Programs?', help_text='Uncheck to select program type(s)')
     program_type = forms.ChoiceField(required=False, choices=((None, ''),), widget=forms.Select())
-    program_instance_all = forms.BooleanField(required=False, initial=True, widget=forms.CheckboxInput(), label='Search All Instances?', help_text='Uncheck to select specific instances')
+    program_instance_all = forms.BooleanField(required=False, initial=True, widget=forms.CheckboxInput(), label='Search All Instances?', help_text='Uncheck to select specific instance(s)')
     program_instances = forms.MultipleChoiceField(required=False, choices=((None, ''),), widget=forms.SelectMultiple(), label='Instance(s) of Program')  #   Choices will be replaced by Ajax request if necessary
 
     student_reg_type_all = forms.BooleanField(required=False, initial=True, widget=forms.CheckboxInput(), label='Search All Students?', help_text='Uncheck to select student registration type(s)')

--- a/esp/esp/program/modules/handlers/bigboardmodule.py
+++ b/esp/esp/program/modules/handlers/bigboardmodule.py
@@ -88,7 +88,7 @@ class BigBoardModule(ProgramModuleObj):
     # bunch if multiple admins are loading the page, but short enough that each
     # time the page refreshes for the same admin, they will get new numbers
 
-    @staticmethod
+    @cache_function_for(105)
     def users_enrolled(prog):
         # Querying for SRs and then extracting the users saves us joining the
         # users table.
@@ -96,12 +96,13 @@ class BigBoardModule(ProgramModuleObj):
             section__parent_class__parent_program=prog,
             relationship__name='Enrolled'
         ).values_list('user', flat = True).distinct()
+    users_enrolled = staticmethod(users_enrolled)
 
     @cache_function_for(105)
     def num_users_enrolled(self, prog):
         return self.users_enrolled(prog).count()
 
-    @staticmethod
+    @cache_function_for(105)
     def users_with_lottery(prog):
         # Past empirical observation has shown that doing the union in SQL is
         # much, much slower for unknown reasons; it also means we would have to
@@ -118,6 +119,7 @@ class BigBoardModule(ProgramModuleObj):
                 section__parent_class__parent_program=prog)
             .values_list('user', flat = True).distinct())
         return users_with_ssis | users_with_srs
+    users_with_lottery = staticmethod(users_with_lottery)
 
     @cache_function_for(105)
     def num_users_with_lottery(self, prog):
@@ -167,9 +169,10 @@ class BigBoardModule(ProgramModuleObj):
         return Record.objects.filter(program=prog,
                                      event__in=['med', 'med_bypass']).count()
 
-    @staticmethod
+    @cache_function_for(105)
     def checked_in_users(prog):
         return Record.objects.filter(program=prog, event='attended').values_list('user', flat = True).distinct()
+    checked_in_users = staticmethod(checked_in_users)
 
     @cache_function_for(105)
     def num_checked_in_users(self, prog):

--- a/esp/esp/program/modules/handlers/teacherbigboardmodule.py
+++ b/esp/esp/program/modules/handlers/teacherbigboardmodule.py
@@ -182,11 +182,10 @@ class TeacherBigBoardModule(ProgramModuleObj):
 
     @cache_function_for(105)
     def get_hours(prog, approved = False, teachers = None):
-        hours = ClassSubject.objects.filter(get_filter(prog, approved, teachers)
+        classes = ClassSubject.objects.filter(get_filter(prog, approved, teachers)
         ).annotate(num_sections=Count('sections')).filter(num_sections__gt=0
-        ).exclude(category__category__iexact="Lunch"
-        ).values_list('timestamp','class_size_max'
-        ).annotate(duration=Sum('sections__duration'))
+        ).exclude(category__category__iexact="Lunch")
+        hours = [[cls.timestamp, cls.class_size_max, sum([sec.duration for sec in cls.get_sections()])] for cls in classes]
         # use mindate if a class is missing a timestamp so we can still calculate static stats
         sorted_hours = sorted(hours, key=lambda x:x[0] or mindate)
         class_hours = [(hour[2],hour[0]) for hour in sorted_hours]

--- a/esp/esp/program/modules/handlers/teacherbigboardmodule.py
+++ b/esp/esp/program/modules/handlers/teacherbigboardmodule.py
@@ -1,7 +1,7 @@
 import datetime
 import subprocess
 
-from django.db.models.aggregates import Min, Sum
+from django.db.models.aggregates import Min
 from django.db.models.query import Q
 from django.db.models import Count
 

--- a/esp/esp/program/modules/handlers/teacherbigboardmodule.py
+++ b/esp/esp/program/modules/handlers/teacherbigboardmodule.py
@@ -13,11 +13,16 @@ from esp.utils.decorators import cached_module_view
 from esp.utils.web import render_to_response
 from esp.program.modules.handlers.bigboardmodule import BigBoardModule
 
-def get_filter(prog, approved):
+def get_filter(prog, approved, teachers = None):
     filt = Q(parent_program=prog)
     if approved:
         filt &= Q(status__gt=0, sections__status__gt=0)
+    if teachers:
+        filt &= Q(teachers__in=teachers)
     return filt
+
+# this is the date we added timestamps
+mindate = datetime.datetime(2016, 1, 30)
 
 class TeacherBigBoardModule(ProgramModuleObj):
 
@@ -78,7 +83,7 @@ class TeacherBigBoardModule(ProgramModuleObj):
             timess_data = []
             class_hourss_data = []
             student_hourss_data = []
-            start = self.mindate
+            start = mindate
         else:
             timess = [
                 ("number of registered classes", [(1, time) for time in self.reg_classes(prog)], True),
@@ -128,21 +133,15 @@ class TeacherBigBoardModule(ProgramModuleObj):
     # bunch if multiple admins are loading the page, but short enough that each
     # time the page refreshes for the same admin, they will get new numbers
 
-    # this is the date we added timestamps
-    mindate = datetime.datetime(2016, 1, 30)
-
-    @staticmethod
-    def teachers_teaching(prog, approved = False):
+    @cache_function_for(105)
+    def num_teachers_teaching(prog, approved = False, teachers = None):
         # Querying for SRs and then extracting the users saves us joining the
         # users table.
-        return ClassSubject.objects.filter(get_filter(prog, approved)
-        ).exclude(category__category__iexact="Lunch"
-        ).exclude(teachers=None
-        ).values_list('teachers', flat = True).distinct()
-
-    @cache_function_for(105)
-    def num_teachers_teaching(self, prog, approved = False):
-        return self.teachers_teaching(prog, approved).count()
+        return ClassSubject.objects.filter(get_filter(prog, approved, teachers)
+            ).exclude(category__category__iexact="Lunch"
+            ).exclude(teachers=None
+            ).values_list('teachers', flat = True).distinct().count()
+    num_teachers_teaching = staticmethod(num_teachers_teaching)
 
     @cache_function_for(105)
     def num_active_users(self, prog, minutes=10):
@@ -161,9 +160,10 @@ class TeacherBigBoardModule(ProgramModuleObj):
             time__day=now.day).count()
 
     @cache_function_for(105)
-    def num_class_reg(self, prog, approved = False):
-        return ClassSubject.objects.filter(get_filter(prog, approved)
+    def num_class_reg(prog, approved = False, teachers = None):
+        return ClassSubject.objects.filter(get_filter(prog, approved, teachers)
         ).exclude(category__category__iexact="Lunch").distinct().count()
+    num_class_reg = staticmethod(num_class_reg)
 
     @cache_function_for(105)
     def reg_classes(self, prog, approved = False):
@@ -181,25 +181,27 @@ class TeacherBigBoardModule(ProgramModuleObj):
         return sorted(teacher_times.itervalues())
 
     @cache_function_for(105)
-    def get_hours(self, prog, approved = False):
-        hours = ClassSubject.objects.filter(get_filter(prog, approved)
+    def get_hours(prog, approved = False, teachers = None):
+        hours = ClassSubject.objects.filter(get_filter(prog, approved, teachers)
         ).annotate(num_sections=Count('sections')).filter(num_sections__gt=0
         ).exclude(category__category__iexact="Lunch"
         ).values_list('timestamp','class_size_max'
         ).annotate(duration=Sum('sections__duration'))
         # use mindate if a class is missing a timestamp so we can still calculate static stats
-        sorted_hours = sorted(hours, key=lambda x:x[0] or self.mindate)
+        sorted_hours = sorted(hours, key=lambda x:x[0] or mindate)
         class_hours = [(hour[2],hour[0]) for hour in sorted_hours]
         student_hours = [(hour[2]*hour[1], hour[0]) for hour in sorted_hours]
         return class_hours, student_hours
+    get_hours = staticmethod(get_hours)
 
     @cache_function_for(105)
-    def static_hours(self, prog, approved = False):
-        hours = self.get_hours(prog, approved)
+    def static_hours(prog, approved = False, teachers = None):
+        hours = TeacherBigBoardModule.get_hours(prog, approved, teachers)
         if hours[0]:
             return [sum(zip(*j)[0]) for j in hours]
         else:
             return [0,0]
+    static_hours = staticmethod(static_hours)
 
     # runs in 9ms, so don't bother caching
     def load_averages(self):

--- a/esp/esp/program/statistics.py
+++ b/esp/esp/program/statistics.py
@@ -336,7 +336,7 @@ def student_reg(form, programs, students, profiles, result_dict={}):
         # set class lottery preferences
         class_lott_num = len(BigBoardModule.users_with_lottery(program) & set(students.values_list('id', flat = True)))
         series_data['Class Lottery'].append([program.name, class_lott_num])
-        stats_list.append(stud_lott_num)
+        stats_list.append(class_lott_num)
         # enrolled in at least one class
         enroll_num = len(set(BigBoardModule.users_enrolled(program)) & set(students.values_list('id', flat = True)))
         series_data['Enrolled'].append([program.name, enroll_num])

--- a/esp/esp/program/statistics.py
+++ b/esp/esp/program/statistics.py
@@ -32,10 +32,14 @@ Learning Unlimited, Inc.
   Phone: 617-379-0178
   Email: web-team@learningu.org
 """
+import json
+from collections import OrderedDict
+
 from django.template.loader import render_to_string
 
 from esp.program.models import Program, StudentRegistration
-from esp.users.models import Record
+from esp.users.models import ESPUser, Record
+from esp.program.modules.handlers.bigboardmodule import BigBoardModule
 
 """
 This file contains a set of functions used to perform statistics queries
@@ -312,3 +316,47 @@ def hours(form, programs, students, profiles, result_dict={}):
     result_dict['hours_data'] = zip(programs, stats_flat, timeslots_flat, students_list)
     return render_to_string('program/statistics/hours.html', result_dict)
 
+def student_reg(form, programs, students, profiles, result_dict={}):
+    stat_names = [
+        'Student Lottery',
+        'Class Lottery',
+        'Enrolled',
+        'Checked In',
+    ]
+    prog_stats = []
+    # ordered dictionary so the legend is in order
+    series_data = OrderedDict((stat, []) for stat in stat_names)
+    for program in programs:
+        stats_list = []
+        # entered student lottery
+        stud_lott_num = len(program.students().get('phasezero', ESPUser.objects.none()) & students)
+        series_data['Student Lottery'].append([program.name, stud_lott_num])
+        stats_list.append(stud_lott_num)
+        # set class lottery preferences
+        class_lott_num = len(BigBoardModule.users_with_lottery(program) & set(students.values_list('id', flat = True)))
+        series_data['Class Lottery'].append([program.name, class_lott_num])
+        stats_list.append(stud_lott_num)
+        # enrolled in at least one class
+        enroll_num = len(set(BigBoardModule.users_enrolled(program)) & set(students.values_list('id', flat = True)))
+        series_data['Enrolled'].append([program.name, enroll_num])
+        stats_list.append(enroll_num)
+        # students checked in
+        checked_num = len(set(BigBoardModule.checked_in_users(program)) & set(students.values_list('id', flat = True)))
+        series_data['Checked In'].append([program.name, checked_num])
+        stats_list.append(checked_num)
+        prog_stats.append(stats_list)
+    prog_data = zip(programs, prog_stats)
+    graph_data = [{"description": desc, "data": json.dumps(data)} for desc, data in series_data.items()]
+    left_axis_data = [
+            {"axis_name": "# Students Registered", "series_data": graph_data},
+    ]
+    result_dict.update({"prog_data": prog_data,
+                        "stat_names": stat_names,
+                        "categories": json.dumps([program.name for program in programs.order_by('id')]),
+                        "left_axis_data": left_axis_data,
+                       })
+    return render_to_string('program/statistics/student_reg.html', result_dict)
+
+def teacher_reg(form, programs, teachers, profiles, result_dict={}):
+    
+    return render_to_string('program/statistics/teacher_reg.html', result_dict)

--- a/esp/esp/program/statistics.py
+++ b/esp/esp/program/statistics.py
@@ -177,17 +177,17 @@ def startreg(form, programs, students, profiles, result_dict={}):
     for student in students:
         for program in programs:
 
-            reg_bits = StudentRegistration.objects.filter(user=student).order_by('start_date')
+            reg_bits = StudentRegistration.objects.filter(user=student, section__parent_class__parent_program = program).order_by('start_date')
             if reg_bits.exists():
                 if reg_bits[0].start_date.date() not in reg_dict[program]:
                     reg_dict[program][reg_bits[0].start_date.date()] = 0
                 reg_dict[program][reg_bits[0].start_date.date()] += 1
 
-            confirm_bits = Record.objects.filter(user=student, event='reg_confirmed', program=program).order_by('-date')
+            confirm_bits = Record.objects.filter(user=student, event='reg_confirmed', program=program).order_by('-time')
             if confirm_bits.exists():
-                if confirm_bits[0].date.date() not in confirm_dict[program]:
-                    confirm_dict[program][confirm_bits[0].date.date()] = 0
-                confirm_dict[program][confirm_bits[0].date.date()] += 1
+                if confirm_bits[0].time.date() not in confirm_dict[program]:
+                    confirm_dict[program][confirm_bits[0].time.date()] = 0
+                confirm_dict[program][confirm_bits[0].time.date()] += 1
 
     #   Compile and render
     startreg_list = []

--- a/esp/esp/program/statistics.py
+++ b/esp/esp/program/statistics.py
@@ -362,6 +362,7 @@ def teacher_reg(form, programs, teachers, profiles, result_dict={}):
     stat_names = [
         'Class Registered',
         'Class Approved',
+        'Class Scheduled',
     ]
     prog_stats = []
     # ordered dictionary so the legend is in order
@@ -376,6 +377,10 @@ def teacher_reg(form, programs, teachers, profiles, result_dict={}):
         teach_app = TeacherBigBoardModule.num_teachers_teaching(program, approved = True, teachers = teachers)
         series_data['Class Approved'].append([program.name, teach_app])
         stats_list.append(teach_app)
+        # teachers with a scheduled class
+        teach_sch = TeacherBigBoardModule.num_teachers_teaching(program, approved = True, scheduled = True, teachers = teachers)
+        series_data['Class Scheduled'].append([program.name, teach_sch])
+        stats_list.append(teach_sch)
         prog_stats.append(stats_list)
     prog_data = zip(programs, prog_stats)
     graph_data = [{"description": desc, "data": json.dumps(data)} for desc, data in series_data.items()]
@@ -390,11 +395,14 @@ def teacher_reg(form, programs, teachers, profiles, result_dict={}):
     return render_to_string('program/statistics/teacher_reg.html', result_dict)
 
 def class_reg(form, programs, teachers, profiles, result_dict={}):
+    stat_categories = ["Classes", "Class-student-hours"]
     stat_names = [
         'Classes Registered',
         'Classes Approved',
+        'Classes Scheduled',
         'Class-student-hours Registered',
         'Class-student-hours Approved',
+        'Class-student-hours Scheduled',
     ]
     prog_stats = []
     # ordered dictionary so the legend is in order
@@ -402,31 +410,39 @@ def class_reg(form, programs, teachers, profiles, result_dict={}):
     for program in programs:
         stats_list = []
         # registered classes
-        teach_reg = TeacherBigBoardModule.num_class_reg(program, teachers = teachers)
-        series_data['Classes Registered'].append([program.name, teach_reg])
-        stats_list.append(teach_reg)
+        class_reg = TeacherBigBoardModule.num_class_reg(program, teachers = teachers)
+        series_data['Classes Registered'].append([program.name, class_reg])
+        stats_list.append(class_reg)
         # teachers with an approved class
-        teach_app = TeacherBigBoardModule.num_class_reg(program, approved = True, teachers = teachers)
-        series_data['Classes Approved'].append([program.name, teach_app])
-        stats_list.append(teach_app)
+        class_app = TeacherBigBoardModule.num_class_reg(program, approved = True, teachers = teachers)
+        series_data['Classes Approved'].append([program.name, class_app])
+        stats_list.append(class_app)
+        class_sch = TeacherBigBoardModule.num_class_reg(program, approved = True, scheduled = True, teachers = teachers)
+        series_data['Classes Approved'].append([program.name, class_sch])
+        stats_list.append(class_sch)
         class_hours, student_hours = TeacherBigBoardModule.static_hours(program, teachers = teachers)
         series_data['Class-student-hours Registered'].append([program.name, float(student_hours)])
         stats_list.append(float(student_hours))
         class_hours_approved, student_hours_approved = TeacherBigBoardModule.static_hours(program, approved = True, teachers = teachers)
         series_data['Class-student-hours Approved'].append([program.name, float(student_hours_approved)])
         stats_list.append(float(student_hours_approved))
+        class_hours_scheduled, student_hours_scheduled = TeacherBigBoardModule.static_hours(program, approved = True, scheduled = True, teachers = teachers)
+        series_data['Class-student-hours Scheduled'].append([program.name, float(student_hours_scheduled)])
+        stats_list.append(float(student_hours_scheduled))
         prog_stats.append(stats_list)
     prog_data = zip(programs, prog_stats)
-    graph_data = [{"description": desc, "data": json.dumps(data)} for desc, data in series_data.items()[0:2]]
+    graph_data = [{"description": desc, "data": json.dumps(data)} for desc, data in series_data.items()[0:3]]
     left_axis_data = [
         {"axis_name": "# Classes", "series_data": graph_data},
     ]
-    graph_data = [{"description": desc, "data": json.dumps(data)} for desc, data in series_data.items()[2:4]]
+    graph_data = [{"description": desc, "data": json.dumps(data)} for desc, data in series_data.items()[3:6]]
     right_axis_data = [
         {"axis_name": "# Class-student-hours", "series_data": graph_data},
     ]
     result_dict.update({"prog_data": prog_data,
-                        "stat_names": stat_names,
+                        "stat_categories": stat_categories,
+                        "stats_per_category": len(stat_names)/len(stat_categories),
+                        "stat_names": [stat_name.split(' ')[1] for stat_name in stat_names],
                         "categories": json.dumps([program.name for program in programs.order_by('id')]),
                         "left_axis_data": left_axis_data,
                         "right_axis_data": right_axis_data,

--- a/esp/esp/program/views.py
+++ b/esp/esp/program/views.py
@@ -823,12 +823,12 @@ def statistics(request, program=None):
             #   Get list of users the query applies to
             users_q = Q()
             for program in programs:
-                if 'student_reg_types' in form.cleaned_data:
+                if 'student_reg_types' in form.cleaned_data and form.cleaned_data['student_reg_types']:
                     students_objects = program.students(QObjects=True)
                     for reg_type in form.cleaned_data['student_reg_types']:
                         if reg_type in students_objects.keys():
                             users_q = users_q | students_objects[reg_type]
-                elif 'teacher_reg_types' in form.cleaned_data:
+                elif 'teacher_reg_types' in form.cleaned_data and form.cleaned_data['teacher_reg_types']:
                     teachers_objects = program.teachers(QObjects=True)
                     for reg_type in form.cleaned_data['teacher_reg_types']:
                         if reg_type in teachers_objects.keys():

--- a/esp/esp/program/views.py
+++ b/esp/esp/program/views.py
@@ -823,12 +823,12 @@ def statistics(request, program=None):
             #   Get list of users the query applies to
             users_q = Q()
             for program in programs:
-                if 'student_reg_types' in form.cleaned_data and form.cleaned_data['student_reg_types']:
+                if 'student_reg_types' in form.cleaned_data and form.cleaned_data['student_reg_types'] and not form.cleaned_data['student_reg_types']:
                     students_objects = program.students(QObjects=True)
                     for reg_type in form.cleaned_data['student_reg_types']:
                         if reg_type in students_objects.keys():
                             users_q = users_q | students_objects[reg_type]
-                elif 'teacher_reg_types' in form.cleaned_data and form.cleaned_data['teacher_reg_types']:
+                elif 'teacher_reg_types' in form.cleaned_data and form.cleaned_data['teacher_reg_types'] and not form.cleaned_data['teacher_reg_types']:
                     teachers_objects = program.teachers(QObjects=True)
                     for reg_type in form.cleaned_data['teacher_reg_types']:
                         if reg_type in teachers_objects.keys():

--- a/esp/public/media/default_styles/statistics.css
+++ b/esp/public/media/default_styles/statistics.css
@@ -1,0 +1,60 @@
+#statistics_form_contents ul
+{
+    list-style-type: none;
+    padding-left: 0px;
+}
+#statistics_form_contents select
+{
+    margin-bottom: 5px;
+}
+#statistics_form_contents select[multiple]
+{
+    border: 1px solid #999999;
+    font-size: 0.9em;
+}
+#statistics_form_contents input[type=submit]
+{
+    border: 1px solid #999999;
+    background-color: #99CCFF;
+    font-size: 1.5em;
+    padding: 3px 15px 3px 15px;
+}
+#statistics_form_contents input[type=submit]:hover
+{
+    background-color: #999999;
+}
+#statistics_form_contents table {
+    width: 100%;
+}
+#statistics_form_contents tr {
+    text-align: center;
+}
+#statistics_form_contents th {
+    text-align: right;
+    padding-right: 10px;
+}
+#statistics_form_contents td {
+    text-align: left;
+    padding-left: 10px;
+}
+#statistics_form_contents td, #statistics_form_contents th
+{
+    padding-top: 5px;
+    padding-bottom: 5px;
+}
+#statistics_form_contents label
+{
+    margin: 0px;
+}
+#statistics_form_contents input[type=checkbox] + br
+{
+  display: none;
+}
+#statistics_form_contents input[type=checkbox] + br + span
+{
+  margin-left: 5px;
+}
+#statistics_form_contents input[type="radio"], #statistics_form_contents input[type="checkbox"]
+{
+    margin: 0px;
+}

--- a/esp/public/media/default_styles/statistics.css
+++ b/esp/public/media/default_styles/statistics.css
@@ -23,7 +23,7 @@
 {
     background-color: #999999;
 }
-#statistics_form_contents table {
+#statistics_form_contents table, #result table {
     width: 100%;
 }
 #statistics_form_contents tr {
@@ -57,4 +57,12 @@
 #statistics_form_contents input[type="radio"], #statistics_form_contents input[type="checkbox"]
 {
     margin: 0px;
+}
+#result table, #result tr, #result td, #result th {
+    border: black solid 1px;
+    border-spacing: 2px;
+    padding: 2px;
+}
+#result table {
+    margin-bottom: 10px;
 }

--- a/esp/templates/program/modules/bigboardmodule/bigboard_graph.html
+++ b/esp/templates/program/modules/bigboardmodule/bigboard_graph.html
@@ -29,8 +29,13 @@
       shared: true,
     },
     xAxis: {
+      {% if categories %}
+      type: 'category',
+      categories: {{ categories|safe }},
+      {% else %}
       type: 'datetime',
       minRange: 24 * 60 * 60 * 1000, // one day
+      {% endif %}
     },
     yAxis: [
       {% for axis in left_axis_data %}
@@ -58,11 +63,13 @@
           type: 'line',
           yAxis: {{ forloop.parentloop.counter0 }},
           name: '{{series.description}}',
+          {% if not categories %}
           pointInterval: 60 * 60 * 1000, // one hour
           pointStart: Date.UTC(
               {{first_hour.year}}, {{first_hour.month}} - 1,
               {{first_hour.day}}, {{first_hour.hour}}),
-          data: {{series.data}},
+          {% endif %}
+          data: {{series.data|safe}},
         },
         {% empty %}
         {
@@ -79,11 +86,13 @@
           type: 'line',
           yAxis: {{ forloop.parentloop.counter0 }} + left_axes,
           name: '{{series.description}}',
+          {% if not categories %}
           pointInterval: 60 * 60 * 1000, // one hour
           pointStart: Date.UTC(
               {{first_hour.year}}, {{first_hour.month}} - 1,
               {{first_hour.day}}, {{first_hour.hour}}),
-          data: {{series.data}},
+          {% endif %}
+          data: {{series.data|safe}},
         },
         {% empty %}
         {

--- a/esp/templates/program/statistics.html
+++ b/esp/templates/program/statistics.html
@@ -6,54 +6,7 @@
 
 {% block stylesheets %}
 {{ block.super }}
-<style type="text/css">
-#statistics_form_contents ul
-{
-    list-style-type: none;
-    padding-left: 0px;
-}
-#statistics_form_contents select
-{
-    margin-bottom: 5px;
-}
-#statistics_form_contents select[multiple]
-{
-    border: 1px solid #999999;
-    font-size: 0.9em;
-}
-#statistics_form_contents input[type=submit]
-{
-    border: 1px solid #999999;
-    background-color: #99CCFF;
-    font-size: 1.5em;
-    padding: 3px 15px 3px 15px;
-}
-#statistics_form_contents input[type=submit]:hover
-{
-    background-color: #999999;
-}
-#statistics_form_contents td, #statistics_form_contents th
-{
-    padding-top: 5px;
-    padding-bottom: 5px;
-}
-#statistics_form_contents label
-{
-    margin: 0px;
-}
-#statistics_form_contents input[type=checkbox] + br
-{
-  display: none;
-}
-#statistics_form_contents input[type=checkbox] + br + span
-{
-  margin-left: 5px;
-}
-#statistics_form_contents input[type="radio"], #statistics_form_contents input[type="checkbox"]
-{
-    margin: 0px;
-}
-</style>
+<link rel="stylesheet" href="/media/styles/statistics.css" type="text/css" />
 {% endblock %}
 
 {% block content %}

--- a/esp/templates/program/statistics.html
+++ b/esp/templates/program/statistics.html
@@ -9,6 +9,12 @@
 <link rel="stylesheet" href="/media/styles/statistics.css" type="text/css" />
 {% endblock %}
 
+{% block xtrajs %}
+  <script type="text/javascript" src="//code.highcharts.com/highcharts.js"></script>
+  <script type="text/javascript" src="//code.highcharts.com/highcharts-more.js"></script>
+  <script type="text/javascript" src="//code.highcharts.com/modules/no-data-to-display.js"></script>
+{% endblock xtrajs %}
+
 {% block content %}
 
 <h2>

--- a/esp/templates/program/statistics.html
+++ b/esp/templates/program/statistics.html
@@ -12,6 +12,10 @@
     list-style-type: none;
     padding-left: 0px;
 }
+#statistics_form_contents select
+{
+    margin-bottom: 5px;
+}
 #statistics_form_contents select[multiple]
 {
     border: 1px solid #999999;
@@ -27,6 +31,27 @@
 #statistics_form_contents input[type=submit]:hover
 {
     background-color: #999999;
+}
+#statistics_form_contents td, #statistics_form_contents th
+{
+    padding-top: 5px;
+    padding-bottom: 5px;
+}
+#statistics_form_contents label
+{
+    margin: 0px;
+}
+#statistics_form_contents input[type=checkbox] + br
+{
+  display: none;
+}
+#statistics_form_contents input[type=checkbox] + br + span
+{
+  margin-left: 5px;
+}
+#statistics_form_contents input[type="radio"], #statistics_form_contents input[type="checkbox"]
+{
+    margin: 0px;
 }
 </style>
 {% endblock %}

--- a/esp/templates/program/statistics/class_reg.html
+++ b/esp/templates/program/statistics/class_reg.html
@@ -1,9 +1,14 @@
+<p>{{ num_users }} users were matched by the query.</p>
 <h2>Class Registration Stats</h2>
 <p>The number of classes that were registered by teachers for each program are shown below (using several metrics).</p>
-<p>{{ num_users }} matched by query.</p>
 <table>
 <tr>
-<th></th>
+<th rowspan="2"></th>
+{% for stat_category in stat_categories %}
+<th colspan="{{ stats_per_category }}">{{ stat_category }}</th>
+{% endfor %}
+</tr>
+<tr>
 {% for stat in stat_names %}
 <th>{{ stat }}</th>
 {% endfor %}

--- a/esp/templates/program/statistics/class_reg.html
+++ b/esp/templates/program/statistics/class_reg.html
@@ -1,0 +1,21 @@
+<h2>Class Registration Stats</h2>
+<p>The number of classes that were registered by teachers for each program are shown below (using several metrics).</p>
+<p>{{ num_users }} matched by query.</p>
+<table>
+<tr>
+<th></th>
+{% for stat in stat_names %}
+<th>{{ stat }}</th>
+{% endfor %}
+</tr>
+{% for prog, stats in prog_data %}
+<tr>
+    <td>{{ prog }}</td>
+    {% for stat in stats %}
+    <td>{{ stat }}</td>
+    {% endfor %}
+</tr>
+{% endfor %}
+</table>
+
+{% include "program/modules/bigboardmodule/bigboard_graph.html" %}

--- a/esp/templates/program/statistics/demographics.html
+++ b/esp/templates/program/statistics/demographics.html
@@ -1,35 +1,73 @@
 <h2>Aggregrate Demographic Info</h2>
 
 <p>Ages and grades are reported as birth years and graduation years to allow aggregating results from multiple programs.</p>
+({{ num_users }} students selected by query)
 
-<ul>
-<li>{{ num_users }} students selected by query</li>
-<li>Program stats (from all registered students)
-    <ul>
-    <li>{{ num_classes }} class subjects; total of {{ num_sections }} class sections</li>
-    <li>{{ num_class_hours }} class-hours</li>
-    <li>{{ num_student_class_hours }} student-class-hours (based on registration)</li>
-    </ul>
-</li>
-<li>Age distribution
-    <ul>
-    {% for pair in birthyear_data %}
-        <li>Born in {{ pair.0 }}: {{ pair.1 }} students
-    {% endfor %}
-    </ul>
-</li>
-<li>Grade distribution
-    <ul>
-    {% for pair in gradyear_data %}
-        <li>Graduating in {{ pair.0 }}: {{ pair.1 }} students
-    {% endfor %}
-    </ul>
-</li>
-<li>Financial aid information
-    <ul>
-        <li>{{ finaid_applied }} applications for financial aid</li>
-        <li>{{ finaid_lunch }} students claimed free/reduced lunch</li>
-        <li>{{ finaid_approved }} students received financial aid</li>
-    </ul>
-</li>
-</ul>
+<h3>Program stats (from all registered students)</h3>
+<table>
+<tr>
+<th width="50%"></th>
+<th>#</th>
+</tr>
+<tr>
+    <td>Class subjects</td>
+    <td>{{ num_classes }}</td>
+</tr>
+<tr>
+    <td>Class sections</td>
+    <td>{{ num_sections }}</td>
+</tr>
+<tr>
+    <td>Class-hours</td>
+    <td>{{ num_class_hours }}</td>
+</tr>
+<tr>
+    <td>Student-class-hours registered</td>
+    <td>{{ num_student_class_hours }}</td>
+</tr>
+</table>
+<h3>Age distribution</h3>
+<table>
+<tr>
+<th width="50%">Birth Year</th>
+<th># of Students</th>
+</tr>
+{% for birth_year, num in birthyear_data %}
+<tr>
+    <td>{{ birth_year }}</td>
+    <td>{{ num }}</td>
+</tr>
+{% endfor %}
+</table>
+<h3>Grade distribution</h3>
+<table>
+<tr>
+<th width="50%">Graduation Year</th>
+<th># of Students</th>
+</tr>
+{% for grad_year, num in gradyear_data %}
+<tr>
+    <td>{{ grad_year }}</td>
+    <td>{{ num }}</td>
+</tr>
+{% endfor %}
+</table>
+<h3>Financial aid information</h3>
+<table>
+<tr>
+<th width="50%"></th>
+<th># of Students</th>
+</tr>
+<tr>
+    <td>Applied for financial aid</td>
+    <td>{{ finaid_applied }}</td>
+</tr>
+<tr>
+    <td>Claimed free/reduced lunch</td>
+    <td>{{ finaid_lunch }}</td>
+</tr>
+<tr>
+    <td>Received financial aid</td>
+    <td>{{ finaid_approved }}</td>
+</tr>
+</table>

--- a/esp/templates/program/statistics/demographics.html
+++ b/esp/templates/program/statistics/demographics.html
@@ -1,7 +1,7 @@
+<p>{{ num_users }} users were matched by the query.</p>
 <h2>Aggregrate Demographic Info</h2>
 
 <p>Ages and grades are reported as birth years and graduation years to allow aggregating results from multiple programs.</p>
-({{ num_users }} students selected by query)
 
 <h3>Program stats (from all registered students)</h3>
 <table>

--- a/esp/templates/program/statistics/demographics.html
+++ b/esp/templates/program/statistics/demographics.html
@@ -3,7 +3,7 @@
 <p>Ages and grades are reported as birth years and graduation years to allow aggregating results from multiple programs.</p>
 
 <ul>
-<li>{{ num_students }} students selected by query</li>
+<li>{{ num_users }} students selected by query</li>
 <li>Program stats (from all registered students)
     <ul>
     <li>{{ num_classes }} class subjects; total of {{ num_sections }} class sections</li>

--- a/esp/templates/program/statistics/form.html
+++ b/esp/templates/program/statistics/form.html
@@ -1,11 +1,11 @@
 <table>
     <tr>
-        <td width="200"></td>
+        <td width="40%"></td>
         <td></td>
     </tr>
     {{ form }}
     <tr>
-        <td colspan="2" align="center">
+        <td colspan="2" style="text-align: center;">
             <input type="submit" value="Go!" />
         </td>
     </tr>

--- a/esp/templates/program/statistics/heardabout.html
+++ b/esp/templates/program/statistics/heardabout.html
@@ -1,6 +1,6 @@
 <h2>How Students Heard About You</h2>
 
-<p>Query matched {{ num_students }} students.  Here are the most popular ways they heard about the program:</p>
+<p>Query matched {{ num_users }} students.  Here are the most popular ways they heard about the program:</p>
 <ul>
 {% for pair in heardabout_data %}
     <li>{{ pair.0 }}: {{ pair.1 }} students

--- a/esp/templates/program/statistics/heardabout.html
+++ b/esp/templates/program/statistics/heardabout.html
@@ -1,9 +1,16 @@
 <h2>How Students Heard About You</h2>
 
 <p>Query matched {{ num_users }} students.  Here are the most popular ways they heard about the program:</p>
-<ul>
-{% for pair in heardabout_data %}
-    <li>{{ pair.0 }}: {{ pair.1 }} students
+<table>
+<tr>
+<th>Heard About</th>
+<th># of Students</th>
+</tr>
+{% for heard_about, num in heardabout_data %}
+<tr>
+    <td>{{ heard_about }}</td>
+    <td>{{ num }}</td>
+</tr>
 {% endfor %}
-</ul>
+</table>
 <p>(Note: Because much of these entries were typed by the student, they are hard to group and you may find duplicates.)</p>

--- a/esp/templates/program/statistics/heardabout.html
+++ b/esp/templates/program/statistics/heardabout.html
@@ -1,6 +1,7 @@
+<p>{{ num_users }} users were matched by the query.</p>
 <h2>How Students Heard About You</h2>
 
-<p>Query matched {{ num_users }} students.  Here are the most popular ways they heard about the program:</p>
+<p>Here are the most popular ways they heard about the program:</p>
 <table>
 <tr>
 <th>Heard About</th>

--- a/esp/templates/program/statistics/hours.html
+++ b/esp/templates/program/statistics/hours.html
@@ -1,6 +1,6 @@
 <h2>Student Participation Time</h2>
 <p>The distribution of student class hours are shown below for each program. These are measured in timeslots; if all timeslots are 2 hr long, double these numbers to get the distribution of hours spent in class.  (Most Splash programs are run with 1 hr timeslots, so the timeslots and class hours are equivalent.)</p>
-<p>{{ num_students }} matched by query.</p>
+<p>{{ num_users }} matched by query.</p>
 <ul>
 {% for prog in hours_data %}
     <li>{{ prog.0 }}: {{ prog.3 }} students matched

--- a/esp/templates/program/statistics/hours.html
+++ b/esp/templates/program/statistics/hours.html
@@ -1,6 +1,6 @@
+<p>{{ num_users }} users were matched by the query.</p>
 <h2>Student Participation Time</h2>
 <p>The distribution of student class hours are shown below for each program. These are measured in timeslots; if all timeslots are 2 hr long, double these numbers to get the distribution of hours spent in class.  (Most Splash programs are run with 1 hr timeslots, so the timeslots and class hours are equivalent.)</p>
-<p>{{ num_users }} matched by query.</p>
 <ul>
 {% for prog in hours_data %}
     <li>{{ prog.0 }}: {{ prog.3 }} students matched

--- a/esp/templates/program/statistics/repeats.html
+++ b/esp/templates/program/statistics/repeats.html
@@ -1,8 +1,15 @@
 <h2>Returning Student Info</h2>
 
-<p>Query captured {{ num_users }} students.  Results include all programs that the selected students registered for.</p>
-<ul>
-{% for pair in repeat_data %}
-    <li>{{ pair.0 }}: {{ pair.1 }} students
+<p>Query captured {{ num_users }} students. Results include all programs that the selected students registered for.</p>
+<table>
+<tr>
+<th>Program</th>
+<th># of Students</th>
+</tr>
+{% for program, num in repeat_data %}
+<tr>
+    <td>{{ program }}</td>
+    <td>{{ num }}</td>
+</tr>
 {% endfor %}
-</ul>
+</table>

--- a/esp/templates/program/statistics/repeats.html
+++ b/esp/templates/program/statistics/repeats.html
@@ -1,6 +1,7 @@
+<p>{{ num_users }} users were matched by the query.</p>
 <h2>Returning Student Info</h2>
 
-<p>Query captured {{ num_users }} students. Results include all programs that the selected students registered for.</p>
+<p>Results include all programs that the selected students registered for.</p>
 <table>
 <tr>
 <th>Program</th>

--- a/esp/templates/program/statistics/repeats.html
+++ b/esp/templates/program/statistics/repeats.html
@@ -1,6 +1,6 @@
 <h2>Returning Student Info</h2>
 
-<p>Query captured {{ num_students }} students.  Results include all programs that the selected students registered for.</p>
+<p>Query captured {{ num_users }} students.  Results include all programs that the selected students registered for.</p>
 <ul>
 {% for pair in repeat_data %}
     <li>{{ pair.0 }}: {{ pair.1 }} students

--- a/esp/templates/program/statistics/schools.html
+++ b/esp/templates/program/statistics/schools.html
@@ -1,6 +1,7 @@
+<p>{{ num_users }} users were matched by the query.</p>
 <h2>School Info</h2>
 
-<p>Of {{ num_users }} students, {{ num_k12school }} selected a school from existing options and {{ num_school }} typed one in manually.</p>
+<p>{{ num_k12school }} students selected a school from existing options and {{ num_school }} typed one in manually.</p>
 <table>
 <tr>
 <th>School</th>

--- a/esp/templates/program/statistics/schools.html
+++ b/esp/templates/program/statistics/schools.html
@@ -1,6 +1,6 @@
 <h2>School Info</h2>
 
-<p>Of {{ num_students }} students, {{ num_k12school }} selected a school from existing options and {{ num_school }} typed one in manually.</p>
+<p>Of {{ num_users }} students, {{ num_k12school }} selected a school from existing options and {{ num_school }} typed one in manually.</p>
 <ul>
 {% for pair in school_data %}
     <li>{{ pair.0 }}: {{ pair.1 }} students

--- a/esp/templates/program/statistics/schools.html
+++ b/esp/templates/program/statistics/schools.html
@@ -1,8 +1,15 @@
 <h2>School Info</h2>
 
 <p>Of {{ num_users }} students, {{ num_k12school }} selected a school from existing options and {{ num_school }} typed one in manually.</p>
-<ul>
-{% for pair in school_data %}
-    <li>{{ pair.0 }}: {{ pair.1 }} students
+<table>
+<tr>
+<th>School</th>
+<th># of Students</th>
+</tr>
+{% for school, num in school_data %}
+<tr>
+    <td>{{ school }}</td>
+    <td>{{ num }}</td>
+</tr>
 {% endfor %}
-</ul>
+</table>

--- a/esp/templates/program/statistics/startreg.html
+++ b/esp/templates/program/statistics/startreg.html
@@ -1,3 +1,4 @@
+<p>{{ num_users }} users were matched by the query.</p>
 <h2>Registration Timing Info</h2>
 <p>The distribution of first class registration and final confirmation dates are shown below for each program.</p>
 <ul>

--- a/esp/templates/program/statistics/student_reg.html
+++ b/esp/templates/program/statistics/student_reg.html
@@ -1,0 +1,21 @@
+<h2>Student Registration Stats</h2>
+<p>The number of students that registered for each program are shown below (using several metrics).</p>
+<p>{{ num_users }} matched by query.</p>
+<table>
+<tr>
+<th></th>
+{% for stat in stat_names %}
+<th>{{ stat }}</th>
+{% endfor %}
+</tr>
+{% for prog, stats in prog_data %}
+<tr>
+    <td>{{ prog }}</td>
+    {% for stat in stats %}
+    <td>{{ stat }}</td>
+    {% endfor %}
+</tr>
+{% endfor %}
+</table>
+
+{% include "program/modules/bigboardmodule/bigboard_graph.html" %}

--- a/esp/templates/program/statistics/student_reg.html
+++ b/esp/templates/program/statistics/student_reg.html
@@ -1,6 +1,6 @@
+<p>{{ num_users }} users were matched by the query.</p>
 <h2>Student Registration Stats</h2>
 <p>The number of students that registered for each program are shown below (using several metrics).</p>
-<p>{{ num_users }} matched by query.</p>
 <table>
 <tr>
 <th></th>

--- a/esp/templates/program/statistics/teacher_reg.html
+++ b/esp/templates/program/statistics/teacher_reg.html
@@ -1,0 +1,21 @@
+<h2>Teacher Registration Stats</h2>
+<p>The number of teachers that registered for each program are shown below (using several metrics).</p>
+<p>{{ num_users }} matched by query.</p>
+<table>
+<tr>
+<th></th>
+{% for stat in stat_names %}
+<th>{{ stat }}</th>
+{% endfor %}
+</tr>
+{% for prog, stats in prog_data %}
+<tr>
+    <td>{{ prog }}</td>
+    {% for stat in stats %}
+    <td>{{ stat }}</td>
+    {% endfor %}
+</tr>
+{% endfor %}
+</table>
+
+{% include "program/modules/bigboardmodule/bigboard_graph.html" %}

--- a/esp/templates/program/statistics/teacher_reg.html
+++ b/esp/templates/program/statistics/teacher_reg.html
@@ -1,6 +1,6 @@
+<p>{{ num_users }} users were matched by the query.</p>
 <h2>Teacher Registration Stats</h2>
 <p>The number of teachers that registered for each program are shown below (using several metrics).</p>
-<p>{{ num_users }} matched by query.</p>
 <table>
 <tr>
 <th></th>

--- a/esp/templates/program/statistics/zip_codes.html
+++ b/esp/templates/program/statistics/zip_codes.html
@@ -1,5 +1,5 @@
 <h2>Zip Code Info</h2>
-<p>Of {{ num_students }} students, {{ invalid }} had invalid Zip codes.</p>
+<p>Of {{ num_users }} students, {{ invalid }} had invalid Zip codes.</p>
 <ul>
 {% for pair in zip_data %}
     <li>Zip code {{ pair.0 }}: {{ pair.1 }} students

--- a/esp/templates/program/statistics/zip_codes.html
+++ b/esp/templates/program/statistics/zip_codes.html
@@ -1,7 +1,14 @@
 <h2>Zip Code Info</h2>
 <p>Of {{ num_users }} students, {{ invalid }} had invalid Zip codes.</p>
-<ul>
-{% for pair in zip_data %}
-    <li>Zip code {{ pair.0 }}: {{ pair.1 }} students
+<table>
+<tr>
+<th>Zip Code</th>
+<th># of Students</th>
+</tr>
+{% for zip_code, num in zip_data %}
+<tr>
+    <td>{{ zip_code }}</td>
+    <td>{{ num }}</td>
+</tr>
 {% endfor %}
-</ul>
+</table>

--- a/esp/templates/program/statistics/zip_codes.html
+++ b/esp/templates/program/statistics/zip_codes.html
@@ -1,5 +1,6 @@
+<p>{{ num_users }} users were matched by the query.</p>
 <h2>Zip Code Info</h2>
-<p>Of {{ num_users }} students, {{ invalid }} had invalid Zip codes.</p>
+<p>{{ invalid }} users had invalid Zip codes.</p>
 <table>
 <tr>
 <th>Zip Code</th>


### PR DESCRIPTION
This adds new queries to the /manage/statistics page to get multiprogram stats on teacher registration (# of teachers), class registration (# of classes), and student registration (# of students). Since these stats are basically already calculated for a single program for the big board modules, The results are shown in a neat table and in a graph (see screenshots below). I just made those static functions and call them for each of the selected programs. While I was at it, I made the form prettier, table-fied most of the outputs of the other queries, and fixed a minor bug on the student big board (#3202).

![image](https://user-images.githubusercontent.com/7232514/107666533-3ceab700-6c54-11eb-9a05-86b7c924f5a3.png)
![image](https://user-images.githubusercontent.com/7232514/107666746-76bbbd80-6c54-11eb-8e12-34f343208075.png)
![image](https://user-images.githubusercontent.com/7232514/107666696-66a3de00-6c54-11eb-91bd-70cbd1ab5bdb.png)

Fixes #2922 and fixes #3202