### PR TITLE
Fix spacing and alignment within login/logout bar in bigpicture

### DIFF
--- a/esp/esp/themes/theme_data/bigpicture/less/main.less
+++ b/esp/esp/themes/theme_data/bigpicture/less/main.less
@@ -177,7 +177,8 @@ div.nav-collapse.collapse {
         margin-top: 0;
     }
     .navbar-inner {
-        padding: 3px 6px 0 10px;
+        margin: 0;
+        padding: 6px;
         background: white;
         background: rgba(255, 255, 255, 0.74);
         min-height: auto;
@@ -195,8 +196,12 @@ div.nav-collapse.collapse {
         text-decoration: none;
     }
     .navbar-form > * {
+        margin: 0;
         display: inline-block;
         vertical-align: middle;
+    }
+    .navbar-form button {
+        margin: 0;
     }
 }
 


### PR DESCRIPTION
Previously looked like this:
![image](https://user-images.githubusercontent.com/7232514/118832989-b3680800-b886-11eb-8fcb-3d8f3ea82fbf.png)

Now it looks like this:
![image](https://user-images.githubusercontent.com/7232514/118833018-bb27ac80-b886-11eb-837e-d9a137be450e.png)

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3259.