### PR TITLE
Add moderator tshirt stats

### DIFF
--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -1227,6 +1227,8 @@ class Program(models.Model, CustomFormsLinkModel):
     getShirtInfo.depend_on_model('users.TeacherInfo')
     getShirtInfo.depend_on_model('users.StudentInfo')
     getShirtInfo.depend_on_model('program.VolunteerOffer')
+    getShirtInfo.depend_on_model('program.ModeratorRecord')
+    getShirtInfo.depend_on_m2m('program.ClassSection', 'moderators', lambda sec, moderator: {'self': sec.parent_class.parent_program})
 
     @cache_function
     def incrementGrade(self):

--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -1192,6 +1192,8 @@ class Program(models.Model, CustomFormsLinkModel):
 
         teacher_dict = self.teachers()
         teacher_types = {'Approved Teachers': 'class_approved', 'All Teachers': 'class_submitted'}
+        if self.hasModule('TeacherModeratorModule'):
+            teacher_types.update({'Assigned Moderators': 'assigned_moderator'})
         shirt_sizes = [x.strip() for x in Tag.getTag('teacher_shirt_sizes').split(',')]
         for teacher_type in teacher_types.items():
             if teacher_type[1] in teacher_dict:


### PR DESCRIPTION
Add moderators to the list of tshirt stats if the moderator module is enabled.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3338.