### PR TITLE
Add many filter options to classsearch

### DIFF
--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -1041,7 +1041,7 @@ class Program(models.Model, CustomFormsLinkModel):
 
         durationList = durationDict.items()
 
-        return durationList
+        return sorted(durationList, key=lambda x: x[0])
 
     def getSurveys(self):
         from esp.survey.models import Survey

--- a/esp/esp/program/modules/handlers/classsearchmodule.py
+++ b/esp/esp/program/modules/handlers/classsearchmodule.py
@@ -93,13 +93,16 @@ class ClassSearchModule(ProgramModuleObj):
                     SelectQInput(options=OrderedDict([(str(grade), {'title': str(grade), 'Q': Q(grade_min__lte=grade)})
                                                       for grade in grades]))])
 
-        # ideally this would have two selects, one to pick "greater than"/"less than"/"equal to"
         num_sections = self.program.classregmoduleinfo.allowed_sections_actual
         sections_filter = SearchFilter(
-            name='num_sections', title='X section(s)',
+            name='num_sections', title='between X and Y section(s)',
             inputs=[SelectQInput(options=OrderedDict([(str(num), {'title': str(num), 'Q': Q(id__in=ClassSubject.objects.annotate(
                                                                                             num_sections=Count("sections")).filter(
-                                                                                            num_sections=num).values_list('id', flat=True))})
+                                                                                            num_sections__gte=num).values_list('id', flat=True))})
+                                                      for num in num_sections])),
+                    SelectQInput(options=OrderedDict([(str(num), {'title': str(num), 'Q': Q(id__in=ClassSubject.objects.annotate(
+                                                                                            num_sections=Count("sections")).filter(
+                                                                                            num_sections__lte=num).values_list('id', flat=True))})
                                                       for num in num_sections]))])
 
         #capacity?

--- a/esp/esp/program/modules/handlers/classsearchmodule.py
+++ b/esp/esp/program/modules/handlers/classsearchmodule.py
@@ -105,7 +105,35 @@ class ClassSearchModule(ProgramModuleObj):
                                                                                             num_sections__lte=num).values_list('id', flat=True))})
                                                       for num in num_sections]))])
 
-        #capacity?
+        capacities = self.program.classregmoduleinfo.getClassSizes()
+        capacity_inputs = None
+        capacity_title = ""
+        # logic copied from the teacher class registration form
+        if self.program.classregmoduleinfo.use_class_size_max:
+            capacity_title = "capacity (max)"
+            capacity_inputs = [SelectQInput(options=OrderedDict([(str(cap), {'title': str(cap), 'Q': Q(class_size_max__gte=cap)})
+                                                                 for cap in capacities])),
+                               SelectQInput(options=OrderedDict([(str(cap), {'title': str(cap), 'Q': Q(class_size_max__lte=cap)})
+                                                                 for cap in capacities]))]
+        elif Tag.getBooleanTag('use_class_size_optimal'):
+            if self.program.classregmoduleinfo.use_class_size_optimal:
+                capacity_title = "capacity (optimal)"
+                capacity_inputs = [SelectQInput(options=OrderedDict([(str(cap), {'title': str(cap), 'Q': Q(class_size_optimal__gte=cap)})
+                                                                     for cap in capacities])),
+                                   SelectQInput(options=OrderedDict([(str(cap), {'title': str(cap), 'Q': Q(class_size_optimal__lte=cap)})
+                                                                     for cap in capacities]))]
+            elif self.program.classregmoduleinfo.use_optimal_class_size_range:
+                capacity_title = "capacity (optimal range)"
+                capacity_inputs = [SelectQInput(options=OrderedDict([(str(cap), {'title': str(cap), 'Q': Q(optimal_class_size_range__range_max__gte=cap)})
+                                                                     for cap in capacities])),
+                                   SelectQInput(options=OrderedDict([(str(cap), {'title': str(cap), 'Q': Q(optimal_class_size_range__range_min__lte=cap)})
+                                                                     for cap in capacities]))]
+            elif self.program.classregmoduleinfo.use_allowable_class_size_ranges:
+                capacity_title = "capacity (allowable range)"
+                capacity_inputs = [SelectQInput(options=OrderedDict([(str(cap), {'title': str(cap), 'Q': Q(allowable_class_size_ranges__range_max__gte=cap)})
+                                                                     for cap in capacities])),
+                                   SelectQInput(options=OrderedDict([(str(cap), {'title': str(cap), 'Q': Q(allowable_class_size_ranges__range_min__lte=cap)})
+                                                                     for cap in capacities]))]
 
         status_filter = SearchFilter(
             name='status', title='the status',
@@ -186,6 +214,12 @@ class ClassSearchModule(ProgramModuleObj):
                 all_scheduled_filter,
                 some_scheduled_filter,
             ]
