### PR TITLE
Fix ajax scheduler highlighting for single-block lunches

### DIFF
--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Matrix.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Matrix.js
@@ -177,9 +177,6 @@ function Matrix(
         var teaching_timeslots = timeslots[1];
         addClassToTimeslots(available_timeslots, "teacher-available-cell");
         addClassToTimeslots(teaching_timeslots, "teacher-teaching-cell");
-        if(section.length<=1) {
-            return;
-        }
         $j.each(available_timeslots, function(j, timeslot_id) {
             var timeslot = this.timeslots.get_by_id(timeslot_id);
             $j.each(this.rooms, function(k, room) {


### PR DESCRIPTION
Previously, if you had a single lunch on a particular day, the scheduler would show this timeblock as available for single-block sections. However, if you tried to schedule one of these sections in this timeblock, it would just fail silently. I realized this is actually because we weren't doing any lunch constraint checks for single-block classes, which I've fixed. Now, if there is a single lunch block, it is marked as available but not schedulable (green with slanted grey lines) for single-block sections, as should be desired.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3236.