### PR TITLE
Fix nametag USC combo selector

### DIFF
--- a/esp/esp/program/modules/handlers/commmodule.py
+++ b/esp/esp/program/modules/handlers/commmodule.py
@@ -38,7 +38,6 @@ from esp.utils.web import render_to_response
 from esp.dbmail.models import MessageRequest
 from esp.users.models   import ESPUser, PersistentQueryFilter
 from esp.users.controllers.usersearch import UserSearchController
-from esp.users.forms.generic_search_form import StudentSearchForm
 from esp.users.views.usersearch import get_user_checklist
 from django.db.models.query   import Q
 from esp.dbmail.models import ActionHandler
@@ -277,10 +276,7 @@ class CommModule(ProgramModuleObj):
 
             else:
                 raise ESPError('What do I do without knowing what kind of users to look for?', log=True)
-        else:
-            student_search_form = StudentSearchForm()
 
-        context['student_search_form'] = student_search_form
         #   Otherwise, render a page that shows the list selection options
         context.update(usc.prepare_context(prog))
 

--- a/esp/esp/program/modules/handlers/grouptextmodule.py
+++ b/esp/esp/program/modules/handlers/grouptextmodule.py
@@ -37,7 +37,6 @@ from esp.program.modules.handlers.listgenmodule import ListGenModule
 from esp.utils.web import render_to_response
 from esp.users.models   import ESPUser, PersistentQueryFilter, ContactInfo
 from esp.users.controllers.usersearch import UserSearchController
-from esp.users.forms.generic_search_form import StudentSearchForm
 from esp.users.views.usersearch import get_user_checklist
 from django.db.models.query   import Q
 from esp.dbmail.models import ActionHandler
@@ -118,10 +117,7 @@ class GroupTextModule(ProgramModuleObj):
             context['num_users'] = ESPUser.objects.filter(filterObj.get_Q()).distinct().count()
             context['est_time'] = float(context['num_users']) * 1.0 / len(settings.TWILIO_ACCOUNT_NUMBERS)
             return render_to_response(self.baseDir()+'options.html', request, context)
-        else:
-            student_search_form = StudentSearchForm()
 
-        context['student_search_form'] = student_search_form
         context.update(usc.prepare_context(prog, target_path='/manage/%s/grouptextpanel' % prog.url))
         return render_to_response(self.baseDir()+'search.html', request, context)
 

--- a/esp/esp/program/modules/handlers/listgenmodule.py
+++ b/esp/esp/program/modules/handlers/listgenmodule.py
@@ -425,10 +425,6 @@ class ListGenModule(ProgramModuleObj):
             })
             return render_to_response(self.baseDir()+'options.html', request, context)
 
-        else:
-            student_search_form = StudentSearchForm()
-
-        context['student_search_form'] = student_search_form
         #   Otherwise, render a page that shows the list selection options
         context.update(usc.prepare_context(prog, target_path='/manage/%s/selectList' % prog.url))
         return render_to_response(self.baseDir()+'search.html', request, context)

--- a/esp/esp/program/modules/handlers/nametagmodule.py
+++ b/esp/esp/program/modules/handlers/nametagmodule.py
@@ -38,7 +38,6 @@ from esp.middleware import ESPError
 from esp.program.modules.base import ProgramModuleObj, needs_admin, main_call, aux_call
 from esp.program.modules.handlers.listgenmodule import ListGenModule
 from esp.users.controllers.usersearch import UserSearchController
-from esp.users.forms.generic_search_form import StudentSearchForm
 from esp.tagdict.models import Tag
 from esp.users.models import ESPUser
 from esp.utils.web import render_to_response
@@ -65,9 +64,10 @@ class NameTagModule(ProgramModuleObj):
         """ Display a page for admins to pick users for nametags """
         context = {'module': self}
         context['groups'] = Group.objects.all()
-        context['student_search_form'] = StudentSearchForm()
         usc = UserSearchController()
         context.update(usc.prepare_context(prog, target_path='/manage/%s/generatetags' % prog.url))
