### PR TITLE
Custom form builder bug fixes

### DIFF
--- a/esp/public/media/default_styles/customforms-style.css
+++ b/esp/public/media/default_styles/customforms-style.css
@@ -4,6 +4,10 @@ body {
 	text-decoration:none;
 }
 
+form {
+    margin: 0;
+}
+
 .wrapper {
 	width:960px;
 	margin:0 auto;
@@ -26,6 +30,7 @@ body {
 
 .form_preview {
 	position:relative;
+    padding: 20px;
 }
 
 .field_wrapper {
@@ -66,15 +71,25 @@ body {
 	color:#FF0000;
 }
 
+.outline, .field_wrapper, .form_preview {
+    border:2px solid transparent;
+}
+
 .field_hover {
-	border:2px dashed blue;
-	padding:8px 8px;
+	border:2px dashed blue !important;
+}
+
+.page_selected {
+    background-color:#edffed;
+}
+
+.section_selected {
+    background-color:#f5dff1;
 }
 
 .field_selected {
 	background-color:#d2f8ff;
-	border:1px dashed blue;
-	padding:9px 9px;
+	border: 2px dashed blue;
 }
 
 .field_text {
@@ -120,6 +135,7 @@ body {
 	position: relative; 
 	top: -0.5em;
 	cursor:pointer;
+    z-index: 1000;
 }
 
 #form_title{

--- a/esp/public/media/default_styles/customforms-style.css
+++ b/esp/public/media/default_styles/customforms-style.css
@@ -30,8 +30,23 @@ form {
 
 .form_preview {
 	position:relative;
-    padding: 20px;
+    padding: 0px 20px;
     min-height: 200px;
+}
+
+.form_preview::before {
+    content: '**Page Break**';
+    position: absolute;
+    width: 569px;
+    margin-left: -22px;
+    height: 20px;
+    text-align: center;
+    background: black;
+    color: white;
+}
+
+.form_preview .outline:first-of-type {
+    margin-top: 40px;
 }
 
 .field_wrapper {

--- a/esp/public/media/default_styles/customforms-style.css
+++ b/esp/public/media/default_styles/customforms-style.css
@@ -31,6 +31,7 @@ form {
 .form_preview {
 	position:relative;
     padding: 20px;
+    min-height: 200px;
 }
 
 .field_wrapper {

--- a/esp/public/media/scripts/custom_form.js
+++ b/esp/public/media/scripts/custom_form.js
@@ -825,7 +825,7 @@ var updateField=function() {
     var field_type=$j('#elem_selector').val();
     var curr_field_id=$j.data($currField[0],'data').parent_id;
 	if(curr_field_type=='section' && field_type=='section'){
-        $field_data = $currField.data('data')
+        var $field_data = $currField.data('data')
         $field_data.question_text = $j('#id_question').val()
         $currField.find('h2').html($j('#id_question').val());
         $field_data.help_text = $j('#id_instructions').val()
@@ -851,7 +851,7 @@ var onSelectField=function($elem, field_data, ftype=null) {
     
 	//De-selecting any previously selected field
 	if($j('div.field_selected').length == 0 || !$elem.hasClass('field_selected')){
-        $divs = $j('div.field_selected');
+        var $divs = $j('div.field_selected');
         $divs.click();
         $divs.removeClass('field_hover');
         $divs.children(".wrapper_button").removeClass("wrapper_button_hover");

--- a/esp/public/media/scripts/custom_form.js
+++ b/esp/public/media/scripts/custom_form.js
@@ -1287,7 +1287,10 @@ var renderNormalField=function(item, field_options, data){
             $j(this).children(".wrapper_button").removeClass("wrapper_button_hover");
         }).toggle(function(){onSelectField($j(this), $j.data(this, 'data'));}, function(){deSelectField($j(this));});
 		$outline.appendTo($currPage);
-		$currPage.sortable();
+		$currPage.sortable({
+            containment: $j(".pages"),
+            connectWith: ".form_preview",
+        });
 		secCount++;
 		$j.data($outline[0],'data',data);
 		return $outline;
@@ -1324,7 +1327,7 @@ var renderNormalField=function(item, field_options, data){
                 return;
             $j(this).next('div.form_preview').removeClass('field_hover');
             $j(this).next('div.form_preview').children(".wrapper_button").removeClass("wrapper_button_hover");
-        }).appendTo($j('div.preview_area'));
+        }).appendTo($j('div.pages'));
 		
 		//Now putting in the page div
 		$currPage=$j('<div class="form_preview"></div>');
@@ -1385,10 +1388,11 @@ var renderNormalField=function(item, field_options, data){
 		});
         $j('.form_preview').removeClass('page_selected');
         $currPage.addClass('page_selected');
-		$currPage.appendTo($j('div.preview_area'));
+		$currPage.appendTo($j('div.pages'));
 		$j.data(($currSection.parent())[0], 'data', {attrs: {}, field_type: 'section', question_text: label_text, help_text: help_text, parent_id:-1});
 		secCount++;
         $j.data($currPage[0], 'data', {'parent_id':-1});
+        $j('div.pages').sortable();
 		return $currPage;
 	}
 	return $new_elem; 
@@ -1532,7 +1536,10 @@ var addElement=function(item, $field=null) {
     }
 	
 	//Making fields draggable
-	$currSection.sortable();
+	$currSection.sortable({
+        containment: $j(".pages"),
+        connectWith: ".section",
+    });
 	return $wrap;	
 };
 
@@ -1564,7 +1571,7 @@ var submit=function() {
 	form['perms']=form_perms;
 	
 	//Constructing the object to be sent to the server
-	$j('div.preview_area').children('div.form_preview').each(function(pidx,pel) {
+	$j('div.pages').children('div.form_preview').each(function(pidx,pel) {
 		page={'sections':[], 'parent_id':$j.data(pel, 'data')['parent_id'], 'seq':page_seq};
 		section_seq=0;
 		$j(pel).children('div.outline').each(function(idx, el) {

--- a/esp/public/media/scripts/custom_form.js
+++ b/esp/public/media/scripts/custom_form.js
@@ -96,7 +96,7 @@ var elemTypes = {
     'instructions': 0
 };
 
-var currElemType, currElemIndex, optionCount=1, formTitle="Form",$prevField, $currField, secCount=1, $currSection, pageCount=1, $currPage;
+var currElemType, currElemIndex, optionCount=1, formTitle="Form",$prevField, $currField, secCount=1, $currSection, pageCount=1, $currPage, disabled_fields=[];
 var perms={};
 
 $j(document).ready(function() {
@@ -624,8 +624,11 @@ var populateFieldsSelector=function(category){
 		var disp_name="";
 		if(category!="Generic" && elem['required'])
 			disp_name=elem['disp_name']+"**";
-		else disp_name=elem['disp_name'];	
-		options_html+="<option value="+index+">"+disp_name+"</option>";
+		else disp_name=elem['disp_name'];
+		options_html+="<option value="+index;
+        if(disabled_fields.includes(index))
+            options_html+=' disabled style="color: lightgrey"';
+        options_html+=">"+disp_name+"</option>";
 	});
 	//Populating options for the Field Selector
 	$j("#elem_selector").html(options_html);
@@ -865,6 +868,8 @@ var onSelectField=function($elem, field_data, ftype=null) {
 	//Select the current field and category in the field and category selectors
 	if(ftype in formElements['Generic']){
 		$j('#cat_selector').val('Generic');
+        // Don't allow changing a field into a page or section (instructions are ok, though)
+        disabled_fields=['page', 'section'];
 		populateFieldsSelector('Generic');
 		$j('#elem_selector').val(ftype);	
 	}
@@ -881,6 +886,12 @@ var onSelectField=function($elem, field_data, ftype=null) {
 		$j('#elem_selector').val(ftype);
 		showCategorySpecificOptions(curr_cat);
 	}
+
+    // Don't allow changing sections or pages to other field types
+    if(['section','page'].includes(ftype)){
+        $j('#cat_selector').prop('disabled', true);;
+        $j('#elem_selector').prop('disabled', true);;
+    }
 	
 	if($wrap.length !=0){
 		$wrap.removeClass('field_hover').addClass('field_selected');
@@ -946,8 +957,11 @@ var deSelectField=function(field) {
 	field.addClass('field_hover');
 	field.children(".wrapper_button").addClass("wrapper_button_hover");
 	$j('#cat_selector').children('option[value=Generic]').prop('selected','selected');
+    disabled_fields=[];
 	onSelectCategory('Generic');
 	onSelectElem('textField');
+    $j('#cat_selector').prop('disabled', false);;
+    $j('#elem_selector').prop('disabled', false);;
 };
 
 var insertField=function(item, $field=null){

--- a/esp/public/media/scripts/custom_form.js
+++ b/esp/public/media/scripts/custom_form.js
@@ -144,37 +144,6 @@ $j(document).ready(function() {
 	$j('.wrapper_button').click(function(e){removeField($j(this)); e.stopPropagation();});
     
     // Make the initial page selectable
-    $j("#page_break_0").click(function(){
-        $j('.form_preview').removeClass('page_selected');
-        $currPage=$j(this).next('div.form_preview'); 
-        $currPage.addClass('page_selected');
-        // If the current section is in another section, switch to the first section in this page
-        if(!$currPage[0].contains($currSection[0])){
-            $currSection=$currPage.find(".section:first");
-            $j('.outline').removeClass('section_selected');
-            $currSection.parent().addClass('section_selected');
-        }
-        // If the currently selected field
-        if($currField && !$currPage[0].contains($currField[0])){
-            var $field=$currField;
-            $field.click();
-            $field.removeClass('field_hover');
-            $field.children(".wrapper_button").removeClass("wrapper_button_hover");
-        }
-    }).mouseover(function(e) {
-        if($j(e.target).is('.page_break, .page_break span, .form_preview, .preview_button')){
-            if($j(this).hasClass('field_selected'))
-                return;
-            $j(this).next('div.form_preview').addClass('field_hover');
-            $j(this).next('div.form_preview').children(".wrapper_button").addClass("wrapper_button_hover");
-        }
-    }).mouseout(function() {
-        if($j(this).hasClass('field_selected'))
-            return;
-        $j(this).next('div.form_preview').removeClass('field_hover');
-        $j(this).next('div.form_preview').children(".wrapper_button").removeClass("wrapper_button_hover");
-    })
-
     $j("#page_0").mouseover(function(e) {
         if($j(e.target).is('.form_preview, .preview_button')){
             if($j(this).hasClass('field_selected'))
@@ -1296,41 +1265,9 @@ var renderNormalField=function(item, field_options, data){
 		return $outline;
 	}
 	else if(item=='page'){
-		//First putting in the page break text
-		var $page_break = $j('<div class="page_break"><span>** Page Break **</span></div>');
-		$page_break.click(function(){
-            $j('.form_preview').removeClass('page_selected');
-			$currPage=$j(this).next('div.form_preview'); 
-            $currPage.addClass('page_selected');
-            // If the current section is in another section, switch to the first section in this page
-            if(!$currPage[0].contains($currSection[0])){
-                $currSection=$currPage.find(".section:first");
-                $j('.outline').removeClass('section_selected');
-                $currSection.parent().addClass('section_selected');
-            }
-            // If the currently selected field
-            if($currField && !$currPage[0].contains($currField[0])){
-                var $field=$currField;
-                $field.click();
-                $field.removeClass('field_hover');
-                $field.children(".wrapper_button").removeClass("wrapper_button_hover");
-            }
-		}).mouseover(function(e) {
-            if($j(e.target).is('.page_break, .page_break span, .form_preview, .preview_button')){
-                if($j(this).hasClass('field_selected'))
-                    return;
-                $j(this).next('div.form_preview').addClass('field_hover');
-                $j(this).next('div.form_preview').children(".wrapper_button").addClass("wrapper_button_hover");
-            }
-        }).mouseout(function() {
-            if($j(this).hasClass('field_selected'))
-                return;
-            $j(this).next('div.form_preview').removeClass('field_hover');
-            $j(this).next('div.form_preview').children(".wrapper_button").removeClass("wrapper_button_hover");
-        }).appendTo($j('div.pages'));
-		
-		//Now putting in the page div
+		// Putting in the page div
 		$currPage=$j('<div class="form_preview"></div>');
+        // Add a section to the page
         $j('.outline').removeClass('section_selected');
         $outline=$j('<div class="outline section_selected"></div>');
         var label_text=$j.trim($j('#id_question').val()), help_text=$j.trim($j('#id_instructions').val());
@@ -1666,7 +1603,6 @@ var onChangeBase=function(){
 var createFromBase=function(){
 	//Clearing previous fields, if any
 	$j('div.form_preview').remove();
-	$j('div.page_break').remove();
 	/*$currPage=$j('<div class="form_preview"></div>');
 	$currSection=$j('<div class="section"></div>');
 	$currPage.append($j('<div class="outline"></div>').append($currSection));

--- a/esp/public/media/scripts/custom_form.js
+++ b/esp/public/media/scripts/custom_form.js
@@ -519,7 +519,9 @@ var onChangeMainCatSpec=function() {
 var createLabel=function(labeltext, required, help_text) {
     //Returns an HTML-formatted label, with a red * if the question is required
     var str='';
-    str+='<div class="field_label">'+labeltext+':';
+    str+='<div class="field_label">'+labeltext;
+    if(!([':','?','.','!'].includes(labeltext.charAt(labeltext.length - 1))))
+        str+=':';
     if(required) str+='<span class="asterisk">'+'*'+'</span>';
     str+='</div>';
     if(help_text) str+=' <img src="/media/default_images/question_mark.jpg" class="qmark" title="' + help_text + '">'

--- a/esp/public/media/scripts/custom_form.js
+++ b/esp/public/media/scripts/custom_form.js
@@ -144,20 +144,23 @@ $j(document).ready(function() {
 	$j('.wrapper_button').click(function(e){removeField($j(this)); e.stopPropagation();});
     
     // Make the initial page selectable
-    $j("#page_break_0").dblclick(function(){
-		$currPage=$j(this).next('div.form_preview'); 
-		//$currSection=$j(this).children(":last").children("div.section");
-	}).toggle(function(){$j(this).next('div.form_preview').children(".wrapper_button").addClass("wrapper_button_hover");}, 
-			function(){$j(this).next('div.form_preview').children(".wrapper_button").removeClass("wrapper_button_hover");}
-			);
-
-    $j("#page_break_0").dblclick(function(){
+    $j("#page_break_0").click(function(){
         $j('.form_preview').removeClass('page_selected');
         $currPage=$j(this).next('div.form_preview'); 
         $currPage.addClass('page_selected');
-        $currSection=$j(this).next().find(".section:first");
-        $j('.outline').removeClass('section_selected');
-        $currSection.parent().addClass('section_selected');
+        // If the current section is in another section, switch to the first section in this page
+        if(!$currPage[0].contains($currSection[0])){
+            $currSection=$currPage.find(".section:first");
+            $j('.outline').removeClass('section_selected');
+            $currSection.parent().addClass('section_selected');
+        }
+        // If the currently selected field
+        if($currField && !$currPage[0].contains($currField[0])){
+            var $field=$currField;
+            $field.click();
+            $field.removeClass('field_hover');
+            $field.children(".wrapper_button").removeClass("wrapper_button_hover");
+        }
     }).mouseover(function(e) {
         if($j(e.target).is('.page_break, .page_break span, .form_preview, .preview_button')){
             if($j(this).hasClass('field_selected'))
@@ -184,13 +187,23 @@ $j(document).ready(function() {
             return;
         $j(this).removeClass('field_hover');
         $j(this).children(".wrapper_button").removeClass("wrapper_button_hover");
-    }).dblclick(function(){
+    }).click(function(){
         $j('.form_preview').removeClass('page_selected');
         $currPage=$j(this);
         $currPage.addClass('page_selected');
-        $currSection=$j(this).find(".section:first");
-        $j('.outline').removeClass('section_selected');
-        $currSection.parent().addClass('section_selected');
+        // If the current section is in another section, switch to the first section in this page
+        if(!$currPage[0].contains($currSection[0])){
+            $currSection=$currPage.find(".section:first");
+            $j('.outline').removeClass('section_selected');
+            $currSection.parent().addClass('section_selected');
+        }
+        // If the currently selected field
+        if($currField && !$currPage[0].contains($currField[0])){
+            var $field=$currField;
+            $field.click();
+            $field.removeClass('field_hover');
+            $field.children(".wrapper_button").removeClass("wrapper_button_hover");
+        }
     });
 	
 	//csrf stuff
@@ -962,8 +975,9 @@ var deSelectField=function(field) {
     disabled_fields=[];
 	onSelectCategory('Generic');
 	onSelectElem('textField');
-    $j('#cat_selector').prop('disabled', false);;
-    $j('#elem_selector').prop('disabled', false);;
+    $j('#cat_selector').prop('disabled', false);
+    $j('#elem_selector').prop('disabled', false);
+    $currField=null;
 };
 
 var insertField=function(item, $field=null){
@@ -1281,13 +1295,23 @@ var renderNormalField=function(item, field_options, data){
 	else if(item=='page'){
 		//First putting in the page break text
 		var $page_break = $j('<div class="page_break"><span>** Page Break **</span></div>');
-		$page_break.dblclick(function(){
+		$page_break.click(function(){
             $j('.form_preview').removeClass('page_selected');
 			$currPage=$j(this).next('div.form_preview'); 
             $currPage.addClass('page_selected');
-			$currSection=$j(this).next().find(".section:first");
-            $j('.outline').removeClass('section_selected');
-            $currSection.parent().addClass('section_selected');
+            // If the current section is in another section, switch to the first section in this page
+            if(!$currPage[0].contains($currSection[0])){
+                $currSection=$currPage.find(".section:first");
+                $j('.outline').removeClass('section_selected');
+                $currSection.parent().addClass('section_selected');
+            }
+            // If the currently selected field
+            if($currField && !$currPage[0].contains($currField[0])){
+                var $field=$currField;
+                $field.click();
+                $field.removeClass('field_hover');
+                $field.children(".wrapper_button").removeClass("wrapper_button_hover");
+            }
 		}).mouseover(function(e) {
             if($j(e.target).is('.page_break, .page_break span, .form_preview, .preview_button')){
                 if($j(this).hasClass('field_selected'))
@@ -1341,13 +1365,23 @@ var renderNormalField=function(item, field_options, data){
                 return;
             $j(this).removeClass('field_hover');
             $j(this).children(".wrapper_button").removeClass("wrapper_button_hover");
-        }).dblclick(function(){
+        }).click(function(){
             $j('.form_preview').removeClass('page_selected');
 			$currPage=$j(this);
             $currPage.addClass('page_selected');
-			$currSection=$j(this).find(".section:first");
-            $j('.outline').removeClass('section_selected');
-            $currSection.parent().addClass('section_selected');
+            // If the current section is in another section, switch to the first section in this page
+            if(!$currPage[0].contains($currSection[0])){
+                $currSection=$currPage.find(".section:first");
+                $j('.outline').removeClass('section_selected');
+                $currSection.parent().addClass('section_selected');
+            }
+            // If the currently selected field
+            if($currField && !$currPage[0].contains($currField[0])){
+                var $field=$currField;
+                $field.click();
+                $field.removeClass('field_hover');
+                $field.children(".wrapper_button").removeClass("wrapper_button_hover");
+            }
 		});
         $j('.form_preview').removeClass('page_selected');
         $currPage.addClass('page_selected');

--- a/esp/templates/customforms/index.html
+++ b/esp/templates/customforms/index.html
@@ -23,9 +23,7 @@
         <h2 id='form_title'>Form Title</h2>
         <p id='form_description' class="field_text"></p>
         <hr />
-        <br /><br/>
         <div class="pages">
-            <div class="page_break" id="page_break_0"><span>** Page Break **</span></div>
             <div class="form_preview page_selected" id="page_0">
                 <div class="outline section_selected ui-sortable-handle">
                     <h2 class="section_header">Section</h2>

--- a/esp/templates/customforms/index.html
+++ b/esp/templates/customforms/index.html
@@ -25,18 +25,21 @@
         <hr />
         <br /><br/>
         <div class="page_break" id="page_break_0"><span>** Page Break **</span></div>
-        <div class="form_preview" id="page_0">
-            <div class="outline" id="outline_0">
-                <div id="section_0" class="section">
-                </div>
-            </div>		
+        <div class="form_preview page_selected" id="page_0">
+            <div class="outline section_selected ui-sortable-handle">
+                <h2 class="section_header">Section</h2>
+                <p class="field_text section_text">Enter a short description about the section</p>
+                <hr>
+                <div id="section_0" class="section"></div><input type="button" value="X" class="section_button wrapper_button">
+            </div>
+            <input type="button" value="X" class="wrapper_button preview_button">
         </div>
     </div>
         
     <div id="form_toolbox">
         <h3 id="header_information"><a href='#'>Form information</a></h3>
         <div id="form_information">
-            <p>Form Title</p> <input type='text' id='input_form_title' size='30'/>
+            <p>Form Title</p> <input type='text' id='input_form_title' size='30' value='Form Title'/>
             <p>Description</p>
             <textarea rows='3' cols='30' id='input_form_description'></textarea>
             <p>Message on Success</p>
@@ -109,7 +112,7 @@
                 <p class="toolboxText">Instructions for user</p>
                 <textarea name="instructions" id="id_instructions" rows=4 cols=30></textarea>
                 <p class="toolboxText">Required&nbsp;
-                    <input type="checkbox" id="id_required" name="required" /></p><br/>
+                    <input type="checkbox" id="id_required" name="required" /><br/><br/></p>
                 <form id="elem_properties">
                     <div id="multi_options"></div>
                 </form>

--- a/esp/templates/customforms/index.html
+++ b/esp/templates/customforms/index.html
@@ -24,15 +24,17 @@
         <p id='form_description' class="field_text"></p>
         <hr />
         <br /><br/>
-        <div class="page_break" id="page_break_0"><span>** Page Break **</span></div>
-        <div class="form_preview page_selected" id="page_0">
-            <div class="outline section_selected ui-sortable-handle">
-                <h2 class="section_header">Section</h2>
-                <p class="field_text section_text">Enter a short description about the section</p>
-                <hr>
-                <div id="section_0" class="section"></div><input type="button" value="X" class="section_button wrapper_button">
+        <div class="pages">
+            <div class="page_break" id="page_break_0"><span>** Page Break **</span></div>
+            <div class="form_preview page_selected" id="page_0">
+                <div class="outline section_selected ui-sortable-handle">
+                    <h2 class="section_header">Section</h2>
+                    <p class="field_text section_text">Enter a short description about the section</p>
+                    <hr>
+                    <div id="section_0" class="section"></div><input type="button" value="X" class="section_button wrapper_button">
+                </div>
+                <input type="button" value="X" class="wrapper_button preview_button">
             </div>
-            <input type="button" value="X" class="wrapper_button preview_button">
         </div>
     </div>
         

--- a/esp/templates/customforms/index.html
+++ b/esp/templates/customforms/index.html
@@ -108,7 +108,7 @@
             <div id="field_properties">
                 
                 <p class="toolboxText">Field label</p>
-                <textarea name="question" id="id_question" rows=4 cols=30></textarea>
+                <textarea name="question" id="id_question" rows=4 cols=30 maxlength=200></textarea>
                 <p class="toolboxText">Instructions for user</p>
                 <textarea name="instructions" id="id_instructions" rows=4 cols=30></textarea>
                 <p class="toolboxText">Required&nbsp;


### PR DESCRIPTION
This makes the many following bug fixes to the custom form builder:

1. If you delete a field, it no longer selects the section that the field was in.
2. If you select a section, it no longer adds an X to all of the fields within it.
3. You can no longer delete the last section of a page or the last page of the form. If you attempt to do this, you receive a popup. You CAN delete the last field in a section.
4. When you select a section, the title/description is now loaded. You can also now change these elements, and they properly update in the actual form.
5. When you select a section, then select something else, the former section is unselected.
6. There are no longer empty sections at the top of each page.
7. The current page and current section now have styling to show where new fields or sections will be added. When a field is selected, the current page and section are shifted to those of the selected field. The current page can be changed by double clicking on the desired page/page break.
8. If you change a non-multi-answer field to a multi-answer field, a blank option is added. You can no longer remove the last blank option for a multi-answer field, which prevents situations where you can't add more options.
9. Fields don't shift in location in small but very annoying ways when hovering or selecting fields.
10. When you add a new page, it now has a section with a header/description.
11. You can now edit/remove the default section when making a brand new custom form.
12. We no longer show a ":" after a field label if the label text ends in a punctuation mark (like in the actual form).
13. Enforces the field label length limit in the builder.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3339, fixes https://github.com/learning-unlimited/ESP-Website/issues/3355, and fixes https://github.com/learning-unlimited/ESP-Website/issues/3354.