### PR TITLE
Fix top margin of catalog sorted by category

### DIFF
--- a/esp/templates/program/modules/programprintables/catalog_category.tex
+++ b/esp/templates/program/modules/programprintables/catalog_category.tex
@@ -3,7 +3,7 @@
 \usepackage{multicol}
 \usepackage{amsfonts, amsmath, amsthm, amssymb}
 \usepackage{fancyhdr}
-\usepackage[left=.5in,top=1cm,bottom=.5in,right=.5in]{geometry}
+\usepackage[left=.5in,top=.75in,bottom=.5in,right=.5in]{geometry}
 
 %   Unicode symbol support.  Can't forget the omicron.
 \usepackage{ucs}


### PR DESCRIPTION
Fixes #3029. 

Looks like the geometry top margin didn't like the cm! The catalog sorted by category now matches the margins when sorted by timeblock.