### PR TITLE
Switch to using required HTML attribute instead of class

### DIFF
--- a/esp/esp/themes/theme_data/fruitsalad/less/main.less
+++ b/esp/esp/themes/theme_data/fruitsalad/less/main.less
@@ -861,9 +861,9 @@ table.plaintable th {
 #content th.small { font-size: .8em }
 #content label.header { font-weight: bold; }
 #content select, input[type=text], input[type=url], input[type=email], input[type=number], input[type=file], input[type=password], textarea { border: 1px solid #b7b7b7; }
-#content select.required, input[type=text].required, input[type=url].required, input[type=email].required, input[type=number].required, input[type=password].required, input[type=file].required, textarea.required { border: 1px solid #FFb7b7; }
+#content select:required, input[type=text]:required, input[type=url]:required, input[type=email]:required, input[type=number]:required, input[type=password]:required, input[type=file]:required, textarea:required { border: 1px solid #FFb7b7; }
 #content select:focus, input[type=text]:focus, input[type=url]:focus, input[type=email]:focus, input[type=number]:focus, input[type=password]:focus, textarea:focus { border: 1px solid red; }
-#content select:focus.required, input[type=text]:focus.required, input[type=url]:focus.required, input[type=email]:focus.required, input[type=number]:focus.required, input[type=password]:focus.required, textarea:focus.required { border: 1px solid #F00; }
+#content select:focus:required, input[type=text]:focus:required, input[type=url]:focus:required, input[type=email]:focus:required, input[type=number]:focus:required, input[type=password]:focus:required, textarea:focus:required { border: 1px solid #F00; }
 .form_error { font-size: 80%; font-style: italic; color: #C00; }
 
 

--- a/esp/esp/users/forms/user_profile.py
+++ b/esp/esp/users/forms/user_profile.py
@@ -64,17 +64,9 @@ class UserContactForm(FormUnrestrictedOtherUser, FormWithTagInitialValues):
             del self.fields['receive_txt_message']
         if self.user.isTeacher() and not Tag.getBooleanTag('teacher_address_required'):
             self.fields['address_street'].required = False
-            if 'class' in self.fields['address_street'].widget.attrs and self.fields['address_street'].widget.attrs['class']:
-                self.fields['address_street'].widget.attrs['class'] = self.fields['address_street'].widget.attrs['class'].replace('required', '')
             self.fields['address_city'].required = False
-            if 'class' in self.fields['address_city'].widget.attrs and self.fields['address_city'].widget.attrs['class']:
-                self.fields['address_city'].widget.attrs['class'] = self.fields['address_city'].widget.attrs['class'].replace('required', '')
             self.fields['address_state'].required = False
-            if 'class' in self.fields['address_state'].widget.attrs and self.fields['address_state'].widget.attrs['class']:
-                self.fields['address_state'].widget.attrs['class'] = self.fields['address_state'].widget.attrs['class'].replace('required', '')
             self.fields['address_zip'].required = False
-            if 'class' in self.fields['address_zip'].widget.attrs and self.fields['address_zip'].widget.attrs['class']:
-                self.fields['address_zip'].widget.attrs['class'] = self.fields['address_zip'].widget.attrs['class'].replace('required', '')
 
     def clean(self):
         super(UserContactForm, self).clean()

--- a/esp/public/media/default_styles/forms.css
+++ b/esp/public/media/default_styles/forms.css
@@ -70,9 +70,9 @@
 
 /* prettier forms */
 #divmaintext form select, #divmaintext form input[type=text], #divmaintext form input[type=url], #divmaintext form input[type=email], #divmaintext form input[type=number], #divmaintext form input[type=file], #divmaintext form input[type=password], #divmaintext form textarea { border: 1px solid #b7b7b7; }
-#divmaintext form select.required, #divmaintext form input[type=text].required, #divmaintext form input[type=url].required, #divmaintext form input[type=email].required, #divmaintext form input[type=number].required, #divmaintext form input[type=password].required, #divmaintext form input[type=file].required, #divmaintext form textarea.required { border: 1px solid #FFb7b7; }
+#divmaintext form select:required, #divmaintext form input[type=text]:required, #divmaintext form input[type=url]:required, #divmaintext form input[type=email]:required, #divmaintext form input[type=number]:required, #divmaintext form input[type=password]:required, #divmaintext form input[type=file]:required, #divmaintext form textarea:required { border: 1px solid #FFb7b7; }
 #divmaintext form select:focus, #divmaintext form input[type=text]:focus, #divmaintext form input[type=url]:focus, #divmaintext form input[type=email]:focus, #divmaintext form input[type=number]:focus, #divmaintext form input[type=password]:focus, #divmaintext form textarea:focus { border: 1px solid black; }
-#divmaintext form select:focus.required, #divmaintext form input[type=text]:focus.required, #divmaintext form input[type=url]:focus.required, #divmaintext form input[type=email]:focus.required, #divmaintext form input[type=number]:focus.required, #divmaintext form input[type=password]:focus.required, #divmaintext form textarea:focus.required { border: 1px solid #F00; }
+#divmaintext form select:focus:required, #divmaintext form input[type=text]:focus:required, #divmaintext form input[type=url]:focus:required, #divmaintext form input[type=email]:focus:required, #divmaintext form input[type=number]:focus:required, #divmaintext form input[type=password]:focus:required, #divmaintext form textarea:focus:required { border: 1px solid #F00; }
 
 #divmaintext form table.plain
 {

--- a/esp/public/media/default_styles/level3.css
+++ b/esp/public/media/default_styles/level3.css
@@ -690,9 +690,9 @@ table.plaintable th {
 #divmaintext th.small { font-size: .8em }
 #divmaintext label.header { font-weight: bold; }
 #divmaintext select, input[type=text], input[type=url], input[type=email], input[type=number], input[type=file], input[type=password], textarea { border: 1px solid #b7b7b7; }
-#divmaintext select.required, input[type=text].required, input[type=url].required, input[type=email].required, input[type=number].required, input[type=password].required, input[type=file].required, textarea.required { border: 1px solid #FFb7b7; }
+#divmaintext select:required, input[type=text]:required, input[type=url]:required, input[type=email]:required, input[type=number]:required, input[type=password]:required, input[type=file]:required, textarea:required { border: 1px solid #FFb7b7; }
 #divmaintext select:focus, input[type=text]:focus, input[type=url]:focus, input[type=email]:focus, input[type=number]:focus, input[type=password]:focus, textarea:focus { border: 1px solid black; }
-#divmaintext select:focus.required, input[type=text]:focus.required, input[type=url]:focus.required, input[type=email]:focus.required, input[type=number]:focus.required, input[type=password]:focus.required, textarea:focus.required { border: 1px solid #F00; }
+#divmaintext select:focus:required, input[type=text]:focus:required, input[type=url]:focus:required, input[type=email]:focus:required, input[type=number]:focus:required, input[type=password]:focus:required, textarea:focus:required { border: 1px solid #F00; }
 .form_error { font-size: 80%; font-style: italic; color: #C00; }
 
 

--- a/esp/templates/django/forms/widgets/blankselect.html
+++ b/esp/templates/django/forms/widgets/blankselect.html
@@ -1,4 +1,4 @@
-<select name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %}>
+<select {% if widget.required %}required {% endif %}name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %}>
   <option value="{{ widget.blank_value }}" selected="selected">{{ widget.blank_label }}</option>
   {% for group_name, group_choices, group_index in widget.optgroups %}
     {% if group_name %}<optgroup label="{{ group_name }}">{% endif %}

--- a/esp/templates/users/profile.html
+++ b/esp/templates/users/profile.html
@@ -2,15 +2,22 @@
 
 {% block title %}Profile Editor{% endblock %}
 
-{% block content %}
-
+{% block stylesheets %}
+{{ block.super }}
 <style>
-div.required label:after {
+div.required label.control-label:after {
   content:"*";
   color:red;
 }
-</style>
 
+#id_receive_txt_message {
+  list-style-type: none;
+  margin-left: 0px;
+}
+</style>
+{% endblock %}
+
+{% block content %}
 <div class="row-fluid">
   <div class="span10">
     <h1>Your Profile Information</h1>
@@ -110,7 +117,7 @@ function check_emerg_state() {
   }
 }
 $j(document).ready(function() {
-  $j(".required").each(function() {
+  $j(":required").each(function() {
     $j(this).closest(".control-group").addClass("required");
   });
   

--- a/esp/templates/users/profiles/usercontact.html
+++ b/esp/templates/users/profiles/usercontact.html
@@ -120,10 +120,14 @@
 {% endif %}
 
 {% if form.receive_txt_message and form.phone_cell %}
- <small><i><label = "id_receive_txt_message">I would like to receive text-message reminders about the program:</label></i></small>
+<div class="control-group">
+ <small><i><label class="control-label" for="id_receive_txt_message">I would like to receive text-message reminders about the program:</label></i></small>
+ <div class="controls">
  {{ form.receive_txt_message }} {% if form.receive_txt_message.errors %}
    <br /><span class="form_error">{{ form.receive_txt_message.errors|join:", " }}</span>
    {% endif %}
+ </div>
+</div>
 {% endif %}
 
 <!-- End User ContactInfo -->


### PR DESCRIPTION
As we've discovered through many iterations of this functionality, Django doesn't do a good job of updating the classes associated with a field when the field is modified as part of the `__init__` function (https://github.com/learning-unlimited/ESP-Website/pull/2427, https://github.com/learning-unlimited/ESP-Website/pull/2806, https://github.com/learning-unlimited/ESP-Website/pull/3086). However, as of Django 1.10, it does a very good job of making sure the `required` HTML attribute is included if a field is required (and vice versa). Therefore, when doing things like adding asterisks to required fields (https://github.com/learning-unlimited/ESP-Website/pull/2420), instead of looking for the `required` class which can be misleading, we should look for the `required` attribute which should also be truthful.

To this end, I've updated the code in the profile template to make sure the asterisks will behave properly for existing and new fields. I've also updated our CSS code to make sure we are styling the correct fields. Finally, I updated one of our custom widgets which wasn't including the required attribute (because of a reasonable change django folks made to select widgets). I also fixed the formatting for the text message field.

This might be a little premature, but I declare that this pull request solves, once and for all, our nerve wracking issues with marking required fields in forms.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/2435.