### PR TITLE
Keep tfoot "headers" from being included in sorttable.js

### DIFF
--- a/esp/templates/program/modules/teacherclassregmodule/section_attendance.html
+++ b/esp/templates/program/modules/teacherclassregmodule/section_attendance.html
@@ -116,9 +116,9 @@ Please select a section from the dropdown below.
             </tbody>
             <tfoot>
                 <tr>
-                    <th colspan="6">TOTAL</th>
-                    <th align="center" name="checkedin_total"></th>
-                    <th align="center" name="attending_total"></th>
+                    <th colspan="6" class="sorttable_nosort">TOTAL</th>
+                    <th align="center" name="checkedin_total" class="sorttable_nosort"></th>
+                    <th align="center" name="attending_total" class="sorttable_nosort"></th>
                 </tr>
             </tfoot>
         </table>
@@ -171,9 +171,9 @@ Please select a section from the dropdown below.
             </tbody>
             <tfoot>
                 <tr>
-                    <th colspan="6">TOTAL</th>
-                    <th align="center" name="checkedin_total"></th>
-                    <th align="center" name="attending_total"></th>
+                    <th colspan="6" class="sorttable_nosort">TOTAL</th>
+                    <th align="center" name="checkedin_total" class="sorttable_nosort"></th>
+                    <th align="center" name="attending_total" class="sorttable_nosort"></th>
                 </tr>
             </tfoot>
         </table>

--- a/esp/templates/program/modules/teacheronsite/sectionroster.html
+++ b/esp/templates/program/modules/teacheronsite/sectionroster.html
@@ -92,9 +92,9 @@ function toggleCheck(element) {
                         </tbody>
                         <tfoot>
                             <tr>
-                                <th colspan="2">TOTAL</th>
-                                <th align="center" name="checkedin_total"></th>
-                                <th align="center" name="attending_total"></th>
+                                <th colspan="2" class="sorttable_nosort">TOTAL</th>
+                                <th align="center" name="checkedin_total" class="sorttable_nosort"></th>
+                                <th align="center" name="attending_total" class="sorttable_nosort"></th>
                             </tr>
                         </tfoot>
                     </table>
@@ -147,9 +147,9 @@ function toggleCheck(element) {
                         </tbody>
                         <tfoot>
                             <tr>
-                                <th colspan="2">TOTAL</th>
-                                <th align="center" name="checkedin_total"></th>
-                                <th align="center" name="attending_total"></th>
+                                <th colspan="2" class="sorttable_nosort">TOTAL</th>
+                                <th align="center" name="checkedin_total" class="sorttable_nosort"></th>
+                                <th align="center" name="attending_total" class="sorttable_nosort"></th>
                             </tr>
                         </tfoot>
                     </table>


### PR DESCRIPTION
This fixes the behavior reported in https://github.com/learning-unlimited/ESP-Website/issues/3395 where the attendance tables would no longer be able to be sorted by specific columns. It appears to have been caused by interaction with the `<tfoot>`, so we just make sure the sorttable.js script doesn't use those "headers".

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3395.