### PR TITLE
Upgrade jquery-ui for grid based class changes

### DIFF
--- a/esp/public/media/default_styles/onsite_ajax_status.css
+++ b/esp/public/media/default_styles/onsite_ajax_status.css
@@ -50,6 +50,8 @@ body {
 
 #student_selector_area {
     position: relative;
+    height: 100px;
+    font-size: 1.1em;
 }
 
 #compact-classes-body td {
@@ -158,10 +160,6 @@ table.narrow {
 .section_hidden > input, .section_search_hidden > input,
 .section_conflict_hidden > input {
     display: none;
-}
-
-#student_selector_area {
-    height: 100px;
 }
 
 input #student_selector {

--- a/esp/public/media/scripts/onsite/ajax_status.js
+++ b/esp/public/media/scripts/onsite/ajax_status.js
@@ -800,10 +800,10 @@ function setup_autocomplete()
             $j( "#student_selector" ).val( ui.item.label );
             return false;
         },
-    }).data("autocomplete")._renderItem = function (ul, item) {
+    }).data("ui-autocomplete")._renderItem = function (ul, item) {
         var listItem = $j("<li>")
                         .attr( "data-value", item.value )
-                        .append("<a href='#'>" + item.label + "</a>")
+                        .append("<div>" + item.label + "</div>")
                         .data("item.autocomplete", item);
 
         if(item.noProfile) {

--- a/esp/templates/program/modules/onsiteclasslist/ajax_status.html
+++ b/esp/templates/program/modules/onsiteclasslist/ajax_status.html
@@ -5,7 +5,7 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/{{ settings.JQUERY_VERSION }}/jquery.min.js" integrity="{{ settings.JQUERY_HASH }}" crossorigin="anonymous"></script>
 <script src="http://code.jquery.com/jquery-migrate-1.4.1.{% if not settings.DEBUG %}min.{% endif %}js"></script>
 <script type="text/javascript" src="/media/scripts/jquery.cookie.js"></script>
-<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.9.2/jquery-ui.js"></script>
+<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jqueryui/{{ settings.JQUERY_UI_VERSION }}/jquery-ui.js"></script>
 <script type="text/javascript" src="/media/scripts/common.js"></script>
 <script type="text/javascript">
     $j(document).ready(function() {
@@ -27,7 +27,7 @@
         background-color: #f7d0d0;
     }
 </style>
-<link href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.9.2/themes/base/jquery-ui.css" rel="stylesheet" type="text/css"/>
+<link href="https://ajax.googleapis.com/ajax/libs/jqueryui/{{ settings.JQUERY_UI_VERSION }}/themes/base/jquery-ui.css" rel="stylesheet" type="text/css"/>
 <link rel="stylesheet" type="text/css" href="/media/styles/forms.css" />
 <link rel="stylesheet" type="text/css" href="/media/styles/onsite_ajax_status.css" />
 


### PR DESCRIPTION
I thought this would be a much larger project than it ended up being. I only needed to fix one thing that was changed between jquery-ui 1.9 and 1.12 (`data("autocomplete")` -> `data("ui-autocomplete")`). The only visual change that I can see is that the student that is hovered over in the student dropdown is now highlighted in blue.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3210.