### PR TITLE
Add program parameter to userview links

### DIFF
--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Moderators.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Moderators.js
@@ -409,7 +409,7 @@ function ModeratorCell(el, moderator, matrix) {
             "</br><a target='_blank' href='" + baseURL +
             "edit_availability?user=" + this.moderator.username +
             "'>Edit Availability</a>" + " <a target='_blank' href='/manage/userview?username=" +
-            this.moderator.username + "'>Userview</a>" + "</td>";
+            this.moderator.username + "&program=" + prog_id + "'>Userview</a>" + "</td>";
     }
 
     this.tooltip = function(){

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/SectionInfoPanel.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/SectionInfoPanel.js
@@ -106,7 +106,7 @@ function SectionInfoPanel(el, sections, togglePanel, sectionCommentDialog) {
     var getTeacherLinks = function(section) {
         var teacher_links_list = []
             $j.each(section.teacher_data, function(index, teacher) {
-                teacher_links_list.push("<a target='_blank' href=/manage/userview?username=" + encodeURIComponent(teacher.username) + ">" + teacher.first_name + " " + teacher.last_name + "</a>");
+                teacher_links_list.push("<a target='_blank' href='/manage/userview?username=" + encodeURIComponent(teacher.username) + "&program=" + prog_id + "'>" + teacher.first_name + " " + teacher.last_name + "</a>");
             });
         var teacher_links = teacher_links_list.join(", ");
         return $j(teacher_links);
@@ -202,7 +202,7 @@ function SectionInfoPanel(el, sections, togglePanel, sectionCommentDialog) {
             "<br/><a target='_blank' href='" + baseURL +
             "edit_availability?user=" + moderator.username +
             "'>Edit Availability</a>" + " <a target='_blank' href='/manage/userview?username=" +
-            moderator.username + "'>Userview</a>");
+            moderator.username + "&program=" + prog_id + "'>Userview</a>");
         toolbar.append(links);
         return toolbar;
 

--- a/esp/public/media/scripts/program/modules/adminclass.js
+++ b/esp/public/media/scripts/program/modules/adminclass.js
@@ -238,7 +238,7 @@ function createTeacherListTd(clsObj) {
             td.append(', ');
         }
         var teacher = json_data.teachers[val];
-        var href = '/manage/userview?username=' + teacher.username;
+        var href = '/manage/userview?username=' + teacher.username + '&program=' + program_id;
         td.append($j('<a/>', {href: href}).text(
             teacher.first_name + ' ' + teacher.last_name));
     });

--- a/esp/templates/program/modules/adminclass/classavailability.html
+++ b/esp/templates/program/modules/adminclass/classavailability.html
@@ -43,7 +43,7 @@ This class is scheduled during at least one timeslot in which at least one teach
 
 <h2>Teachers:</h2>
 {% for teacher in class.get_teachers %}
-<a href="/manage/userview?username={{ teacher.username|urlencode }}" target="_blank">{{ teacher.nonblank_name }}</a>{% if program|hasModule:"CheckAvailabilityModule" %} (<a href="/manage/{{ program.getUrlBase }}/edit_availability?user={{ teacher.username|urlencode }}" target="_blank">edit availability</a>){% endif %}
+<a href="/manage/userview?username={{ teacher.username|urlencode }}&program={{ program.id }}" target="_blank">{{ teacher.nonblank_name }}</a>{% if program|hasModule:"CheckAvailabilityModule" %} (<a href="/manage/{{ program.getUrlBase }}/edit_availability?user={{ teacher.username|urlencode }}" target="_blank">edit availability</a>){% endif %}
 </br>
 {% endfor %}
 </br>

--- a/esp/templates/program/modules/adminclass/manageclass.html
+++ b/esp/templates/program/modules/adminclass/manageclass.html
@@ -198,7 +198,7 @@ Please use the form below to alter {{ class.title }}.  Note that changes made to
     <th>{{ program.getModeratorTitle }}(s)</th>
     <td>
         {% for mod in form.sec.get_moderators %}
