### PR TITLE
Show options for tags that hide form fields

### DIFF
--- a/esp/esp/program/forms.py
+++ b/esp/esp/program/forms.py
@@ -423,7 +423,23 @@ class TagSettingsForm(BetterForm):
             if tag_info.get('is_setting', False):
                 self.categories.add(tag_info.get('category'))
                 field = tag_info.get('field')
-                if field is not None:
+                # Some field widgets need to be setup manually because we can't do it during compilation
+                if key == 'teacher_profile_hide_fields':
+                    from esp.users.forms.user_profile import TeacherProfileForm
+                    self.fields[key] = forms.MultipleChoiceField(choices=[(field, field) for field in TeacherProfileForm.declared_fields.keys()])
+                elif key == 'student_profile_hide_fields':
+                    from esp.users.forms.user_profile import StudentProfileForm
+                    self.fields[key] = forms.MultipleChoiceField(choices=[(field, field) for field in StudentProfileForm.declared_fields.keys()])
+                elif key == 'volunteer_profile_hide_fields':
+                    from esp.users.forms.user_profile import VolunteerProfileForm
+                    self.fields[key] = forms.MultipleChoiceField(choices=[(field, field) for field in VolunteerProfileForm.declared_fields.keys()])
+                elif key == 'educator_profile_hide_fields':
+                    from esp.users.forms.user_profile import EducatorProfileForm
+                    self.fields[key] = forms.MultipleChoiceField(choices=[(field, field) for field in EducatorProfileForm.declared_fields.keys()])
+                elif key == 'guardian_profile_hide_fields':
+                    from esp.users.forms.user_profile import GuardianProfileForm
+                    self.fields[key] = forms.MultipleChoiceField(choices=[(field, field) for field in GuardianProfileForm.declared_fields.keys()])
+                elif field is not None:
                     self.fields[key] = field
                 elif tag_info.get('is_boolean', False):
                     self.fields[key] = forms.BooleanField()
@@ -434,6 +450,8 @@ class TagSettingsForm(BetterForm):
                 self.fields[key].required = False
                 set_val = Tag.getBooleanTag(key) if tag_info.get('is_boolean', False) else Tag.getTag(key)
                 if set_val != None and set_val != self.fields[key].initial:
+                    if isinstance(self.fields[key], forms.MultipleChoiceField):
+                        set_val = set_val.split(",")
                     self.fields[key].initial = set_val
 
     def save(self):
@@ -442,6 +460,8 @@ class TagSettingsForm(BetterForm):
             tag_info = all_global_tags[key]
             if tag_info.get('is_setting', False):
                 set_val = self.cleaned_data[key]
+                if isinstance(set_val, list):
+                    set_val = ",".join(set_val)
                 if not set_val in ("", "None", None, tag_info.get('default')):
                     # Set a [new] tag if a value was provided and the value is not the default
                     Tag.setTag(key, value=set_val)

--- a/esp/esp/program/forms.py
+++ b/esp/esp/program/forms.py
@@ -426,19 +426,19 @@ class TagSettingsForm(BetterForm):
                 # Some field widgets need to be setup manually because we can't do it during compilation
                 if key == 'teacher_profile_hide_fields':
                     from esp.users.forms.user_profile import TeacherProfileForm
-                    self.fields[key] = forms.MultipleChoiceField(choices=[(field, field) for field in TeacherProfileForm.declared_fields.keys()])
+                    self.fields[key] = forms.MultipleChoiceField(choices=[(field[0], field[0]) for field in TeacherProfileForm.declared_fields.items() if not field[1].required])
                 elif key == 'student_profile_hide_fields':
                     from esp.users.forms.user_profile import StudentProfileForm
-                    self.fields[key] = forms.MultipleChoiceField(choices=[(field, field) for field in StudentProfileForm.declared_fields.keys()])
+                    self.fields[key] = forms.MultipleChoiceField(choices=[(field[0], field[0]) for field in StudentProfileForm.declared_fields.items() if not field[1].required])
                 elif key == 'volunteer_profile_hide_fields':
                     from esp.users.forms.user_profile import VolunteerProfileForm
-                    self.fields[key] = forms.MultipleChoiceField(choices=[(field, field) for field in VolunteerProfileForm.declared_fields.keys()])
+                    self.fields[key] = forms.MultipleChoiceField(choices=[(field[0], field[0]) for field in VolunteerProfileForm.declared_fields.items() if not field[1].required])
                 elif key == 'educator_profile_hide_fields':
                     from esp.users.forms.user_profile import EducatorProfileForm
-                    self.fields[key] = forms.MultipleChoiceField(choices=[(field, field) for field in EducatorProfileForm.declared_fields.keys()])
+                    self.fields[key] = forms.MultipleChoiceField(choices=[(field[0], field[0]) for field in EducatorProfileForm.declared_fields.items() if not field[1].required])
                 elif key == 'guardian_profile_hide_fields':
                     from esp.users.forms.user_profile import GuardianProfileForm
