### PR TITLE
Master moderator schedule

### DIFF
--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -375,6 +375,15 @@ class ClassSection(models.Model):
     def get_moderators(self):
         return self.moderators.all()
 
+    def getModeratorNames(self):
+        moderators = []
+        for moderator in self.get_moderators():
+            name = moderator.name()
+            if name.strip() == '':
+                name = moderator.username
+            moderators.append(name)
+        return moderators
+
     def getModeratorNamesLast(self):
         moderators = []
         for moderator in self.get_moderators():

--- a/esp/templates/program/modules/programprintables/options.html
+++ b/esp/templates/program/modules/programprintables/options.html
@@ -72,6 +72,9 @@ Please select from options below.
 {% endif %}
 <li><a href="./volunteerschedules" title="Volunteer Schedules">Volunteer Schedules</a> (by volunteers)</li>
 <li><a href="./roomschedules" title="Room Schedules">Room Schedules</a></li>
+{% if program|hasModule:"TeacherModeratorModule" %}
+    <li><a href="./moderator_rooms_spr" title="Complete Moderator Schedule by Room">Complete Moderator Schedule by Room</a> (CSV format)</li>
+{% endif %}
 </ul>
 
 <h3>Nametags</h3>

--- a/esp/templates/program/modules/programprintables/roomrosters.html
+++ b/esp/templates/program/modules/programprintables/roomrosters.html
@@ -1,3 +1,4 @@
+{% load modules %}
 <html>
 <head>
 <title>Room Schedules</title>
@@ -64,13 +65,19 @@ td.newday { border-width: 2px 1px 0 1px;}
     <th>Time</th>
     <th>Class</th>
     <th>Teacher(s)</th>
+    {% if program|hasModule:"TeacherModeratorModule" %}
+        <th>{{ program.getModeratorTitle }}(s)</th>
+    {% endif %}
 </tr>
 {% endifchanged %}
 {% autoescape off %}
 <tr>
  <td>{{ scheditem.timeblock.start|date:"b j"|capfirst }}, {{ scheditem.timeblock.short_time }}</td>
  <td>{{ scheditem.cls.title }}</td>
-  <td>{{ scheditem.cls.parent_class.getTeacherNames|join:", " }}</td> 
+  <td>{{ scheditem.cls.parent_class.getTeacherNames|join:", " }}</td>
+    {% if program|hasModule:"TeacherModeratorModule" %}
+        <td>{{ scheditem.cls.getModeratorNames|join:", " }}</td>
+    {% endif %}
 </tr>
 {% endautoescape %}
 


### PR DESCRIPTION
Adds two locations to get a copy of the moderator schedule. The first is in an extra column on the room schedules, showing the moderator of each class during each time in that room. The second is a new csv, which mimics the google spreadsheet Rainstorm was making (rooms as rows, times as columns, filled in with moderators).

Requested by Rainstorm.