### PR TITLE
Fix scheduling checks affected by floating resources

### DIFF
--- a/esp/esp/program/modules/handlers/schedulingcheckmodule.py
+++ b/esp/esp/program/modules/handlers/schedulingcheckmodule.py
@@ -237,7 +237,7 @@ class SchedulingCheckRunner:
         problem_classes = []
         for s in self._all_class_sections():
             mt =  sorted(s.get_meeting_times())
-            rooms = s.getResources()
+            rooms = [a.resource for a in s.classroomassignments()]
             if(len(rooms) != len(mt)):
                 problem_classes.append(s)
             else:
@@ -250,7 +250,7 @@ class SchedulingCheckRunner:
         output = []
         for s in self._all_class_sections():
             mt = sorted(s.get_meeting_times())
-            rooms = s.getResources()
+            rooms = [a.resource for a in s.classroomassignments()]
             res_events = sorted([x.event for x in rooms])
             if res_events != mt:
                 output.append({"Section": s, "Resource events": res_events,


### PR DESCRIPTION
This fixes the "Mismatched rooms and meeting times" and "Classes not completely scheduled or with gaps" scheduling checks that were broken when sections had been assigned floating resources (e.g. through the teacher check-in module). Now we only look at the classroom assignments, instead of all resource assignments, to determine if there are mismatches or the classes are not completely scheduled.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3108.