-            <a href="/manage/userview?username={{ mod.username|urlencode }}">{{ mod.nonblank_name }}</a> (<a href="mailto:{{ mod.email }}" target="_blank">{{ mod.email }}</a>)<br/>
+            <a href="/manage/userview?username={{ mod.username|urlencode }}&program={{ program.id }}">{{ mod.nonblank_name }}</a> (<a href="mailto:{{ mod.email }}" target="_blank">{{ mod.email }}</a>)<br/>
         {% endfor %}
     </td>
 </tr>

--- a/esp/templates/program/modules/adminclass/manageclass_class_info.html
+++ b/esp/templates/program/modules/adminclass/manageclass_class_info.html
@@ -1,12 +1,12 @@
 <tr>
     <th class="smaller">Teacher(s):</th>
-	<td>{% for teacher in class.get_teachers %}<a href="/manage/userview?username={{ teacher.username|urlencode }}">{{ teacher.nonblank_name }}</a> (<a href="mailto:{{teacher.email}}" target="_blank">{{teacher.email}}</a>)<br/>{% endfor %}</td>
+	<td>{% for teacher in class.get_teachers %}<a href="/manage/userview?username={{ teacher.username|urlencode }}&program={{ program.id }}">{{ teacher.nonblank_name }}</a> (<a href="mailto:{{teacher.email}}" target="_blank">{{teacher.email}}</a>)<br/>{% endfor %}</td>
 </tr>
 {% if class.moderators.count > 0 %}
 <tr>
     <th class="smaller">{{ program.getModeratorTitle }}(s):</th>
 	<td>
-        {% for mod in class.moderators.all %}<a href="/manage/userview?username={{ mod.username|urlencode }}">{{ mod.nonblank_name }}</a> (<a href="mailto:{{ mod.email }}" target="_blank">{{ mod.email }}</a>)<br/>{% endfor %}
+        {% for mod in class.moderators.all %}<a href="/manage/userview?username={{ mod.username|urlencode }}&program={{ program.id }}">{{ mod.nonblank_name }}</a> (<a href="mailto:{{ mod.email }}" target="_blank">{{ mod.email }}</a>)<br/>{% endfor %}
     </td>
 </tr>
 {% endif %}

--- a/esp/templates/program/modules/admincore/mainpage.html
+++ b/esp/templates/program/modules/admincore/mainpage.html
@@ -1,6 +1,6 @@
 {% extends "main.html" %}
 
-{% block title %}{{program.niceName}} Management{% endblock %}
+{% block title %}{{program.niceName}} Admin Dashboard{% endblock %}
 
 {% block xtrajs %}
 {{block.super }}
