### PR TITLE
Fix fruitsalad tabs for long text

### DIFF
--- a/esp/esp/themes/theme_data/fruitsalad/less/main.less
+++ b/esp/esp/themes/theme_data/fruitsalad/less/main.less
@@ -209,15 +209,15 @@ li.tabcolor9 a { background-color: @tabcolor9_base_color; }
 #page.tabcolor9 #login_arrow2 { border-right: 10px solid @tabcolor9_accent2_color; }
 
 #menu li.tabcolor0 .accent { background-color: @tabcolor0_accent1_color; height: 106px; }
-#menu li.tabcolor1 .accent { background-color: @tabcolor1_accent1_color; height: 35px; }
-#menu li.tabcolor2 .accent { background-color: @tabcolor2_accent1_color; height: 35px; }
-#menu li.tabcolor3 .accent { background-color: @tabcolor3_accent1_color; height: 35px; }
-#menu li.tabcolor4 .accent { background-color: @tabcolor4_accent1_color; height: 35px; }
-#menu li.tabcolor5 .accent { background-color: @tabcolor5_accent1_color; height: 35px; }
-#menu li.tabcolor6 .accent { background-color: @tabcolor6_accent1_color; height: 35px; }
-#menu li.tabcolor7 .accent { background-color: @tabcolor7_accent1_color; height: 35px; }
-#menu li.tabcolor8 .accent { background-color: @tabcolor8_accent1_color; height: 35px; }
-#menu li.tabcolor9 .accent { background-color: @tabcolor9_accent1_color; height: 35px; }
+#menu li.tabcolor1 .accent { background-color: @tabcolor1_accent1_color; }
+#menu li.tabcolor2 .accent { background-color: @tabcolor2_accent1_color; }
+#menu li.tabcolor3 .accent { background-color: @tabcolor3_accent1_color; }
+#menu li.tabcolor4 .accent { background-color: @tabcolor4_accent1_color; }
+#menu li.tabcolor5 .accent { background-color: @tabcolor5_accent1_color; }
+#menu li.tabcolor6 .accent { background-color: @tabcolor6_accent1_color; }
+#menu li.tabcolor7 .accent { background-color: @tabcolor7_accent1_color; }
+#menu li.tabcolor8 .accent { background-color: @tabcolor8_accent1_color; }
+#menu li.tabcolor9 .accent { background-color: @tabcolor9_accent1_color; }
 
 /*
  * Utilities
@@ -302,13 +302,13 @@ width: 121px;
     width: 20px;
     border-top-left-radius: @rounding_radius;
     border-bottom-left-radius: @rounding_radius;
-    height: 35px;
+    height: 100%;
     z-index: -1;
 }
 
 #menu a {
 display: block;
-height: 35px;
+word-break: break-word;
 border-top-left-radius: @rounding_radius; 
 border-bottom-left-radius: @rounding_radius;
 /*width: 100%;*/


### PR DESCRIPTION
This makes it so that all of the text for a fruitsalad tab is displayed, even if it requires multiple lines.

Before:
![image](https://user-images.githubusercontent.com/7232514/128031992-ab3789d6-89aa-41cc-a331-24c5489a7782.png)

After:
![image](https://user-images.githubusercontent.com/7232514/128031716-92f9d776-19e7-4406-b456-38e1c1bf4980.png)

Fixes https://github.com/learning-unlimited/ESP-Website/issues/2461.