### PR TITLE
Always show moderating/teaching sections, regardless of subject matching

### DIFF
--- a/esp/public/media/default_styles/scheduling.css
+++ b/esp/public/media/default_styles/scheduling.css
@@ -99,12 +99,6 @@ td.moderator-unavailable-cell {
     color: white !important;
 }
 
-td.moderator-moderating-or-teaching-cell {
-    background: #42b3f4 !important;
-    opacity: .9 !important;
-    color: black !important;
-}
-
 td .selected-section {
     outline: 1px solid yellow;
 }
@@ -126,6 +120,12 @@ td.hiddenCell {
     background: #222222 !important;
     opacity: 0.35 !important;
     color: #222222 !important;
+}
+
+td.moderator-moderating-or-teaching-cell {
+    background: #42b3f4 !important;
+    opacity: .9 !important;
+    color: black !important;
 }
 
 .component-div {


### PR DESCRIPTION
This makes it so that a section is always shown on the scheduler (specifically, when a moderator is selected) if the moderator is moderating or teaching the section, regardless of whether the subject of the class is preferred by the moderator (if the checkbox is checked).

All I did was change the CSS order so that the mod/teaching styling takes precedence over the hidden styling.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3280.