### PR TITLE
Exclude cancelled classes for some things

### DIFF
--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -910,7 +910,7 @@ class ClassSection(models.Model):
         user = teacher
         if meeting_times is None:
             meeting_times = self.meeting_times.all()
-        for sec in user.getTaughtSections(self.parent_program).exclude(id=self.id):
+        for sec in user.getTaughtSections(self.parent_program, include_cancelled = False).exclude(id=self.id):
             for time in sec.meeting_times.all():
                 if meeting_times.filter(id = time.id).count() > 0:
                     return (sec, time)
@@ -1782,13 +1782,12 @@ class ClassSubject(models.Model, CustomFormsLinkModel):
 
     def conflicts(self, teacher):
         user = teacher
-        for cls in user.getTaughtClasses().filter(parent_program = self.parent_program):
+        for cls in user.getTaughtClasses(self.parent_program, include_cancelled = False):
             for section in cls.get_sections():
                 for time in section.meeting_times.all():
                     for sec in self.sections.all().exclude(id=section.id):
                         if sec.meeting_times.filter(id = time.id).count() > 0:
                             return True
-
 
         #   Check that adding this teacher as a coteacher would not overcommit them
         #   to more hours of teaching than the program allows.
@@ -1799,7 +1798,7 @@ class ClassSubject(models.Model, CustomFormsLinkModel):
             td = tg.duration()
             time_avail += (td.seconds / 3600.0)
         #   Subtract out time already pledged for teaching classes other than this one
-        for cls in user.getTaughtClasses(self.parent_program):
+        for cls in user.getTaughtClasses(self.parent_program, include_cancelled = False):
             if cls.id != self.id:
                 for sec in cls.get_sections():
                     time_avail -= float(str(sec.duration))

--- a/esp/esp/program/modules/handlers/availabilitymodule.py
+++ b/esp/esp/program/modules/handlers/availabilitymodule.py
@@ -142,7 +142,7 @@ class AvailabilityModule(ProgramModuleObj):
         taken_slots = []
         avail_and_teaching = []
         unscheduled_classes = []
-        user_sections = teacher.getTaughtSections(self.program)
+        user_sections = teacher.getTaughtSections(self.program, include_cancelled = False)
         teaching_times = {}
         conflict_found = False
         for section in user_sections:


### PR DESCRIPTION
This adds the ability to exclude cancelled classes/sections when getting lists of sections or classes for a user. The default for all of these functions is to not exclude them, because that was the original behavior. However, for the availability module and for checking if a user conflicts with a class (mostly used for adding coteachers), the default is now to exclude the cancelled classes/sections. This means that a teacher with two hours of availability and two hours of cancelled class(es) can now be added as a coteacher for another two hours of class(es).

Fixes https://github.com/learning-unlimited/ESP-Website/issues/2199.