-                    self.fields[key] = forms.MultipleChoiceField(choices=[(field, field) for field in GuardianProfileForm.declared_fields.keys()])
+                    self.fields[key] = forms.MultipleChoiceField(choices=[(field[0], field[0]) for field in GuardianProfileForm.declared_fields.items() if not field[1].required])
                 elif field is not None:
                     self.fields[key] = field
                 elif tag_info.get('is_boolean', False):

--- a/esp/esp/program/modules/forms/admincore.py
+++ b/esp/esp/program/modules/forms/admincore.py
@@ -125,7 +125,7 @@ class ProgramTagSettingsForm(BetterForm):
                 field = tag_info.get('field')
                 if key == 'teacherreg_hide_fields':
                     from esp.program.modules.forms.teacherreg import TeacherClassRegForm
-                    self.fields[key] = forms.MultipleChoiceField(choices=[(field, field) for field in TeacherClassRegForm.declared_fields.keys()])
+                    self.fields[key] = forms.MultipleChoiceField(choices=[(field[0], field[1].label if field[1].label else field[0]) for field in TeacherClassRegForm.declared_fields.items() if not field[1].required])
                 elif field is not None:
                     self.fields[key] = field
                 elif tag_info.get('is_boolean', False):

--- a/esp/esp/program/modules/forms/admincore.py
+++ b/esp/esp/program/modules/forms/admincore.py
@@ -123,7 +123,10 @@ class ProgramTagSettingsForm(BetterForm):
             if tag_info.get('is_setting', False):
                 self.categories.add(tag_info.get('category'))
                 field = tag_info.get('field')
-                if field is not None:
+                if key == 'teacherreg_hide_fields':
+                    from esp.program.modules.forms.teacherreg import TeacherClassRegForm
+                    self.fields[key] = forms.MultipleChoiceField(choices=[(field, field) for field in TeacherClassRegForm.declared_fields.keys()])
+                elif field is not None:
                     self.fields[key] = field
                 elif tag_info.get('is_boolean', False):
                     self.fields[key] = forms.BooleanField()
@@ -134,6 +137,8 @@ class ProgramTagSettingsForm(BetterForm):
                 self.fields[key].required = False
                 set_val = Tag.getBooleanTag(key, program = self.program) if tag_info.get('is_boolean', False) else Tag.getProgramTag(key, program = self.program)
                 if set_val != None and set_val != self.fields[key].initial:
+                    if isinstance(self.fields[key], forms.MultipleChoiceField):
+                        set_val = set_val.split(",")
                     self.fields[key].initial = set_val
 
     def save(self):
@@ -143,6 +148,8 @@ class ProgramTagSettingsForm(BetterForm):
             tag_info = all_program_tags[key]
             if tag_info.get('is_setting', False):
                 set_val = self.cleaned_data[key]
+                if isinstance(set_val, list):
+                    set_val = ",".join(set_val)
                 global_val = Tag.getBooleanTag(key, default = tag_info.get('default')) if tag_info.get('is_boolean', False) else Tag.getProgramTag(key, default = tag_info.get('default'))
                 if not set_val in ("", "None", None, global_val):
                     # Set a [new] tag if a value was provided and the value is not the default (or if it is but there is also a global tag set)

--- a/esp/esp/program/modules/forms/teacherreg.py
+++ b/esp/esp/program/modules/forms/teacherreg.py
@@ -232,7 +232,7 @@ class TeacherClassRegForm(FormWithRequiredCss):
         #   Hide fields as desired.
         tag_data = Tag.getProgramTag('teacherreg_hide_fields', prog)
         if tag_data:
-            for field_name in tag_data.split(','):
+            for field_name in [x.strip().lower() for x in tag_data.split(',')]:
                 hide_field(self.fields[field_name])
 
         tag_data = Tag.getProgramTag('teacherreg_default_min_grade', prog)

--- a/esp/esp/tagdict/__init__.py
+++ b/esp/esp/tagdict/__init__.py
@@ -307,42 +307,38 @@ all_global_tags = {
         'category': 'teach',
         'is_setting': True,
     },
