### PR TITLE
Make default availability none for teacher availability form

### DIFF
--- a/esp/esp/program/modules/handlers/availabilitymodule.py
+++ b/esp/esp/program/modules/handlers/availabilitymodule.py
@@ -192,14 +192,6 @@ class AvailabilityModule(ProgramModuleObj):
 
         #   Show new form
 
-        if not (len(available_slots) or blank): # I'm not sure whether or not we want the "or blank"
-            #   If they didn't enter anything, make everything checked by default.
-            available_slots = self.program.getTimeSlots(types=[self.event_type()])
-            #   The following 2 lines mark the teacher as always available.  This
-            #   is sometimes helpful, but not usually the desired behavior.
-            #   for a in available_slots:
-            #       teacher.addAvailableTime(self.program, a)
-
         context =   {
                         'groups': [
                             [


### PR DESCRIPTION
This changes the default behavior for the teacher availability form from all timeblocks available to all timeblocks not available. I believe this should increase availability accuracy, since the current default behavior was opposite of how our other forms work (e.g. volunteer signup) and how other forms on the internet work (e.g. whenisgood, when2meet).

It should be noted that teachers have always had no availability by default if the availability module is enabled, but previously we just highlighted all of the timeblocks in the form if they hadn't filled it out before. This change only affects the default behavior of the form itself.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/2584.