### PR TITLE
Fix moderator forms on admin coteachers page

### DIFF
--- a/esp/public/media/scripts/program/modules/teacherclassregmodule.js
+++ b/esp/public/media/scripts/program/modules/teacherclassregmodule.js
@@ -42,7 +42,7 @@ function setup_autocomplete()
 	}
     });
 
-    $j("#moderator_name").autocomplete({
+    $j("[name=moderator_name]").autocomplete({
 	source: function(request, response) {
             $j.ajax({
 		url: "/teach/"+base_url+"/moderatorlookup/",
@@ -61,7 +61,7 @@ function setup_autocomplete()
 	    });
 	},
 	select: function(event, ui) {
-	    $j("#moderator_id").val(ui.item.id);
+	    $j("#moderator_id_" + $j(this).data("secid")).val(ui.item.id);
 	}
     });
 }

--- a/esp/templates/program/modules/adminclass/coteachers.html
+++ b/esp/templates/program/modules/adminclass/coteachers.html
@@ -71,7 +71,7 @@
     </tr>
 </table>
 </form>
-<form action="{{request.path}}" method="post" name="addteacher" onsubmit="cleanTeacherSubmit($j(this))">
+<form action="{{request.path}}" method="post" name="addteacher">
 <table align="center" width="400">
     <tr>
         <th colspan="2">Add a coteacher</th>
@@ -113,7 +113,7 @@
             <input type="hidden" name="secid" value="{{ section.id }}" />
             <input type="hidden" name="moderators" value="{% for moderator in section.get_moderators %}{{ moderator.id }}{% if not forloop.last %},{% endif %}{% endfor %}" />
 
-            <select id="current_moderators"
+            <select id="current_moderators_{{ section.id }}"
                     class="moderators" name="delete_moderators" 
                     size="5" multiple="multiple">
             {% for moderator in section.get_moderators %}
@@ -131,7 +131,7 @@
     </tr>
 </table>
 </form>
-<form action="{{request.path}}" method="post" name="addmoderator" onsubmit="cleanTeacherSubmit($j(this))">
+<form action="{{request.path}}" method="post" name="addmoderator">
 <table align="center" width="400">
     <tr>
         <th colspan="2">Add a {{ program.getModeratorTitle|lower }}</th>
@@ -146,8 +146,8 @@
             <input type="hidden" name="op" value="addmod" />
             <input type="hidden" name="moderators" value="{% for moderator in section.get_moderators %}{{ moderator.id }}{% if not forloop.last %},{% endif %}{% endfor %}" />
 
-	    <input type="text" name="moderator_name" id="moderator_name" />
-	    <input type="hidden" name="moderator_selected" id="moderator_id" />
+	    <input type="text" name="moderator_name" id="moderator_name_{{ section.id }}" data-secid="{{ section.id }}"/>
+	    <input type="hidden" name="moderator_selected" id="moderator_id_{{ section.id }}" data-secid="{{ section.id }}"/>
         </td>
         <td>
             <input type="submit" class="button" value="Add {{ program.getModeratorTitle }}" />

--- a/esp/templates/program/modules/adminclass/coteachers.html
+++ b/esp/templates/program/modules/adminclass/coteachers.html
@@ -147,7 +147,7 @@
             <input type="hidden" name="moderators" value="{% for moderator in section.get_moderators %}{{ moderator.id }}{% if not forloop.last %},{% endif %}{% endfor %}" />
 
 	    <input type="text" name="moderator_name" id="moderator_name_{{ section.id }}" data-secid="{{ section.id }}"/>
-	    <input type="hidden" name="moderator_selected" id="moderator_id_{{ section.id }}" data-secid="{{ section.id }}"/>
+	    <input type="hidden" name="moderator_selected" id="moderator_id_{{ section.id }}"/>
         </td>
         <td>
             <input type="submit" class="button" value="Add {{ program.getModeratorTitle }}" />


### PR DESCRIPTION
This fixes the autocomplete text boxes for moderators for sections 2+ on the admin version of the /coteachers page.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3308.