### PR TITLE
Fixes for debug toolbar 1.11.1

### DIFF
--- a/esp/esp/django_settings.py
+++ b/esp/esp/django_settings.py
@@ -320,8 +320,6 @@ ADDITIONAL_TEMPLATE_SCRIPTS = ''
 
 DEBUG_TOOLBAR = True # set to False in local_settings to globally disable the debug toolbar
 
-DEBUG_TOOLBAR_PATCH_SETTINGS = False
-
 DEBUG_TOOLBAR_PANELS = (
     'debug_toolbar.panels.cache.CachePanel',
     'debug_toolbar.panels.headers.HeadersPanel',
@@ -352,7 +350,7 @@ DEBUG_TOOLBAR_CONFIG = {
         'argcache.signals.cache_deleted',
     ],
     'SHOW_TEMPLATE_CONTEXT': True,
-    'INSERT_BEFORE': '</div>',
+    'INSERT_BEFORE': '</body>',
     'ENABLE_STACKTRACES' : True,
     'RENDER_PANELS': None,
     'SHOW_COLLAPSED': False, # Ideally would be True, but there is a bug in their code.

--- a/esp/esp/middleware/debugtoolbar/middleware.py
+++ b/esp/esp/middleware/debugtoolbar/middleware.py
@@ -43,7 +43,7 @@ class ESPDebugToolbarMiddleware(DebugToolbarMiddleware):
         # short-circuiting to only call request.user.isAdmin() when necessary,
         # because calling request.user.isAdmin() sets Vary:Cookie and prevents
         # proxy caching. See Github issue #739.
-        enabled = ((not request.is_ajax()) and settings.DEBUG_TOOLBAR and (
+        enabled = (settings.DEBUG_TOOLBAR and (
                 (settings.DEBUG and not request.session.get('debug_toolbar') == 'f') or
                 (request.session.get('debug_toolbar') == 't' and
                 (request.user.isAdmin() or request.user.is_morphed()))))


### PR DESCRIPTION
We recently upgraded django-debug-toolbar from v.1.5 to v.1.11.1 (https://github.com/learning-unlimited/ESP-Website/pull/3262). However, this PR didn't check for any breaking changes in the [change list](https://django-debug-toolbar.readthedocs.io/en/latest/changes.html). This PR fixes two things based on the change list:

- Allow AJAX calls for some debug toolbar panels
- Remove deprecated `DEBUG_TOOLBAR_PATCH_SETTINGS` setting.

This PR also fixes a bug related to a very old setting that we used to define where the toolbar was placed in the HTML document. We originally used `</div>`, but now we use `</body>`. This fixes two bugs:

- Fixes https://github.com/learning-unlimited/ESP-Website/issues/3285.
- Puts the debug toolbar on pages that didn't have it before (e.g. ajax scheduler, grid-based class changes).