### PR TITLE
Fix scheduler message panel

### DIFF
--- a/esp/public/media/default_styles/scheduling.css
+++ b/esp/public/media/default_styles/scheduling.css
@@ -150,18 +150,19 @@ input.numeric {
 
 #info-panel {
     height: 35%;
-    padding-top: 10px;
     padding-bottom: 10px;
     margin-bottom: calc(11px - .2em);
 }
 
-#message-div {
-    height: 100%;
+#section-info-div {
+    font-size: 1em;
+    min-height: 50%;
 }
 
-#section-info-div {
+#section-info-and-message-wrapper {
     height: 100%;
-    font-size: 1em;
+    display: flex;
+    flex-direction: column;
 }
 
 #separator {

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/MessagePanel.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/MessagePanel.js
@@ -21,8 +21,8 @@ function MessagePanel(el, initialMessage) {
      *
      * @param msg: The message to add
      */
-    this.addMessage = function(msg) {
-        this.el.append( "<p>" + msg + "</p>");
+    this.addMessage = function(msg, color="black") {
+        this.el.append( "<p " + "style='color:" + color + "'>" + msg + "</p>");
         // some browsers need delay before scrollHeight is updated
         setTimeout(function() {
             this.el.scrollTop(this.el[0].scrollHeight);

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Moderators.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Moderators.js
@@ -275,7 +275,8 @@ function ModeratorDirectory(el, moderators) {
             }.bind(this),
             function(msg) {
                 // If unsuccessful, report the error message
-                this.matrix.messagePanel.addMessage("Error: " + msg)
+                this.matrix.messagePanel.addMessage("Error: " + msg, color = "red");
+                this.matrix.messagePanel.show();
                 console.log(msg);
             }.bind(this)
         );
@@ -291,7 +292,7 @@ function ModeratorDirectory(el, moderators) {
             section.moderators.push(moderator.id);
             section.moderator_data.push(moderator);
             $j("body").trigger("schedule-changed");
-            this.matrix.messagePanel.addMessage("Success: " + moderator.first_name + " " + moderator.last_name + " was assigned to " + section.emailcode)
+            this.matrix.messagePanel.addMessage("Success: " + moderator.first_name + " " + moderator.last_name + " was assigned to " + section.emailcode, color = "blue")
             // Update cell coloring
             this.matrix.updateCells();
         }
@@ -311,7 +312,7 @@ function ModeratorDirectory(el, moderators) {
             }.bind(this),
             function(msg) {
                 // If unsuccessful, report the error message
-                this.matrix.messagePanel.addMessage("Error: " + msg)
+                this.matrix.messagePanel.addMessage("Error: " + msg, color = "red")
                 console.log(msg);
             }.bind(this)
         );
@@ -327,7 +328,7 @@ function ModeratorDirectory(el, moderators) {
             section.moderators.splice(section.moderators.indexOf(moderator), 1);
             section.moderator_data.splice(section.moderator_data.indexOf(moderator), 1);
             $j("body").trigger("schedule-changed");
-            this.matrix.messagePanel.addMessage("Success: " + moderator.first_name + " " + moderator.last_name + " was unassigned from " + section.emailcode)
+            this.matrix.messagePanel.addMessage("Success: " + moderator.first_name + " " + moderator.last_name + " was unassigned from " + section.emailcode, color = "blue")
             // Update cell coloring
             this.matrix.updateCells();
         }

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
@@ -402,7 +402,7 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
 
         // Make sure section not locked
         if (section.schedulingLocked){
-            this.matrix.messagePanel.addMessage("Error: the specified section is locked (" + section.schedulingComment + ")! Unlock it first.");
+            this.matrix.messagePanel.addMessage("Error: the specified section is locked (" + section.schedulingComment + ")! Unlock it first.", color = "red");
             this.unselectSection();
             return;
         }
@@ -420,7 +420,7 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
                 this.scheduleSectionLocal(section,
                     old_assignment.room_id,
                     old_assignment.timeslots);
-                this.matrix.messagePanel.addMessage("Error: " + msg)
+                this.matrix.messagePanel.addMessage("Error: " + msg, color = "red")
                 console.log(msg);
             }.bind(this)
         );
@@ -510,7 +510,7 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
     this.unscheduleSection = function(section){
         // Make sure section not locked
         if (section.schedulingLocked){
-            this.matrix.messagePanel.addMessage("Error: the specified section is locked (" + section.schedulingComment + ")! Unlock it first.");
+            this.matrix.messagePanel.addMessage("Error: the specified section is locked (" + section.schedulingComment + ")! Unlock it first.", color = "red");
             this.unselectSection();
             return;
         }
@@ -527,7 +527,7 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
             // If the server returns an error, put the class back in its original spot
             function(msg){
                 this.scheduleSectionLocal(section, old_room_id, old_schedule_timeslots);
-                this.matrix.messagePanel.addMessage("Error: " + msg);
+                this.matrix.messagePanel.addMessage("Error: " + msg, color = "red");
                 console.log(msg);
             }.bind(this)
         );
@@ -556,7 +556,7 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
 
         if(!remote) {
             this.apiClient.set_comment(section.id, comment, locked, function(){}, function(msg){
-                this.matrix.messagePanel.addMessage("Error: " + msg);
+                this.matrix.messagePanel.addMessage("Error: " + msg, color = "red");
                 console.log(msg);
             }.bind(this));
             this.unselectSection();

--- a/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
+++ b/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
@@ -68,8 +68,10 @@
     <td class="no-border">
       <div id="side-panel-wrapper" class="ui-widget">
         <div id="info-panel">
-          <div id="section-info-div" class="component-div ui-widget ui-corner-all ui-helper-hidden"></div>
-          <div id="message-div" class="component-div ui-widget-content ui-corner-all"></div>
+          <div id="section-info-and-message-wrapper">
+            <div id="section-info-div" class="component-div ui-widget ui-corner-all ui-helper-hidden"></div>
+            <div id="message-div" class="component-div ui-widget-content ui-corner-all"></div>
+          </div>
           <div id="separator" class="ui-resizable-handle ui-resizable-s"></div>
         </div>
         <div id="side-panel" class="component-div ui-widget">


### PR DESCRIPTION
This fixes the message panel on the ajax scheduler so that it is shown, even if there is a class or moderator selected. I've also made it so that errors are displayed in red and success messages are displayed in blue.

![image](https://user-images.githubusercontent.com/7232514/127746623-62df120e-0137-49d9-9444-2e14606818a7.png)

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3245.