-    # TODO: For the next five, we probably want to pull the fields from the forms (e.g. TeacherProfileForm.declared_fields.keys())
-    # and then use those values in a MultipleChoiceField, but I see two problems:
-    # 1) How do we handle the conversion of the list of selected values to a comma-separated string (and back)?
-    #    We could maybe check if the field is a MultipleChoiceField, then use getlist on the cleaned_data?
-    # 2) We'll probably run into import loops when we try to import the forms
+    # For the next five, we populate the widgets as MultipleChoiceFields when initializing the form to avoid import loops
     'teacher_profile_hide_fields': {
         'is_boolean': False,
-        'help_text': 'Comma-separated list of fields to hide in the teacher profile form',
+        'help_text': 'Select the field(s) to hide in the teacher profile form',
         'default': '',
         'category': 'teach',
         'is_setting': True,
     },
     'student_profile_hide_fields': {
         'is_boolean': False,
-        'help_text': 'Comma-separated list of fields to hide in the student profile form',
+        'help_text': 'Select the field(s) to hide in the student profile form',
         'default': '',
         'category': 'learn',
         'is_setting': True,
     },
     'volunteer_profile_hide_fields': {
         'is_boolean': False,
-        'help_text': 'Comma-separated list of fields to hide in the volunteer profile form',
+        'help_text': 'Select the field(s) to hide in the volunteer profile form',
         'default': '',
         'category': 'volunteer',
         'is_setting': True,
     },
     'educator_profile_hide_fields': {
         'is_boolean': False,
-        'help_text': 'Comma-separated list of fields to hide in the educator profile form',
+        'help_text': 'Select the field(s) to hide in the educator profile form',
         'default': '',
         'category': 'teach',
         'is_setting': True,
     },
     'guardian_profile_hide_fields': {
         'is_boolean': False,
-        'help_text': 'Comma-separated list of fields to hide in the guardian profile form',
+        'help_text': 'Select the field(s) to hide in the guardian profile form',
         'default': '',
         'category': 'learn',
         'is_setting': True,
@@ -664,9 +660,10 @@ all_program_tags = {
         'category': 'teach',
         'is_setting': True,
     },
+    # We populate the next widget as a MultipleChoiceField when initializing the form to avoid import loops
     'teacherreg_hide_fields': {
         'is_boolean': False,
-        'help_text': 'A comma seperated list of what fields (e.g. \'purchase_requests\') you want to hide from teachers during teacher registration',
+        'help_text': 'Select the field(s) you want to hide from teachers during teacher registration',
         'default': None,
         'category': 'teach',
         'is_setting': True,

--- a/esp/esp/tagdict/__init__.py
+++ b/esp/esp/tagdict/__init__.py
@@ -310,35 +310,35 @@ all_global_tags = {
     # For the next five, we populate the widgets as MultipleChoiceFields when initializing the form to avoid import loops
     'teacher_profile_hide_fields': {
         'is_boolean': False,
-        'help_text': 'Select the field(s) to hide in the teacher profile form',
+        'help_text': 'Select the field(s) to hide in the teacher profile form (only fields that are not required may be hidden)',
         'default': '',
         'category': 'teach',
         'is_setting': True,
     },
     'student_profile_hide_fields': {
         'is_boolean': False,
-        'help_text': 'Select the field(s) to hide in the student profile form',
+        'help_text': 'Select the field(s) to hide in the student profile form (only fields that are not required may be hidden)',
         'default': '',
         'category': 'learn',
         'is_setting': True,
     },
     'volunteer_profile_hide_fields': {
         'is_boolean': False,
-        'help_text': 'Select the field(s) to hide in the volunteer profile form',
+        'help_text': 'Select the field(s) to hide in the volunteer profile form (only fields that are not required may be hidden)',
         'default': '',
         'category': 'volunteer',
         'is_setting': True,
     },
     'educator_profile_hide_fields': {
         'is_boolean': False,
-        'help_text': 'Select the field(s) to hide in the educator profile form',
+        'help_text': 'Select the field(s) to hide in the educator profile form (only fields that are not required may be hidden)',
         'default': '',
         'category': 'teach',
         'is_setting': True,
     },
     'guardian_profile_hide_fields': {
         'is_boolean': False,
-        'help_text': 'Select the field(s) to hide in the guardian profile form',
+        'help_text': 'Select the field(s) to hide in the guardian profile form (only fields that are not required may be hidden)',
         'default': '',
         'category': 'learn',
         'is_setting': True,
@@ -663,7 +663,7 @@ all_program_tags = {
     # We populate the next widget as a MultipleChoiceField when initializing the form to avoid import loops
     'teacherreg_hide_fields': {
         'is_boolean': False,
-        'help_text': 'Select the field(s) you want to hide from teachers during teacher registration',
+        'help_text': 'Select the field(s) you want to hide from teachers during teacher registration (only fields that are not required may be hidden)',
         'default': None,
         'category': 'teach',
         'is_setting': True,


### PR DESCRIPTION
This shows all of the fields that could be hidden for each form for the tags that let admins hide the fields, hopefully making it much easier for these tags to be used:

![image](https://user-images.githubusercontent.com/7232514/124294088-51591e80-db25-11eb-9477-88b466708978.png)

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3358 and fixes https://github.com/learning-unlimited/ESP-Website/issues/3357.