### PR TITLE
Student big board upgrades

### DIFF
--- a/esp/esp/program/modules/handlers/bigboardmodule.py
+++ b/esp/esp/program/modules/handlers/bigboardmodule.py
@@ -185,7 +185,7 @@ class BigBoardModule(ProgramModuleObj):
     def popular_classes_wrapper(self, prog):
         # this caches this based on time, so even if the dependencies are updated,
         # we only update the cache every 105 seconds
-        return popular_classes(self, prog)
+        return self.popular_classes(prog)
 
     @cache_function
     def popular_classes(self, prog):

--- a/esp/public/media/default_styles/bigboard.css
+++ b/esp/public/media/default_styles/bigboard.css
@@ -35,6 +35,16 @@
   line-height: normal;
 }
 
+.popular-classeses {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.popular-classes-chart {
+  width: 50%;
+}
+
 .bigboard-number-block {
   display: inline-block;
   min-width: 250px;

--- a/esp/templates/program/modules/bigboardmodule/bigboard.html
+++ b/esp/templates/program/modules/bigboardmodule/bigboard.html
@@ -127,23 +127,77 @@
 
 {% if popular_classes %}
     <div class="popular-classeses">
-      {% for description, classes in popular_classes %}
-        <div class="popular-classes-block">
-          <div class="popular-classes-heading">
-            {{description}}
-          </div>
-          <table class="popular-classes bigboard-description">
-            {% for class in classes %}
-              <tr>
-                <td class="popular-class-num">{{class.points}}</td>
-                <td class="popular-class-title">
-                  {{class.category__symbol}}{{class.id}}: {{class.title}}
-                </td>
-              </tr>
-            {% endfor %}
-          </table>
-        </div>
-      {% endfor %}
+        {% for description, series in popular_classes %}
+        <div class="popular-classes-chart" id="popular-classes-chart-{{ forloop.counter }}"></div>
+        <script type="text/javascript">
+            $j('#popular-classes-chart-{{ forloop.counter }}').highcharts({
+                // mostly grabbed from https://www.highcharts.com/demo/column-stacked
+                chart: {
+                    type: 'column',
+                    zoomType: 'xy',
+                    panning: {
+                        enabled: true,
+                        type: 'xy', // currently mostly broken for the y axis (https://github.com/highcharts/highcharts/issues/16217)
+                                    // but including it here for when it is fixed in highcharts
+                    },
+                    panKey: 'shift'
+                },
+                credits: {
+                    enabled: false
+                },
+                title: {
+                    text: '{{ description }}'
+                },
+                subtitle: {
+                    text: 'Click and drag to zoom in. Hold down shift key to pan.'
+                },
+                xAxis: {
+                    type: 'category',
+                    categories: [{% for ts in timeslots %}'{{ ts.start }}'{% if not forloop.last %},{% endif %}{% endfor %}],
+                    min: 0,
+                    max: {{ timeslots.count|add:"-1" }}
+                },
+                yAxis: {
+                    title: {
+                        text: '# of Students'
+                    },
+                    stackLabels: {
+                        enabled: true,
+                        style: {
+                            fontWeight: 'bold',
+                            color: ( // theme
+                                Highcharts.defaultOptions.title.style &&
+                                Highcharts.defaultOptions.title.style.color
+                            ) || 'gray'
+                        }
+                    }
+                },
+                tooltip: {
+                    headerFormat: '<b>{point.x}</b><br/>',
+                    pointFormat: '{series.name}: {point.y}<br/>Total: {point.stackTotal}'
+                },
+                plotOptions: {
+                    column: {
+                        stacking: 'normal',
+                        dataLabels: {
+                            enabled: true
+                        }
+                    }
+                },
+                legend: {
+                    enabled: false
+                },
+                series: [
+                    {% for ser in series %}
+                    {
+                        name: '{{ ser.name|truncatechars:30 }}',
+                        data: [{% for dat in ser.data %}['{{ dat.0 }}', {{ dat.1 }}],{% endfor %}]
+                    }{% if not forloop.last %},{% endif %}
+                    {% endfor %}
+                ]
+            });
+        </script>
+        {% endfor %}
     </div>
 {% endif %}
 

--- a/esp/templates/program/modules/bigboardmodule/bigboard.html
+++ b/esp/templates/program/modules/bigboardmodule/bigboard.html
@@ -16,6 +16,167 @@
   <script type="text/javascript" src="//code.highcharts.com/highcharts-more.js"></script>
   <script type="text/javascript" src="//code.highcharts.com/modules/no-data-to-display.js"></script>
   <script type="text/javascript" src="//code.highcharts.com/modules/solid-gauge.js"></script>
+  <script type="text/javascript">
+    // Fix for vertical panning from https://github.com/highcharts/highcharts/issues/16217
+    (function(H) {
+      var fireEvent = H.fireEvent,
+        pick = H.pick,
+        isNumber = H.isNumber,
+        objectEach = H.objectEach,
+        css = H.css;
+
+      H.Chart.prototype.pan = function(e, panning) {
+        var chart = this,
+          hoverPoints = chart.hoverPoints,
+          panningOptions = (typeof panning === 'object' ?
+            panning : {
+              enabled: panning,
+              type: 'x'
+            }),
+          chartOptions = chart.options.chart,
+          hasMapNavigation = chart.options.mapNavigation &&
+          chart.options.mapNavigation.enabled;
+        if (chartOptions && chartOptions.panning) {
+          chartOptions.panning = panningOptions;
+        }
+        var type = panningOptions.type;
+        var doRedraw;
+        fireEvent(this, 'pan', {
+          originalEvent: e
+        }, function() {
+          // remove active points for shared tooltip
+          if (hoverPoints) {
+            hoverPoints.forEach(function(point) {
+              point.setState();
+            });
+          }
+          var axes = chart.xAxis;
+          if (type === 'xy') {
+            axes = axes.concat(chart.yAxis);
+          } else if (type === 'y') {
+            axes = chart.yAxis;
+          }
+          var nextMousePos = {};
+          axes.forEach(function(axis) {
+            if (!axis.options.panningEnabled || axis.options.isInternal) {
+              return;
+            }
+            var horiz = axis.horiz,
+              mousePos = e[horiz ? 'chartX' : 'chartY'],
+              mouseDown = horiz ? 'mouseDownX' : 'mouseDownY',
+              startPos = chart[mouseDown],
+              halfPointRange = axis.minPointOffset || 0,
+              pointRangeDirection = (axis.reversed && !chart.inverted) ||
+              (!axis.reversed && chart.inverted) ?
+              -1 :
+              1,
+              extremes = axis.getExtremes(),
+              panMin = axis.toValue(startPos - mousePos, true) +
+              halfPointRange * pointRangeDirection,
+              panMax = axis.toValue(startPos + axis.len - mousePos, true) -
+              ((halfPointRange * pointRangeDirection) ||
+                (axis.isXAxis && axis.pointRangePadding) ||
+                0),
+              flipped = panMax < panMin,
+              hasVerticalPanning = axis.hasVerticalPanning();
+            var newMin = flipped ? panMax : panMin,
+              newMax = flipped ? panMin : panMax,
+              panningState = axis.panningState,
+              spill;
+            // General calculations of panning state.
+            // This is related to using vertical panning. (#11315).
+            if (hasVerticalPanning &&
+              !axis.isXAxis && (!panningState || panningState.isDirty)) {
+              axis.series.forEach(function(series) {
+                var processedData = series.getProcessedData(true),
+                  dataExtremes = series.getExtremes(processedData.yData,
+                    true);
+                if (!panningState) {
+                  panningState = {
+                    startMin: Number.MAX_VALUE,
+                    startMax: -Number.MAX_VALUE
+                  };
+                }
+                if (isNumber(dataExtremes.dataMin) &&
+                  isNumber(dataExtremes.dataMax)) {
+                  panningState.startMin = Math.min(pick(series.options.threshold, Infinity), dataExtremes.dataMin, panningState.startMin);
+                  panningState.startMax = Math.max(pick(series.options.threshold, -Infinity), dataExtremes.dataMax, panningState.startMax);
+                }
+              });
+            }
+            var paddedMin = Math.min(pick(panningState && panningState.startMin,
+                extremes.dataMin),
+              halfPointRange ?
+              extremes.min :
+              axis.toValue(axis.toPixels(extremes.min) -
+                axis.minPixelPadding));
+
+            var paddedMax = Math.max(
+              panningState && panningState.startMax,
+              extremes.dataMax,
+              halfPointRange ? extremes.max : axis.toValue(axis.toPixels(extremes.max) + axis.minPixelPadding)
+            );
+            axis.panningState = panningState;
+            // It is not necessary to calculate extremes on ordinal axis,
+            // because they are already calculated, so we don't want to
+            // override them.
+            if (!axis.isOrdinal) {
+              // If the new range spills over, either to the min or max,
+              // adjust the new range.
+              spill = paddedMin - newMin;
+
+              if (spill > 0) {
+                newMax += spill;
+                newMin = paddedMin;
+              }
+              spill = newMax - paddedMax;
+              if (spill > 0) {
+                newMax = paddedMax;
+                newMin -= spill;
+              }
+
+              //console.log(paddedMax)
+              // Set new extremes if they are actually new
+              if (
+                axis.series.length &&
+                newMin !== extremes.min &&
+                newMax !== extremes.max &&
+                newMin >= paddedMin &&
+                newMax <= paddedMax
+              ) {
+
+                axis.setExtremes(newMin, newMax, false, false, {
+                  trigger: 'pan'
+                });
+                if (!chart.resetZoomButton &&
+                  !hasMapNavigation &&
+                  // Show reset zoom button only when both newMin and
+                  // newMax values are between padded axis range.
+                  newMin !== paddedMin &&
+                  newMax !== paddedMax &&
+                  type.match('y')) {
+                  chart.showResetZoom();
+                  axis.displayBtn = false;
+                }
+                doRedraw = true;
+              }
+              // set new reference for next run:
+              nextMousePos[mouseDown] = mousePos;
+            }
+          });
+          objectEach(nextMousePos, function(pos, down) {
+            chart[down] = pos;
+          });
+          if (doRedraw) {
+            chart.redraw(false);
+          }
+          css(chart.container, {
+            cursor: 'move'
+          });
+        });
+      };
+    })(Highcharts)
+  </script>
 {% endblock xtrajs %}
 
 
@@ -137,8 +298,7 @@
                     zoomType: 'xy',
                     panning: {
                         enabled: true,
-                        type: 'xy', // currently mostly broken for the y axis (https://github.com/highcharts/highcharts/issues/16217)
-                                    // but including it here for when it is fixed in highcharts
+                        type: 'xy', // see fix above
                     },
                     panKey: 'shift'
                 },


### PR DESCRIPTION
This makes two changes to the student big board (/bigboard):

1. Split the "signed up for classes" line into separate "set class lottery preferences" and "enrolled in classes" lines (for the example below I changed the arguments for `make_graph_data()`)
![image](https://user-images.githubusercontent.com/7232514/129921469-e8e1ec91-07ad-4a68-bc59-f63b71abc296.png)

2. Changed the popular class information from lists to bar charts (through time), adding another axis of information to the visualization. The charts cover stars, first priorities, and enrollments. Each chart is only shown if we have data for that information type.
![image](https://user-images.githubusercontent.com/7232514/129921754-d550e31b-e8f2-40e3-8172-705f3c6ab017.png)


Fixes https://github.com/learning-unlimited/ESP-Website/issues/2728.