### PR TITLE
Add scheduler support for timeslots of any length

### DIFF
--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Cell.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Cell.js
@@ -323,7 +323,14 @@ function Cell(el, section, room_id, timeslot_id, matrix) {
         tooltip_parts['Teachers'] = this.matrix.sections.getTeachersString(this.section);
         if(has_moderator_module === "True") tooltip_parts[moderator_title + 's'] = this.matrix.sections.getModeratorsString(this.section);
         tooltip_parts['Class size max'] = this.section.class_size_max;
-        tooltip_parts['Length'] = Math.ceil(this.section.length);
+        var length_str = '';
+        if(Math.floor(this.section.length) > 0){
+            length_str += Math.floor(this.section.length);
+            length_str += ' hour';
+            if(Math.floor(this.section.length) > 1) length_str += 's';
+        }
+        if((this.section.length % 1) * 60 > 0) length_str += ' ' + ((this.section.length % 1) * 60) + ' minutes';
+        tooltip_parts['Length'] = length_str;
         tooltip_parts['Grades'] = this.section.grade_min + "-" + this.section.grade_max;
         tooltip_parts['Room Request'] = this.section.requested_room;
         tooltip_parts['Resource Requests'] = this.matrix.sections.getResourceString(this.section);

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Cell.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Cell.js
@@ -329,7 +329,7 @@ function Cell(el, section, room_id, timeslot_id, matrix) {
             length_str += ' hour';
             if(Math.floor(this.section.length) > 1) length_str += 's';
         }
-        if((this.section.length % 1) * 60 > 0) length_str += ' ' + ((this.section.length % 1) * 60) + ' minutes';
+        if((this.section.length % 1) * 60 > 0) length_str += ' ' + Math.round((this.section.length % 1) * 60) + ' minutes';
         tooltip_parts['Length'] = length_str;
         tooltip_parts['Grades'] = this.section.grade_min + "-" + this.section.grade_max;
         tooltip_parts['Room Request'] = this.section.requested_room;

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Matrix.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Matrix.js
@@ -257,20 +257,10 @@ function Matrix(
                 $j.each(this.rooms, function(k, room) {
                     var cell = this.getCell(room.id, timeslot_id);
                     if(cell.el.hasClass("teacher-available-cell")) {
-                        var scheduleTimeslots = [timeslot.id];
-                        var notEnoughSlots = false;
-                        for(var i=1; i<section.length; i++) {
-                            var nextTimeslot = this.timeslots.get_by_order(timeslot.order+i);
-                            if(nextTimeslot) {
-                                scheduleTimeslots.push(nextTimeslot.id);
-                            } else {
-                                notEnoughSlots = true;
-                            }
-                        }
-                        if(notEnoughSlots ||
-                           !this.validateAssignment(section, room.id, scheduleTimeslots).valid) {
-                                    cell.el.removeClass("teacher-available-cell");
-                                    cell.el.addClass("teacher-available-not-first-cell");
+                        var scheduleTimeslots = this.timeslots.get_timeslots_to_schedule_section(section, timeslot_id);
+                        if(scheduleTimeslots == null || !this.validateAssignment(section, room.id, scheduleTimeslots).valid) {
+                            cell.el.removeClass("teacher-available-cell");
+                            cell.el.addClass("teacher-available-not-first-cell");
                         }
                     }
                 }.bind(this));

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Matrix.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Matrix.js
@@ -253,7 +253,6 @@ function Matrix(
         
         if(section){
             $j.each(available_timeslots, function(j, timeslot_id) {
-                var timeslot = this.timeslots.get_by_id(timeslot_id);
                 $j.each(this.rooms, function(k, room) {
                     var cell = this.getCell(room.id, timeslot_id);
                     if(cell.el.hasClass("teacher-available-cell")) {

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Scheduler.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Scheduler.js
@@ -106,7 +106,7 @@ function Scheduler(
 
     // Set up keyboard shortcuts
     $j("body").keydown(function(evt) {
-        console.log(evt);
+        // console.log(evt);
         if(evt.keyCode == 46) { // delete is pressed
             this.sections.unscheduleSection(this.sections.selectedSection);
         } else if(evt.keyCode == 27) { // escape is pressed

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/SectionInfoPanel.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/SectionInfoPanel.js
@@ -146,7 +146,7 @@ function SectionInfoPanel(el, sections, togglePanel, sectionCommentDialog) {
             length_str += ' hour';
             if(Math.floor(section.length) > 1) length_str += 's';
         }
-        if((section.length % 1) * 60 > 0) length_str += ' ' + ((section.length % 1) * 60) + ' minutes';
+        if((section.length % 1) * 60 > 0) length_str += ' ' + Math.round((section.length % 1) * 60) + ' minutes';
         content_parts['Length'] = length_str;
         content_parts['Grades'] = section.grade_min + "-" + section.grade_max;
         content_parts['Room Request'] = section.requested_room;

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/SectionInfoPanel.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/SectionInfoPanel.js
@@ -140,7 +140,14 @@ function SectionInfoPanel(el, sections, togglePanel, sectionCommentDialog) {
         content_parts['Teachers'] = teacher_links;
         if(has_moderator_module === "True") content_parts[moderator_title + 's'] = getModeratorLinks(section);
         content_parts['Class size max'] = section.class_size_max;
-        content_parts['Length'] = Math.ceil(section.length);
+        var length_str = '';
+        if(Math.floor(section.length) > 0){
+            length_str += Math.floor(section.length);
+            length_str += ' hour';
+            if(Math.floor(section.length) > 1) length_str += 's';
+        }
+        if((section.length % 1) * 60 > 0) length_str += ' ' + ((section.length % 1) * 60) + ' minutes';
+        content_parts['Length'] = length_str;
         content_parts['Grades'] = section.grade_min + "-" + section.grade_max;
         content_parts['Room Request'] = section.requested_room;
         content_parts['Resource Requests'] = resources;

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
@@ -304,6 +304,7 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
         this.matrix.sectionInfoPanel.hide();
         this.matrix.sectionInfoPanel.override = override;
         this.matrix.unhighlightTimeslots(this.availableTimeslots);
+        this.unscheduleAsGhost();
     };
 
     /**

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Timeslots.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Timeslots.js
@@ -80,7 +80,7 @@ function Timeslots(timeslots_data, lunch_timeslots){
         var start = new Date(...this.timeslots[id_1].start);
         var end = new Date(...this.timeslots[id_2].end);
 
-        return Math.round((end - start)/3600000, 2);
+        return Math.round(((end - start)/3600000) + Number.EPSILON) * 100) / 100;
     };
 
     /**

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Timeslots.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Timeslots.js
@@ -64,9 +64,7 @@ function Timeslots(timeslots_data, lunch_timeslots){
             var last_timeslot = this.get_by_id(last_timeslot_id);
             next_timeslot = this.get_by_order(last_timeslot.order + 1);
 
-            if (!this.are_timeslots_contiguous([last_timeslot, next_timeslot])){
-                console.log("timeslot " + last_timeslot.id + " and timeslot " +
-                        next_timeslot.id +" are not contiguous");
+            if (next_timeslot === undefined || !this.are_timeslots_contiguous([last_timeslot, next_timeslot])){
                 return null;
             }
             last_timeslot_id = next_timeslot.id;
@@ -86,7 +84,7 @@ function Timeslots(timeslots_data, lunch_timeslots){
         var minutes = end[4] - start[4];
 
         if (minutes > 0){
-            hours = hours + 1;
+            hours = hours + minutes/60;
         }
         return hours;
     };

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Timeslots.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Timeslots.js
@@ -80,7 +80,7 @@ function Timeslots(timeslots_data, lunch_timeslots){
         var start = new Date(...this.timeslots[id_1].start);
         var end = new Date(...this.timeslots[id_2].end);
 
-        return Math.round(((end - start)/3600000) + Number.EPSILON) * 100) / 100;
+        return Math.round((((end - start)/3600000) + Number.EPSILON) * 100) / 100;
     };
 
     /**

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Timeslots.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Timeslots.js
@@ -80,7 +80,7 @@ function Timeslots(timeslots_data, lunch_timeslots){
         var start = new Date(...this.timeslots[id_1].start);
         var end = new Date(...this.timeslots[id_2].end);
 
-        return (end - start)/3600000;
+        return Math.round((end - start)/3600000, 2);
     };
 
     /**

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Timeslots.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Timeslots.js
@@ -77,28 +77,20 @@ function Timeslots(timeslots_data, lunch_timeslots){
      * Get the number of hours spanned by the two timeslots with ids id_1 and id_2
      */
     this.get_hours_spanned = function(id_1, id_2) {
-        var start = this.timeslots[id_1].start;
-        var end = this.timeslots[id_2].end;
+        var start = new Date(...this.timeslots[id_1].start);
+        var end = new Date(...this.timeslots[id_2].end);
 
-        var hours = end[3] - start[3];
-        var minutes = end[4] - start[4];
-
-        if (minutes > 0){
-            hours = hours + minutes/60;
-        }
-        return hours;
+        return (end - start)/3600000;
     };
 
     /**
      * Get the number of minutes between the two timeslots with ids id_1 and id_2
      */
     this.get_minutes_between = function(id_1, id_2) {
-        var end = this.timeslots[id_1].end;
-        var start = this.timeslots[id_2].start;
+        var end = new Date(...this.timeslots[id_1].end);
+        var start = new Date(...this.timeslots[id_2].start);
 
-        var hours = start[3] - end[3];
-        var minutes = start[4] - end[4];
-        return hours * 60 + minutes;
+        return (start - end)/60000;
     };
 
     /**


### PR DESCRIPTION
Previously, parts of the ajax scheduler code assumed timeslots were once per hour, never longer than an hour, and always the same length across a program. This removes those assumptions and allows for timeslots of any length (possibly varying across a program) and any number per hour.

Given that this now supports timeslots that may be longer than the scheduled classes (e.g., you can now schedule a 2 hour class across two 1.5 hour timeslots, which would result in a large time gap between the end of the class and the end of the second timeslot), this puts a little extra responsibility on the admins that are scheduling the classes. To hopefully help with this, the "length" on the hover and infopanel tooltips is now shown as "X hours and Y minutes".

Fixes #2705.