### PR TITLE
Add texescape to program names in tex documents

### DIFF
--- a/esp/templates/program/modules/programprintables/catalog_category.tex
+++ b/esp/templates/program/modules/programprintables/catalog_category.tex
@@ -22,7 +22,7 @@
 \setlength{}{}
 
 \lhead{ {{ group_name }} }
-\chead{% templatetag openbrace %} {{program.niceName}} }
+\chead{% templatetag openbrace %} {{program.niceName|texescape}} }
 
 \newcommand{\cat}[1]{\begin{center}\section*{#1}\end{center} }
 

--- a/esp/templates/program/modules/programprintables/catalog_timeblock.tex
+++ b/esp/templates/program/modules/programprintables/catalog_timeblock.tex
@@ -16,7 +16,7 @@
 \setlength{}{}
 
 \lhead{ {{ group_name }} }
-\chead{% templatetag openbrace %} {{program.niceName}} }
+\chead{% templatetag openbrace %} {{program.niceName|texescape}} }
 
 \newcommand{\cat}[1]{\begin{center}\section*{#1}\end{center} }
 

--- a/esp/templates/program/modules/programprintables/completion_certificate.tex
+++ b/esp/templates/program/modules/programprintables/completion_certificate.tex
@@ -8,7 +8,7 @@
 
 \vspace{0.3in}
 
-This is to certify that \underline{ {{ user.first_name }} {{ user.last_name }} } attended {{ prog.niceName }} and completed the following classes: \\
+This is to certify that \underline{ {{ user.first_name }} {{ user.last_name }} } attended {{ prog.niceName|texescape }} and completed the following classes: \\
 
 \hspace{1in} {{ schedule }}
 

--- a/esp/templates/program/modules/programprintables/studentschedule.tex
+++ b/esp/templates/program/modules/programprintables/studentschedule.tex
@@ -11,7 +11,7 @@
 \usepackage[code=Code39,X=.5mm,ratio=2.25,H=2cm]{makebarcode}
 
 \pagestyle{fancy}
-\fancyhead[C]{\Huge \textsf{\textbf{ {{ program.niceName }} } }}
+\fancyhead[C]{\Huge \textsf{\textbf{ {{ program.niceName|texescape }} } }}
 \setlength\headheight{16pt}
 \renewcommand{\headrulewidth}{3pt}
 \renewcommand{\footrulewidth}{0pt}

--- a/esp/templates/survey/review.tex
+++ b/esp/templates/survey/review.tex
@@ -7,7 +7,7 @@
 {\bf {\underline {\Large Survey Reviews for {{ user.name }}} \hspace{1in} }
 \vspace*{0.1in}
 
-\normalsize {{ program.niceName }}: {{ program.date_range }} } \\
+\normalsize {{ program.niceName|texescape }}: {{ program.date_range }} } \\
 
 \vspace{0.3in}
 


### PR DESCRIPTION
Adds texescape to program names in case they have underscores in them. Fixes #3340.