+        context['combo_form'] = False
+        context['include_continue'] = False
 
         return render_to_response(self.baseDir()+'selectoptions.html', request, context)
 

--- a/esp/esp/users/controllers/usersearch.py
+++ b/esp/esp/users/controllers/usersearch.py
@@ -408,6 +408,8 @@ class UserSearchController(object):
         context = {}
         context['program'] = program
         context['student_search_form'] = StudentSearchForm()
+        context['combo_form'] = True
+        context['include_continue'] = True
         context['user_types'] = ESPUser.getTypes()
         category_lists = {}
         list_descriptions = program.getListDescriptions()

--- a/esp/public/media/scripts/commpanel.js
+++ b/esp/public/media/scripts/commpanel.js
@@ -133,6 +133,7 @@ function clear_filters()
 
 function move_filters(wrapper_name)
 {
+    clear_filters();
     $j("#filter_accordion").detach().appendTo('#'+wrapper_name)
     $j("#filter_accordion").accordion("option", "active", false);
 }
@@ -196,7 +197,6 @@ function initialize()
 
     //  Handle the outer level tabs
     $j("#tab_select_basic").click(function () {
-        clear_filters();
         move_filters("base_filter_accordion");
         recipient_type_change();
         set_step("basic_step_container", "recipient_type_select"); return false;
@@ -273,7 +273,6 @@ function initialize()
 
     //  Handle the outer level tabs
     $j("#tab_select_combo").click(function () {
-        clear_filters();
         move_filters("combo_filter_accordion");
         prepare_accordion("combo");
         $j("[name=base_list]").prop('checked', false);

--- a/esp/public/media/scripts/commpanel.js
+++ b/esp/public/media/scripts/commpanel.js
@@ -218,15 +218,6 @@ function initialize()
     });
 
     /*  Combination list tab    */
-
-    //  Initialize the filtering options accordion
-    $j("#filter_accordion").accordion({
-        heightStyle: "content",
-        collapsible: true,
-        active: false,
-    });
-    $j("#filter_accordion").accordion("option", "active", false);
-
     //  Make AND/OR/NOT into buttons
     for (var i = 0; i < list_names.length; i++)
     {

--- a/esp/public/media/scripts/commpanel.js
+++ b/esp/public/media/scripts/commpanel.js
@@ -62,18 +62,22 @@ function submit_prev_selection()
     return true;
 }
 
-function prepare_accordion(accordion_id, rb_selected)
+function prepare_accordion(rb_selected)
 {
-    $j("#" + accordion_id).children(".ui-accordion-header:not(.any)").hide();
+    $j("#filter_accordion").children(".ui-accordion-header:not(.any)").hide();
     
     //  Show school/grade options for students, graduation year options for teachers
     if (rb_selected.toLowerCase().substr(0, 7) == "student")
     {
-        $j("#" + accordion_id).children(".ui-accordion-header.student").show();
+        $j("#filter_accordion").children(".ui-accordion-header.student").show();
     }
     else if (rb_selected.toLowerCase().substr(0, 7) == "teacher")
     {
-        $j("#" + accordion_id).children(".ui-accordion-header.teacher").show();
+        $j("#filter_accordion").children(".ui-accordion-header.teacher").show();
+    }
+    else // otherwise, show all options
+    {
+        $j("#filter_accordion").children(".ui-accordion-header").show();
     }
 }
 
@@ -102,30 +106,35 @@ function msgreq_select_item(event, ui)
     target_div.append(inner_div3);
 }
 
-function clear_filters(form_name)
+function clear_filters()
 {
     //  Remove any existing data in the "user filtering options" part of a comm panel form
-    var form = $j("#"+form_name)[0];
-    field_names = ["userid", "username", "first_name", "last_name", "email", "zipcode", "zipdistance", "zipdistance_exclude", "states", "school", "grade_min", "grade_max", "gradyear_min", "gradyear_max", "groups_include", "groups_exclude", "clsid", "regtypes", "hours_min", "hours_max", "teaching_times", "teacher_events", "class_times", "target_user"];
+    var form = $j("#filter_accordion")[0];
+    var field_names = ["userid", "username", "first_name", "last_name", "email", "zipcode", "zipdistance", "zipdistance_exclude", "states", "school", "grade_min", "grade_max", "gradyear_min", "gradyear_max", "groups_include", "groups_exclude", "clsid", "regtypes", "hours_min", "hours_max", "teaching_times", "teacher_events", "class_times", "target_user", "target_user_raw"];
     for (var i = 0; i < field_names.length; i++)
     {
         var form_fields = $j(form).find(':input[name=' + field_names[i] + ']');
         if (form_fields.length) {
-            var form_field = form_fields[0];
-            switch (form_field.type) {
-                case 'password':
-                case 'select-multiple':
-                case 'select-one':
-                case 'text':
-                case 'textarea':
-                    $j(form_field).val('');
-                    break;
-                case 'checkbox':
-                case 'radio':
-                    form_field.checked = false;
-            };
+            for (var form_field of form_fields) {
+                switch (form_field.type) {
+                    case 'checkbox':
+                        form_field.checked = false;
+                        break;
+                    case 'radio':
+                        form_field.checked = false;
+                        break;
+                    default:
+                        $j(form_field).val('');
+                };
+            }
         }
     }
+}
+
+function move_filters(wrapper_name)
+{
+    $j("#filter_accordion").detach().appendTo('#'+wrapper_name)
+    $j("#filter_accordion").accordion("option", "active", false);
 }
 
 function set_field(form_name, field_name, value)
@@ -158,9 +167,8 @@ function initialize()
         $j("#recipient_list_options_" + rb_selected).removeClass("commpanel_hidden");
         $j(".sendto_fn_select").addClass("commpanel_hidden");
         $j("." + rb_selected + ".sendto_fn_select").removeClass("commpanel_hidden");
-        //  console.log("Selected " + rb_selected);
 
-        prepare_accordion("filter_accordion", rb_selected);
+        prepare_accordion(rb_selected);
     }
     $j("select[name=recipient_type]").change(recipient_type_change);
     $j("#recipient_type_next").click(function () {
@@ -187,7 +195,12 @@ function initialize()
     $j("#recipient_list_select").children("div").addClass("commpanel_hidden");
 
     //  Handle the outer level tabs
-    $j("#tab_select_basic").click(function () {set_step("basic_step_container", "recipient_type_select"); return false;});
+    $j("#tab_select_basic").click(function () {
+        clear_filters();
+        move_filters("base_filter_accordion");
+        recipient_type_change();
+        set_step("basic_step_container", "recipient_type_select"); return false;
+    });
 
     //  Prepare "back" buttons
     $j("#recipient_list_back").click(function () {set_step("basic_step_container", "recipient_type_select"); return false;});
@@ -207,12 +220,12 @@ function initialize()
     /*  Combination list tab    */
 
     //  Initialize the filtering options accordion
-    $j("#combo_filter_accordion").accordion({
+    $j("#filter_accordion").accordion({
         heightStyle: "content",
         collapsible: true,
         active: false,
     });
-    $j("#combo_filter_accordion").accordion("option", "active", false);
+    $j("#filter_accordion").accordion("option", "active", false);
 
     //  Make AND/OR/NOT into buttons
     for (var i = 0; i < list_names.length; i++)
@@ -240,16 +253,16 @@ function initialize()
 
     //  Handle step transitions
     combo_base_list_change = function () {
-        clear_filters("form_combo_list");
-        $j("#combo_filter_accordion").accordion("option", "active", false);
+        clear_filters();
+        $j("#filter_accordion").accordion("option", "active", false);
         var list_selected = $j("select[name=combo_base_list]").val();
         $j("#combo_starting_list").html($j("#list_description_" + list_selected.substr(list_selected.indexOf(":") + 1)).html());
-        $j("#form_combo_list .sendto_fn_select").hide();
+        $j("#tab_combo .sendto_fn_select").hide();
         try {
-            $j("#form_combo_list .sendto_fn_select." + list_selected.split(":")[0]).show();
+            $j("#tab_combo .sendto_fn_select." + list_selected.split(":")[0]).show();
         } catch(e){}
         //  TODO: Prepare filtering options based on choice of starting list (students/teachers/other)
-        //  prepare_accordion("combo_filter_accordion", rb_selected);
+        prepare_accordion("combo");
     }
     combo_base_list_change();
     $j("select[name=combo_base_list]").change(combo_base_list_change);
@@ -259,7 +272,13 @@ function initialize()
     });
 
     //  Handle the outer level tabs
-    $j("#tab_select_combo").click(function () {set_step("combo_step_container", "starting_list_select"); return false;});
+    $j("#tab_select_combo").click(function () {
+        clear_filters();
+        move_filters("combo_filter_accordion");
+        prepare_accordion("combo");
+        $j("[name=base_list]").prop('checked', false);
+        set_step("combo_step_container", "starting_list_select"); return false;
+    });
 
     //  Prepare "back" buttons
     $j("#combo_options_back").click(function () {set_step("combo_step_container", "starting_list_select"); return false;});

--- a/esp/public/media/scripts/commpanel.js
+++ b/esp/public/media/scripts/commpanel.js
@@ -109,26 +109,21 @@ function msgreq_select_item(event, ui)
 function clear_filters()
 {
     //  Remove any existing data in the "user filtering options" part of a comm panel form
-    var form = $j("#filter_accordion")[0];
-    var field_names = ["userid", "username", "first_name", "last_name", "email", "zipcode", "zipdistance", "zipdistance_exclude", "states", "school", "grade_min", "grade_max", "gradyear_min", "gradyear_max", "groups_include", "groups_exclude", "clsid", "regtypes", "hours_min", "hours_max", "teaching_times", "teacher_events", "class_times", "target_user", "target_user_raw"];
-    for (var i = 0; i < field_names.length; i++)
-    {
-        var form_fields = $j(form).find(':input[name=' + field_names[i] + ']');
-        if (form_fields.length) {
-            for (var form_field of form_fields) {
-                switch (form_field.type) {
-                    case 'checkbox':
-                        form_field.checked = false;
-                        break;
-                    case 'radio':
-                        form_field.checked = false;
-                        break;
-                    default:
-                        $j(form_field).val('');
-                };
-            }
+    var $form = $j("#filter_accordion");
+    var form_fields = $form.find('input');
+    form_fields.each(function(i, form_field) {
+        switch (form_field.type) {
+            case 'checkbox':
+                form_field.checked = false;
+                break;
+            case 'radio':
+                form_field.checked = false;
+                break;
+            default:
+                $j(form_field).val('');
         }
-    }
+    });
+    $j("#filter_accordion").accordion("option", "active", false);
 }
 
 function move_filters(wrapper_name)
@@ -168,7 +163,7 @@ function initialize()
         $j("#recipient_list_options_" + rb_selected).removeClass("commpanel_hidden");
         $j(".sendto_fn_select").addClass("commpanel_hidden");
         $j("." + rb_selected + ".sendto_fn_select").removeClass("commpanel_hidden");
-
+        clear_filters();
         prepare_accordion(rb_selected);
     }
     $j("select[name=recipient_type]").change(recipient_type_change);
@@ -245,7 +240,6 @@ function initialize()
     //  Handle step transitions
     combo_base_list_change = function () {
         clear_filters();
-        $j("#filter_accordion").accordion("option", "active", false);
         var list_selected = $j("select[name=combo_base_list]").val();
         $j("#combo_starting_list").html($j("#list_description_" + list_selected.substr(list_selected.indexOf(":") + 1)).html());
         $j("#tab_combo .sendto_fn_select").hide();

--- a/esp/public/media/scripts/commpanel.js
+++ b/esp/public/media/scripts/commpanel.js
@@ -110,7 +110,7 @@ function clear_filters()
 {
     //  Remove any existing data in the "user filtering options" part of a comm panel form
     var $form = $j("#filter_accordion");
-    var form_fields = $form.find('input');
+    var form_fields = $form.find(':input');
     form_fields.each(function(i, form_field) {
         switch (form_field.type) {
             case 'checkbox':

--- a/esp/templates/users/usersearch/filter_accordion.html
+++ b/esp/templates/users/usersearch/filter_accordion.html
@@ -1,3 +1,4 @@
+<div id="filter_accordion">
 <h4 class="any"><a href="#">User ID</a></h4>
 <div>Enter ID number: <input type="text" size="6" name="userid" id="userid" /> <br />
 <small>(Can be a comma-separated list)</small></div>
@@ -96,4 +97,5 @@ Max number: <input type="text" size="3" name="hours_max" value="" />
 <form id="student_in_class" name="student_in_class" method="POST" action="{{ request.path }}">
     {{ student_search_form }}
 </form>
+</div>
 </div>

--- a/esp/templates/users/usersearch/list_selector.html
+++ b/esp/templates/users/usersearch/list_selector.html
@@ -95,7 +95,7 @@ $j(document).ready(function() {
     </div>
 
     <div id="tab_combo">
-        <form id="form_combo_list" method="POST" action="{{ action_path }}" autocomplete="off">
+        {% if combo_form %}<form id="form_combo_list" method="POST" action="{{ action_path }}" autocomplete="off">{% endif %}
         <div id="combo_step_container">
 
         <div id="starting_list_select">
@@ -147,7 +147,9 @@ $j(document).ready(function() {
             <p>&nbsp;</p>
             <button type="button" class="btn btn-default recipient_step_button" id="combo_options_back">Go back</button>
             <button type="button" class="btn btn-default recipient_step_button" id="combo_options_next">Add filters</button>
+            {% if include_continue %}
             <button type="button" class="btn btn-primary recipient_step_button" id="combo_options_done">Continue</button>
+            {% endif %}
         </div>
 
         <div id="combo_filter_select" class="commpanel_hidden">
@@ -162,11 +164,13 @@ $j(document).ready(function() {
             {% if include_checklist %}
             <button type="button" class="btn btn-default recipient_step_button" id="combo_filter_checklist">Recipient checklist</button>
             {% endif %}
+            {% if include_continue %}
             <button type="button" class="btn btn-primary recipient_step_button" id="combo_filter_done">Continue</button>
+            {% endif %}
         </div>
 
         </div>
-        </form>
+        {% if combo_form %}</form>{% endif %}
     </div>
 
     {% if include_prev_list %}

--- a/esp/templates/users/usersearch/list_selector.html
+++ b/esp/templates/users/usersearch/list_selector.html
@@ -76,7 +76,7 @@ $j(document).ready(function() {
             <div class="step_header"><span class="step_label">Step 3:</span> <span class="step_text">Do you need to filter this list down?</span></div>
             <div class="step_instructions">(For any criteria you don't need, just leave them blank.)</div>
             <div class="step_instructions step_highlight">Currently selected: <span id="filter_current_list"></span></div>
-            <div id="filter_accordion">
+            <div id="base_filter_accordion">
                 {% include "users/usersearch/filter_accordion.html" %}
             </div>
 
@@ -155,9 +155,7 @@ $j(document).ready(function() {
         <div id="combo_filter_select" class="commpanel_hidden">
             <div class="step_header"><span class="step_label">Step 3:</span> <span class="step_text">Do you need to filter this list down?</span></div>
             <div class="step_instructions">(For any criteria you don't need, just leave them blank.)</div>
-            <div id="combo_filter_accordion">
-                {% include "users/usersearch/filter_accordion.html" %}
-            </div>
+            <div id="combo_filter_accordion"></div>
 
             <button type="button" class="btn btn-default recipient_step_button" id="combo_filter_back">Go back</button>
             <input type="hidden" name="use_checklist" value="0" />


### PR DESCRIPTION
This fixes the combo selector for the AUL/USC user selector in the nametag module. In the process, I also fixed the "teachers of a student" form field by removing one instance of the filter accordion and just moving the remaining accordion between the two tabs. This way we don't have any duplicate IDs and everything should just work (TM).

I also made it so that all filters are now cleared, rather than just those in a list, since that's gotten us into trouble multiple times in the past.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3251 and fixes https://github.com/learning-unlimited/ESP-Website/issues/3248.