### PR TITLE
Contiguous blocks tolerance tags

### DIFF
--- a/esp/esp/cal/models.py
+++ b/esp/esp/cal/models.py
@@ -141,9 +141,9 @@ class Event(models.Model):
         return newList
 
     @staticmethod
-    def contiguous(event1, event2):
-        """ Returns true if the second argument is less than 20 minutes apart from the first one. """
-        tol = timedelta(minutes=20)
+    def contiguous(event1, event2, tol = 20):
+        """ Returns true if the second argument is less than <tol> minutes apart from the first one. """
+        tol = timedelta(minutes=tol)
 
         if (event2.start - event1.end) < tol:
             return True
@@ -151,7 +151,7 @@ class Event(models.Model):
             return False
 
     @staticmethod
-    def group_contiguous(event_list):
+    def group_contiguous(event_list, tol = 20):
         """ Takes a list of events and returns a list of lists where each sublist is a contiguous group. """
         from copy import copy
         sorted_list = copy(event_list)
@@ -163,7 +163,7 @@ class Event(models.Model):
 
         for event in sorted_list:
 
-            if last_event is None or Event.contiguous(last_event, event):
+            if last_event is None or Event.contiguous(last_event, event, tol):
                 current_group.append(event)
             else:
                 grouped_list.append(copy(current_group))

--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -997,7 +997,7 @@ class Program(models.Model, CustomFormsLinkModel):
         from esp.program.modules.module_ext import ClassRegModuleInfo
         from decimal import Decimal
 
-        times = Event.group_contiguous(list(self.getTimeSlots()), int(Tag.getTag('timeblock_contiguous_tolerance')))
+        times = Event.group_contiguous(list(self.getTimeSlots()), int(Tag.getProgramTag('timeblock_contiguous_tolerance', program = self)))
         crmi = self.classregmoduleinfo
         if crmi and crmi.class_max_duration is not None:
             max_seconds = crmi.class_max_duration * 60

--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -997,7 +997,7 @@ class Program(models.Model, CustomFormsLinkModel):
         from esp.program.modules.module_ext import ClassRegModuleInfo
         from decimal import Decimal
 
-        times = Event.group_contiguous(list(self.getTimeSlots()))
+        times = Event.group_contiguous(list(self.getTimeSlots()), int(Tag.getTag('timeblock_contiguous_tolerance')))
         crmi = self.classregmoduleinfo
         if crmi and crmi.class_max_duration is not None:
             max_seconds = crmi.class_max_duration * 60

--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -736,7 +736,7 @@ class ClassSection(models.Model):
                 if k not in available_times:
                     available_times.append(k)
 
-        timeslots = Event.group_contiguous(available_times)
+        timeslots = Event.group_contiguous(available_times, int(Tag.getTag('timeblock_contiguous_tolerance')))
 
         viable_list = []
 

--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -736,7 +736,7 @@ class ClassSection(models.Model):
                 if k not in available_times:
                     available_times.append(k)
 
-        timeslots = Event.group_contiguous(available_times, int(Tag.getTag('timeblock_contiguous_tolerance')))
+        timeslots = Event.group_contiguous(available_times, int(Tag.getProgramTag('timeblock_contiguous_tolerance', program = self.parent_class.parent_program)))
 
         viable_list = []
 

--- a/esp/esp/program/modules/handlers/adminclass.py
+++ b/esp/esp/program/modules/handlers/adminclass.py
@@ -476,7 +476,7 @@ class AdminClass(ProgramModuleObj):
         if not Tag.getBooleanTag('availability_group_timeslots'):
             time_groups = [list(time_options)]
         else:
-            time_groups = Event.group_contiguous(list(time_options))
+            time_groups = Event.group_contiguous(list(time_options), int(Tag.getTag('availability_group_tolerance')))
 
         teachers = cls.get_teachers()
 
@@ -521,7 +521,7 @@ class AdminClass(ProgramModuleObj):
         context['unscheduled'] = unscheduled_sections
         context['conflict_found'] = conflict_found
         # this seems kinda hacky, but it's probably fine for now
-        context['is_overbooked'] = sum([sec.duration for sec in cls.get_sections()]) > sum([Event.total_length(events).seconds/3600.0 for events in Event.group_contiguous(viable_times)])
+        context['is_overbooked'] = sum([sec.duration for sec in cls.get_sections()]) > sum([Event.total_length(events).seconds/3600.0 for events in Event.group_contiguous(viable_times, int(Tag.getTag('timeblock_contiguous_tolerance')))])
         context['num_groups'] = len(context['groups'])
         context['program'] = prog
 

--- a/esp/esp/program/modules/handlers/adminclass.py
+++ b/esp/esp/program/modules/handlers/adminclass.py
@@ -476,7 +476,7 @@ class AdminClass(ProgramModuleObj):
         if not Tag.getBooleanTag('availability_group_timeslots'):
             time_groups = [list(time_options)]
         else:
