### PR TITLE
Fix theme palette management

### DIFF
--- a/esp/esp/themes/controllers.py
+++ b/esp/esp/themes/controllers.py
@@ -46,6 +46,7 @@ import textwrap
 import distutils.dir_util
 import json
 import hashlib
+from urllib import quote, unquote
 
 from django.conf import settings
 from django.template.loader import render_to_string
@@ -517,13 +518,13 @@ class ThemeController(object):
         context['save_name'] = save_name
         context['palette'] = palette
 
-        f = open(os.path.join(themes_settings.themes_dir, '%s.less' % save_name), 'w')
+        f = open(os.path.join(themes_settings.themes_dir, '%s.less' % quote(save_name, safe = "")), 'w')
         f.write(render_to_string('themes/custom_vars.less', context))
         f.close()
 
     def load_customizations(self, save_name):
 
-        f = open(os.path.join(themes_settings.themes_dir, '%s.less' % save_name), 'r')
+        f = open(os.path.join(themes_settings.themes_dir, '%s.less' % quote(save_name, safe = "")), 'r')
         data = f.read()
         f.close()
 
@@ -552,14 +553,14 @@ class ThemeController(object):
         return (vars, palette)
 
     def delete_customizations(self, save_name):
-        os.remove(os.path.join(themes_settings.themes_dir, '%s.less' % save_name))
+        os.remove(os.path.join(themes_settings.themes_dir, '%s.less' % quote(save_name, safe = "")))
 
     def get_customization_names(self):
         result = []
         filenames = os.listdir(os.path.join(themes_settings.themes_dir))
         for fn in filenames:
             if fn.endswith('.less'):
-                result.append(fn[:-5])
+                result.append(unquote(fn[:-5]))
         return result
 
     ##  Palette getter/setter -- palette is a list of strings which each contain

--- a/esp/esp/themes/controllers.py
+++ b/esp/esp/themes/controllers.py
@@ -581,7 +581,7 @@ class ThemeController(object):
 
         palette_base = list(palette_base)
         palette_base.sort()
-        
+
         return {'base': palette_base, 'custom': palette_custom}
 
     def set_palette(self, palette):

--- a/esp/esp/themes/views.py
+++ b/esp/esp/themes/views.py
@@ -214,7 +214,7 @@ def editor(request):
         #   Re-generate the CSS for the current theme given the supplied settings
         if vars:
             tc.customize_theme(vars)
-        if palette:
+        if palette != None:
             tc.set_palette(palette)
 
     #   Get current theme and customization settings

--- a/esp/public/media/theme_editor/theme_editor.js
+++ b/esp/public/media/theme_editor/theme_editor.js
@@ -1,51 +1,74 @@
 function showColor() {
     $j('.color').each(function(i){
-	$j(this).spectrum({
-	    showInput: true,
-	    showPalette: true,
-	    showInitial: true,
-	    showButtons: false,
-	    preferredFormat: "name",
-	    palette: [palette_list],
-	    showPaletteOnly: true
-	});
-    })
-	}
+        $j(this).spectrum({
+            type: "color",
+            showInput: true,
+            showInitial: true,
+            showButtons: false,
+            preferredFormat: "hex",
+            palette: [palette_list],
+            showPaletteOnly: true
+        });
+    });
+}
 
-function showPalette() {
-    $j('.palette').each(function(i){
-	$j(this).spectrum({
-	    showInput: true,
-	    showPalette: true,
-	    showInitial: true,
-	    showButtons: false,
-	    preferredFormat: "name",
-	    palette: [palette_list]
-	});
-    })
-	}
+function showBasePalette() {
+    $j('#palette_base_div .palette').each(function(i){
+        $j(this).spectrum({
+            type: "color",
+            showInput: true,
+            allowEmpty: false,
+            showPalette: false,
+            showInitial: true,
+            showButtons: true,
+            preferredFormat: "hex",
+            disabled: true
+        });
+    });
+}
+
+function showCustomPalette() {
+    $j('#palette_custom_div .palette').each(function(i){
+        $j(this).spectrum({
+            type: "color",
+            showInput: true,
+            allowEmpty: false,
+            showPalette: false,
+            showInitial: true,
+            showButtons: true,
+            preferredFormat: "hex",
+            cancelText: "Remove",
+        });
+    });
+    var $active;
+    $j("#palette_custom_div .sp-replacer").click(function(e) {
+        $active = $j(e.target).closest(".sp-replacer").prev();
+    });
+    $j(".sp-container button.sp-cancel").click(function(e) {
+        $active.spectrum("destroy");
+        $active.remove();
+    });
+}
 
 $j(document).ready(function(){
     showColor();
-    showPalette();
+    showBasePalette();
+    showCustomPalette();
     $j('#addToPalette').click(function(){
-	var newColor = $j('<input>');
-	newColor.addClass('palette');
-	newColor.attr({
-	    name: 'palette',
-	    type: 'text',
-	    value: 'black'
-	});
-	$j('#palette_div').append(newColor);
-	showPalette()
+        var newColor = $j('<input>');
+        newColor.addClass('palette');
+        newColor.attr({
+            name: 'palette',
+            type: 'text',
+            value: 'black'
+        });
+        $j('#palette_custom_div').append(newColor);
+        $j('#palette_custom_div').append(" ");
+        showCustomPalette();
     });
 
-    $j('#removeFromPalette').click(function(){
-	$j('#palette_div div.sp-replacer.sp-light:last').remove();
-	$j('#palette_div input:last').remove()
-    });    
     $j('[rel=popover]').each(function(){
-	$j(this).popover({placement:'left', animation:false});
+        $j(this).popover({placement:'left', animation:false});
     });
     
     //  Show optional variable selector if there are optional variables available

--- a/esp/templates/themes/editor.html
+++ b/esp/templates/themes/editor.html
@@ -11,25 +11,37 @@
 {% endblock %}
 
 {% block xtrajs %}
-<script src="/media/theme_editor/spectrum.js" type="text/javascript"></script>
+<script src="https://cdn.jsdelivr.net/npm/spectrum-colorpicker2/dist/spectrum.min.js"></script>
 <script type="text/javascript">
-var palette_list = [{% for color in palette %} "{{color}}"{% if not forloop.last %},{% endif %} {% endfor %}];
+var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% for color in palette.custom %} "{{color}}"{% if not forloop.last %},{% endif %} {% endfor %}];
 </script>
 <link href="{{ settings.CDN_ADDRESS }}/bootstrap/docs/assets/css/bootstrap.css" type="text/css" />
