### PR TITLE
Add student search form to accounting module

### DIFF
--- a/esp/esp/program/modules/handlers/accountingmodule.py
+++ b/esp/esp/program/modules/handlers/accountingmodule.py
@@ -34,6 +34,7 @@ Learning Unlimited, Inc.
 
 from esp.accounting.controllers import IndividualAccountingController
 from esp.program.modules.base import ProgramModuleObj, needs_student, needs_admin, main_call, aux_call
+from esp.users.forms.generic_search_form import StudentSearchForm
 from esp.users.models import ESPUser
 from esp.utils.web import render_to_response
 
@@ -48,8 +49,6 @@ class AccountingModule(ProgramModuleObj):
             "choosable": 0,
             }
 
-    # TODO: create a user search page as main_call instead of this default
-
     @main_call
     @needs_admin
     def accounting(self, request, tl, one, two, module, extra, prog):
@@ -58,29 +57,38 @@ class AccountingModule(ProgramModuleObj):
         Defaults to the current user, but can take the user ID in the extra
         argument instead.'''
 
+        user = None
+        context = {}
         if extra:
             user = ESPUser.objects.get(id=extra)
+        elif 'target_user' in request.POST:
+            form = StudentSearchForm(request.POST)
+            if form.is_valid():
+                user = form.cleaned_data['target_user']
         else:
-            user = request.user
+            form = StudentSearchForm()
 
-        iac = IndividualAccountingController(prog, user)
-        classified_transfers = [
-            { 'transfer': t, 'type': iac.classify_transfer(t) }
-            for t in iac.get_transfers().select_related('line_item')
-        ]
-        context = {
-            'target_user': user,
-            'transfers': classified_transfers,
-            'identifier': iac.get_identifier(),
-            'grant': iac.latest_finaid_grant(),
-        }
-        if iac.transfers_to_program_exist():
-            context['transfers_exist'] = True
-            context['requested'] = iac.amount_requested(ensure_required=False)
-            context['finaid'] = iac.amount_finaid()
-            context['siblingdiscount'] = iac.amount_siblingdiscount()
-            context['paid'] = iac.amount_paid()
-            context['due'] = iac.amount_due()
+        if user:
+            form = StudentSearchForm(initial={'target_user': user.id})
+            iac = IndividualAccountingController(prog, user)
+            classified_transfers = [
+                { 'transfer': t, 'type': iac.classify_transfer(t) }
+                for t in iac.get_transfers().select_related('line_item')
+            ]
+            context.update({
+                'transfers': classified_transfers,
+                'identifier': iac.get_identifier(),
+                'grant': iac.latest_finaid_grant(),
+            })
+            if iac.transfers_to_program_exist():
+                context['transfers_exist'] = True
+                context['requested'] = iac.amount_requested(ensure_required=False)
+                context['finaid'] = iac.amount_finaid()
+                context['siblingdiscount'] = iac.amount_siblingdiscount()
+                context['paid'] = iac.amount_paid()
+                context['due'] = iac.amount_due()
+        context['target_user'] = user
+        context['form'] = form
         return render_to_response(self.baseDir()+'accounting.html', request, context)
 
     class Meta:

--- a/esp/templates/program/modules/accountingmodule/accounting.html
+++ b/esp/templates/program/modules/accountingmodule/accounting.html
@@ -2,8 +2,49 @@
 
 {% block title %}{{program.niceName}} Accounting{% endblock %}
 
+{% block stylesheets %}
+{{ block.super }}
+<link rel='stylesheet' type='text/css' href='/media/styles/forms.css' />
+
+<style type="text/css">
+table {
+    table-layout: fixed;
+    width: 100%;
+}
+#id_target_user {
+    width: calc(100% - 10px);
+}
+</style>
+{% endblock %}
+
 {% block content %}
-<h2>Accounting for {{ target_user.name }} ({{ target_user.username }} / {{ target_user.id }})</h2>
+<h2>Accounting{% if target_user %} for {{ target_user.name }} ({{ target_user.username }} / {{ target_user.id }}){% endif %} for {{ program.niceName }}</h2>
+<div id="program_form">
+<form id="accountingsearchform" name="accountingsearchform" method="POST" action="/manage/{{ program.getUrlBase }}/accounting">
+<table>
+    <col width="85%">
+    <col width="15%">
+    <tr>
+        <th colspan="2">
+            Choose Individual Student for Accounting
+        </th>
+    </tr>
+    <tr>
+        <td>
+            <table>
+                <col width="20%">
+                <col width="80%">
+                {{ form }}
+            </table>
+        </td>
+        <td align="center">
+            <input class="button" type="submit" value="Select" />
+        </td>
+    </tr>
+</table>
+</form>
+</div>
+{% if target_user %}
 <h3>Transfers</h3>
 <table class="table">
     <tr><th>Type</th><th>Line Item</th><th>Amount</th></tr>
@@ -50,5 +91,5 @@ No grant
     <tr><td><em>Paid</em></td><td><em>${{ paid|floatformat:"-2" }}</em></td></tr>
     <tr><td><strong>Owed</strong></td><td><strong>${{ due|floatformat:"-2" }}</strong></td></tr>
 </table>
-</div>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
This adds a student search form to the program accounting module:
![image](https://user-images.githubusercontent.com/7232514/118000588-91f9a000-b30b-11eb-849a-802bc7f9f87a.png)

You can still use the extra parameter, so this doesn't affect the link from the userview page. Also, it didn't make much sense to use request.user by default, so the default now is to just show the search form.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3284.