+
+        if capacity_inputs:
+            capacity_filter = SearchFilter(
+                name='capacity', title= capacity_title + ' between X and Y',
+                inputs=capacity_inputs)
+            filters.append(capacity_filter)
 
         if Tag.getTag('class_style_choices'):
             style_choices = json.loads(Tag.getTag('class_style_choices'))

--- a/esp/esp/program/modules/handlers/classsearchmodule.py
+++ b/esp/esp/program/modules/handlers/classsearchmodule.py
@@ -87,17 +87,22 @@ class ClassSearchModule(ProgramModuleObj):
 
         grades = self.program.classregmoduleinfo.getClassGrades()
         grade_filter = SearchFilter(
-            name='grade', title='the grade',
-            inputs=[SelectQInput(options=OrderedDict([(str(grade), {'title': str(grade), 'Q': Q(grade_min__lte=grade) & Q(grade_max__gte=grade)})
+            name='grade', title='grades between X and Y',
+            inputs=[SelectQInput(options=OrderedDict([(str(grade), {'title': str(grade), 'Q': Q(grade_max__gte=grade)})
+                                                      for grade in grades])),
+                    SelectQInput(options=OrderedDict([(str(grade), {'title': str(grade), 'Q': Q(grade_min__lte=grade)})
                                                       for grade in grades]))])
 
+        # ideally this would have two selects, one to pick "greater than"/"less than"/"equal to"
         num_sections = self.program.classregmoduleinfo.allowed_sections_actual
         sections_filter = SearchFilter(
-            name='num_sections', title='[X] section(s)',
+            name='num_sections', title='X section(s)',
             inputs=[SelectQInput(options=OrderedDict([(str(num), {'title': str(num), 'Q': Q(id__in=ClassSubject.objects.annotate(
                                                                                             num_sections=Count("sections")).filter(
                                                                                             num_sections=num).values_list('id', flat=True))})
                                                       for num in num_sections]))])
+
+        #capacity?
 
         status_filter = SearchFilter(
             name='status', title='the status',

--- a/esp/esp/utils/query_builder.py
+++ b/esp/esp/utils/query_builder.py
@@ -156,6 +156,31 @@ class SelectInput(object):
             raise ESPError('Invalid choice %s for input %s'
                            % (value, self.field_name))
 
+class SelectQInput(object):
+    """An input represented by an HTML <select> with a fixed set of options. Each
+       option has a fixed Q object.
+
+    Arguments:
+        `options`: a dict where the keys are ids and the values are dictionaries with a user-friendly title
+            and Q object.  The ids should be strings.
+    """
+    def __init__(self, options):
+        self.options = options
+        # TODO: warn if option ids are not strings.
+
+    def spec(self):
+        return {
+            'reactClass': 'SelectInput',
+            'options': [{'name': k, 'title': v['title']}
+                        for k, v in self.options.items()],
+        }
+
+    def as_q(self, value):
+        if value in self.options:
+            return self.options[value]['Q']
+        else:
+            return Q()
+
 
 class ConstantInput(object):
     """An input which adds a fixed Q object to the filter.


### PR DESCRIPTION
This adds the following filters to the classsearch page:

- class duration
- class grade (as a range)
- number of sections (as a range)
- class capacity (as a range; works for all capacity types)
- has a message for directors
- has prerequisites
- has a room request
- has a purchase request
- class style
- class hardness

The complete filter options are now as follows:
![image](https://user-images.githubusercontent.com/7232514/127586696-1208a943-2346-4ade-9a69-56cec85cd868.png)

The range filters look like this:
![image](https://user-images.githubusercontent.com/7232514/127586974-2da50553-0af2-48fd-89c7-c27183207230.png)

Fixes #3373.