### PR TITLE
Fix filter population with GET parameters

### DIFF
--- a/esp/public/media/scripts/commpanel.js
+++ b/esp/public/media/scripts/commpanel.js
@@ -106,6 +106,16 @@ function msgreq_select_item(event, ui)
     target_div.append(inner_div3);
 }
 
+function populate_get()
+{
+    //  Populate fields with GET parameters
+    var items = location.search.substr(1).split("&").filter(Boolean);
+    for (var index = 0; index < items.length; index++) {
+        var key_val = items[index].split("=");
+        $j("[name=" + key_val[0] + "]").val(key_val[1].split(",")).change();
+    }
+}
+
 function clear_filters()
 {
     //  Remove any existing data in the "user filtering options" part of a comm panel form
@@ -124,6 +134,7 @@ function clear_filters()
         }
     });
     $j("#filter_accordion").accordion("option", "active", false);
+    populate_get(); // Repopulate any filters with GET parameters
 }
 
 function move_filters(wrapper_name)
@@ -308,12 +319,7 @@ function initialize()
     //  Handle submit button
     $j("#prev_select_done").click(submit_prev_selection);
 
-    //  Populate fields with GET parameters
-    var items = location.search.substr(1).split("&").filter(Boolean);
-    for (var index = 0; index < items.length; index++) {
-        var key_val = items[index].split("=");
-        $j("[name=" + key_val[0] + "]").val(key_val[1].split(",")).change();
-    }
+    populate_get();
 }
 
 $j(document).ready(initialize);


### PR DESCRIPTION
This makes it so that if GET parameters are specified (for filters) for the comm panel or other USC pages, they will always be repopulated any time the filters are cleared (e.g. if you change the recipient type). This seems logical to me, because if you open the page with those GET parameters (e.g. from a link on the /classsearch page), you probably want those filters set.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3313.