@@ -13,8 +13,9 @@ function updateDocs(docs) {
 //-->
 </script>
 
-<script type="text/javascript"> var base_url = "{{ program.getUrlBase }}" </script>
+<script type="text/javascript"> var base_url = "{{ program.getUrlBase }}"; </script>
 <script type="text/javascript"> var program_base_url = "/json/"+base_url+"/"; </script>
+<script type="text/javascript"> var program_id = "{{ program.id }}"; </script>
 <script type="text/javascript" src="/media/scripts/json_fetch.js"></script>
 <script type="text/javascript" src="/media/scripts/sorttable.js"></script>
 <script type="text/javascript" src="/media/scripts/program/modules/admincore.js"></script>

--- a/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
+++ b/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
@@ -32,6 +32,7 @@
 <!--Scheduler-->
 <script type="text/javascript">
   var base_url = "{{ program.getUrlBase }}";
+  var prog_id = "{{ program.id }}";
   var program_base_url = "/json/"+base_url+"/";
   var has_autoscheduler_frontend = "{{ has_autoscheduler_frontend }}";
   var has_moderator_module = "{{ has_moderator_module }}";

--- a/esp/templates/program/modules/creditcardviewer/viewpay.html
+++ b/esp/templates/program/modules/creditcardviewer/viewpay.html
@@ -49,7 +49,7 @@ Payments:
 {% for payment in payment_table %}
 <tr{% if not forloop.last %} style="border-bottom: 1px dashed #699;"{% endif %}>
 <td>
-<b><a href="/manage/userview?username={{ payment.0.username}}">{{ payment.0.get_full_name }}</a></b> (ID: {{ payment.0.id }}) <br />
+<b><a href="/manage/userview?username={{ payment.0.username}}&program={{ program.id }}">{{ payment.0.get_full_name }}</a></b> (ID: {{ payment.0.id }}) <br />
 ${{ payment.2 }} billed; ${{ payment.3 }} owed
 </td>
 <td>

--- a/esp/templates/program/modules/finaidapprovemodule/finaid.html
+++ b/esp/templates/program/modules/finaidapprovemodule/finaid.html
@@ -58,7 +58,7 @@ function toggle(source) {
             <i align="center" class="glyphicon glyphicon-minus-sign" style="color:firebrick; width:100%; font-size:1.5em;" />
             {% endif %}
           </td>
-          <td align="center" style="max-width: 70px; overflow-wrap:break-word;"><a href="/manage/userview?username={{ req.user.username|urlencode }}">{{ req.user.name }}</a></td>
+          <td align="center" style="max-width: 70px; overflow-wrap:break-word;"><a href="/manage/userview?username={{ req.user.username|urlencode }}&program={{ program.id }}">{{ req.user.name }}</a></td>
           <td align="center">
             {% if req.reduced_lunch %}
             <i align="center" class="glyphicon glyphicon-ok-sign" style="color:green; width:100%; font-size:1.5em;" />

--- a/esp/templates/program/modules/onsiteattendance/attendance.html
+++ b/esp/templates/program/modules/onsiteattendance/attendance.html
@@ -118,7 +118,7 @@ or select a timeslot from the dropdown below to see attendance stats:
     <th class="small">{{ forloop.counter }}</th>
     <td>{{ student.first_name }}</td>
     <td>{{ student.last_name }}</td>
-    <td><a href="/manage/userview?username={{ student.username|urlencode }}">{{ student.username }}</a></td>
+    <td><a href="/manage/userview?username={{ student.username|urlencode }}&program={{ program.id }}">{{ student.username }}</a></td>
     <td>{{ student.id }}</td>
     <td>{{ student|getGradeForProg:program.id }}</td>
     <td>{{ student.getLastProfile.student_info.getSchool }}</td>
@@ -175,7 +175,7 @@ or select a timeslot from the dropdown below to see attendance stats:
     <th class="small">{{ forloop.counter }}</th>
     <td>{{ student.first_name }}</td>
     <td>{{ student.last_name }}</td>
-    <td><a href="/manage/userview?username={{ student.username|urlencode }}">{{ student.username }}</a></td>
+    <td><a href="/manage/userview?username={{ student.username|urlencode }}&program={{ program.id }}">{{ student.username }}</a></td>
     <td>{{ student.id }}</td>
     <td>{{ student|getGradeForProg:program.id }}</td>
     <td>{{ student.getLastProfile.student_info.getSchool }}</td>
@@ -234,7 +234,7 @@ or select a timeslot from the dropdown below to see attendance stats:
     <th class="small">{{ forloop.counter }}</th>
     <td>{{ student.first_name }}</td>
     <td>{{ student.last_name }}</td>
-    <td><a href="/manage/userview?username={{ student.username|urlencode }}">{{ student.username }}</a></td>
+    <td><a href="/manage/userview?username={{ student.username|urlencode }}&program={{ program.id }}">{{ student.username }}</a></td>
     <td>{{ student.id }}</td>
     <td>{{ student|getGradeForProg:program.id }}</td>
     <td>{{ student.getLastProfile.student_info.getSchool }}</td>
@@ -291,8 +291,8 @@ or select a timeslot from the dropdown below to see attendance stats:
     <td>{{ section.emailcode }}</td>
     <td>{{ section.title }}</td>
     <td>
-        {% if program|hasModule:"TeacherModeratorModule" %}Teachers:<br>{% endif %}{% for teacher in section.parent_class.get_teachers %}<a href="/manage/userview?username={{ teacher.username|urlencode }}">{{ teacher.nonblank_name }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}
-        {% if program|hasModule:"TeacherModeratorModule" and section.get_moderators %}<br>Moderators:<br>{% for moderator in section.get_moderators %}<a href="/manage/userview?username={{ moderator.username|urlencode }}">{{ moderator.nonblank_name }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}{% endif %}
+        {% if program|hasModule:"TeacherModeratorModule" %}Teachers:<br>{% endif %}{% for teacher in section.parent_class.get_teachers %}<a href="/manage/userview?username={{ teacher.username|urlencode }}&program={{ program.id }}">{{ teacher.nonblank_name }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}
+        {% if program|hasModule:"TeacherModeratorModule" and section.get_moderators %}<br>Moderators:<br>{% for moderator in section.get_moderators %}<a href="/manage/userview?username={{ moderator.username|urlencode }}&program={{ program.id }}">{{ moderator.nonblank_name }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}{% endif %}
     </td>
     <td>{{ section.friendly_times_with_date|join:", " }}</td>
     <td>{{ section.num_students }}</td>

--- a/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
+++ b/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
@@ -127,7 +127,7 @@
     </td>
     {% for teacher in section.teachers_list %}
         <td{% if forloop.last %} style="border-bottom: 1px solid #ccc;"{% endif %}>
-            <a href="/manage/userview?username={{ teacher.username }}" target="_blank">{{ teacher.name }}</a>
+            <a href="/manage/userview?username={{ teacher.username }}&program={{ program.id }}" target="_blank">{{ teacher.name }}</a>
         </td>
         <td class="phone"{% if forloop.last %} style="border-bottom: 1px solid #ccc;"{% endif %}> {{ teacher.phone }} </td>
         {% if forloop.first %}
@@ -223,7 +223,7 @@
         {% else %}
         <td class="not-checked-in">
         {% endif %}
-            <a href="/manage/userview?username={{ teacher.username }}" target="_blank">{{ teacher.name }}</a>
+            <a href="/manage/userview?username={{ teacher.username }}&program={{ program.id }}" target="_blank">{{ teacher.name }}</a>
         </td>
         <td class="checkin-column">
             {% if teacher.id not in arrived %}
@@ -262,7 +262,7 @@
             {% else %}
             <td class="not-checked-in"{% if forloop.first %} style="border-top:1px solid #ccc;"{% endif %}>
             {% endif %}
-                <a href="/manage/userview?username={{ teacher.username }}" target="_blank">{{ teacher.name }}</a>
+                <a href="/manage/userview?username={{ teacher.username }}&program={{ program.id }}" target="_blank">{{ teacher.name }}</a>
             </td>
             <td class="checkin-column"{% if forloop.first %} style="border-top:1px solid #ccc;"{% endif %}>
                 {% if teacher.id not in arrived %}

--- a/esp/templates/program/modules/teachereventsmodule/event_row.html
+++ b/esp/templates/program/modules/teachereventsmodule/event_row.html
@@ -6,7 +6,7 @@
         <td style="width:45%">
             {% if timeslot.teachers %}
                 {% for teacher in timeslot.teachers %}
-                    <a href="/manage/userview?username={{ teacher.user.username|urlencode }}">{{ teacher.user.first_name }} {{ teacher.user.last_name }}</a> (<a href="mailto:{{ teacher.user.email }}" target="_blank">{{ teacher.user.email }}</a>) <br />
+                    <a href="/manage/userview?username={{ teacher.user.username|urlencode }}&program={{ program.id }}">{{ teacher.user.first_name }} {{ teacher.user.last_name }}</a> (<a href="mailto:{{ teacher.user.email }}" target="_blank">{{ teacher.user.email }}</a>) <br />
                 {% endfor %}
             {% else %}
                 <em>(None)</em>


### PR DESCRIPTION
This adds the `program` GET parameter to any userview links that are on program-specific pages. This way, when we go to the userview page via these links the program we are most likely interested in is already selected in the dropdown.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3331.