### PR TITLE
More sorttable fixes

### DIFF
--- a/esp/public/media/scripts/sorttable.js
+++ b/esp/public/media/scripts/sorttable.js
@@ -43,7 +43,8 @@ var sorttable = {
 
 	addOnClick: function(info,cells) {
 		for (var i=0,ie=cells.length; i<ie; ++i) {
-			if (/\bsorttable_nosort\b/.test(cells[i].className))
+            // Will G: also check that the cell is a TH
+			if ((/\bsorttable_nosort\b/.test(cells[i].className)) || cells[i].nodeName != 'TH')
 				continue;
 			if (!info[i])
 				info[i] = {known:-1,func:null,heads:[]};
@@ -251,6 +252,7 @@ var sorttable = {
 		var i,tb,tbe;
 
 		sorttable.updateArrows(info,col,inverse,!sorted);
+        // Will G: flipped order here to save computational time
 		if (sorted) {
 			sorttable.reverseSort(table);
 			return;
@@ -345,6 +347,7 @@ var sorttable = {
 		return aa - bb;
 	},
 	sort_alpha: function(a,b) {
+        // Will G: added .toLowerCase() for better alphanumeric sorting
 		if (a[0].toLowerCase() == b[0].toLowerCase()) return 0;
 		if (a[0].toLowerCase() < b[0].toLowerCase()) return -1;
 		return 1;

--- a/esp/templates/program/modules/onsiteattendance/attendance.html
+++ b/esp/templates/program/modules/onsiteattendance/attendance.html
@@ -105,7 +105,7 @@ or select a timeslot from the dropdown below to see attendance stats:
 <div class="dspcont">
 <table class="sortable" width="100%">
 <tr>
-    <th width="5%">#</th>
+    <th width="5%" class="sorttable_nosort">#</th>
     <th width="15%">First Name</th>
     <th width="15%">Last Name</th>
     <th width="15%">Username</th>
@@ -115,7 +115,7 @@ or select a timeslot from the dropdown below to see attendance stats:
 </tr>
 {% for student in checked_in_ts %}
 <tr>
-    <th class="small">{{ forloop.counter }}</th>
+    <th class="small sorttable_nosort">{{ forloop.counter }}</th>
     <td>{{ student.first_name }}</td>
     <td>{{ student.last_name }}</td>
     <td><a href="/manage/userview?username={{ student.username|urlencode }}&program={{ program.id }}">{{ student.username }}</a></td>
@@ -161,7 +161,7 @@ or select a timeslot from the dropdown below to see attendance stats:
 <div class="dspcont">
 <table class="sortable" width="100%">
 <tr>
-    <th width="5%">#</th>
+    <th width="5%" class="sorttable_nosort">#</th>
     <th width="15%">First Name</th>
     <th width="15%">Last Name</th>
     <th width="15%">Username</th>
@@ -172,7 +172,7 @@ or select a timeslot from the dropdown below to see attendance stats:
 </tr>
 {% for student in not_attending %}
 <tr>
-    <th class="small">{{ forloop.counter }}</th>
+    <th class="small sorttable_nosort">{{ forloop.counter }}</th>
     <td>{{ student.first_name }}</td>
     <td>{{ student.last_name }}</td>
     <td><a href="/manage/userview?username={{ student.username|urlencode }}&program={{ program.id }}">{{ student.username }}</a></td>
@@ -219,7 +219,7 @@ or select a timeslot from the dropdown below to see attendance stats:
 <div class="dspcont">
 <table class="sortable" width="100%">
 <tr>
-    <th width="5%">#</th>
+    <th width="5%" class="sorttable_nosort">#</th>
     <th width="10%">First Name</th>
     <th width="10%">Last Name</th>
     <th width="15%">Username</th>
@@ -231,7 +231,7 @@ or select a timeslot from the dropdown below to see attendance stats:
 </tr>
 {% for student in onsite %}
 <tr>
-    <th class="small">{{ forloop.counter }}</th>
+    <th class="small sorttable_nosort">{{ forloop.counter }}</th>
     <td>{{ student.first_name }}</td>
     <td>{{ student.last_name }}</td>
     <td><a href="/manage/userview?username={{ student.username|urlencode }}&program={{ program.id }}">{{ student.username }}</a></td>
@@ -278,7 +278,7 @@ or select a timeslot from the dropdown below to see attendance stats:
 <div class="dspcont">
 <table class="sortable">
 <tr>
-    <th width="5%">#</th>
+    <th width="5%" class="sorttable_nosort">#</th>
     <th width="10%">Email Code</th>
     <th width="30%">Class Title</th>
     <th width="20%">Teachers{% if program|hasModule:"TeacherModeratorModule" %} and {{ program.getModeratorTitle }}s{% endif %}</th>
@@ -287,7 +287,7 @@ or select a timeslot from the dropdown below to see attendance stats:
 </tr>
 {% for section in no_attendance %}
 <tr>
-    <th class="small">{{ forloop.counter }}</th>
+    <th class="small sorttable_nosort">{{ forloop.counter }}</th>
     <td>{{ section.emailcode }}</td>
     <td>{{ section.title }}</td>
     <td>

--- a/esp/templates/program/modules/teacherclassregmodule/section_attendance.html
+++ b/esp/templates/program/modules/teacherclassregmodule/section_attendance.html
@@ -91,7 +91,7 @@ Please select a section from the dropdown below.
             </tr>
                 {% for student in section.enrolled_list %}
                     <tr>
-                        <th class="small">{{ forloop.counter }}</th>
+                        <th class="small sorttable_nosort">{{ forloop.counter }}</th>
                         <td>{{ student.first_name }}</td>
                         <td>{{ student.last_name }}</td>
                         <td align="center">{{ student.id }}</td>
@@ -152,7 +152,7 @@ Please select a section from the dropdown below.
             <tbody>
                 {% for student in section.attended_list %}
                     <tr>
-                        <th class="small">{{ forloop.counter }}</th>
+                        <th class="small sorttable_nosort">{{ forloop.counter }}</th>
                         <td>{{ student.first_name }}</td>
                         <td>{{ student.last_name }}</td>
                         <td align="center">{{ student.id }}</td>


### PR DESCRIPTION
This fixes a bug where a sorttable with a single row with a `<th>` tag in it assumes that all of the `<td>`s in that row are also `<th>`s, causing them to have the arrows and be sortable. I'm honestly not sure what the purpose of the code in sorttable.js is to handle this single row case, but this seems like a better overall fix anyways (where we just always check that the header is a `<th>`).

While I was at it, I added some comments to sorttable.js to point out what local modifications I've made here and in the past. I also added the "nosort" class to a bunch of `<th>` tags that we don't want to be handled.