### PR TITLE
Add "Return to main program management page" links to manage modules

### DIFF
--- a/esp/templates/program/modules/accountingmodule/accounting.html
+++ b/esp/templates/program/modules/accountingmodule/accounting.html
@@ -92,4 +92,5 @@ No grant
     <tr><td><strong>Owed</strong></td><td><strong>${{ due|floatformat:"-2" }}</strong></td></tr>
 </table>
 {% endif %}
+{% include "program/modules/admincore/returnlink.html" %}
 {% endblock %}

--- a/esp/templates/program/modules/admincore/deadlines.html
+++ b/esp/templates/program/modules/admincore/deadlines.html
@@ -142,6 +142,8 @@
 
 <p>Please proceed to edit <a href="#existing">existing deadlines</a> or <a href="#new">create a new deadline</a> if necessary.</p>
 
+{% include "program/modules/admincore/returnlink.html" %}
+
 <a name="existing"></a>
 <h2>Existing Deadlines</h2>
 

--- a/esp/templates/program/modules/admincore/registrationtype_management.html
+++ b/esp/templates/program/modules/admincore/registrationtype_management.html
@@ -26,4 +26,6 @@
         <h3 style="font-weight:bold; color:red;">There was an error with saving your settings. Please try again.</h3><br /><br />
     {% endif %}
     <p>If you know what you're doing and you have reason to do so, you may manually manipulate RegistrationTypes in <a href="/admin/program/registrationtype/">the admin panel</a>.</p>
+    
+    {% include "program/modules/admincore/returnlink.html" %}
 {% endblock %}

--- a/esp/templates/program/modules/adminmaterials/listmaterials.html
+++ b/esp/templates/program/modules/adminmaterials/listmaterials.html
@@ -31,8 +31,6 @@ td.instructions {
 From this page, you can view documents related to the program (in the first section of the table below).  Teachers of your classes have also provided materials, which you can review and delete if necessary (in the second section of the table below).  Finally, you may upload new documents using the form at the bottom of the page.
 </p>
 
-{% include "program/modules/admincore/returnlink.html" %}
-
 <table cellpadding="2" cellspacing="0" align="center" width="550">
 <tr>
 		<th colspan="2" style="text-align: center;">
@@ -128,5 +126,7 @@ From this page, you can view documents related to the program (in the first sect
 
 
 </div>
+
+{% include "program/modules/admincore/returnlink.html" %}
 
 {% endblock %}

--- a/esp/templates/program/modules/availabilitymodule/availability_form.html
+++ b/esp/templates/program/modules/availabilitymodule/availability_form.html
@@ -111,4 +111,8 @@ You submitted a schedule with no available times.  You can't register a class wi
 </form>
 {% endif %}
 
+{% if isAdmin %}
+{% include "program/modules/admincore/returnlink.html" %}
+{% endif %}
+
 {% endblock %}

--- a/esp/templates/program/modules/bigboardmodule/bigboard.html
+++ b/esp/templates/program/modules/bigboardmodule/bigboard.html
@@ -147,4 +147,6 @@
     </div>
 {% endif %}
 
+{% include "program/modules/admincore/returnlink.html" %}
+
 {% endblock %}

--- a/esp/templates/program/modules/classsearchmodule/class_search.html
+++ b/esp/templates/program/modules/classsearchmodule/class_search.html
@@ -161,4 +161,5 @@ Your query returned {{queryset|length}} of {{program.classsubject_set.count}} cl
 {% elif query %}
 No classes were found.
 {% endif %}
+{% include "program/modules/admincore/returnlink.html" %}
 {% endblock %}

--- a/esp/templates/program/modules/creditcardviewer/viewpay.html
+++ b/esp/templates/program/modules/creditcardviewer/viewpay.html
@@ -65,5 +65,6 @@ ${{ payment.2 }} billed; ${{ payment.3 }} owed
 </table>
 </div>
 
+{% include "program/modules/admincore/returnlink.html" %}
 {% endblock %}
 

--- a/esp/templates/program/modules/finaidapprovemodule/finaid.html
+++ b/esp/templates/program/modules/finaidapprovemodule/finaid.html
@@ -111,4 +111,5 @@ function toggle(source) {
   {% endif %}
 </div>
 
+{% include "program/modules/admincore/returnlink.html" %}
 {% endblock %}

--- a/esp/templates/program/modules/lineitemsmodule/lineitems.html
+++ b/esp/templates/program/modules/lineitemsmodule/lineitems.html
@@ -114,7 +114,5 @@ You can use this page to add, remove, edit, delete, and import line items, which
 <script id="lineitemsscript" src="/media/scripts/program/modules/lineitems.js" data-prog_url="{{ prog.url }}"></script>
 <script type="text/javascript" src="/media/scripts/expand_display.js"></script>
 
-<br /><br />
-<button type="button" class="btn btn-primary" onclick="location.href = '/manage/{{ prog.url }}/main';">Main Program Management Page</button>
-<br /><br />
+{% include "program/modules/admincore/returnlink.html" %}
 {% endblock %}

--- a/esp/templates/program/modules/mailinglabels/mailinglabel_index.html
+++ b/esp/templates/program/modules/mailinglabels/mailinglabel_index.html
@@ -43,4 +43,6 @@ Using this tool you can create mailing labels for your progrma.
 <li>Good luck!</li>
 </ol>
 
+{% include "program/modules/admincore/returnlink.html" %}
+
 {% endblock %}

--- a/esp/templates/program/modules/resourcemodule/resource_main.html
+++ b/esp/templates/program/modules/resourcemodule/resource_main.html
@@ -35,7 +35,5 @@ Each step below is a form that you can expand or contract by clicking on the hea
 <script id="resourcesscript" src="/media/scripts/program/modules/resources.js" data-prog_url="{{ prog.url }}"></script>
 <script type="text/javascript" src="/media/scripts/expand_display.js"></script>
 
-<br /><br />
-<button type="button" class="btn btn-primary" onclick="location.href = '/manage/{{ prog.url }}/main';">Main Program Management Page</button>
-<br /><br />
+{% include "program/modules/admincore/returnlink.html" %}
 {% endblock %}

--- a/esp/templates/program/modules/studentregphasezero/status.html
+++ b/esp/templates/program/modules/studentregphasezero/status.html
@@ -162,5 +162,6 @@ td {
     {% endfor %}
 </table>
 {% endif %}
+{% include "program/modules/admincore/returnlink.html" %}
 <script type="text/javascript" src="/media/scripts/expand_display.js"></script>
 {% endblock %}

--- a/esp/templates/program/modules/teachereventsmodule/teacher_events.html
+++ b/esp/templates/program/modules/teachereventsmodule/teacher_events.html
@@ -50,4 +50,5 @@ Teacher Events include (for now) <a href="#training">teacher training</a> and <a
 </table>
 </div>
 
+{% include "program/modules/admincore/returnlink.html" %}
 {% endblock %}

--- a/esp/templates/program/modules/volunteermanage/main.html
+++ b/esp/templates/program/modules/volunteermanage/main.html
@@ -82,5 +82,5 @@ You may request groups of volunteers for your program here.  At the <a href="/vo
 </form>
 </div>
 
-
+{% include "program/modules/admincore/returnlink.html" %}
 {% endblock %}


### PR DESCRIPTION
I _think_ this covers all of the management modules that didn't previously have links, but it's entirely possible I missed one or more.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3324.