### PR TITLE
Clean up old attributes when modifying custom form fields

### DIFF
--- a/esp/esp/customforms/models.py
+++ b/esp/esp/customforms/models.py
@@ -61,6 +61,10 @@ class Field(models.Model):
             attr = Attribute.objects.create(field=self, attr_type=atype, value=value)
         return attr
 
+    def clean_attributes(self, keep):
+        from esp.customforms.models import Attribute
+        Attribute.objects.filter(field=self).exclude(attr_type__in=keep).delete()
+
 class Attribute(models.Model):
     field = models.ForeignKey(Field)
     attr_type = models.CharField(max_length=80)

--- a/esp/esp/customforms/views.py
+++ b/esp/esp/customforms/views.py
@@ -256,6 +256,8 @@ def onModify(request):
 
                             for atype, aval in field['data']['attrs'].items():
                                 curr_field.set_attribute(atype, aval)
+                            curr_field.clean_attributes(field['data']['attrs'].keys())
+
                             curr_keys['fields'].append(curr_field.id)
 
                 del_fields = old_fields.exclude(id__in=curr_keys['fields'])


### PR DESCRIPTION
We now clean up unnecessary attributes when we save the modified form.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3364.