### PR TITLE
Add coteacher and catalog preview buttons to class edit page

### DIFF
--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -524,15 +524,18 @@ class TeacherClassRegModule(ProgramModuleObj):
     @needs_teacher
     @meets_deadline('/Classes/Coteachers')
     def coteachers(self, request, tl, one, two, module, extra, prog):
-        if not 'clsid' in request.POST:
+        if 'clsid' in request.GET:
+            classes = ClassSubject.objects.filter(id = request.GET['clsid'])
+        elif 'clsid' in request.POST:
+            classes = ClassSubject.objects.filter(id = request.POST['clsid'])
+        else:
             return self.goToCore(tl) # just fails.
 
         if extra == 'nojs':
             ajax = False
         else:
             ajax = True
-
-        classes = ClassSubject.objects.filter(id = request.POST['clsid'])
+        
         if len(classes) != 1 or not request.user.canEdit(classes[0]):
             return render_to_response(self.baseDir()+'cannoteditclass.html', request, {})
 

--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -535,7 +535,7 @@ class TeacherClassRegModule(ProgramModuleObj):
             ajax = False
         else:
             ajax = True
-        
+
         if len(classes) != 1 or not request.user.canEdit(classes[0]):
             return render_to_response(self.baseDir()+'cannoteditclass.html', request, {})
 

--- a/esp/templates/program/modules/teacherclassregmodule/classedit.html
+++ b/esp/templates/program/modules/teacherclassregmodule/classedit.html
@@ -27,6 +27,17 @@
     <a href="/manage/{{ program.getUrlBase }}/main">Return to the {{ program.niceName }} admin portal</a><br />
     </p>
 {% else %}
+    {% if addoredit == 'Edit' %}
+        {% load modules %}
+        <center>
+        <a class="btn" title="Modify Coteachers" href="/teach/{{ program.getUrlBase }}/coteachers?clsid={{ class.id }}">Modify Coteachers</a>
+        {% if program|hasModule:"TeacherPreviewModule" %}
+        <a class="btn" title="Catalog Preview" href="/teach/{{ program.getUrlBase }}/catalogpreview/{{ class.id }}">Catalog Preview</a>
+        {% endif %}
+        <br /><br />
+        </center>
+    {% endif %}
+
     {% inline_program_qsd_block program qsd_name %}
         <p>
         Thank you for your interest in teaching a {{ classtype }} for {{ one }}!  Please ensure that you are available to teach your class at any of the times you have <a href="/teach/{{ program.url }}/availability">specified that you are available</a>.  If there is any chance that your plans may change and you won't be able to teach, please do not fill out this form; <a href="mailto:{{ program.director_email }}">contact the program directors</a>.</p>


### PR DESCRIPTION
This adds two buttons/links to the top of the edit class page to hopefully make it easier to find the coteacher and catalog preview pages.

![image](https://user-images.githubusercontent.com/7232514/109678784-930a9600-7b40-11eb-947a-8d71bd448bc0.png)


Fixes https://github.com/learning-unlimited/ESP-Website/issues/2501.