### PR TITLE
Fix background of fruitsalad tabs

### DIFF
--- a/esp/esp/themes/theme_data/fruitsalad/less/main.less
+++ b/esp/esp/themes/theme_data/fruitsalad/less/main.less
@@ -374,8 +374,8 @@ margin-bottom: 10px;
     border-style: solid;
     border-width: 11px;
     padding-left: 0px;
-    border-top-color: white;
-    border-left-color: white;
+    border-top-color: @bodyBackground;
+    border-left-color: @bodyBackground;
     border-top-right-radius: 0px;
     margin: 0px;
     top: 0.0em;
@@ -384,8 +384,8 @@ margin-bottom: 10px;
 #search_box .leftedge {
     border-style: solid;
     border-width: 14px;
-    border-top-color: white;
-    border-left-color: white;
+    border-top-color: @bodyBackground;
+    border-left-color: @bodyBackground;
     float: left;
 }
 


### PR DESCRIPTION
The background behind the tabs used to always be white:
![image](https://user-images.githubusercontent.com/7232514/118064153-1a099500-b360-11eb-9fc9-f71472138ef7.png)

Now it is the same color as the background:
![image](https://user-images.githubusercontent.com/7232514/118064177-24c42a00-b360-11eb-816f-0f277a5348e9.png)

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3121.