### PR TITLE
Fix invalid template syntax in credit card failure.html template

### DIFF
--- a/esp/esp/program/modules/handlers/creditcardmodule_stripe.py
+++ b/esp/esp/program/modules/handlers/creditcardmodule_stripe.py
@@ -316,7 +316,6 @@ class CreditCardModule_Stripe(ProgramModuleObj):
         if 'error_type' in context:
             #   If we got any sort of error, send an email to the admins and render an error page.
             self.send_error_email(request, context)
-            context['support_email'] = settings.DEFAULT_EMAIL_ADDRESSES['support']
             return render_to_response(self.baseDir() + 'failure.html', request, context)
 
         #   Render the success page, which doesn't do much except direct back to studentreg.

--- a/esp/esp/program/modules/handlers/creditcardmodule_stripe.py
+++ b/esp/esp/program/modules/handlers/creditcardmodule_stripe.py
@@ -316,6 +316,7 @@ class CreditCardModule_Stripe(ProgramModuleObj):
         if 'error_type' in context:
             #   If we got any sort of error, send an email to the admins and render an error page.
             self.send_error_email(request, context)
+            context['support_email'] = settings.DEFAULT_EMAIL_ADDRESSES['support']
             return render_to_response(self.baseDir() + 'failure.html', request, context)
 
         #   Render the success page, which doesn't do much except direct back to studentreg.

--- a/esp/templates/program/modules/creditcardmodule_stripe/failure.html
+++ b/esp/templates/program/modules/creditcardmodule_stripe/failure.html
@@ -21,7 +21,7 @@
 <p>Your credit card transaction was not successful.
 </p>
 {% if error_type == "inconsistent_po" %}
-<b>Inconsistent payment information.</b> Please <a href="mailto:{{ support_email }}">contact the administrators</a> with the following information.
+<b>Inconsistent payment information.</b> Please <a href="mailto:{{ settings.DEFAULT_EMAIL_ADDRESSES.support }}">contact the administrators</a> with the following information.
 <ul>
     <li>Payment PO number: {{ error_info.request_po }}</li>
     <li>User PO number: {{ error_info.user_po }}</li>
@@ -46,7 +46,7 @@
 {% endif %}
 
 {% if error_type == "auth" %}
-<b>Authentication error.</b>  The site was unable to authenticate with the payment processor; please <a href="mailto:{{ support_email }}">let the administrators know</a> so they can correct the issue.
+<b>Authentication error.</b>  The site was unable to authenticate with the payment processor; please <a href="mailto:{{ settings.DEFAULT_EMAIL_ADDRESSES.support }}">let the administrators know</a> so they can correct the issue.
 {% endif %}
 
 {% if error_type == "api" %}

--- a/esp/templates/program/modules/creditcardmodule_stripe/failure.html
+++ b/esp/templates/program/modules/creditcardmodule_stripe/failure.html
@@ -21,7 +21,7 @@
 <p>Your credit card transaction was not successful.
 </p>
 {% if error_type == "inconsistent_po" %}
-<b>Inconsistent payment information.</b> Please <a href="{{ settings.DEFAULT_EMAIL_ADDRESSES['support'] }}">contact the administrators</a> with the following information.
+<b>Inconsistent payment information.</b> Please <a href="mailto:{{ support_email }}">contact the administrators</a> with the following information.
 <ul>
     <li>Payment PO number: {{ error_info.request_po }}</li>
     <li>User PO number: {{ error_info.user_po }}</li>
@@ -46,7 +46,7 @@
 {% endif %}
 
 {% if error_type == "auth" %}
-<b>Authentication error.</b>  The site was unable to authenticate with the payment processor; please <a href="{{ settings.DEFAULT_EMAIL_ADDRESSES['support'] }}">let the administrators know</a> so they can correct the issue.
+<b>Authentication error.</b>  The site was unable to authenticate with the payment processor; please <a href="mailto:{{ support_email }}">let the administrators know</a> so they can correct the issue.
 {% endif %}
 
 {% if error_type == "api" %}


### PR DESCRIPTION
Fix invalid template syntax in the credit card failure message page.

Fixes #3309.
