### PR TITLE
Fix review_single survey links

### DIFF
--- a/esp/templates/survey/answers.html
+++ b/esp/templates/survey/answers.html
@@ -5,6 +5,8 @@ Expects:
         'answers': [iterable of <Answer object>s],
         }
     "num_students": Total count of people who could have answered the question
+    "survey": The <Survey object>
+    "tl": teach/manage
 {% endcomment %}
 
 {% load survey %}
@@ -97,7 +99,7 @@ Expects:
         {% else %}
             <ul>
             {% for ans in q.answers|drop_empty_answers %}
-                <li><a href="/{{ tl }}/{{ program.getUrlBase }}/survey/review_single?{{ ans.survey_response.id }}" title="View this person&quot;s other responses">{{ ans.answer }}</a></li>
+                <li><a href="/{{ tl }}/{{ survey.program.getUrlBase }}/survey/review_single?{{ ans.survey_response.id }}" title="View this person&quot;s other responses" target="_blank">{{ ans.answer }}</a></li>
             {% empty %}
                 <li>There are no responses to this question.</li>
             {% endfor %}

--- a/esp/templates/survey/review.html
+++ b/esp/templates/survey/review.html
@@ -99,7 +99,7 @@ td, th {
             <tr><th><h2><a name="class{{ c.class.parent_class.id }}"></a>Responses for {{ sec.parent_class.emailcode }}: {{ sec.title }}<span style="float:right;font-weight: normal;"><a href="#top">[to top]</a></span></h2></th></tr>
             {% endifchanged %}
             <tr style="border-top: 1px dashed black;"><th><h3><a name="class{{ sec.parent_class.id }}-{{ sec.index }}"></a>Responses for Section {{ sec.index }}<span style="float:right;font-weight: normal;"><a href="#top">[to top]</a></span></h3></th></tr>
-            {% render_responses_for_section sec s %}
+            {% render_responses_for_section sec s tl %}
             {% if forloop.last %}
             </table></br></br>
             {% endif %}
@@ -115,7 +115,7 @@ td, th {
         <tr><th><h2><a name="class{{ sec.parent_class.id }}"></a>Responses for {{ sec.parent_class.emailcode }}: {{ sec.title }}<span style="float:right;font-weight: normal;"><a href="#top">[to top]</a></span></h2></th></tr>
         {% endifchanged %}
         <tr style="border-top: 1px dashed black;"><th><h3><a name="class{{ sec.parent_class.id }}-{{ sec.index }}"></a>Responses for Section {{ sec.index }}<span style="float:right;font-weight: normal;"><a href="#top">[to top]</a></span></h3></th></tr>
-        {% render_responses_for_section sec survey %}
+        {% render_responses_for_section sec survey tl %}
         {% if forloop.last %}
         </table>
         {% endif %}


### PR DESCRIPTION
This adds the tl and one/two parts to the review_single links for the HTML versions of the survey results pages for admins/teachers.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3301.