### PR TITLE
Add scheduling checks to ajax scheduler

### DIFF
--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Cell.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Cell.js
@@ -234,7 +234,8 @@ function Cell(el, section, room_id, timeslot_id, matrix) {
                 teacher_loop:
                     for(var teacher of section.teacher_data){
                         for(var sec of teacher.sections){
-                            if(sec == section.id || (sec in this.matrix.sections.scheduleAssignments && this.matrix.sections.scheduleAssignments[sec].room_id == scheduleAssignment.room_id)) continue;
+                            if(sec == section.id || !(sec in this.matrix.sections.scheduleAssignments)) continue;
+                            if(sec in this.matrix.sections.scheduleAssignments && this.matrix.sections.scheduleAssignments[sec].room_id == scheduleAssignment.room_id) continue;
                             for(var ts1 of this.matrix.sections.scheduleAssignments[sec].timeslots){
                                 for(var ts2 of scheduleAssignment.timeslots){
                                     if(ts1==ts2) continue;

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Cell.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Cell.js
@@ -216,7 +216,7 @@ function Cell(el, section, room_id, timeslot_id, matrix) {
                 teacher_loop:
                     for(var teacher of section.teacher_data){
                         for(var sec of teacher.sections){
-                            if(sec == section.id || !(sec in this.matrix.sections.scheduleAssignments[sec])) continue;
+                            if(sec == section.id || !(sec in this.matrix.sections.scheduleAssignments)) continue;
                             for(var ts of this.matrix.sections.scheduleAssignments[sec].timeslots){
                                 if(scheduleAssignment.timeslots.includes(ts)){
                                     n_teachers += 1;
@@ -234,7 +234,7 @@ function Cell(el, section, room_id, timeslot_id, matrix) {
                 teacher_loop:
                     for(var teacher of section.teacher_data){
                         for(var sec of teacher.sections){
-                            if(sec == section.id || (sec in this.matrix.sections.scheduleAssignments[sec] && this.matrix.sections.scheduleAssignments[sec].room_id == scheduleAssignment.room_id)) continue;
+                            if(sec == section.id || (sec in this.matrix.sections.scheduleAssignments && this.matrix.sections.scheduleAssignments[sec].room_id == scheduleAssignment.room_id)) continue;
                             for(var ts1 of this.matrix.sections.scheduleAssignments[sec].timeslots){
                                 for(var ts2 of scheduleAssignment.timeslots){
                                     if(ts1==ts2) continue;

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Cell.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Cell.js
@@ -211,7 +211,7 @@ function Cell(el, section, room_id, timeslot_id, matrix) {
                 if(n_teachers == 0) return grey;
                 return this.cellColors.HSLToRGB(0,100,100 - 10 * n_teachers); // Color red based on number of teachers
             case "double_booked":
-                // Count how many teachers are teaching other sections at the same time as this one
+                // Count how many of the coteachers are teaching other sections at the same time as this one
                 var n_teachers = 0;
                 teacher_loop:
                     for(var teacher of section.teacher_data){
@@ -229,16 +229,16 @@ function Cell(el, section, room_id, timeslot_id, matrix) {
                 if(n_teachers == 0) return grey;
                 return this.cellColors.HSLToRGB(0,100,100 - 10 * n_teachers); // Color red based on number of teachers
             case "running":
-                // Count how many teachers are teaching other sections immediately before or after this one in a different room
+                // Count how many of the coteachers are teaching other sections immediately before or after this one in a different room
                 var n_teachers = 0;
                 teacher_loop:
                     for(var teacher of section.teacher_data){
                         for(var sec of teacher.sections){
                             if(sec == section.id || !(sec in this.matrix.sections.scheduleAssignments)) continue;
-                            if(sec in this.matrix.sections.scheduleAssignments && this.matrix.sections.scheduleAssignments[sec].room_id == scheduleAssignment.room_id) continue;
+                            if(this.matrix.sections.scheduleAssignments[sec].room_id == scheduleAssignment.room_id) continue;
                             for(var ts1 of this.matrix.sections.scheduleAssignments[sec].timeslots){
+                                if(scheduleAssignment.timeslots.includes(ts1)) continue;
                                 for(var ts2 of scheduleAssignment.timeslots){
-                                    if(ts1==ts2) continue;
                                     if(this.matrix.timeslots.are_timeslots_contiguous([this.matrix.timeslots.get_by_id(ts1), this.matrix.timeslots.get_by_id(ts2)]) ||
                                        this.matrix.timeslots.are_timeslots_contiguous([this.matrix.timeslots.get_by_id(ts2), this.matrix.timeslots.get_by_id(ts1)])){
                                         n_teachers += 1;

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Cell.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Cell.js
@@ -167,7 +167,7 @@ function Cell(el, section, room_id, timeslot_id, matrix) {
                 if(n_req == 0) return grey;
                 return this.cellColors.HSLToRGB(0,100,100 - 10 * n_req); // Color red based on number of resource requests
             case "hungry":
-                // If this section overlaps with lunch, count how many teachers are teaching other sections that overlap with the rest of the lunch time timeslots
+                // If this section overlaps with lunch, count how many of the coteachers are teaching other sections that overlap with the rest of the lunch time timeslots
                 var today = undefined;
                 var n_teachers = 0;
                 // Find which day, if any, of lunch constraints to worry about (we only care if this section overlaps with lunch at all)
@@ -181,7 +181,7 @@ function Cell(el, section, room_id, timeslot_id, matrix) {
                         }
                     }
                 if(today){
-                    // Figure out which teachers, if any, have sections that overlap with all of the lunch constraints for that day
+                    // Count how many of the coteachers have sections that overlap with all of the lunch constraints for that day
                     teacher_loop:
                         for(var teacher of section.teacher_data){
                             var lunch_ids = this.matrix.timeslots.lunch_timeslots[today].map(x => x.id);

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Cell.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Cell.js
@@ -216,7 +216,7 @@ function Cell(el, section, room_id, timeslot_id, matrix) {
                 teacher_loop:
                     for(var teacher of section.teacher_data){
                         for(var sec of teacher.sections){
-                            if(sec == section.id) continue;
+                            if(sec == section.id || !(sec in this.matrix.sections.scheduleAssignments[sec])) continue;
                             for(var ts of this.matrix.sections.scheduleAssignments[sec].timeslots){
                                 if(scheduleAssignment.timeslots.includes(ts)){
                                     n_teachers += 1;
@@ -234,7 +234,7 @@ function Cell(el, section, room_id, timeslot_id, matrix) {
                 teacher_loop:
                     for(var teacher of section.teacher_data){
                         for(var sec of teacher.sections){
-                            if(sec == section.id || this.matrix.sections.scheduleAssignments[sec].room_id == scheduleAssignment.room_id) continue;
+                            if(sec == section.id || (sec in this.matrix.sections.scheduleAssignments[sec] && this.matrix.sections.scheduleAssignments[sec].room_id == scheduleAssignment.room_id)) continue;
                             for(var ts1 of this.matrix.sections.scheduleAssignments[sec].timeslots){
                                 for(var ts2 of scheduleAssignment.timeslots){
                                     if(ts1==ts2) continue;

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Cell.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Cell.js
@@ -144,10 +144,10 @@ function Cell(el, section, room_id, timeslot_id, matrix) {
                 }
             case "lunch":
                 // Check if section overlaps with all lunch timeslots for a single day
-                for(day in this.matrix.timeslots.lunch_timeslots){
+                for(var day in this.matrix.timeslots.lunch_timeslots){
                     var n_overlap = 0;
                     var n_lunch = this.matrix.timeslots.lunch_timeslots[day].length;
-                    for(lunch_timeslot of this.matrix.timeslots.lunch_timeslots[day]){
+                    for(var lunch_timeslot of this.matrix.timeslots.lunch_timeslots[day]){
                         if(scheduleAssignment.timeslots.includes(lunch_timeslot.id)) n_overlap += 1;
                     }
                     if(n_overlap == n_lunch) return red;
@@ -157,8 +157,8 @@ function Cell(el, section, room_id, timeslot_id, matrix) {
                 // Count how many resoure requests are not fulfilled by the room
                 var n_req = 0;
                 req_loop:
-                    for(req of section.resource_requests[section.id]){
-                        for(res of this.matrix.rooms[this.room_id].associated_resources){
+                    for(var req of section.resource_requests[section.id]){
+                        for(var res of this.matrix.rooms[this.room_id].associated_resources){
                             if(req[0].id == res.res_type_id && req[1] == res.value) continue req_loop;
                         }
                         n_req += 1;
@@ -172,8 +172,8 @@ function Cell(el, section, room_id, timeslot_id, matrix) {
                 var n_teachers = 0;
                 // Find which day, if any, of lunch constraints to worry about (we only care if this section overlaps with lunch at all)
                 day_loop:
-                    for(day in this.matrix.timeslots.lunch_timeslots){
-                        for(ts of this.matrix.timeslots.lunch_timeslots[day].map(x => x.id)){
+                    for(var day in this.matrix.timeslots.lunch_timeslots){
+                        for(var ts of this.matrix.timeslots.lunch_timeslots[day].map(x => x.id)){
                             if(scheduleAssignment.timeslots.includes(ts)){
                                 today = day;
                                 break day_loop;
@@ -183,10 +183,10 @@ function Cell(el, section, room_id, timeslot_id, matrix) {
                 if(today){
                     // Figure out which teachers, if any, have sections that overlap with all of the lunch constraints for that day
                     teacher_loop:
-                        for(teacher of section.teacher_data){
+                        for(var teacher of section.teacher_data){
                             var lunch_ids = this.matrix.timeslots.lunch_timeslots[today].map(x => x.id);
                             // Address this section separately, since it might be a ghost section (and therefore not in sections.scheduleAssignments)
-                            for(ts of scheduleAssignment.timeslots){
+                            for(var ts of scheduleAssignment.timeslots){
                                 if(lunch_ids.includes(ts)){
                                     lunch_ids.splice(lunch_ids.indexOf(ts), 1)
                                 }
@@ -195,8 +195,8 @@ function Cell(el, section, room_id, timeslot_id, matrix) {
                                     continue teacher_loop;
                                 }
                             }
-                            for(sec of teacher.sections){
-                                for(ts of this.matrix.sections.scheduleAssignments[sec].timeslots){
+                            for(var sec of teacher.sections){
+                                for(var ts of this.matrix.sections.scheduleAssignments[sec].timeslots){
                                     if(lunch_ids.includes(ts)){
                                         lunch_ids.splice(lunch_ids.indexOf(ts), 1)
                                     }
@@ -214,10 +214,10 @@ function Cell(el, section, room_id, timeslot_id, matrix) {
                 // Count how many teachers are teaching other sections at the same time as this one
                 var n_teachers = 0;
                 teacher_loop:
-                    for(teacher of section.teacher_data){
-                        for(sec of teacher.sections){
+                    for(var teacher of section.teacher_data){
+                        for(var sec of teacher.sections){
                             if(sec == section.id) continue;
-                            for(ts of this.matrix.sections.scheduleAssignments[sec].timeslots){
+                            for(var ts of this.matrix.sections.scheduleAssignments[sec].timeslots){
                                 if(scheduleAssignment.timeslots.includes(ts)){
                                     n_teachers += 1;
                                     continue teacher_loop;
@@ -232,11 +232,11 @@ function Cell(el, section, room_id, timeslot_id, matrix) {
                 // Count how many teachers are teaching other sections immediately before or after this one in a different room
                 var n_teachers = 0;
                 teacher_loop:
-                    for(teacher of section.teacher_data){
-                        for(sec of teacher.sections){
+                    for(var teacher of section.teacher_data){
+                        for(var sec of teacher.sections){
                             if(sec == section.id || this.matrix.sections.scheduleAssignments[sec].room_id == scheduleAssignment.room_id) continue;
-                            for(ts1 of this.matrix.sections.scheduleAssignments[sec].timeslots){
-                                for(ts2 of scheduleAssignment.timeslots){
+                            for(var ts1 of this.matrix.sections.scheduleAssignments[sec].timeslots){
+                                for(var ts2 of scheduleAssignment.timeslots){
                                     if(ts1==ts2) continue;
                                     if(this.matrix.timeslots.are_timeslots_contiguous([this.matrix.timeslots.get_by_id(ts1), this.matrix.timeslots.get_by_id(ts2)]) ||
                                        this.matrix.timeslots.are_timeslots_contiguous([this.matrix.timeslots.get_by_id(ts2), this.matrix.timeslots.get_by_id(ts1)])){
@@ -254,8 +254,8 @@ function Cell(el, section, room_id, timeslot_id, matrix) {
                 // Count how many teachers are not available for some or all of this section
                 var n_teachers = 0;
                 teacher_loop:
-                    for(teacher of section.teacher_data){
-                        for(ts of scheduleAssignment.timeslots){
+                    for(var teacher of section.teacher_data){
+                        for(var ts of scheduleAssignment.timeslots){
                             if(!teacher.availability.includes(ts)){
                                 n_teachers += 1;
                                 continue teacher_loop;

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/CellColors.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/CellColors.js
@@ -5,19 +5,57 @@
  * @method color(section)
  * @method textColor(section)
  */
-var colors = palette('tol-rainbow', 100);
-
-function hexToRGB(hex) {
-    var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-    return result ? {
-        r: parseInt(result[1], 16),
-        g: parseInt(result[2], 16),
-        b: parseInt(result[3], 16)
-    } : null;
-}
-
 function CellColors() {
+    this.colors = palette('tol-rainbow', 100);
     this.specialColor = "rgb(255, 153, 0)";
+
+    this.hexToRGB = function(hex) {
+        var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+        return result ? {
+            r: parseInt(result[1], 16),
+            g: parseInt(result[2], 16),
+            b: parseInt(result[3], 16)
+        } : null;
+    }
+
+    this.HSLToRGB = function(h,s,l) {
+        // Must be fractions of 1
+        s /= 100;
+        l /= 100;
+
+        let c = (1 - Math.abs(2 * l - 1)) * s,
+            x = c * (1 - Math.abs((h / 60) % 2 - 1)),
+            m = l - c/2,
+            r = 0,
+            g = 0,
+            b = 0;
+        if (0 <= h && h < 60) {
+            r = c; g = x; b = 0;  
+        } else if (60 <= h && h < 120) {
+            r = x; g = c; b = 0;
+        } else if (120 <= h && h < 180) {
+            r = 0; g = c; b = x;
+        } else if (180 <= h && h < 240) {
+            r = 0; g = x; b = c;
+        } else if (240 <= h && h < 300) {
+            r = x; g = 0; b = c;
+        } else if (300 <= h && h < 360) {
+            r = c; g = 0; b = x;
+        }
+        r = Math.round((r + m) * 255);
+        g = Math.round((g + m) * 255);
+        b = Math.round((b + m) * 255);
+
+        return {r: r, g: g, b: b};
+    }
+
+    this.RGBToString = function(rgb) {
+        return "rgb(" +
+              rgb.r + "," +
+              rgb.g + "," +
+              rgb.b + ")";
+    }
+
     /**
      * Returns the primary background color of the section, as an array of red,
      * green, and blue components.
@@ -28,36 +66,19 @@ function CellColors() {
         var code = section.emailcode;
         var colcode = code.substr(1, code.lastIndexOf("s") - 1).padStart(2, "0");
         /* Use the last two digits of the class code to get a color */
-        var col = colors[parseInt(colcode.substr(colcode.length - 2)) * 23 % 100];
-        return hexToRGB(col);
-    };
-    this.background = function(section) {
-        var color = this.color(section);
-        var rgb = ("rgb(" +
-          color.r + "," +
-          color.g + "," +
-          color.b + ")");
-        if (section.flags.indexOf("Special scheduling needs") !== -1) {
-          return ("linear-gradient(to bottom right, " +
-            this.specialColor + " 0%," +
-            rgb + " 50%," +
-            this.specialColor + " 100%)");
-        } else {
-          return rgb;
-        }
+        var col = this.colors[parseInt(colcode.substr(colcode.length - 2)) * 23 % 100];
+        return this.hexToRGB(col);
     };
 
     /**
-     * Returns the text color of the section (white if dark, black if light)
+     * Returns the text color given the rgb color (white if dark, black if light)
      *
-     * @param section: The section to compute the background color of
+     * @param rgb: The rgb background to use to compute text color
      */
-    this.textColor = function(section) {
-        var color = this.color(section);
-
+    this.textColor = function(rgb) {
         // The relative luminance is a measure of how bright the color is.
         // Green counts more because human eyes are more sensitive to it.
-        relativeLuminance = 0.2126 * color.r + 0.7152 * color.g + 0.0722 * color.b;
+        relativeLuminance = 0.2126 * rgb.r + 0.7152 * rgb.g + 0.0722 * rgb.b;
         if(relativeLuminance < 128) {
             return "white";
         } else {

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Matrix.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Matrix.js
@@ -113,7 +113,6 @@ function Matrix(
 
     // Set up scheduling checks
     this.updateCells = function(){
-        var filt_rooms = this.filteredRooms()
         $j.each(this.cells, function(index, room) {
             $j.each(room, function(index, cell) {
                 if(!cell.disabled && cell.section) cell.update();

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Matrix.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Matrix.js
@@ -72,8 +72,8 @@ function Matrix(
     /**
      * Get the rooms satisfying the search criteria.
      */
-    this.filtered_rooms = function(allowScheduled){
-        var returned_rooms = [];
+    this.filteredRooms = function(){
+        var returnedRooms = [];
         $j.each(this.rooms, function(index, room) {
             var roomValid;
             // check every criterion in the room filter tab, short-circuiting if possible
@@ -89,18 +89,18 @@ function Matrix(
                 }
             }
             if (roomValid) {
-                returned_rooms.push(room);
+                returnedRooms.push(room);
             }
         }.bind(this));
-        return returned_rooms;
+        return returnedRooms;
     };
     
-    this.update = function(){
-        var filt_rooms = this.filtered_rooms()
+    this.updateRooms = function(){
+        var filtRooms = this.filteredRooms()
         $j.each(this.rooms, function(index, room) {
             // get rows to show or hide
             var rows = $j(".room[data-id='" + room.id + "']").parent();
-            if (filt_rooms.includes(room)) {
+            if (filtRooms.includes(room)) {
                 rows.css("display", "table-row");
             } else {
                 rows.css("display", "none");
@@ -111,6 +111,22 @@ function Matrix(
     this.sections = sections;
     this.sections.bindMatrix(this);
 
+    // Set up scheduling checks
+    this.updateCells = function(){
+        var filt_rooms = this.filteredRooms()
+        $j.each(this.cells, function(index, room) {
+            $j.each(room, function(index, cell) {
+                if(!cell.disabled && cell.section) cell.update();
+            })
+        });
+    };
+    
+    this.scheduling_check = "";
+    $j('input[type=radio][name=scheduling-checks]').change(function() {
+        this.scheduling_check = event.target.value;
+        this.updateCells();
+    }.bind(this));
+
     this.messagePanel = messagePanel;
     this.sectionInfoPanel = sectionInfoPanel;
     this.timeslotHeaders = {};
@@ -119,7 +135,7 @@ function Matrix(
      * Initialize the matrix
      */
     this.init = function(){
-        $j("body").on("room-filters-changed", this.update.bind(this));
+        $j("body").on("room-filters-changed", this.updateRooms.bind(this));
         // set up cells
         var matrix = this;
         this.cells = function(){

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
@@ -410,7 +410,6 @@ function Sections(sections_data, section_details_data, teacher_data, scheduleAss
             this.unselectSection();
         }
 
-
         // Add section to cells
         for(timeslot_index in schedule_timeslots){
             var timeslot_id = schedule_timeslots[timeslot_index];
@@ -426,6 +425,9 @@ function Sections(sections_data, section_details_data, teacher_data, scheduleAss
 
         // Trigger the event that tells the directory to update itself.
         $j("body").trigger("schedule-changed");
+
+        // Update cell coloring
+        this.matrix.updateCells();
     }
 
     /**
@@ -437,10 +439,10 @@ function Sections(sections_data, section_details_data, teacher_data, scheduleAss
     this.scheduleAsGhost = function(room_id, first_timeslot_id) {
         var schedule_timeslots = this.matrix.timeslots.
             get_timeslots_to_schedule_section(this.selectedSection, first_timeslot_id);
+        this.ghostScheduleAssignment = {'room_id': room_id, 'timeslots': schedule_timeslots};
         $j.each(schedule_timeslots, function(index, timeslot_id) {
             this.matrix.getCell(room_id, timeslot_id).addGhostSection(this.selectedSection);
         }.bind(this));
-        this.ghostScheduleAssignment = {'room_id': room_id, 'timeslots': schedule_timeslots};
     };
 
     /**

--- a/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
+++ b/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
@@ -72,6 +72,7 @@
             <li><a href="#classes">Classes</a></li>
             <li><a href="#filters">Class Filters</a></li>
             <li><a href="#filters2">Room Filters</a></li>
+            <li><a href="#checks">Checks</a></li>
           </ul>
           <div id="side-panel-inner">
                 <div id="classes">
@@ -164,6 +165,31 @@
                     <div id="room-filter-name">
                         <label for="room-filter-name-text"><b>Name</b></label><br />
                         <input id="room-filter-name-text"></input>
+                    </div>
+                  </form>
+                </div>
+                <div id="checks">
+                  <form>
+                    <label for="scheduling-checks"><b>Scheduling Checks</b></label><br />
+                    <div id="scheduling-checks">
+                        <input type="radio" name="scheduling-checks" value="" checked></input> None
+                        <br />
+                        <input type="radio" name="scheduling-checks" value="capacity"></input> Room Capacity Mismatch
+                        <br />
+                        <input type="radio" name="scheduling-checks" value="unapproved"></input> Unapproved Classes
+                        <br />
+                        <input type="radio" name="scheduling-checks" value="requests"></input> Unfulfilled Resource Requests
+                        <br />
+                        <input type="radio" name="scheduling-checks" value="lunch"></input> Classes Scheduled Over Lunch
+                        <br />
+                        <input type="radio" name="scheduling-checks" value="hungry"></input> Hungry Teachers
+                        <br />
+                        <input type="radio" name="scheduling-checks" value="running"></input> Running Teachers
+                        <br />
+                        <input type="radio" name="scheduling-checks" value="double_booked"></input> Double-Booked Teachers
+                        <br />
+                        <input type="radio" name="scheduling-checks" value="unavailable"></input> Unavailable Teachers
+                        <br />
                     </div>
                   </form>
                 </div>


### PR DESCRIPTION
This adds a set of scheduling checks to the ajax scheduler that can be enabled by selecting them in the new options tab (only one can be enabled at a time):
![image](https://user-images.githubusercontent.com/7232514/110218295-907ca900-7e7e-11eb-83b0-c3e94fb30a0d.png)

Once a scheduling check is enabled, it will be used to color the cells in the scheduling matrix. For example, for the "Double-Booked Teachers" check, it will color sections red that overlap in time and have the same teacher(s):
![image](https://user-images.githubusercontent.com/7232514/110218305-b013d180-7e7e-11eb-9728-aa419e821c09.png)

This functionality works for looking at sections that are already scheduled and for scheduling sections in new spots (e.g. if the capacity check is enabled, the color of the cell will change as you move your cursor over different cells in the matrix based on the capacities of the classrooms). This means that in addition to using these checks AFTER scheduling, you can also use them DURING scheduling to see if adding/moving a section in a particular spot will cause or remove an issue (e.g. will make a teacher "hungry" or have to "run"). You can see this in this example screenshot where I am moving the B6s1 section:
![image](https://user-images.githubusercontent.com/7232514/110218520-d423e280-7e7f-11eb-94f5-cad736b98441.png)

Then, once a section is scheduled, we update the colors of ALL cells to indicate if new issues have arisen. Note: I'm not sure how the performance is for this last part for larger programs, but I imagine it shouldn't be too bad since javascript is pretty efficient, and it's not like it will prevent you from scheduling other sections.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/1406.