### PR TITLE
Add doc strings to module handlers

### DIFF
--- a/esp/esp/program/modules/handlers/accountingmodule.py
+++ b/esp/esp/program/modules/handlers/accountingmodule.py
@@ -38,6 +38,8 @@ from esp.users.models import ESPUser
 from esp.utils.web import render_to_response
 
 class AccountingModule(ProgramModuleObj):
+    doc = """Lists accounting information for the program for a single user."""
+
     @classmethod
     def module_properties(cls):
         return {

--- a/esp/esp/program/modules/handlers/adminclass.py
+++ b/esp/esp/program/modules/handlers/adminclass.py
@@ -53,7 +53,7 @@ from esp.program.models import RegistrationProfile
 """ Module in the middle of a rewrite. -Michael """
 
 class AdminClass(ProgramModuleObj):
-    doc = """ This module is extremely useful for managing classes if you have them in your program.
+    doc = """This module is extremely useful for managing classes if you have them in your program.
         Works best with student and teacher class modules, but they are not necessary.
         Options for this are available on the main manage page.
         """

--- a/esp/esp/program/modules/handlers/adminclass.py
+++ b/esp/esp/program/modules/handlers/adminclass.py
@@ -53,7 +53,7 @@ from esp.program.models import RegistrationProfile
 """ Module in the middle of a rewrite. -Michael """
 
 class AdminClass(ProgramModuleObj):
-    doc = """ This module is extremely useful for managing classes if you have them them in your program.
+    doc = """ This module is extremely useful for managing classes if you have them in your program.
         Works best with student and teacher class modules, but they are not necessary.
         Options for this are available on the main manage page.
         """

--- a/esp/esp/program/modules/handlers/admincore.py
+++ b/esp/esp/program/modules/handlers/admincore.py
@@ -60,6 +60,7 @@ class NewPermissionForm(forms.Form):
     end_date = forms.DateTimeField(label='Closing date/time', initial=None, widget=DateTimeWidget(), required=False)
 
 class AdminCore(ProgramModuleObj, CoreModule):
+    doc = """Includes the core views for managing a program (e.g. settings, dashboard)."""
 
     @classmethod
     def module_properties(cls):
@@ -76,7 +77,7 @@ class AdminCore(ProgramModuleObj, CoreModule):
         context = {}
         modules = self.program.getModules(request.user, 'manage')
 
-        context['modules'] = modules
+        context['modules'] = sorted(modules, key = lambda pmo: pmo.module.link_title)
         context['one'] = one
         context['two'] = two
 

--- a/esp/esp/program/modules/handlers/adminreviewapps.py
+++ b/esp/esp/program/modules/handlers/adminreviewapps.py
@@ -46,6 +46,8 @@ from django.db.models.query import Q
 __all__ = ['AdminReviewApps']
 
 class AdminReviewApps(ProgramModuleObj):
+    doc = """View student applications and select students to be admitted for the program."""
+
     @classmethod
     def module_properties(cls):
         return {

--- a/esp/esp/program/modules/handlers/adminvitals.py
+++ b/esp/esp/program/modules/handlers/adminvitals.py
@@ -38,8 +38,7 @@ class KeyDoesNotExist(Exception):
     pass
 
 class AdminVitals(ProgramModuleObj):
-    doc = """ This allows you to view the major numbers for your program on the main page.
-        This will present itself below the options in a neat little table. """
+    doc = """ This allows you to view the major numbers for your program on the dashboard. """
 
     @classmethod
     def module_properties(cls):

--- a/esp/esp/program/modules/handlers/adminvitals.py
+++ b/esp/esp/program/modules/handlers/adminvitals.py
@@ -38,7 +38,7 @@ class KeyDoesNotExist(Exception):
     pass
 
 class AdminVitals(ProgramModuleObj):
-    doc = """ This allows you to view the major numbers for your program on the dashboard. """
+    doc = """This allows you to view the major numbers for your program on the dashboard."""
 
     @classmethod
     def module_properties(cls):

--- a/esp/esp/program/modules/handlers/admissionsdashboard.py
+++ b/esp/esp/program/modules/handlers/admissionsdashboard.py
@@ -42,11 +42,8 @@ from django.http import HttpResponse
 import json
 
 class AdmissionsDashboard(ProgramModuleObj):
-    """
-    A dashboard for Junction core teachers to review applications for their class.
-
-    Not to be confused with TeacherReviewApps, the app questions module.
-    """
+    doc = """A dashboard for Junction core teachers to review applications for their class.
+    Not to be confused with TeacherReviewApps, the app questions module."""
 
     @classmethod
     def module_properties(cls):

--- a/esp/esp/program/modules/handlers/ajaxschedulingmodule.py
+++ b/esp/esp/program/modules/handlers/ajaxschedulingmodule.py
@@ -52,7 +52,7 @@ from esp.utils.decorators         import json_response
 import calendar, time, datetime
 
 class AJAXSchedulingModule(ProgramModuleObj):
-    doc = """ Provides an application to use for scheduling classes. """
+    doc = """Provides an application to use for scheduling classes."""
 
     @classmethod
     def module_properties(cls):

--- a/esp/esp/program/modules/handlers/ajaxschedulingmodule.py
+++ b/esp/esp/program/modules/handlers/ajaxschedulingmodule.py
@@ -52,7 +52,7 @@ from esp.utils.decorators         import json_response
 import calendar, time, datetime
 
 class AJAXSchedulingModule(ProgramModuleObj):
-    """ This program module allows teachers to indicate their availability for the program. """
+    doc = """ Provides an application to use for scheduling classes. """
 
     @classmethod
     def module_properties(cls):

--- a/esp/esp/program/modules/handlers/autoschedulerfrontendmodule.py
+++ b/esp/esp/program/modules/handlers/autoschedulerfrontendmodule.py
@@ -11,6 +11,7 @@ from esp.utils.decorators import json_response
 
 
 class AutoschedulerFrontendModule(ProgramModuleObj):
+    doc = """Augments the AJAX scheduler, adding an interface to automatically schedule individual sections."""
 
     @classmethod
     def module_properties(cls):
@@ -111,6 +112,9 @@ class AutoschedulerFrontendModule(ProgramModuleObj):
     @needs_admin
     def autoscheduler_clear(self, request, tl, one, two, module, extra, prog):
         return {'response': [{'success': 'yes'}]}
+
+    def isStep(self):
+        return False
 
     class Meta:
         proxy = True

--- a/esp/esp/program/modules/handlers/availabilitymodule.py
+++ b/esp/esp/program/modules/handlers/availabilitymodule.py
@@ -48,7 +48,7 @@ from esp.users.forms.generic_search_form import TeacherSearchForm
 
 
 class AvailabilityModule(ProgramModuleObj):
-    """ This program module allows teachers to indicate their availability for the program. """
+    doc = """ This program module allows teachers to indicate their availability for the program. """
 
     @classmethod
     def module_properties(cls):

--- a/esp/esp/program/modules/handlers/availabilitymodule.py
+++ b/esp/esp/program/modules/handlers/availabilitymodule.py
@@ -48,7 +48,7 @@ from esp.users.forms.generic_search_form import TeacherSearchForm
 
 
 class AvailabilityModule(ProgramModuleObj):
-    doc = """ This program module allows teachers to indicate their availability for the program. """
+    doc = """This program module allows teachers to indicate their availability for the program."""
 
     @classmethod
     def module_properties(cls):
@@ -244,4 +244,3 @@ class AvailabilityModule(ProgramModuleObj):
     class Meta:
         proxy = True
         app_label = 'modules'
-

--- a/esp/esp/program/modules/handlers/bigboardmodule.py
+++ b/esp/esp/program/modules/handlers/bigboardmodule.py
@@ -14,6 +14,7 @@ from esp.utils.web import render_to_response
 
 
 class BigBoardModule(ProgramModuleObj):
+    doc = """Shows statistics about student registration that refresh automatically."""
 
     @classmethod
     def module_properties(cls):

--- a/esp/esp/program/modules/handlers/bulkcreateaccountmodule.py
+++ b/esp/esp/program/modules/handlers/bulkcreateaccountmodule.py
@@ -6,6 +6,7 @@ from django.contrib.auth.models import Group
 import random
 
 class BulkCreateAccountModule(ProgramModuleObj):
+    doc = """Create a bulk set of accounts (e.g. for outreach)."""
 
     MAX_PREFIX_LENGTH = 30
     MAX_NUMBER_OF_ACCOUNTS = 1000  # backstop so that an errant request can't fill up the DB with accounts

--- a/esp/esp/program/modules/handlers/checkavailabilitymodule.py
+++ b/esp/esp/program/modules/handlers/checkavailabilitymodule.py
@@ -41,7 +41,7 @@ from esp.program.modules.handlers.availabilitymodule import AvailabilityModule
 
 
 class CheckAvailabilityModule(ProgramModuleObj):
-    """ This program module allows admins to check a teacher's availability for the program. """
+    doc = """ Check a teacher's availability for the program. """
 
     @classmethod
     def module_properties(cls):

--- a/esp/esp/program/modules/handlers/checkavailabilitymodule.py
+++ b/esp/esp/program/modules/handlers/checkavailabilitymodule.py
@@ -41,7 +41,7 @@ from esp.program.modules.handlers.availabilitymodule import AvailabilityModule
 
 
 class CheckAvailabilityModule(ProgramModuleObj):
-    doc = """ Check a teacher's availability for the program. """
+    doc = """Check a teacher's availability for the program."""
 
     @classmethod
     def module_properties(cls):

--- a/esp/esp/program/modules/handlers/classsearchmodule.py
+++ b/esp/esp/program/modules/handlers/classsearchmodule.py
@@ -19,7 +19,8 @@ from esp.utils.web import render_to_response
 
 
 class ClassSearchModule(ProgramModuleObj):
-    """Search for classes matching certain criteria."""
+    doc = """Search for classes matching certain criteria."""
+
     @classmethod
     def module_properties(cls):
         return {

--- a/esp/esp/program/modules/handlers/commmodule.py
+++ b/esp/esp/program/modules/handlers/commmodule.py
@@ -47,6 +47,7 @@ from esp.middleware.threadlocalrequest import AutoRequestContext as Context
 from esp.middleware import ESPError
 
 class CommModule(ProgramModuleObj):
+    doc = """Email users that match specific search criteria."""
     """ Want to email all ESP students within a 60 mile radius of NYC?
     How about emailing all esp users within a 30 mile radius of New Hampshire whose last name contains 'e' and 'a'?
     Do that and even more useful things in the communication panel.

--- a/esp/esp/program/modules/handlers/creditcardmodule_cybersource.py
+++ b/esp/esp/program/modules/handlers/creditcardmodule_cybersource.py
@@ -44,6 +44,8 @@ from esp.middleware      import ESPError
 from esp.middleware.threadlocalrequest import get_current_request
 
 class CreditCardModule_Cybersource(ProgramModuleObj):
+    doc = """Accept credit card payments via Cybersource."""
+
     @classmethod
     def module_properties(cls):
         return {

--- a/esp/esp/program/modules/handlers/creditcardmodule_stripe.py
+++ b/esp/esp/program/modules/handlers/creditcardmodule_stripe.py
@@ -53,6 +53,8 @@ import json
 import re
 
 class CreditCardModule_Stripe(ProgramModuleObj):
+    doc = """Accept credit card payments via Stripe."""
+
     @classmethod
     def module_properties(cls):
         return {

--- a/esp/esp/program/modules/handlers/creditcardviewer.py
+++ b/esp/esp/program/modules/handlers/creditcardviewer.py
@@ -38,6 +38,8 @@ from esp.accounting.controllers import ProgramAccountingController, IndividualAc
 from argcache            import cache_function
 
 class CreditCardViewer(ProgramModuleObj):
+    doc = """Lists the credit card payments for the program."""
+
     @classmethod
     def module_properties(cls):
         return {

--- a/esp/esp/program/modules/handlers/customformmodule.py
+++ b/esp/esp/program/modules/handlers/customformmodule.py
@@ -50,6 +50,7 @@ from django import forms
 import re
 
 class CustomFormModule(ProgramModuleObj):
+    doc = """Serve a custom form as part of student and/or teacher registration."""
 
     def __init__(self, *args, **kwargs):
         super(CustomFormModule, self).__init__(*args, **kwargs)

--- a/esp/esp/program/modules/handlers/donationmodule.py
+++ b/esp/esp/program/modules/handlers/donationmodule.py
@@ -87,6 +87,7 @@ class DonationForm(forms.Form):
 
 
 class DonationModule(ProgramModuleObj):
+    doc = """Solicit donations from students."""
 
     event = "donation_done"
 

--- a/esp/esp/program/modules/handlers/finaidapprovemodule.py
+++ b/esp/esp/program/modules/handlers/finaidapprovemodule.py
@@ -40,6 +40,8 @@ from esp.accounting.models import FinancialAidGrant
 
 
 class FinAidApproveModule(ProgramModuleObj):
+    doc = """View and approve student financial aid applications."""
+
     @classmethod
     def module_properties(cls):
         return {

--- a/esp/esp/program/modules/handlers/financialaidappmodule.py
+++ b/esp/esp/program/modules/handlers/financialaidappmodule.py
@@ -47,8 +47,9 @@ from esp.middleware.threadlocalrequest import get_current_request
 from django              import forms
 
 
-# student class picker module
 class FinancialAidAppModule(ProgramModuleObj):
+    doc = """Serve a financial aid application to students."""
+
     @classmethod
     def module_properties(cls):
         return {

--- a/esp/esp/program/modules/handlers/formstackappmodule.py
+++ b/esp/esp/program/modules/handlers/formstackappmodule.py
@@ -44,9 +44,8 @@ from esp.application.models import FormstackStudentProgramApp
 from urllib import urlencode
 
 class FormstackAppModule(ProgramModuleObj):
-    """
+    doc = """
     Student application module for Junction.
-
     Not to be confused with StudentJunctionAppModule, the app questions module.
     """
 

--- a/esp/esp/program/modules/handlers/formstackmedliabmodule.py
+++ b/esp/esp/program/modules/handlers/formstackmedliabmodule.py
@@ -45,7 +45,7 @@ from esp.users.forms.generic_search_form import StudentSearchForm
 
 # hackish solution for Splash 2012
 class FormstackMedliabModule(ProgramModuleObj):
-    """ Module for collecting medical information online via Formstack """
+    doc = """ Module for collecting medical information online via Formstack """
 
     @classmethod
     def module_properties(cls):

--- a/esp/esp/program/modules/handlers/formstackmedliabmodule.py
+++ b/esp/esp/program/modules/handlers/formstackmedliabmodule.py
@@ -45,7 +45,7 @@ from esp.users.forms.generic_search_form import StudentSearchForm
 
 # hackish solution for Splash 2012
 class FormstackMedliabModule(ProgramModuleObj):
-    doc = """ Module for collecting medical information online via Formstack """
+    doc = """Module for collecting medical information online via Formstack"""
 
     @classmethod
     def module_properties(cls):

--- a/esp/esp/program/modules/handlers/grouptextmodule.py
+++ b/esp/esp/program/modules/handlers/grouptextmodule.py
@@ -50,6 +50,7 @@ from twilio import TwilioRestException
 from twilio.rest import TwilioRestClient
 
 class GroupTextModule(ProgramModuleObj):
+    doc = """Text users that match specific search criteria."""
     """ Want to tell all enrolled students about a last-minute lunch location
         change? Want to inform students about a cancelled class? The Group Text
         Panel is your friend!

--- a/esp/esp/program/modules/handlers/jsondatamodule.py
+++ b/esp/esp/program/modules/handlers/jsondatamodule.py
@@ -62,7 +62,7 @@ from esp.accounting.models import Transfer
 from decimal import Decimal
 
 class JSONDataModule(ProgramModuleObj, CoreModule):
-    """ A program module dedicated to returning program-specific data in JSON form. """
+    doc = """ A program module dedicated to returning program-specific data in JSON form. """
 
     @classmethod
     def module_properties(cls):

--- a/esp/esp/program/modules/handlers/jsondatamodule.py
+++ b/esp/esp/program/modules/handlers/jsondatamodule.py
@@ -62,7 +62,7 @@ from esp.accounting.models import Transfer
 from decimal import Decimal
 
 class JSONDataModule(ProgramModuleObj, CoreModule):
-    doc = """ A program module dedicated to returning program-specific data in JSON form. """
+    doc = """A program module dedicated to returning program-specific data in JSON form."""
 
     @classmethod
     def module_properties(cls):

--- a/esp/esp/program/modules/handlers/lineitemsmodule.py
+++ b/esp/esp/program/modules/handlers/lineitemsmodule.py
@@ -39,6 +39,7 @@ from esp.program.modules.forms.lineitems import OptionFormset, LineItemForm, Lin
 from esp.utils.web import render_to_response
 
 class LineItemsModule(ProgramModuleObj, CoreModule):
+    doc = """Create and/or edit line items for the program."""
 
     @classmethod
     def module_properties(cls):

--- a/esp/esp/program/modules/handlers/listgenmodule.py
+++ b/esp/esp/program/modules/handlers/listgenmodule.py
@@ -279,6 +279,7 @@ class ListGenForm(forms.Form):
         self.fields['fields'].initial = ['02_username','04_firstname','05_lastname','06_email']
 
 class ListGenModule(ProgramModuleObj):
+    doc = """Get information for users that match specific search criteria."""
     """ While far from complete, this will allow you to just generate a simple list of users matching a criteria (criteria very similar to the communications panel)."""
     @classmethod
     def module_properties(cls):

--- a/esp/esp/program/modules/handlers/lotteryfrontendmodule.py
+++ b/esp/esp/program/modules/handlers/lotteryfrontendmodule.py
@@ -8,6 +8,7 @@ from esp.users.models import ESPUser
 from esp.utils.decorators import json_response
 
 class LotteryFrontendModule(ProgramModuleObj):
+    doc = """Run the class lottery and assign students to classes."""
 
     @classmethod
     def module_properties(cls):

--- a/esp/esp/program/modules/handlers/lotterystudentregmodule.py
+++ b/esp/esp/program/modules/handlers/lotterystudentregmodule.py
@@ -59,6 +59,7 @@ from esp.utils.query_utils import nest_Q
 
 
 class LotteryStudentRegModule(ProgramModuleObj):
+    doc = """Allows students to enter a lottery for particular classes."""
 
     def students(self, QObject = False):
         q = Q(studentregistration__section__parent_class__parent_program=self.program) & nest_Q(StudentRegistration.is_valid_qobject(), 'studentregistration')

--- a/esp/esp/program/modules/handlers/mailinglabels.py
+++ b/esp/esp/program/modules/handlers/mailinglabels.py
@@ -46,7 +46,7 @@ import operator
 
 
 class MailingLabels(ProgramModuleObj):
-    doc = """ This allows one to generate Mailing Labels for both schools and users. You have the option of either creating a file which can be sent to MIT mailing services or actually create printable files.
+    doc = """This allows one to generate Mailing Labels for both schools and users. You have the option of either creating a file which can be sent to MIT mailing services or actually create printable files.
     """
 
     @classmethod

--- a/esp/esp/program/modules/handlers/mailinglabels.py
+++ b/esp/esp/program/modules/handlers/mailinglabels.py
@@ -46,7 +46,7 @@ import operator
 
 
 class MailingLabels(ProgramModuleObj):
-    """ This allows one to generate Mailing Labels for both schools and users. You have the option of either creating a file which can be sent to MIT mailing services or actually create printable files.
+    doc = """ This allows one to generate Mailing Labels for both schools and users. You have the option of either creating a file which can be sent to MIT mailing services or actually create printable files.
     """
 
     @classmethod

--- a/esp/esp/program/modules/handlers/mapgenmodule.py
+++ b/esp/esp/program/modules/handlers/mapgenmodule.py
@@ -44,7 +44,8 @@ import json
 from collections import Counter
 
 class MapGenModule(ProgramModuleObj):
-    """ Allows you to generate a map showing the distribution of the selected users. """
+    doc = """ Allows you to generate a map showing the distribution of the selected users. """
+
     @classmethod
     def module_properties(cls):
         return {

--- a/esp/esp/program/modules/handlers/mapgenmodule.py
+++ b/esp/esp/program/modules/handlers/mapgenmodule.py
@@ -44,7 +44,7 @@ import json
 from collections import Counter
 
 class MapGenModule(ProgramModuleObj):
-    doc = """ Allows you to generate a map showing the distribution of the selected users. """
+    doc = """Allows you to generate a map showing the distribution of the selected users."""
 
     @classmethod
     def module_properties(cls):

--- a/esp/esp/program/modules/handlers/nametagmodule.py
+++ b/esp/esp/program/modules/handlers/nametagmodule.py
@@ -47,7 +47,8 @@ from django.db.models.query import Q
 
 
 class NameTagModule(ProgramModuleObj):
-    """ This module allows you to generate a bunch of IDs for everyone in the program. """
+    doc = """ This module allows you to generate a bunch of IDs for users that match specific criteria. """
+
     @classmethod
     def module_properties(cls):
         return {

--- a/esp/esp/program/modules/handlers/nametagmodule.py
+++ b/esp/esp/program/modules/handlers/nametagmodule.py
@@ -47,7 +47,7 @@ from django.db.models.query import Q
 
 
 class NameTagModule(ProgramModuleObj):
-    doc = """ This module allows you to generate a bunch of IDs for users that match specific criteria. """
+    doc = """This module allows you to generate a bunch of IDs for users that match specific criteria."""
 
     @classmethod
     def module_properties(cls):

--- a/esp/esp/program/modules/handlers/onsiteattendance.py
+++ b/esp/esp/program/modules/handlers/onsiteattendance.py
@@ -50,6 +50,8 @@ from esp.program.modules.handlers.teacherclassregmodule import TeacherClassRegMo
 import datetime
 
 class OnSiteAttendance(ProgramModuleObj):
+    doc = """Provides statistics on program attendance and allows admins to take attendance for classes."""
+
     @classmethod
     def module_properties(cls):
         return {

--- a/esp/esp/program/modules/handlers/onsitecheckinmodule.py
+++ b/esp/esp/program/modules/handlers/onsitecheckinmodule.py
@@ -50,6 +50,8 @@ import json
 
 
 class OnSiteCheckinModule(ProgramModuleObj):
+    doc = """Check in students for a program (including for payments and forms)."""
+
     @classmethod
     def module_properties(cls):
         return {

--- a/esp/esp/program/modules/handlers/onsitecheckoutmodule.py
+++ b/esp/esp/program/modules/handlers/onsitecheckoutmodule.py
@@ -42,6 +42,8 @@ from esp.program.modules.handlers.studentclassregmodule import StudentClassRegMo
 from esp.middleware.esperrormiddleware import ESPError
 
 class OnSiteCheckoutModule(ProgramModuleObj):
+    doc = """Check students out (temporarily or indefinitely) from a program."""
+
     @classmethod
     def module_properties(cls):
         return {

--- a/esp/esp/program/modules/handlers/onsiteclasslist.py
+++ b/esp/esp/program/modules/handlers/onsiteclasslist.py
@@ -59,6 +59,8 @@ from esp.tagdict.models import Tag
 from esp.accounting.controllers import IndividualAccountingController
 
 class OnSiteClassList(ProgramModuleObj):
+    doc = """Display lists of classes for onsite registration purposes."""
+
     @classmethod
     def module_properties(cls):
         return {

--- a/esp/esp/program/modules/handlers/onsiteclassschedule.py
+++ b/esp/esp/program/modules/handlers/onsiteclassschedule.py
@@ -41,6 +41,8 @@ from esp.utils.models import Printer, PrintRequest
 from datetime         import datetime, timedelta
 
 class OnsiteClassSchedule(ProgramModuleObj):
+    doc = """Get and/or print a student's schedule for the program."""
+
     @classmethod
     def module_properties(cls):
         return {

--- a/esp/esp/program/modules/handlers/onsitecore.py
+++ b/esp/esp/program/modules/handlers/onsitecore.py
@@ -42,6 +42,8 @@ from django.http import HttpResponseRedirect
 
 
 class OnsiteCore(ProgramModuleObj, CoreModule):
+    doc = """Serves the main onsite page."""
+
     @classmethod
     def module_properties(cls):
         return {
@@ -55,7 +57,7 @@ class OnsiteCore(ProgramModuleObj, CoreModule):
     @main_call
     @needs_onsite
     def main(self, request, tl, one, two, module, extra, prog):
-        """ Display a teacher eg page """
+        """ Display the onsite landing page """
         context = {}
         modules = self.program.getModules(request.user, 'onsite')
 

--- a/esp/esp/program/modules/handlers/onsitepaiditemsmodule.py
+++ b/esp/esp/program/modules/handlers/onsitepaiditemsmodule.py
@@ -45,6 +45,8 @@ from esp.accounting.controllers import IndividualAccountingController
 
 
 class OnsitePaidItemsModule(ProgramModuleObj):
+    doc = """Lists the items that a student has requested/paid for."""
+
     @classmethod
     def module_properties(cls):
         return {

--- a/esp/esp/program/modules/handlers/onsiteprintschedules.py
+++ b/esp/esp/program/modules/handlers/onsiteprintschedules.py
@@ -47,6 +47,8 @@ from django.db.models.query   import Q
 from django.template.loader import select_template
 
 class OnsitePrintSchedules(ProgramModuleObj):
+    doc = """Automatically print student schedules at onsite registration."""
+
     @classmethod
     def module_properties(cls):
         return {

--- a/esp/esp/program/modules/handlers/onsiteregister.py
+++ b/esp/esp/program/modules/handlers/onsiteregister.py
@@ -44,6 +44,8 @@ from esp.program.modules.forms.onsite import OnSiteRegForm
 from esp.accounting.controllers import IndividualAccountingController
 
 class OnSiteRegister(ProgramModuleObj):
+    doc = """Register a new student onsite."""
+
     @classmethod
     def module_properties(cls):
         return {

--- a/esp/esp/program/modules/handlers/programprintables.py
+++ b/esp/esp/program/modules/handlers/programprintables.py
@@ -65,6 +65,8 @@ import copy
 import csv
 
 class ProgramPrintables(ProgramModuleObj):
+    doc = """A wide variety of printable documents that are useful for a program."""
+
     """ This is extremely useful for printing a wide array of documents for your program.
     Things from checklists to rosters to attendance sheets can be found here. """
     @classmethod

--- a/esp/esp/program/modules/handlers/regprofilemodule.py
+++ b/esp/esp/program/modules/handlers/regprofilemodule.py
@@ -41,6 +41,8 @@ from esp.middleware.threadlocalrequest import get_current_request
 
 # reg profile module
 class RegProfileModule(ProgramModuleObj):
+    doc = """Serves the profile editor during student and/or teacher registration."""
+
     @classmethod
     def module_properties(cls):
         return [ {

--- a/esp/esp/program/modules/handlers/schedulingcheckmodule.py
+++ b/esp/esp/program/modules/handlers/schedulingcheckmodule.py
@@ -17,6 +17,7 @@ import re
 
 
 class SchedulingCheckModule(ProgramModuleObj):
+    doc = """Provides diagnostics to check for invalid class schedule assignments."""
 
     @classmethod
     def module_properties(cls):

--- a/esp/esp/program/modules/handlers/splashinfomodule.py
+++ b/esp/esp/program/modules/handlers/splashinfomodule.py
@@ -45,6 +45,8 @@ from esp.users.models import ESPUser
 from django.db.models.query import Q
 
 class SplashInfoModule(ProgramModuleObj):
+    doc = """Serves a form during student registration that asks for lunch preferences and if a student has a sibling(s)."""
+
     @classmethod
     def module_properties(cls):
       return {

--- a/esp/esp/program/modules/handlers/studentacknowledgementmodule.py
+++ b/esp/esp/program/modules/handlers/studentacknowledgementmodule.py
@@ -16,6 +16,8 @@ def studentacknowledgementform_factory(prog):
     return type(name, bases, d)
 
 class StudentAcknowledgementModule(ProgramModuleObj):
+    doc = """Serves a form asking students to acknowledge some agreement."""
+
     @classmethod
     def module_properties(cls):
         return {

--- a/esp/esp/program/modules/handlers/studentclassregmodule.py
+++ b/esp/esp/program/modules/handlers/studentclassregmodule.py
@@ -129,6 +129,8 @@ def json_encode(obj):
 
 # student class picker module
 class StudentClassRegModule(ProgramModuleObj):
+    doc = """Allows students to directly enroll in classes."""
+
     @classmethod
     def module_properties(cls):
         return [ {

--- a/esp/esp/program/modules/handlers/studentextracosts.py
+++ b/esp/esp/program/modules/handlers/studentextracosts.py
@@ -66,6 +66,7 @@ class MultiSelectCostItem(forms.Form):
 
 # pick extra items to buy for each program
 class StudentExtraCosts(ProgramModuleObj):
+    doc = """Serves a form during student registration for students to purchases other items."""
 
     @classmethod
     def module_properties(cls):

--- a/esp/esp/program/modules/handlers/studentextracosts.py
+++ b/esp/esp/program/modules/handlers/studentextracosts.py
@@ -66,7 +66,7 @@ class MultiSelectCostItem(forms.Form):
 
 # pick extra items to buy for each program
 class StudentExtraCosts(ProgramModuleObj):
-    doc = """Serves a form during student registration for students to purchases other items."""
+    doc = """Serves a form during student registration for students to purchase other items."""
 
     @classmethod
     def module_properties(cls):

--- a/esp/esp/program/modules/handlers/studentjunctionappmodule.py
+++ b/esp/esp/program/modules/handlers/studentjunctionappmodule.py
@@ -43,8 +43,9 @@ from esp.program.models  import StudentApplication
 from django              import forms
 from esp.middleware.threadlocalrequest import get_current_request
 
-# student class picker module
 class StudentJunctionAppModule(ProgramModuleObj):
+    doc = """Allows students to submit applications for a program."""
+
     @classmethod
     def module_properties(cls):
         return {

--- a/esp/esp/program/modules/handlers/studentlunchselection.py
+++ b/esp/esp/program/modules/handlers/studentlunchselection.py
@@ -103,6 +103,7 @@ class StudentLunchSelectionForm(forms.Form):
 
 
 class StudentLunchSelection(ProgramModuleObj):
+    doc = """Allows students to enroll in lunch blocks."""
 
     @classmethod
     def module_properties(cls):

--- a/esp/esp/program/modules/handlers/studentonsite.py
+++ b/esp/esp/program/modules/handlers/studentonsite.py
@@ -47,6 +47,8 @@ from django.http import HttpResponseRedirect
 from esp.program.modules.handlers.studentclassregmodule import StudentClassRegModule
 
 class StudentOnsite(ProgramModuleObj, CoreModule):
+    doc = """Serves a mobile-friendly interface for common onsite functions for students."""
+
     @classmethod
     def module_properties(cls):
         return {

--- a/esp/esp/program/modules/handlers/studentregconfirm.py
+++ b/esp/esp/program/modules/handlers/studentregconfirm.py
@@ -38,7 +38,7 @@ from esp.middleware.threadlocalrequest import get_current_request
 from django.http import HttpResponseRedirect
 
 class StudentRegConfirm(ProgramModuleObj):
-    """ Basically, a dirty hack to add a link to registration confirmation into the list of stuffs to do during reg """
+    doc = """ Basically, a dirty hack to add a link to registration confirmation into the list of stuffs to do during reg """
     @classmethod
     def module_properties(cls):
         return {

--- a/esp/esp/program/modules/handlers/studentregconfirm.py
+++ b/esp/esp/program/modules/handlers/studentregconfirm.py
@@ -38,7 +38,7 @@ from esp.middleware.threadlocalrequest import get_current_request
 from django.http import HttpResponseRedirect
 
 class StudentRegConfirm(ProgramModuleObj):
-    doc = """ Basically, a dirty hack to add a link to registration confirmation into the list of stuffs to do during reg """
+    doc = """Basically, a dirty hack to add a link to registration confirmation into the list of stuffs to do during reg"""
     @classmethod
     def module_properties(cls):
         return {

--- a/esp/esp/program/modules/handlers/studentregcore.py
+++ b/esp/esp/program/modules/handlers/studentregcore.py
@@ -53,6 +53,8 @@ from django.template.loader import render_to_string, get_template, select_templa
 import operator
 
 class StudentRegCore(ProgramModuleObj, CoreModule):
+    doc = """Serves the main page for student registration."""
+
     @classmethod
     def module_properties(cls):
         return {

--- a/esp/esp/program/modules/handlers/studentregphasezero.py
+++ b/esp/esp/program/modules/handlers/studentregphasezero.py
@@ -51,6 +51,8 @@ from django.db.models.query import Q
 import random, copy, datetime, re
 
 class StudentRegPhaseZero(ProgramModuleObj):
+    doc = """Allows students to enter a lottery for admission to the program."""
+
     def students(self, QObject = False):
         q_phasezero = Q(phasezerorecord__program=self.program)
 

--- a/esp/esp/program/modules/handlers/studentregphasezeromanage.py
+++ b/esp/esp/program/modules/handlers/studentregphasezeromanage.py
@@ -47,6 +47,8 @@ from django.db.models.query import Q
 import copy, datetime, json, re
 
 class StudentRegPhaseZeroManage(ProgramModuleObj):
+    doc = """Track registration for the student lottery and/or run the student lottery."""
+
     def isCompleted(self):
         return get_current_request().user.can_skip_phase_zero(self.program)
 

--- a/esp/esp/program/modules/handlers/studentregtwophase.py
+++ b/esp/esp/program/modules/handlers/studentregtwophase.py
@@ -51,6 +51,7 @@ from esp.utils.web import render_to_response
 from esp.utils.query_utils import nest_Q
 
 class StudentRegTwoPhase(ProgramModuleObj):
+    doc = """Allows students to set preferences for the class lottery."""
 
     def students(self, QObject = False):
         q_sr = Q(studentregistration__section__parent_class__parent_program=self.program) & nest_Q(StudentRegistration.is_valid_qobject(), 'studentregistration')

--- a/esp/esp/program/modules/handlers/studentsurveymodule.py
+++ b/esp/esp/program/modules/handlers/studentsurveymodule.py
@@ -41,7 +41,7 @@ from esp.survey.views   import survey_view
 import datetime
 
 class StudentSurveyModule(ProgramModuleObj):
-    doc = """ A module for students to take surveys about the program and/or classes. """
+    doc = """A module for students to take surveys about the program and/or classes."""
 
     @classmethod
     def module_properties(cls):

--- a/esp/esp/program/modules/handlers/studentsurveymodule.py
+++ b/esp/esp/program/modules/handlers/studentsurveymodule.py
@@ -41,7 +41,7 @@ from esp.survey.views   import survey_view
 import datetime
 
 class StudentSurveyModule(ProgramModuleObj):
-    """ A module for people to take surveys. """
+    doc = """ A module for students to take surveys about the program and/or classes. """
 
     @classmethod
     def module_properties(cls):

--- a/esp/esp/program/modules/handlers/surveymanagement.py
+++ b/esp/esp/program/modules/handlers/surveymanagement.py
@@ -47,7 +47,7 @@ from collections import OrderedDict
 import json
 
 class SurveyManagement(ProgramModuleObj):
-    doc = """Manage the post-program/class surveys that are served to students/teachers during registration (not to be confused with custom forms)."""
+    doc = """Manage the post-program/class surveys that are served to students/teachers during registration."""
 
     @classmethod
     def module_properties(cls):

--- a/esp/esp/program/modules/handlers/surveymanagement.py
+++ b/esp/esp/program/modules/handlers/surveymanagement.py
@@ -47,6 +47,8 @@ from collections import OrderedDict
 import json
 
 class SurveyManagement(ProgramModuleObj):
+    doc = """Manage the post-program/class surveys that are served to students/teachers during registration (not to be confused with custom forms)."""
+
     @classmethod
     def module_properties(cls):
         return {

--- a/esp/esp/program/modules/handlers/teacheracknowledgementmodule.py
+++ b/esp/esp/program/modules/handlers/teacheracknowledgementmodule.py
@@ -25,6 +25,8 @@ def teacheracknowledgementform_factory(prog):
     return type(name, bases, d)
 
 class TeacherAcknowledgementModule(ProgramModuleObj):
+    doc = """Serves a form asking teachers to acknowledge some agreement."""
+
     @classmethod
     def module_properties(cls):
         return {

--- a/esp/esp/program/modules/handlers/teacherbigboardmodule.py
+++ b/esp/esp/program/modules/handlers/teacherbigboardmodule.py
@@ -27,6 +27,7 @@ def get_filter(prog, approved = False, scheduled = False, teachers = None):
 mindate = datetime.datetime(2016, 1, 30)
 
 class TeacherBigBoardModule(ProgramModuleObj):
+    doc = """Shows lots of statistics for teacher registration that are updated automatically."""
 
     @classmethod
     def module_properties(cls):

--- a/esp/esp/program/modules/handlers/teacherbiomodule.py
+++ b/esp/esp/program/modules/handlers/teacherbiomodule.py
@@ -40,7 +40,7 @@ from django.db.models.query   import Q
 
 # reg profile module
 class TeacherBioModule(ProgramModuleObj):
-    doc = """ Module for teacher to edit their biography for each program. """
+    doc = """Module for teacher to edit their biography for each program."""
 
     @classmethod
     def module_properties(cls):

--- a/esp/esp/program/modules/handlers/teacherbiomodule.py
+++ b/esp/esp/program/modules/handlers/teacherbiomodule.py
@@ -40,7 +40,8 @@ from django.db.models.query   import Q
 
 # reg profile module
 class TeacherBioModule(ProgramModuleObj):
-    """ Module for teacher to edit their biography for each program. """
+    doc = """ Module for teacher to edit their biography for each program. """
+
     @classmethod
     def module_properties(cls):
         return {

--- a/esp/esp/program/modules/handlers/teachercheckinmodule.py
+++ b/esp/esp/program/modules/handlers/teachercheckinmodule.py
@@ -56,6 +56,8 @@ import collections
 import json
 
 class TeacherCheckinModule(ProgramModuleObj):
+    doc = """Check in teachers for a program."""
+
     @classmethod
     def module_properties(cls):
         return {

--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -60,6 +60,8 @@ import datetime
 from copy import deepcopy
 
 class TeacherClassRegModule(ProgramModuleObj):
+    doc = """Allows teachers to register and manage classes and view their enrolled students."""
+
     """ This program module allows teachers to register classes, and for them to modify classes/view class statuses
         as the program goes on. It is suggested, though not required, that this module is used in conjunction with
         StudentClassRegModule. Please be mindful of all the options of this module. """

--- a/esp/esp/program/modules/handlers/teachereventsmodule.py
+++ b/esp/esp/program/modules/handlers/teachereventsmodule.py
@@ -48,6 +48,8 @@ from datetime import datetime
 from django.contrib.auth.models import Group
 
 class TeacherEventsModule(ProgramModuleObj):
+    doc = """Allows teachers to sign up for one or more teacher events (e.g. interviews, training)."""
+
     # Initialization
     def __init__(self, *args, **kwargs):
         super(TeacherEventsModule, self).__init__(*args, **kwargs)

--- a/esp/esp/program/modules/handlers/teachermoderatormodule.py
+++ b/esp/esp/program/modules/handlers/teachermoderatormodule.py
@@ -7,6 +7,8 @@ from django.db.models.query import Q
 from esp.middleware.threadlocalrequest import get_current_request
 
 class TeacherModeratorModule(ProgramModuleObj):
+    doc = """Adds a form to teacher registration allowing teachers to sign up as section moderators (also adds moderator features elsewhere on the site)."""
+
     @classmethod
     def module_properties(cls):
         return {

--- a/esp/esp/program/modules/handlers/teacheronsite.py
+++ b/esp/esp/program/modules/handlers/teacheronsite.py
@@ -39,6 +39,8 @@ from esp.program.modules.handlers.teacherclassregmodule import TeacherClassRegMo
 from django.db.models import Count
 
 class TeacherOnsite(ProgramModuleObj, CoreModule):
+    doc = """Provides a mobile-friendly interface for common onsite functions for teachers."""
+
     @classmethod
     def module_properties(cls):
         return {

--- a/esp/esp/program/modules/handlers/teacherpreviewmodule.py
+++ b/esp/esp/program/modules/handlers/teacherpreviewmodule.py
@@ -42,8 +42,8 @@ from esp.middleware.threadlocalrequest import get_current_request
 from esp.utils.web               import render_to_response
 
 class TeacherPreviewModule(ProgramModuleObj):
-    doc = """ This program module allows teachers to view classes already added to the program.
-        And, for now, also some printables. """
+    doc = """This program module allows teachers to view classes already added to the program.
+        And, for now, also some printables."""
 
     @classmethod
     def module_properties(cls):

--- a/esp/esp/program/modules/handlers/teacherpreviewmodule.py
+++ b/esp/esp/program/modules/handlers/teacherpreviewmodule.py
@@ -42,7 +42,7 @@ from esp.middleware.threadlocalrequest import get_current_request
 from esp.utils.web               import render_to_response
 
 class TeacherPreviewModule(ProgramModuleObj):
-    """ This program module allows teachers to view classes already added to the program.
+    doc = """ This program module allows teachers to view classes already added to the program.
         And, for now, also some printables. """
 
     @classmethod

--- a/esp/esp/program/modules/handlers/teacherquizmodule.py
+++ b/esp/esp/program/modules/handlers/teacherquizmodule.py
@@ -80,6 +80,8 @@ class TeacherQuizController(object):
         return False
 
 class TeacherQuizModule(ProgramModuleObj):
+    doc = """Serves a custom form quiz during teacher registration."""
+
     # Initialization
     def __init__(self, *args, **kwargs):
         super(TeacherQuizModule, self).__init__(*args, **kwargs)

--- a/esp/esp/program/modules/handlers/teacherregcore.py
+++ b/esp/esp/program/modules/handlers/teacherregcore.py
@@ -37,6 +37,8 @@ from esp.utils.web import render_to_response
 from esp.miniblog.models import Entry
 
 class TeacherRegCore(ProgramModuleObj, CoreModule):
+    doc = """Serves the main teacher registration page."""
+
     @classmethod
     def module_properties(cls):
         return {

--- a/esp/esp/program/modules/handlers/teacherreviewapps.py
+++ b/esp/esp/program/modules/handlers/teacherreviewapps.py
@@ -47,6 +47,8 @@ from esp.middleware.threadlocalrequest import get_current_request
 __all__ = ['TeacherReviewApps']
 
 class TeacherReviewApps(ProgramModuleObj):
+    doc = """Allows teachers to review student applications for their classes."""
+
     @classmethod
     def module_properties(cls):
         return {

--- a/esp/esp/program/modules/handlers/teachersurveymodule.py
+++ b/esp/esp/program/modules/handlers/teachersurveymodule.py
@@ -41,7 +41,7 @@ from esp.survey.views   import survey_view, survey_review, survey_graphical, sur
 import datetime
 
 class TeacherSurveyModule(ProgramModuleObj):
-    """ A module for people to take surveys. """
+    doc = """ Allows teachers to take post-program/class surveys. """
 
     @classmethod
     def module_properties(cls):

--- a/esp/esp/program/modules/handlers/teachersurveymodule.py
+++ b/esp/esp/program/modules/handlers/teachersurveymodule.py
@@ -41,7 +41,7 @@ from esp.survey.views   import survey_view, survey_review, survey_graphical, sur
 import datetime
 
 class TeacherSurveyModule(ProgramModuleObj):
-    doc = """ Allows teachers to take post-program/class surveys. """
+    doc = """Allows teachers to take post-program/class surveys."""
 
     @classmethod
     def module_properties(cls):

--- a/esp/esp/program/modules/handlers/textmessagemodule.py
+++ b/esp/esp/program/modules/handlers/textmessagemodule.py
@@ -43,6 +43,8 @@ class TextMessageForm(forms.Form):
     phone_number = USPhoneNumberField()
 
 class TextMessageModule(ProgramModuleObj):
+    doc = """Asks students for a cell phone number at which they would like to receive text message reminders."""
+
     @classmethod
     def module_properties(cls):
         return {

--- a/esp/esp/program/modules/handlers/unenrollmodule.py
+++ b/esp/esp/program/modules/handlers/unenrollmodule.py
@@ -44,7 +44,7 @@ from esp.utils.web import render_to_response
 logger = logging.getLogger(__name__)
 
 class UnenrollModule(ProgramModuleObj):
-    doc = """ Frontend to unenroll students from classes. """
+    doc = """Frontend to unenroll students from classes."""
 
     @classmethod
     def module_properties(cls):

--- a/esp/esp/program/modules/handlers/unenrollmodule.py
+++ b/esp/esp/program/modules/handlers/unenrollmodule.py
@@ -44,7 +44,7 @@ from esp.utils.web import render_to_response
 logger = logging.getLogger(__name__)
 
 class UnenrollModule(ProgramModuleObj):
-    """ Frontend to kick students from classes. """
+    doc = """ Frontend to unenroll students from classes. """
 
     @classmethod
     def module_properties(cls):

--- a/esp/esp/program/modules/handlers/volunteermanage.py
+++ b/esp/esp/program/modules/handlers/volunteermanage.py
@@ -46,6 +46,8 @@ from django.http import HttpResponse, HttpResponseRedirect
 import csv
 
 class VolunteerManage(ProgramModuleObj):
+    doc = """Manage timeslots for volunteers and the volunteers that have signed up for those timeslots."""
+
     @classmethod
     def module_properties(cls):
         return {

--- a/esp/esp/program/modules/handlers/volunteersignup.py
+++ b/esp/esp/program/modules/handlers/volunteersignup.py
@@ -45,6 +45,8 @@ from django.db.models.query import Q
 from esp.tagdict.models import Tag
 
 class VolunteerSignup(ProgramModuleObj, CoreModule):
+    doc = """Provides a form for volunteers to signup for particular timeslots."""
+
     @classmethod
     def module_properties(cls):
         return {


### PR DESCRIPTION
I ensured that every module handler had a doc string. These are mostly used on the /main management page, so only mostly useful for management modules, but this at least gives us the option to use them in more places in the future.

I also alphabetized the "Additional Modules" list on the /main management page.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3088.