-            time_groups = Event.group_contiguous(list(time_options), int(Tag.getTag('availability_group_tolerance')))
+            time_groups = Event.group_contiguous(list(time_options), int(Tag.getProgramTag('availability_group_tolerance', program = prog)))
 
         teachers = cls.get_teachers()
 
@@ -521,7 +521,7 @@ class AdminClass(ProgramModuleObj):
         context['unscheduled'] = unscheduled_sections
         context['conflict_found'] = conflict_found
         # this seems kinda hacky, but it's probably fine for now
-        context['is_overbooked'] = sum([sec.duration for sec in cls.get_sections()]) > sum([Event.total_length(events).seconds/3600.0 for events in Event.group_contiguous(viable_times, int(Tag.getTag('timeblock_contiguous_tolerance')))])
+        context['is_overbooked'] = sum([sec.duration for sec in cls.get_sections()]) > sum([Event.total_length(events).seconds/3600.0 for events in Event.group_contiguous(viable_times, int(Tag.getProgramTag('timeblock_contiguous_tolerance', program = prog)))])
         context['num_groups'] = len(context['groups'])
         context['program'] = prog
 

--- a/esp/esp/program/modules/handlers/admincore.py
+++ b/esp/esp/program/modules/handlers/admincore.py
@@ -170,6 +170,7 @@ class AdminCore(ProgramModuleObj, CoreModule):
             form = ProgramTagSettingsForm(request.POST, program = prog)
             if form.is_valid():
                 form.save()
+                form = ProgramTagSettingsForm(program = prog) # replace null responses with defaults if processed successfully
         else:
             form = ProgramTagSettingsForm(program = prog)
 

--- a/esp/esp/program/modules/handlers/availabilitymodule.py
+++ b/esp/esp/program/modules/handlers/availabilitymodule.py
@@ -128,7 +128,7 @@ class AvailabilityModule(ProgramModuleObj):
         if not Tag.getBooleanTag('availability_group_timeslots'):
             time_groups = [list(time_options)]
         else:
-            time_groups = Event.group_contiguous(list(time_options), int(Tag.getTag('availability_group_tolerance')))
+            time_groups = Event.group_contiguous(list(time_options), int(Tag.getProgramTag('availability_group_tolerance', program = prog)))
 
         blank = False
 

--- a/esp/esp/program/modules/handlers/availabilitymodule.py
+++ b/esp/esp/program/modules/handlers/availabilitymodule.py
@@ -117,7 +117,7 @@ class AvailabilityModule(ProgramModuleObj):
         #   Renders the teacher availability page and handles submissions of said page.
 
         if tl == "manage":
-            # They probably want to be check or edit someone's availability instead
+            # They probably want to check or edit someone's availability instead
             return HttpResponseRedirect( '/manage/%s/%s/edit_availability' % (one, two) )
         else:
             return self.availabilityForm(request, tl, one, two, prog, request.user, False)
@@ -128,7 +128,7 @@ class AvailabilityModule(ProgramModuleObj):
         if not Tag.getBooleanTag('availability_group_timeslots'):
             time_groups = [list(time_options)]
         else:
-            time_groups = Event.group_contiguous(list(time_options))
+            time_groups = Event.group_contiguous(list(time_options), int(Tag.getTag('availability_group_tolerance')))
 
         blank = False
 

--- a/esp/esp/program/modules/handlers/resourcemodule.py
+++ b/esp/esp/program/modules/handlers/resourcemodule.py
@@ -633,7 +633,7 @@ class ResourceModule(ProgramModuleObj):
 
         #   Group contiguous blocks of time for the program
         time_options = self.program.getTimeSlots(types=['Class Time Block','Open Class Time Block'])
-        time_groups = Event.group_contiguous(list(time_options))
+        time_groups = Event.group_contiguous(list(time_options), int(Tag.getTag('availability_group_tolerance')))
 
         #   Retrieve remaining context information
         context['timeslots'] = [{'selections': group} for group in time_groups]

--- a/esp/esp/program/modules/handlers/resourcemodule.py
+++ b/esp/esp/program/modules/handlers/resourcemodule.py
@@ -633,7 +633,7 @@ class ResourceModule(ProgramModuleObj):
 
         #   Group contiguous blocks of time for the program
         time_options = self.program.getTimeSlots(types=['Class Time Block','Open Class Time Block'])
-        time_groups = Event.group_contiguous(list(time_options), int(Tag.getTag('availability_group_tolerance')))
+        time_groups = Event.group_contiguous(list(time_options), int(Tag.getProgramTag('availability_group_tolerance', program = prog)))
 
         #   Retrieve remaining context information
         context['timeslots'] = [{'selections': group} for group in time_groups]

--- a/esp/esp/program/modules/handlers/volunteersignup.py
+++ b/esp/esp/program/modules/handlers/volunteersignup.py
@@ -97,7 +97,7 @@ class VolunteerSignup(ProgramModuleObj, CoreModule):
         if not Tag.getBooleanTag('availability_group_timeslots'):
             time_groups = [list(time_options)]
         else:
