### PR TITLE
Add sorting options to grid-based class changes

### DIFF
--- a/esp/public/media/default_styles/onsite_ajax_status.css
+++ b/esp/public/media/default_styles/onsite_ajax_status.css
@@ -183,7 +183,7 @@ span {
     font-style: italic;
 }
 
-#messages, #category_controls, #settings_controls, #class_search_controls {
+#messages, #category_controls, #settings_controls, #class_search_controls, #sort_controls {
     text-align: left;
     background-color: #EEF3FF;
     border: 1px solid #99CCFF;

--- a/esp/public/media/scripts/onsite/ajax_status.js
+++ b/esp/public/media/scripts/onsite/ajax_status.js
@@ -912,7 +912,7 @@ function render_table(display_mode, student_id)
             filtered_sections.sort((a, b) => data.sections[a].class_id - data.sections[b].class_id);
             break;
         case "category":
-            filtered_sections.sort((a, b) => (data.classes[data.sections[a].class_id].category__id > data.classes[data.sections[b].class_id].category__id) ? 1 : -1);
+            filtered_sections.sort((a, b) => data.classes[data.sections[a].class_id].category__id - data.classes[data.sections[b].class_id].category__id);
             break;
         case "fullness":
             filtered_sections.sort((a, b) => data.sections[a].num_students_enrolled / data.sections[a].capacity - data.sections[b].num_students_enrolled / data.sections[b].capacity);

--- a/esp/public/media/scripts/onsite/ajax_status.js
+++ b/esp/public/media/scripts/onsite/ajax_status.js
@@ -23,7 +23,8 @@ var settings = {
     hide_past_time_blocks: false,
     hide_conflicting: false,
     search_term: "",
-    categories_to_display: {}
+    categories_to_display: {},
+    sort_setting: "length"
 };
 
 /*  Ajax status flags
@@ -162,6 +163,7 @@ function setup_settings()
     $j("#show_closed_reg").unbind("change");
     $j("#hide_past_time_blocks").unbind("change");
     $j("#hide_conflicting").unbind("change");
+    $j("#sort_control").unbind("change");
 
 
     //  Apply settings
@@ -174,6 +176,7 @@ function setup_settings()
     settings.show_closed_reg = $j("#show_closed_reg").prop("checked");
     settings.hide_past_time_blocks = $j("#hide_past_time_blocks").prop("checked");
     settings.hide_conflicting = $j("#hide_conflicting").prop("checked");
+    settings.sort_setting = $j("#sort_control").val();
 
     $j("#hide_full_control").change(handle_settings_change);
     $j("#override_control").change(handle_settings_change);
@@ -184,6 +187,7 @@ function setup_settings()
     $j("#show_closed_reg").change(handle_settings_change);
     $j("#hide_past_time_blocks").change(handle_settings_change);
     $j("#hide_conflicting").change(handle_settings_change);
+    $j("#sort_control").change(handle_settings_change);
 }
 
 function hide_sidebar()
@@ -898,6 +902,21 @@ function render_table(display_mode, student_id)
     //exclude the class if it started in the past (and we're not showing past timeblocks)
     if (settings.hide_past_time_blocks) {
         filtered_sections = filtered_sections.filter(sec_id => check_timeslots(sec_id));
+    }
+    
+    //sort the sections as desired
+    switch(settings.sort_setting) {
+        case "length":
+            break; //we've already sorted by this
+        case "class_id":
+            filtered_sections.sort((a, b) => data.sections[a].class_id - data.sections[b].class_id);
+            break;
+        case "category":
+            filtered_sections.sort((a, b) => (data.classes[data.sections[a].class_id].category__id > data.classes[data.sections[b].class_id].category__id) ? 1 : -1);
+            break;
+        case "fullness":
+            filtered_sections.sort((a, b) => data.sections[a].num_students_enrolled / data.sections[a].capacity - data.sections[b].num_students_enrolled / data.sections[b].capacity);
+            break;
     }
     
     for (var sec_id of filtered_sections)

--- a/esp/templates/program/modules/onsiteclasslist/ajax_status.html
+++ b/esp/templates/program/modules/onsiteclasslist/ajax_status.html
@@ -71,6 +71,21 @@
 </tr>
 <tr>
 <td>
+    <div id="sort_controls">
+        <b>Sort sections by:</b>
+        <div>
+            <select id="sort_control">
+                <option value="length" selected># of Timeblocks</option>
+                <option value="class_id">Class ID</option>
+                <option value="category">Category</option>
+                <option value="fullness">Fullness</option>
+            </select>
+        </div>
+    </div>
+</td>
+</tr>
+<tr>
+<td>
     <div id="category_controls">
         <b>Categories to display</b>
         <div>


### PR DESCRIPTION
This adds a dropdown menu to the grid-based class changes page that lets the user specify whether sections are sorted by class ID (ascending), length of section (descending, default), fullness (ascending), or category (ascending by category ID).

Fixes https://github.com/learning-unlimited/ESP-Website/issues/1544.