### PR TITLE
Fix scheduler popup for open classes

### DIFF
--- a/esp/esp/program/modules/handlers/jsondatamodule.py
+++ b/esp/esp/program/modules/handlers/jsondatamodule.py
@@ -160,6 +160,8 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
     @cached_module_view
     def categories(prog):
         categories = prog.class_categories.all()
+        if prog.open_class_registration:
+            categories = categories.union(ClassCategories.objects.filter(pk=prog.open_class_category.pk))
         if len(categories) == 0:
             categories = ClassCategories.objects.filter(program__isnull=True)
 


### PR DESCRIPTION
In cases where you have open class registration but don't have the class category as a selected category, this includes the open class category for the scheduler so the popup still works.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3347.