### PR TITLE
Add module name to usersearch page

### DIFF
--- a/esp/esp/program/modules/handlers/adminmorph.py
+++ b/esp/esp/program/modules/handlers/adminmorph.py
@@ -85,7 +85,7 @@ class AdminMorph(ProgramModuleObj):
         else:
             query = saved_queries['program']
 
-        user, found = search_for_user(request, ESPUser.objects.filter(query))
+        user, found = search_for_user(request, ESPUser.objects.filter(query), add_to_context = {'module': self.module.link_title})
 
         if not found:
             return user

--- a/esp/esp/program/modules/handlers/onsitecheckinmodule.py
+++ b/esp/esp/program/modules/handlers/onsitecheckinmodule.py
@@ -296,11 +296,11 @@ class OnSiteCheckinModule(ProgramModuleObj):
             else:
                 error = True
 
-            context = {'error': error, 'message': message}
+            context = {'error': error, 'message': message, 'module': self.module.link_title}
             return render_to_response('users/usersearch.html', request, context)
 
         else:
-            user, found = search_for_user(request, self.program.students_union())
+            user, found = search_for_user(request, self.program.students_union(), add_to_context = {'tl': 'onsite', 'module': self.module.link_title})
             if not found:
                 return user
 

--- a/esp/esp/program/modules/handlers/onsiteclassschedule.py
+++ b/esp/esp/program/modules/handlers/onsiteclassschedule.py
@@ -85,7 +85,7 @@ class OnsiteClassSchedule(ProgramModuleObj):
         """ Redirect to student registration, having morphed into the desired
         student. """
 
-        user, found = search_for_user(request, ESPUser.getAllOfType('Student', False), add_to_context = {'tl': 'onsite'})
+        user, found = search_for_user(request, ESPUser.getAllOfType('Student', False), add_to_context = {'tl': 'onsite', 'module': self.module.link_title})
         if not found:
             return user
 

--- a/esp/esp/program/modules/handlers/onsitepaiditemsmodule.py
+++ b/esp/esp/program/modules/handlers/onsitepaiditemsmodule.py
@@ -60,7 +60,7 @@ class OnsitePaidItemsModule(ProgramModuleObj):
     def paiditems(self, request, tl, one, two, module, extra, prog):
 
         #   Get a user
-        user, found = search_for_user(request, add_to_context = {'tl': 'onsite'})
+        user, found = search_for_user(request, add_to_context = {'tl': 'onsite', 'module': self.module.link_title})
         if not found:
             return user
 

--- a/esp/esp/program/modules/handlers/onsiteprintschedules.py
+++ b/esp/esp/program/modules/handlers/onsiteprintschedules.py
@@ -34,7 +34,6 @@ Learning Unlimited, Inc.
 """
 import json
 from django.http      import HttpResponse
-from esp.users.views  import search_for_user
 from esp.program.models import SplashInfo
 from esp.program.modules.base import ProgramModuleObj, needs_teacher, needs_student, needs_admin, usercheck_usetl, needs_onsite, main_call, aux_call
 from esp.program.modules.handlers.programprintables import ProgramPrintables

--- a/esp/esp/program/modules/handlers/programprintables.py
+++ b/esp/esp/program/modules/handlers/programprintables.py
@@ -1644,7 +1644,7 @@ class ProgramPrintables(ProgramModuleObj):
     @aux_call
     @needs_admin
     def certificate(self, request, tl, one, two, module, extra, prog):
-        user, found = search_for_user(request, self.program.students_union())
+        user, found = search_for_user(request, self.program.students_union(), add_to_context = {'module': 'Completion Certificate'})
         if not found:
             return user
 

--- a/esp/templates/users/usersearch.html
+++ b/esp/templates/users/usersearch.html
@@ -11,10 +11,8 @@
 <style type="text/css">
 .nocheckmark { border: 1px solid black; }
 </style>
-<br />
-<br />
 
-<h1>Search For User</h1>
+<h1>{% if module %}{{ module }}{% else %}Search For User{% endif %}</h1>
 
 <center>
 <p>
@@ -91,14 +89,14 @@ miles from <input type="text" size="5" name="zipcode" value="02139" />.</td>
 
 <tr><td><label><strong>Grade Limits (students):</strong></label></td> <td>
 Min: 
-<input type="text" size="3" name="grade_min" value="" /> &nbsp;&nbsp;&nbsp;
+<input type="text" size="3" name="grade_min" value="" /><br>
 Max:
 <input type="text" size="3" name="grade_max" value="" /></td>
 </tr>
 
 <tr><td><label><strong>Graduation Year (teachers):</strong></label></td> <td>
 Min: 
-<input type="text" size="3" name="gradyear_min" value="" /> &nbsp;&nbsp;&nbsp;
+<input type="text" size="3" name="gradyear_min" value="" /><br>
 Max:
 <input type="text" size="3" name="gradyear_max" value="" /></td>
 </tr>


### PR DESCRIPTION
Instead of just saying "Search for User" at the top of the page (that can be served by several different modules), we now list the module name at the top:
![image](https://user-images.githubusercontent.com/7232514/118061699-0ad41880-b35b-11eb-84ae-c63113a60a08.png)

Fixes https://github.com/learning-unlimited/ESP-Website/issues/2683.