-            time_groups = Event.group_contiguous(list(time_options))
+            time_groups = Event.group_contiguous(list(time_options), int(Tag.getTag('availability_group_tolerance')))
 
         context['groups'] = [[{'slot': t, 'id': time_options_dict[t].id} for t in group] for group in time_groups]
 

--- a/esp/esp/program/modules/handlers/volunteersignup.py
+++ b/esp/esp/program/modules/handlers/volunteersignup.py
@@ -97,7 +97,7 @@ class VolunteerSignup(ProgramModuleObj, CoreModule):
         if not Tag.getBooleanTag('availability_group_timeslots'):
             time_groups = [list(time_options)]
         else:
-            time_groups = Event.group_contiguous(list(time_options), int(Tag.getTag('availability_group_tolerance')))
+            time_groups = Event.group_contiguous(list(time_options), int(Tag.getProgramTag('availability_group_tolerance', program = prog)))
 
         context['groups'] = [[{'slot': t, 'id': time_options_dict[t].id} for t in group] for group in time_groups]
 

--- a/esp/esp/program/views.py
+++ b/esp/esp/program/views.py
@@ -785,6 +785,7 @@ def tags(request, section=""):
         form = TagSettingsForm(request.POST)
         if form.is_valid():
             form.save()
+            form = TagSettingsForm() # replace null responses with defaults if processed successfully
     else:
         form = TagSettingsForm()
 

--- a/esp/esp/tagdict/__init__.py
+++ b/esp/esp/tagdict/__init__.py
@@ -115,22 +115,6 @@ all_global_tags = {
         'category': 'teach',
         'is_setting': True,
     },
-    'availability_group_tolerance': {
-        'is_boolean': False,
-        'help_text': 'Time blocks must be less than this many minutes apart to be shown as contiguous for the availability module(s). This will not impact the calculation of possible class durations (see the "Timeblock contiguous tolerance" tag below).',
-        'default': '20',
-        'category': 'teach',
-        'is_setting': True,
-        'field': forms.IntegerField(min_value=0),
-    },
-    'timeblock_contiguous_tolerance': {
-        'is_boolean': False,
-        'help_text': 'Time blocks must be less than this many minutes apart to be considered contiguous for a single class.',
-        'default': '20',
-        'category': 'teach',
-        'is_setting': True,
-        'field': forms.IntegerField(min_value=0),
-    },
     'group_phone_number': {
         'is_boolean': False,
         'help_text': 'Phone number that will be displayed on nametags and room rosters',
@@ -961,6 +945,22 @@ all_program_tags = {
         'default': 'Note: Please make sure to check in before your first class today.',
         'category': 'teach',
         'is_setting': True,
+    },
+    'availability_group_tolerance': {
+        'is_boolean': False,
+        'help_text': 'Time blocks must be less than this many minutes apart to be shown as contiguous for the availability module(s). This will not impact the calculation of possible class durations (see the "Timeblock contiguous tolerance" tag below).',
+        'default': '20',
+        'category': 'teach',
+        'is_setting': True,
+        'field': forms.IntegerField(min_value=0),
+    },
+    'timeblock_contiguous_tolerance': {
+        'is_boolean': False,
+        'help_text': 'Time blocks must be less than this many minutes apart to be considered contiguous for a single class.',
+        'default': '20',
+        'category': 'teach',
+        'is_setting': True,
+        'field': forms.IntegerField(min_value=0),
     },
 }
 

--- a/esp/esp/tagdict/__init__.py
+++ b/esp/esp/tagdict/__init__.py
@@ -115,6 +115,22 @@ all_global_tags = {
         'category': 'teach',
         'is_setting': True,
     },
+    'availability_group_tolerance': {
+        'is_boolean': False,
+        'help_text': 'Time blocks must be less than this many minutes apart to be shown as contiguous for the availability module(s). This will not impact the calculation of possible class durations (see the "Timeblock contiguous tolerance" tag below).',
+        'default': '20',
+        'category': 'teach',
+        'is_setting': True,
+        'field': forms.IntegerField(min_value=0),
+    },
+    'timeblock_contiguous_tolerance': {
+        'is_boolean': False,
+        'help_text': 'Time blocks must be less than this many minutes apart to be considered contiguous for a single class.',
+        'default': '20',
+        'category': 'teach',
+        'is_setting': True,
+        'field': forms.IntegerField(min_value=0),
+    },
     'group_phone_number': {
         'is_boolean': False,
         'help_text': 'Phone number that will be displayed on nametags and room rosters',


### PR DESCRIPTION
This adds two global tags which allow for admins to adjust how tolerant we are of classes' contiguousness (in minutes) for visual purposes ('availability_group_tolerance') and for functional/scheduling purposes ('timeblock_contiguous_tolerance'). I imagine the former will be more useful, but I guess there are some weird edge cases for the latter, so I included it.

I also made a little fix to the tag settings forms where if you saved the form with a blank answer, it would show as blank after the form was submitted, even though the website would then be using the default for the tag (so now we show that default after successful form submission).

First step towards fixing https://github.com/learning-unlimited/ESP-Website/issues/246