### PR TITLE
Update remaining bootstrap stuff to 2.3.2

### DIFF
--- a/esp/templates/elements/html
+++ b/esp/templates/elements/html
@@ -14,7 +14,7 @@
     {% block stylesheets %}
     <link rel="stylesheet" type="text/css" href="/media/styles/qsd.css" />
 
-    <link href="{{ settings.CDN_ADDRESS }}/bootstrap/docs/assets/css/bootstrap-responsive.css" rel="stylesheet"/>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/2.3.2/css/bootstrap-responsive.css" rel="stylesheet"/>
     <link rel="stylesheet" type="text/css" href="/media/styles/theme_compiled.css"/>
     <link href="{{ settings.CDN_ADDRESS }}/bootstrap/docs/assets/js/google-code-prettify/prettify.css" rel="stylesheet"/>
 
@@ -95,18 +95,7 @@
     {% block javascript_footer %}
     <!-- Placed at the end of the document so the pages load faster -->
     <script type="text/javascript" src="{{ settings.CDN_ADDRESS }}/bootstrap/docs/assets/js/google-code-prettify/prettify.js"></script>
-    <script type="text/javascript" src="{{ settings.CDN_ADDRESS }}/bootstrap/docs/assets/js/bootstrap-transition.js"></script>
-    <script type="text/javascript" src="{{ settings.CDN_ADDRESS }}/bootstrap/docs/assets/js/bootstrap-alert.js"></script>
-    <script type="text/javascript" src="{{ settings.CDN_ADDRESS }}/bootstrap/docs/assets/js/bootstrap-modal.js"></script>
-    <script type="text/javascript" src="{{ settings.CDN_ADDRESS }}/bootstrap/docs/assets/js/bootstrap-dropdown.js"></script>
-    <script type="text/javascript" src="{{ settings.CDN_ADDRESS }}/bootstrap/docs/assets/js/bootstrap-scrollspy.js"></script>
-    <script type="text/javascript" src="{{ settings.CDN_ADDRESS }}/bootstrap/docs/assets/js/bootstrap-tab.js"></script>
-    <script type="text/javascript" src="{{ settings.CDN_ADDRESS }}/bootstrap/docs/assets/js/bootstrap-tooltip.js"></script>
-    <script type="text/javascript" src="{{ settings.CDN_ADDRESS }}/bootstrap/docs/assets/js/bootstrap-popover.js"></script>
-    <script type="text/javascript" src="{{ settings.CDN_ADDRESS }}/bootstrap/docs/assets/js/bootstrap-button.js"></script>
-    <script type="text/javascript" src="{{ settings.CDN_ADDRESS }}/bootstrap/docs/assets/js/bootstrap-collapse.js"></script>
-    <script type="text/javascript" src="{{ settings.CDN_ADDRESS }}/bootstrap/docs/assets/js/bootstrap-carousel.js"></script>
-    <script type="text/javascript" src="{{ settings.CDN_ADDRESS }}/bootstrap/docs/assets/js/bootstrap-typeahead.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/2.3.2/js/bootstrap.js"></script>
     
     <script src="/media/scripts/nav.js" type="text/javascript"></script>
 


### PR DESCRIPTION
This is just a quick upgrade for some of the css and javascript that we load in elements/html to make the version the same as the bootstrap we load with themes. From a quick look around my dev server, nothing seems to have broken.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3206.