-<link href="/media/theme_editor/spectrum.css" rel="stylesheet" />
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/spectrum-colorpicker2/dist/spectrum.min.css">
 <script src="/media/theme_editor/css_auto-reload.js" rel="text/javascript"></script>
 <script type="text/javascript">
   document.styleSheets.reload()
 </script>
 <style>
   form.centered-form div.control-group {
-      margin-left:20%;
+      margin-left:10%;
+      margin-right:10%;
   }
   div.form-actions {
       border-top:None;
   }
   h5 {
   margin-left:3%;
+  }
+  .sp-palette-row {
+      max-width: 132px;
+  }
+  .sp-container button.sp-cancel {
+      background-color: red;
+      color: white;
+      margin-left: 5px;
+  }
+  .sp-palette .sp-thumb-inner {
+      border: 1px solid black;
   }
 </style>
 {% endblock %}
@@ -64,7 +76,7 @@ var palette_list = [{% for color in palette %} "{{color}}"{% if not forloop.last
 <br />
 <div class="row-fluid">
   <div class="span12">
-    <form class="well form-horizontal centered-form" method="post" action="/themes/customize/">
+    <form class="form-horizontal centered-form" method="post" action="/themes/customize/">
       {% csrf_token %} 
       <div class="accordion">
 
@@ -74,15 +86,21 @@ var palette_list = [{% for color in palette %} "{{color}}"{% if not forloop.last
 	  <div class="collapse" id="theme_palette">
 
 	    <div class="control-group">
-	      <div id="palette_div">
-		{% for color in palette %}
-		<input type="text" name="palette" class="palette" value="{{color}}" />
-		{% endfor %}
+	      <div id="palette_base_div">
+            <h3>Theme Palette:</h3>
+            {% for color in palette.base %}
+            <input type="text" name="palette" class="palette" value="{{color}}" />
+            {% endfor %}
+          </div>
+          <div id="palette_custom_div">
+            <h3>Custom Palette:</h3>
+            {% for color in palette.custom %}
+            <input type="text" name="palette" class="palette" value="{{color}}" />
+            {% endfor %}
 	      </div>
 	    </div>
 	    <div class="controls">
 	      <button type="button" class="btn btn-default" id="addToPalette">Add Another Color</button>
-	      <button type="button" class="btn btn-default" id="removeFromPalette">Remove Last Color</button>
 	      <button type="submit" class="btn btn-primary" name="apply" value="apply">Update Palette</button> 
 	    </div>
 	  </div>
@@ -152,16 +170,16 @@ var palette_list = [{% for color in palette %} "{{color}}"{% if not forloop.last
 	      <label class="control-label" for="baseFontSize">Font Size:  </label>
 	      <div class="controls">
 		<select id="baseFontSize" name="baseFontSize">
-		  <option value="{{ baseFontSize }}">Current: {{ baseFontSize }}</option>
-		  <option value="10px">10</option>
-		  <option value="11px">11</option>
-		  <option value="12px">12</option>
-		  <option value="13px">13</option>
-		  <option value="14px">14</option>
-		  <option value="15px">15</option>
-		  <option value="16px">16</option>
-		  <option value="17px">17</option>
-		  <option value="18px">18</option>
+		  <option value="{{ baseFontSize }}" style="font-size: {{ baseFontSize }};">Current: {{ baseFontSize }}</option>
+		  <option value="10px" style="font-size: 10px;">10</option>
+		  <option value="11px" style="font-size: 11px;">11</option>
+		  <option value="12px" style="font-size: 12px;">12</option>
+		  <option value="13px" style="font-size: 13px;">13</option>
+		  <option value="14px" style="font-size: 14px;">14</option>
+		  <option value="15px" style="font-size: 15px;">15</option>
+		  <option value="16px" style="font-size: 16px;">16</option>
+		  <option value="17px" style="font-size: 17px;">17</option>
+		  <option value="18px" style="font-size: 18px;">18</option>
 		</select>
 	      </div>
 	    </div>
@@ -170,9 +188,9 @@ var palette_list = [{% for color in palette %} "{{color}}"{% if not forloop.last
 	      <label class="control-label" for="sansFontFamily">Font Family:  </label>
 	      <div class="controls">
 		<select id="sansFontFamily" name="sansFontFamily" type="text">
-		  <option value="{{ sansFontFamily }}">Current: {{sansFontFamily}}</option>
+		  <option value="{{ sansFontFamily }}" style="font-family: {{sansFontFamily}};">Current: {{sansFontFamily}}</option>
 		  {% for family_name, family in sans_fonts %}
-		  <option value="{{family}}">{{family_name}}</option>
+		  <option value="{{family}}" style="font-family: {{family}};">{{family_name}}</option>
 		  {% endfor %}
 		</select>
 	      </div>

--- a/esp/templates/themes/editor.html
+++ b/esp/templates/themes/editor.html
@@ -51,383 +51,376 @@ var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% 
 {% block title %}Theme Editor{% endblock %}
 {% block content %} 
 <div class="row-fluid">
-
-<div class="span12">
-  <h1>Theme Editor</h1>
-  <div class="alert alert-info">
-    <p>New to the theme editor? <a href="#help-modal" data-toggle="modal">Click here</a>.</p>
-  </div>
-  <div id="help-modal" class="modal hide fade">
-    <div class="modal-header">
-      <button type="button" class="close" data-dismiss="modal">x</button>
-      <h3>Welcome to the theme editor! It's easy to get started</h3>
+    <div class="span12">
+        <h1>Theme Editor</h1>
+        <div class="alert alert-info">
+            <p>New to the theme editor?<a href="#help-modal" data-toggle="modal">Click here</a>.</p>
+        </div>
+        <div id="help-modal" class="modal hide fade">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">x</button>
+                <h3>Welcome to the theme editor! It's easy to get started</h3>
+            </div>
+            <div class="modal-body">
+                <ol>
+                    <li><strong>Add colors</strong>to your Palette.</li>
+                    <li>Dive into the sections and<strong>customize</strong>at will. Press<strong>Test</strong>often to see your changes in action.</li>
+                    <li>When you're happy with your changes, just enter a name under Theme Properties and press<strong>Save</strong>!</li>
+                </ol>
+                <p>For even more<strong>color picking power</strong>, we recommend using a full featured colour picker like<a href='http://colorschemedesigner.com' target="_blank">this one</a>to decide your colours, and enter the hex values when adding to your palette.</p>
+            </div>
+            <div class="modal-footer"></div>
+        </div>
     </div>
-    <div class="modal-body">
-      <ol>
-	<li><strong>Add colors</strong> to your Palette.</li>
-	<li>Dive into the sections and <strong>customize</strong> at will. Press <strong>Test</strong> often to see your changes in action.</li>
-	<li>When you're happy with your changes, just enter a name under Theme Properties and press <strong>Save</strong>!</li>
-      </ol>
-      <p>For even more <strong>color picking power</strong>, we recommend using a full featured colour picker like <a href='http://colorschemedesigner.com' target="_blank">this one</a> to decide your colours, and enter the hex values when adding to your palette.</p>
-    </div>
-    
-    <div class="modal-footer"></div>
-  </div>
-</p>
 </div>
 
 <br />
 <div class="row-fluid">
-  <div class="span12">
-    <form class="form-horizontal centered-form" method="post" action="/themes/customize/">
-      {% csrf_token %} 
-      <div class="accordion">
+    <div class="span12">
+        <form class="form-horizontal centered-form" method="post" action="/themes/customize/">
+            {% csrf_token %} 
+            <div class="accordion">
+                <div class="accordion-group">
+                    <div class="accordion-heading">
+                        <h3 class="accordion-toggle" data-toggle="collapse" href="#theme_palette" data-content="Your theme palette holds the colors that are used in your theme. Use this to control the colors available to you in the other sections." data-original-title="Theme Palette" rel="popover">Palette</h3>
+                    </div>
+                    <div class="collapse" id="theme_palette">
+                        <div class="control-group">
+                            <div id="palette_base_div">
+                                <h3>Theme Palette:</h3>
+                                {% for color in palette.base %}
+                                <input type="text" name="palette" class="palette" value="{{color}}"/>
+                                {% endfor %}
+                            </div>
+                            <div id="palette_custom_div">
+                                <h3>Custom Palette:</h3>
+                                {% for color in palette.custom %}
+                                <input type="text" name="palette" class="palette" value="{{color}}"/>
+                                {% endfor %}
+                            </div>
+                        </div>
+                        <div class="controls">
+                            <button type="button" class="btn btn-default" id="addToPalette">Add Another Color</button>
+                            <button type="submit" class="btn btn-primary" name="apply" value="apply">Update Custom Palette</button>
+                        </div>
+                    </div>
+                </div>
 
-	<div class="accordion-group">
-	  <div class="accordion-heading"><h3 class="accordion-toggle" data-toggle="collapse" href="#theme_palette" data-content="Your theme palette holds the colors that are used in your theme. Use this to control the colors available to you in the other sections." data-original-title="Theme Palette" rel="popover">Palette</h3></div>
+                <div class="accordion-group">
+                    <div class="accordion-heading">
+                        <h3 class="accordion-toggle" data-toggle="collapse" href="#scaffolding" rel="popover" data-original-title="Scaffolding" data-content="Use this section to change the color of the text and background.">Scaffolding</h3>
+                    </div>
+                    <div class="collapse" id="scaffolding">
+                        <div class="control-group">
+                            <label class="control-label" for="bodybg">Background :</label>
+                            <div class="controls">
+                                <input type="text" id="bodybg" name="bodyBackground" class="color" value="{{bodyBackground}}"/>
+                            </div>
+                        </div>
 
-	  <div class="collapse" id="theme_palette">
+                        <div class="control-group">
+                            <label class="control-label" for="wellbg">Well Background:</label>
+                            <div class="controls">
+                                <input type="text" id="wellbg" name="wellBackground" class="color" value="{{wellBackground}}"/>
+                            </div>
+                        </div>
 
-	    <div class="control-group">
-	      <div id="palette_base_div">
-            <h3>Theme Palette:</h3>
-            {% for color in palette.base %}
-            <input type="text" name="palette" class="palette" value="{{color}}" />
-            {% endfor %}
-          </div>
-          <div id="palette_custom_div">
-            <h3>Custom Palette:</h3>
-            {% for color in palette.custom %}
-            <input type="text" name="palette" class="palette" value="{{color}}" />
-            {% endfor %}
-	      </div>
-	    </div>
-	    <div class="controls">
-	      <button type="button" class="btn btn-default" id="addToPalette">Add Another Color</button>
-	      <button type="submit" class="btn btn-primary" name="apply" value="apply">Update Custom Palette</button> 
-	    </div>
-	  </div>
-	</div>
+                        <div class="control-group">
+                            <label class="control-label" for="heroUnitBackground">Hero Unit Background:</label>
+                            <div class="controls">
+                                <input type="text" id="heroUnitBackground" name="heroUnitBackground" class="color" value="{{heroUnitBackground}}"/>
+                            </div>
+                        </div>
 
-	<div class="accordion-group">
-	  <div class="accordion-heading"><h3 class="accordion-toggle" data-toggle="collapse" href="#scaffolding" rel="popover" data-original-title="Scaffolding" data-content="Use this section to change the color of the text and background." >Scaffolding</h3></div>
+                        <div class="control-group">
+                            <label class="control-label" for="textColor">Text :</label>
+                            <div class="controls">
+                                <input type="text" class="color" id="textColor" name="textColor" value="{{ textColor }}"/>
+                            </div>
+                        </div>
+                    </div>
+                </div>
 
-	  <div class="collapse" id="scaffolding">
+                <div class="accordion-group">
+                    <div class="accordion-heading">
+                        <h3 class="accordion-toggle" data-toggle="collapse" href="#links" rel="popover" data-original-title="Links" data-content="Use this section to control the color of links normally, and when you hover on them.">Links</h3>
+                    </div>
+                    <div class="collapse" id="links">
+                        <div class="control-group">
+                            <label class="control-label" for="linkColor">Links :</label>
+                            <div class="controls">
+                                <input type="text" class="color" id="linkColor" name="linkColor" value="{{ linkColor }}"/>
+                            </div>
+                        </div>
 
-	    <div class="control-group">
-	      <label class="control-label" for="bodybg">Background :  </label>
-	      <div class="controls">
-		<input type="text" id="bodybg" name="bodyBackground" class="color" value="{{bodyBackground}}" />
-	      </div>
-	    </div>
+                        <div class="control-group">
+                            <label class="control-label" for="linkColorHover">Link Hover Effect:</label>
+                            <div class="controls">
+                                <input type="text" class="color" id="linkColorHover" name="linkColorHover" value="{{ linkColorHover }}"/>
+                            </div>
+                        </div>
+                    </div>
+                </div>
 
-	    <div class="control-group">
-	      <label class="control-label" for="wellbg">Well Background:  </label>
-	      <div class="controls">
-		<input type="text" id="wellbg" name="wellBackground" class="color" value="{{wellBackground}}" />
-	      </div>
-	    </div>
+                <div class="accordion-group">
+                    <div class="accordion-heading">
+                        <h3 class="accordion-toggle" data-toggle="collapse" href="#typography" rel="popover" data-original-title="Typography" data-content="Use this section to control the size (base font size), and the font family of your text.">Typography</h3>
+                    </div>
+                    <div class="collapse" id="typography">
+                        <div class="control-group">
+                            <label class="control-label" for="baseFontSize">Font Size:</label>
+                            <div class="controls">
+                                <select id="baseFontSize" name="baseFontSize">
+                                    <option value="{{ baseFontSize }}" style="font-size: {{ baseFontSize }};">Current: {{ baseFontSize }}</option>
+                                    <option value="10px" style="font-size: 10px;">10</option>
+                                    <option value="11px" style="font-size: 11px;">11</option>
+                                    <option value="12px" style="font-size: 12px;">12</option>
+                                    <option value="13px" style="font-size: 13px;">13</option>
+                                    <option value="14px" style="font-size: 14px;">14</option>
+                                    <option value="15px" style="font-size: 15px;">15</option>
+                                    <option value="16px" style="font-size: 16px;">16</option>
+                                    <option value="17px" style="font-size: 17px;">17</option>
+                                    <option value="18px" style="font-size: 18px;">18</option>
+                                </select>
+                            </div>
+                        </div>
 
-	    <div class="control-group">
-	      <label class="control-label" for="heroUnitBackground">Hero Unit Background:  </label>
-	      <div class="controls">
-		<input type="text" id="heroUnitBackground" name="heroUnitBackground" class="color" value="{{heroUnitBackground}}" />
-	      </div>
-	    </div>
+                        <div class="control-group">
+                            <label class="control-label" for="sansFontFamily">Font Family:</label>
+                            <div class="controls">
+                                <select id="sansFontFamily" name="sansFontFamily" type="text">
+                                    <option value="{{ sansFontFamily }}" style="font-family: {{sansFontFamily}};">Current: {{sansFontFamily}}</option>
+                                    {% for family_name, family in sans_fonts %}
+                                    <option value="{{family}}" style="font-family: {{family}};">{{family_name}}</option>
+                                    {% endfor %}
+                                </select>
+                            </div>
+                        </div>
+                    </div>
+                </div>
 
-	    <div class="control-group">
-	      <label class="control-label" for="textColor">Text :  </label>
-	      <div class="controls">
-		<input type="text" class="color" id="textColor" name="textColor" value="{{ textColor }}"/>
-	      </div>
-	    </div>
+                <div class="accordion-group">
+                    <div class="accordion-heading">
+                        <h3 class="accordion-toggle" data-toggle="collapse" href="#navbar_edit_group" rel="popover" data-original-title="Navbar" data-content="Use this section to control the colors for the various elements of the navigation bar. The background fades into the highlight.">Navbar</h3>
+                    </div>
+                    <div class="collapse" id="navbar_edit_group">
+                        <div class="control-group">
+                            <label class="control-label" for="navbarBackground">Background :</label>
+                            <div class="controls">
+                                <input type="text" class="color" id="navbarBackground" name="navbarBackground" value="{{ navbarBackground }}"/>
+                            </div>
+                        </div>
 
-	  </div>
-	</div>
-      
-	
-	<div class="accordion-group">
-	  <div class="accordion-heading"><h3 class="accordion-toggle" data-toggle="collapse" href="#links" rel="popover" data-original-title="Links" data-content="Use this section to control the color of links normally, and when you hover on them.">Links</h3></div>
-	  <div class="collapse" id="links">
-	    <div class="control-group">
-	      <label class="control-label" for="linkColor">Links :  </label>
-	      <div class="controls">
-		<input type="text" class="color" id="linkColor" name="linkColor" value="{{ linkColor }}"/>
-	      </div>
-	    </div>
+                        <div class="control-group">
+                            <label class="control-label" for="navbarBackgroundHighlight">Highlight :</label>
+                            <div class="controls">
+                                <input type="text" class="color" id="navbarBackgroundHighlight" name="navbarBackgroundHighlight" value="{{ navbarBackgroundHighlight }}"/>
+                            </div>
+                        </div>
 
-	    <div class="control-group">
-	      <label class="control-label" for="linkColorHover">Link Hover Effect:  </label>
-	      <div class="controls">
-		<input type="text" class="color" id="linkColorHover" name="linkColorHover" value="{{ linkColorHover }}"/>
-	      </div>
-	    </div>
-	  </div>
-	</div>
-	
+                        <div class="control-group">
+                            <label class="control-label" for="navbarText">Text :</label>
+                            <div class="controls">
+                                <input type="text" class="color" id="navbarText" name="navbarText" value="{{ navbarText }}"/>
+                            </div>
+                        </div>
 
-	<div class="accordion-group">
-	  <div class="accordion-heading"><h3 class="accordion-toggle" data-toggle="collapse" href="#typography" rel="popover" data-original-title="Typography" data-content="Use this section to control the size (base font size), and the font family of your text.">Typography</h3></div>
-	  <div class="collapse" id="typography">
-	    <div class="control-group">
-	      <label class="control-label" for="baseFontSize">Font Size:  </label>
-	      <div class="controls">
-		<select id="baseFontSize" name="baseFontSize">
-		  <option value="{{ baseFontSize }}" style="font-size: {{ baseFontSize }};">Current: {{ baseFontSize }}</option>
-		  <option value="10px" style="font-size: 10px;">10</option>
-		  <option value="11px" style="font-size: 11px;">11</option>
-		  <option value="12px" style="font-size: 12px;">12</option>
-		  <option value="13px" style="font-size: 13px;">13</option>
-		  <option value="14px" style="font-size: 14px;">14</option>
-		  <option value="15px" style="font-size: 15px;">15</option>
-		  <option value="16px" style="font-size: 16px;">16</option>
-		  <option value="17px" style="font-size: 17px;">17</option>
-		  <option value="18px" style="font-size: 18px;">18</option>
-		</select>
-	      </div>
-	    </div>
+                        <div class="control-group">
+                            <label class="control-label" for="navbarLinkColor">Links :</label>
+                            <div class="controls">
+                                <input type="text" class="color" id="navbarLinkColor" name="navbarLinkColor" value="{{ navbarLinkColor }}"/>
+                            </div>
+                        </div>
 
-	    <div class="control-group">
-	      <label class="control-label" for="sansFontFamily">Font Family:  </label>
-	      <div class="controls">
-		<select id="sansFontFamily" name="sansFontFamily" type="text">
-		  <option value="{{ sansFontFamily }}" style="font-family: {{sansFontFamily}};">Current: {{sansFontFamily}}</option>
-		  {% for family_name, family in sans_fonts %}
-		  <option value="{{family}}" style="font-family: {{family}};">{{family_name}}</option>
-		  {% endfor %}
-		</select>
-	      </div>
-	    </div>
-	  </div>
-	  </div>
+                        <div class="control-group">
+                            <label class="control-label" for="navbarLinkColorHover">Link Hover:</label>
+                            <div class="controls">
+                                <input type="text" class="color" id="navbarLinkColorHover" name="navbarLinkColorHover" value="{{ navbarLinkColorHover }}"/>
+                            </div>
+                        </div>
+                    </div>
+                </div>
 
-	  <div class="accordion-group">
-	    <div class="accordion-heading"><h3 class="accordion-toggle" data-toggle="collapse" href="#navbar_edit_group" rel="popover" data-original-title="Navbar" data-content="Use this section to control the colors for the various elements of the navigation bar. The background fades into the highlight.">Navbar</h3></div>
-	    <div class="collapse" id="navbar_edit_group">
+                <div class="accordion-group">
+                    <div class="accordion-heading">
+                        <h3 class="accordion-toggle" data-toggle="collapse" href="#sidebar_theme" rel="popover" data-original-title="Sidebar" data-content="Use this section to control the colors used in the sidebar elements. A link is active in the sidebar when it points to the currently loaded page.">Sidebar</h3>
+                    </div>
+                    <div class="collapse" id="sidebar_theme">
+                        <div class="control-group">
+                            <label class="control-label" for="sidebarLink">Links:</label>
+                            <div class="controls">
+                                <input type="text" class="color" id="sidebarLink" name="sidebarLink" value="{{ sidebarLink }}"/>
+                            </div>
+                        </div>
 
-	      <div class="control-group">
-		<label class="control-label" for="navbarBackground">Background :  </label>
-		<div class="controls">
-		  <input type="text" class="color" id="navbarBackground" name="navbarBackground" value="{{ navbarBackground }}"/>
-		</div>
-	      </div>
+                        <div class="control-group">
+                            <label class="control-label" for="sidebarHeader">Headers:</label>
+                            <div class="controls">
+                                <input type="text" class="color" id="sidebarHeader" name="sidebarHeader" value="{{ sidebarHeader }}"/>
+                            </div>
+                        </div>
 
-	      <div class="control-group">
-		<label class="control-label" for="navbarBackgroundHighlight">Highlight :  </label>
-		<div class="controls">
-		  <input type="text" class="color" id="navbarBackgroundHighlight" name="navbarBackgroundHighlight" value="{{ navbarBackgroundHighlight }}"/>
-		</div>
-	      </div>
+                        <div class="control-group">
+                            <label class="control-label" for="sidebarBackground">Background :</label>
+                            <div class="controls">
+                                <input type="text" class="color" id="sidebarBackground" name="sidebarBackground" value="{{ sidebarBackground }}"/>
+                            </div>
+                        </div>
 
-	      <div class="control-group">
-		<label class="control-label" for="navbarText">Text :  </label>
-		<div class="controls">
-		  <input type="text" class="color" id="navbarText" name="navbarText" value="{{ navbarText }}"/>
-		</div>
-	      </div>
-
-	      <div class="control-group">
-		<label class="control-label" for="navbarLinkColor">Links :  </label>
-		<div class="controls">
-		  <input type="text" class="color" id="navbarLinkColor" name="navbarLinkColor" value="{{ navbarLinkColor }}"/>
-		</div>
-	      </div>
-
-	      <div class="control-group">
-		<label class="control-label" for="navbarLinkColorHover">Link Hover:  </label>
-		<div class="controls">
-		  <input type="text" class="color" id="navbarLinkColorHover" name="navbarLinkColorHover" value="{{ navbarLinkColorHover }}"/>
-		</div>
-	      </div>
-	    </div>
-	  </div>
-
-	  <div class="accordion-group">
-	    <div class="accordion-heading"><h3 class="accordion-toggle" data-toggle="collapse" href="#sidebar_theme" rel="popover" data-original-title="Sidebar" data-content="Use this section to control the colors used in the sidebar elements. A link is active in the sidebar when it points to the currently loaded page.">Sidebar</h3></div>
-	    <div class="collapse" id="sidebar_theme">
-
-
-
-
-	      <div class="control-group">
-		<label class="control-label" for="sidebarLink">Links:  </label>
-		<div class="controls">
-		  <input type="text" class="color" id="sidebarLink" name="sidebarLink" value="{{ sidebarLink }}"/>
-		</div>
-	      </div>
-
-	      <div class="control-group">
-		<label class="control-label" for="sidebarHeader">Headers:  </label>
-		<div class="controls">
-		  <input type="text" class="color" id="sidebarHeader" name="sidebarHeader" value="{{ sidebarHeader }}"/>
-		</div>
-	      </div>
-
-	      <div class="control-group">
-		<label class="control-label" for="sidebarBackground">Background :  </label>
-		<div class="controls">
-		  <input type="text" class="color" id="sidebarBackground" name="sidebarBackground" value="{{ sidebarBackground }}"/>
-		</div>
-	      </div>
-
-	      <h5>Hover</h5>
-
-	      <div class="control-group">
-		<label class="control-label" for="sidebarLinkHover">Links:  </label>
-		<div class="controls">
-		  <input type="text" class="color" id="sidebarLinkHover" name="sidebarLinkHover" value="{{ sidebarLinkHover }}"/>
-		</div>
-	      </div>
+                        <h5>Hover</h5>
+                        <div class="control-group">
+                            <label class="control-label" for="sidebarLinkHover">Links:</label>
+                            <div class="controls">
+                                <input type="text" class="color" id="sidebarLinkHover" name="sidebarLinkHover" value="{{ sidebarLinkHover }}"/>
+                            </div>
+                        </div>
 	      
-	      <div class="control-group">
-		<label class="control-label" for="sidebarHover">Background:  </label>
-		<div class="controls">
-		  <input type="text" class="color" id="sidebarHover" name="sidebarHover" value="{{ sidebarHover }}"/>
-		</div>
-	      </div>
+                        <div class="control-group">
+                            <label class="control-label" for="sidebarHover">Background:</label>
+                            <div class="controls">
+                                <input type="text" class="color" id="sidebarHover" name="sidebarHover" value="{{ sidebarHover }}"/>
+                            </div>
+                        </div>
 
+                        <h5>Active</h5>
+                        <div class="control-group">
+                            <label class="control-label" for="sidebarActive">Links:</label>
+                            <div class="controls">
+                                <input type="text" class="color" id="sidebarActive" name="sidebarActive" value="{{ sidebarActive }}"/>
+                            </div>
+                        </div>
 
+                        <div class="control-group">
+                            <label class="control-label" for="sidebarActiveBackground">Background:</label>
+                            <div class="controls">
+                                <input type="text" class="color" id="sidebarActiveBackground" name="sidebarActiveBackground" value="{{ sidebarActiveBackground }}"/>
+                            </div>
+                        </div>
 
-	      <h5>Active</h5>
-	      
-	      <div class="control-group">
-		<label class="control-label" for="sidebarActive">Links:  </label>
-		<div class="controls">
-		  <input type="text" class="color" id="sidebarActive" name="sidebarActive" value="{{ sidebarActive }}"/>
-		</div>
-	      </div>
+                        {% comment %}
+                        <div class="control-group">
+                            <label class="control-label" for="navbarLinkColor">Links :</label>
+                            <div class="controls">
+                                <input type="text" class="color" id="navbarLinkColor" name="navbarLinkColor" value="{{ navbarLinkColor }}"/>
+                            </div>
+                        </div>
 
-	      <div class="control-group">
-		<label class="control-label" for="sidebarActiveBackground">Background:  </label>
-		<div class="controls">
-		  <input type="text" class="color" id="sidebarActiveBackground" name="sidebarActiveBackground" value="{{ sidebarActiveBackground }}"/>
-		</div>
-	      </div>
+                        <div class="control-group">
+                            <label class="control-label" for="navbarLinkColorHover">Link Hover:</label>
+                            <div class="controls">
+                                <input type="text" class="color" id="navbarLinkColorHover" name="navbarLinkColorHover" value="{{ navbarLinkColorHover }}"/>
+                            </div>
+                        </div>
+                        {% endcomment %}
+                    </div>
+                </div>
 
+                <div class="accordion-group">
+                    <div class="accordion-heading">
+                        <h3 class="accordion-toggle" data-toggle="collapse" href="#buttons" rel="popover" data-original-title="Buttons" data-content="Buttons come in three types. You can see the normal and primary buttons at the end of this form, and the inverse buttons in the navbar.">Buttons</h3>
+                    </div>
+                    <div class="collapse" id="buttons">
+                        <div class="control-group">
+                            <label class="control-label" for="btnBackground">Buttons:</label>
+                            <div class="controls">
+                                <input type="text" class="color" id="btnBackground" name="btnBackground" value="{{ btnBackground }}"/>
+                            </div>
+                        </div>
 
+                        <div class="control-group">
+                            <label class="control-label" for="btnPrimaryBackground">Primary Buttons:</label>
+                            <div class="controls">
+                                <input type="text" class="color" id="btnPrimaryBackground" name="btnPrimaryBackground" value="{{ btnPrimaryBackground }}"/>
+                            </div>
+                        </div>
 
-{% comment %}
-	      <div class="control-group">
-		<label class="control-label" for="navbarLinkColor">Links :  </label>
-		<div class="controls">
-		  <input type="text" class="color" id="navbarLinkColor" name="navbarLinkColor" value="{{ navbarLinkColor }}"/>
-		</div>
-	      </div>
+                        <div class="control-group">
+                            <label class="control-label" for="btnInverseBackground">Inverse Buttons:</label>
+                            <div class="controls">
+                                <input type="text" class="color" id="btnInverseBackground" name="btnInverseBackground" value="{{ btnInverseBackground }}"/>
+                            </div>
+                        </div>
+                    </div>
+                </div>
 
-	      <div class="control-group">
-		<label class="control-label" for="navbarLinkColorHover">Link Hover:  </label>
-		<div class="controls">
-		  <input type="text" class="color" id="navbarLinkColorHover" name="navbarLinkColorHover" value="{{ navbarLinkColorHover }}"/>
-		</div>
-	      </div>
-{% endcomment %}
-	    </div>
-	  </div>
+                <div class="accordion-group">
+                    <div class="accordion-heading">
+                        <h3 class="accordion-toggle" data-toggle="collapse" href="#advanced" rel="popover" data-original-title="Advanced" data-content="These are additional parameters specific to the currently selected theme.">Advanced</h3>
+                    </div>
+                    <div class="collapse" id="advanced">
+                        {% for category, data in adv_vars.items %}{% if not data|length_is:0 %}
+                        <div id="adv_category_{{ forloop.counter0 }}">
+                            <h3>Category: {{ category }}<hr/></h3>
+                            <!-- Dropdown box for adding an optional variable override that is not yet defined -->
+                            <div class="control-group opt_var_div hidden">
+                                <label class="control-label" for="new_opt_var_{{ forloop.counter0 }}">Add a variable:</label>
+                                <div class="controls">
+                                    <select id="new_opt_var_{{ forloop.counter0 }}" name="new_opt_var_{{ forloop.counter0 }}" class="select_opt_var">
+                                        {% for item in data %}{% if not item.2 %}
+                                        <option value="{{ item.0 }}">{{ item.0 }}</option>
+                                        {% endif %}{% endfor %}
+                                    </select>
+                                    <button class="btn add_opt_var_button" id="add_opt_var_{{ forloop.counter0 }}">Add</button>
+                                </div>
+                            </div>
+                            {% for item in data %}{% if item.2 %}
+                            <div class="control-group" id="ctlgrp_{{ item.0 }}">
+                                <label class="control-label" for="{{ item.0 }}">{{ item.0 }}:</label>
+                                <div class="controls">
+                                    <input type="text" class="{{ item.1 }}" id="id_{{ item.0 }}" name="{{ item.0 }}" value="{{ item.2 }}"/>
+                                </div>
+                            </div>
+                            {% endif %}{% endfor %}
+                        </div>
+                        {% endif %}{% endfor %}
+                    </div>
+                </div>
 
-	  <div class="accordion-group">
-	      <div class="accordion-heading"><h3 class="accordion-toggle" data-toggle="collapse" href="#buttons" rel="popover" data-original-title="Buttons" data-content="Buttons come in three types. You can see the normal and primary buttons at the end of this form, and the inverse buttons in the navbar.">Buttons</h3></div>
-	      <div class="collapse" id="buttons">
+                <div class="accordion-group">
+                    <div class="accordion-heading">
+                        <h3 class="accordion-toggle" data-toggle="collapse" href="#theme-properties" rel='popover' data-original-title="Saved Settings" data-content="When you're finished making changes, enter a name and press Save! Enter the name of an existing configuration to overwrite it. If you just want to see your changes in action, you're probably looking for the Test button. You can also load or delete saved settings, or revert to the last configuration.">Theme Properties</h3>
+                    </div>
+                    <div class="in collapse" id="theme-properties">
+                        <div class="control-group">
+                            <input id="save" type="text" value="" name="saveThemeName" placeholder="Current: {{ last_used_setting }}"/>
+                            <button type="submit" class="btn btn-primary" name="save" value="save">Save</button>
 
+                            <br/>
+                            <br/>
 
-		<div class="control-group">
-		  <label class="control-label" for="btnBackground">Buttons:  </label>
-		  <div class="controls">
-		    <input type="text" class="color" id="btnBackground" name="btnBackground" value="{{ btnBackground }}"/>
-		  </div>
-		</div>
+                            <select name="loadThemeName">
+                                <option value="">Select from saved settings...</option>
+                                <optgroup label="---------">
+                                    {% for theme in available_themes %}
+                                    <option value="{{theme}}">{{theme}}</option>
+                                    {% endfor %}
+                                </optgroup>
+                                <optgroup>
+                                    <option value="{{last_used_settings}}">Last used settings...</option>
+                                </optgroup>
+                            </select>
+                            <button type="submit" class="btn btn-default" name="load" value="load">Load</button>
+                            <button type="submit" class="btn btn-danger" name="delete" value="delete">Delete</button>
+                        </div>
+                    </div>
+                </div>
 
-		<div class="control-group">
-		  <label class="control-label" for="btnPrimaryBackground">Primary Buttons:  </label>
-		  <div class="controls">
-		    <input type="text" class="color" id="btnPrimaryBackground" name="btnPrimaryBackground" value="{{ btnPrimaryBackground }}"/>
-		  </div>
-		</div>
-
-		<div class="control-group">
-		  <label class="control-label" for="btnInverseBackground">Inverse Buttons:  </label>
-		  <div class="controls">
-		    <input type="text" class="color" id="btnInverseBackground" name="btnInverseBackground" value="{{ btnInverseBackground }}"/>
-		  </div>
-		</div>
-	      </div>
-	    </div>
-
-        <div class="accordion-group">
-	      <div class="accordion-heading"><h3 class="accordion-toggle" data-toggle="collapse" href="#advanced" rel="popover" data-original-title="Advanced" data-content="These are additional parameters specific to the currently selected theme.">Advanced</h3></div>
-	      <div class="collapse" id="advanced">
-        {% for category, data in adv_vars.items %}{% if not data|length_is:0 %}
-        <div id="adv_category_{{ forloop.counter0 }}">
-        <h3>Category: {{ category }}<hr /></h3>
-        <!-- Dropdown box for adding an optional variable override that is not yet defined -->
-        <div class="control-group opt_var_div hidden">
-            <label class="control-label" for="new_opt_var_{{ forloop.counter0 }}">Add a variable: </label>
-            <div class="controls">
-                <select id="new_opt_var_{{ forloop.counter0 }}" name="new_opt_var_{{ forloop.counter0 }}" class="select_opt_var">
-                {% for item in data %}{% if not item.2 %}
-                    <option value="{{ item.0 }}">{{ item.0 }}</option>
-                {% endif %}{% endfor %}
-                </select>
-                <button class="btn add_opt_var_button" id="add_opt_var_{{ forloop.counter0 }}">Add</button>
+                <div class="form-actions" style="text-align:center;">
+                    <button type="submit" class="btn btn-primary" name="apply" value="apply">Test</button>
+                    <button type="submit" class="btn btn-default" name="reset" value="reset">Reset Without Saving</button>
+                </div>
             </div>
-        </div>
-        {% for item in data %}{% if item.2 %}
-		<div class="control-group" id="ctlgrp_{{ item.0 }}">
-            <label class="control-label" for="{{ item.0 }}">{{ item.0 }}: </label>
-            <div class="controls">
-                <input type="text" class="{{ item.1 }}" id="id_{{ item.0 }}" name="{{ item.0 }}" value="{{ item.2 }}"/>
-            </div>
-		</div>
-        {% endif %}{% endfor %}
-        </div>
-        {% endif %}{% endfor %}
-	      </div>
-	    </div>
-
-	    <div class="accordion-group">
-	      <div class="accordion-heading"><h3 class="accordion-toggle" data-toggle="collapse" href="#theme-properties" rel='popover' data-original-title="Saved Settings" data-content="When you're finished making changes, enter a name and press Save! Enter the name of an existing configuration to overwrite it. If you just want to see your changes in action, you're probably looking for the Test button. You can also load or delete saved settings, or revert to the last configuration.">Theme Properties</h3></div>
-	      <div class="in collapse" id="theme-properties">
-
-		<div class="control-group">
-		  <input id="save" type="text" value="" name="saveThemeName" placeholder="Current: {{ last_used_setting }}" />
-		  <button type="submit" class="btn btn-primary" name="save" value="save"> Save </button> 
-
-		  <br />
-		  <br />
-
-		  <select name="loadThemeName" >
-		    <option value="">Select from saved settings...</option> 
-		    <optgroup label="---------">
-		      {% for theme in available_themes %}
-		      <option value="{{theme}}"> {{theme}} </option>
-		      {% endfor %}
-		    </optgroup>
-		    <optgroup>
-		      <option value="{{last_used_settings}}"> Last used settings... </option>
-		    </optgroup>
-		  </select>
-		  <button type="submit" class="btn btn-default" name="load" value="load"> Load </button>
-		  <button type="submit" class="btn btn-danger" name="delete" value="delete"> Delete </button>
-		</div>
-	      </div>
-	    </div>
-
-
-      <div class="form-actions" style="text-align:center;">
-	<button type="submit" class="btn btn-primary" name="apply" value="apply"> Test </button>
-
-	<button type="submit" class="btn btn-default" name="reset" value="reset"> Reset Without Saving </button>
-      </div>
-    </form>
-  </div>
-  <div align="center">
-    <a href="/themes/">
-    <button type="button" class="btn btn-large btn-primary">Return to themes page</button>
-    </a>
-    <a href="/">
-    <button type="button" class="btn btn-large btn-inverse">Return to home page</button>
-    </a>
-    <br /><br />
-  </div>
+        </form>
+    </div>
+    <div align="center">
+        <a href="/themes/">
+            <button type="button" class="btn btn-large btn-primary">Return to themes page</button>
+        </a>
+        <a href="/">
+            <button type="button" class="btn btn-large btn-inverse">Return to home page</button>
+        </a>
+        <br/><br/>
+    </div>
 </div>
 
 {% endblock %}  

--- a/esp/templates/themes/editor.html
+++ b/esp/templates/themes/editor.html
@@ -26,11 +26,14 @@ var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% 
       margin-left:10%;
       margin-right:10%;
   }
+  form.centered-form div.controls {
+      margin-left:20%;
+  }
   div.form-actions {
       border-top:None;
   }
   h5 {
-  margin-left:3%;
+      margin-left:3%;
   }
   .sp-palette-row {
       max-width: 132px;
@@ -101,7 +104,7 @@ var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% 
 	    </div>
 	    <div class="controls">
 	      <button type="button" class="btn btn-default" id="addToPalette">Add Another Color</button>
-	      <button type="submit" class="btn btn-primary" name="apply" value="apply">Update Palette</button> 
+	      <button type="submit" class="btn btn-primary" name="apply" value="apply">Update Custom Palette</button> 
 	    </div>
 	  </div>
 	</div>


### PR DESCRIPTION
This fixes the management of a custom theme palette on the `/themes/customize` page. Since we can't change what the theme colors are, I've separated them out and now we only save the "Custom Palette" that is defined by the user:
![image](https://user-images.githubusercontent.com/7232514/128203411-2917b935-d592-45be-a851-c4f0402d6564.png)

If you somehow specify a color that is already in the theme palette or a duplicate of a color already in your custom palette, it's automatically removed. Also, you can now remove any colors from your palette (not just the last one) by clicking on them then clicking the "Remove" button:
![image](https://user-images.githubusercontent.com/7232514/128203733-387d7999-2903-4e01-ac33-10d26ac729ae.png)

I also updated the colorpicker (v. 1 -> v. 2), which is a little more visually appealing. While I was at it, I updated the font size and family pickers so you can actually see what the different font sizes and families look like when you are picking them:
![image](https://user-images.githubusercontent.com/7232514/128203959-ed872c31-c23d-4892-87a7-0603feb4af5e.png)

Fixes https://github.com/learning-unlimited/ESP-Website/issues/2907.