### PR TITLE
Fixes Class Seach on Big Picture

### DIFF
--- a/esp/esp/themes/theme_data/bigpicture/less/main.less
+++ b/esp/esp/themes/theme_data/bigpicture/less/main.less
@@ -274,3 +274,6 @@ div.nav-collapse.collapse {
   margin: 0;
   padding: 0;
 }
+select#regtypes {
+    font-size: 13px;
+}

--- a/esp/esp/themes/theme_data/bigpicture/less/main.less
+++ b/esp/esp/themes/theme_data/bigpicture/less/main.less
@@ -274,6 +274,6 @@ div.nav-collapse.collapse {
   margin: 0;
   padding: 0;
 }
-select#regtypes {
+#reg_types_div {
     font-size: 13px;
 }


### PR DESCRIPTION
Fixes #3258
Just adds a little code to override the inherit for this specific filter box.
I think this is easier to do then alternative because the inherit is definitely used (for better or for worse) in other input boxes