### PR TITLE
Add confirm page for volunteer shift import

### DIFF
--- a/esp/esp/program/modules/handlers/volunteermanage.py
+++ b/esp/esp/program/modules/handlers/volunteermanage.py
@@ -86,8 +86,10 @@ class VolunteerManage(ProgramModuleObj):
             response['Content-Disposition'] = 'attachment; filename=volunteers.csv'
             return response
 
-        elif 'import' in request.POST:
-            context = self.volunteer_import(request, tl, one, two, module, extra, prog)
+        elif 'import' in request.POST or 'import_confirm' in request.POST:
+            (response, context) = self.volunteer_import(request, tl, one, two, module, extra, prog)
+            if response: # Show the import confirmation page
+                return response
             form = VolunteerRequestForm(program=prog)
 
         elif 'op' in request.GET:
@@ -118,6 +120,12 @@ class VolunteerManage(ProgramModuleObj):
         context = {}
         response = None
 
+        import_mode = 'preview'
+        to_import = []
+        if 'import_confirm' in request.POST and request.POST['import_confirm'] == 'yes':
+            import_mode = 'save'
+            to_import = request.POST.getlist('to_import')
+
         import_form = VolunteerImportForm(request.POST, cur_prog = prog)
         if not import_form.is_valid():
             context['import_request_form'] = import_form
@@ -128,34 +136,49 @@ class VolunteerManage(ProgramModuleObj):
                 context['import_error'] = "You can only import shifts from previous programs"
             else:
                 #Figure out timeslot dates
+                new_requests = []
                 prev_timeslots = []
-                prev_requests = past_program.getVolunteerRequests().order_by('timeslot__start')
+                prev_requests = past_program.getVolunteerRequests()
                 for prev_request in prev_requests:
                     prev_timeslots.append(prev_request.timeslot)
                 time_delta = start_date - prev_timeslots[0].start.date()
                 for i,orig_timeslot in enumerate(prev_timeslots):
-                    new_timeslot, _ = Event.objects.get_or_create(
+                    new_timeslot = Event(
                         program = self.program,
                         start = orig_timeslot.start + time_delta,
                         end   = orig_timeslot.end + time_delta,
                         event_type = orig_timeslot.event_type,
-                        defaults={
-                            'short_description': orig_timeslot.short_description,
-                            'description': orig_timeslot.description,
-                            'priority': orig_timeslot.priority,
-                        }
+                        short_description = orig_timeslot.short_description,
+                        description = orig_timeslot.description,
+                        priority = orig_timeslot.priority
                     )
-                    new_timeslot.save()
-                    new_request, _ = VolunteerRequest.objects.get_or_create(
+                    #   Save the new timeslot only if it doesn't duplicate an existing one
+                    if import_mode == 'save' and str(prev_requests[i].id) in to_import:
+                        if Event.objects.filter(program=new_timeslot.program, start=new_timeslot.start, end=new_timeslot.end, event_type=new_timeslot.event_type).exists():
+                            new_timeslot = Event.objects.get(program=new_timeslot.program, start=new_timeslot.start, end=new_timeslot.end, event_type=new_timeslot.event_type)
+                        else:
+                            new_timeslot.save()
+                    new_request = VolunteerRequest(
                         program = self.program,
                         timeslot = new_timeslot,
-                        defaults={
-                            'num_volunteers': prev_requests[i].num_volunteers,
-                        }
+                        num_volunteers = prev_requests[i].num_volunteers
                     )
-                    new_request.save()
+                    #   Save the new timeslot only if it doesn't duplicate an existing one
+                    if import_mode == 'save' and not VolunteerRequest.objects.filter(program=new_request.program, timeslot=new_timeslot,
+                                                                                     num_volunteers=new_request.num_volunteers).exists() and str(prev_requests[i].id) in to_import:
+                        new_request.save()
+                    else:
+                        new_request.old_id = prev_requests[i].id
+                    new_requests.append(new_request)
+                #   Render a preview page showing the resources for the previous program if desired
+                context['past_program'] = past_program
+                context['start_date'] = start_date.strftime('%m/%d/%Y')
+                context['new_requests'] = new_requests
+                if import_mode == 'preview':
+                    context['prog'] = self.program
+                    response = render_to_response(self.baseDir()+'import.html', request, context)
 
-        return context
+        return (response, context)
 
     @aux_call
     @needs_admin

--- a/esp/templates/program/modules/volunteermanage/import.html
+++ b/esp/templates/program/modules/volunteermanage/import.html
@@ -1,0 +1,77 @@
+{% extends "main.html" %}
+
+{% block title %}Manage Volunteers for {{ program.niceName }}{% endblock %}
+
+{% block stylesheets %}
+    {{ block.super }}
+    <link rel="stylesheet" href="/media/styles/forms.css" type="text/css" />
+{% endblock %}
+
+{% block xtrajs %}
+<script>
+function toggle(source) {
+  $j('input[name=to_import]').prop('checked', source.checked);
+}
+</script>
+{% endblock %}
+
+{% block content %}
+
+<h1>Manage Volunteers for {{ program.niceName }}</h1>
+
+{% if new_requests %}
+    <h2>Confirm Volunteer Request Import</h2>
+
+    {% load render_qsd %}
+    {% inline_program_qsd_block program "volunteer_import_instructions" %}
+    <p>
+    You have chosen to import the volunteer requests from {{ past_program.niceName }} to {{ prog.niceName }}.  Please review the table below carefully before clicking "Submit" to complete the import.  In particular, check that each resource type has the appropriate start and end times, descriptions, and number of volunteers.  If any of this data is not correct, please <a href="/manage/{{ prog.getUrlBase }}/volunteering">GO BACK</a>; add the resource types manually or contact <a href="mailto:{{ DEFAULT_EMAIL_ADDRESSES.support }}">technical support</a> for assistance in automating the process.
+    </p>
+    {% end_inline_program_qsd_block %}
+
+    <div id="program_form">
+        <form method="post" action="{{ request.path }}">
+            <input type="hidden" name="import_confirm" value="yes" />
+            <input type="hidden" name="program" value="{{ past_program.id }}" />
+            <input type="hidden" name="start_date" value="{{ start_date }}" />
+            <table align="center" cellpadding="0" cellspacing="0" width="550">
+                <tr><th colspan="3">Proposed volunteer requests for {{ prog.niceName }}</th></tr>
+                <tr><td colspan="3"><table cellpadding="0" cellspacing="0" width="100%">
+                <tr>
+                    <td width="30%"><b>Time</b></td>
+                    <td width="55%"><b>Description</b></td>
+                    <td><b>Import? <input type="checkbox" onclick=toggle(this) checked></b></td>
+                </tr>
+                {% for vr in new_requests %}
+                {% ifchanged vr.timeslot.start.date %}
+                <th colspan="3" align="center">{{ vr.timeslot.pretty_date }}</th>
+                {% endifchanged %}
+                <tr>
+                    <td>{{ vr.timeslot.short_time }}</td>
+                    <td>{{ vr.timeslot.description }}: {{ vr.num_offers }} / {{ vr.num_volunteers }} volunteers</td>
+                    <td><input type="checkbox" name="to_import" value="{{ vr.old_id }}" checked></td>
+                </tr>
+                {% endfor %}
+                </table></td></tr>
+                <tr><td colspan="3" align="center"><input class="fancybutton" type="submit" value="Complete Import" /></td></tr>
+            </table>
+        </form>
+    </div>
+
+{% else %}
+
+    <h2>Volunteer Request Import Not Available</h2>
+
+    {% load render_qsd %}
+    {% inline_program_qsd_block program "volunteer_import_empty" %}
+    <p>
+    You have chosen to import the volunteer requests from {{ past_program.niceName }}, but this program does not have any volunteer requests to import. Please <a href="/manage/{{ prog.getUrlBase }}/volunteering">go back</a> and add volunteer requests manually or select a different program from which to import volunteer requests.
+    </p>
+    {% end_inline_program_qsd_block %}
+
+{% endif %}
+
+<br>
+<a class="btn btn-primary" href="/manage/{{ prog.getUrlBase }}/volunteering">Return to the volunteer management page</a>
+
+{% endblock %}

--- a/esp/templates/program/modules/volunteermanage/import.html
+++ b/esp/templates/program/modules/volunteermanage/import.html
@@ -20,12 +20,12 @@ function toggle(source) {
 <h1>Manage Volunteers for {{ program.niceName }}</h1>
 
 {% if new_requests %}
-    <h2>Confirm Volunteer Request Import</h2>
+    <h2>Confirm Volunteer Shift Import</h2>
 
     {% load render_qsd %}
     {% inline_program_qsd_block program "volunteer_import_instructions" %}
     <p>
-    You have chosen to import the volunteer requests from {{ past_program.niceName }} to {{ prog.niceName }}.  Please review the table below carefully before clicking "Submit" to complete the import.  In particular, check that each resource type has the appropriate start and end times, descriptions, and number of volunteers.  If any of this data is not correct, please <a href="/manage/{{ prog.getUrlBase }}/volunteering">GO BACK</a>; add the resource types manually or contact <a href="mailto:{{ DEFAULT_EMAIL_ADDRESSES.support }}">technical support</a> for assistance in automating the process.
+    You have chosen to import the volunteer shifts from {{ past_program.niceName }} to {{ prog.niceName }}.  Please review the table below carefully before clicking "Submit" to complete the import.  In particular, check that each shift has the appropriate start and end times, descriptions, and number of volunteers.  If any of this data is not correct, please <a href="/manage/{{ prog.getUrlBase }}/volunteering">GO BACK</a>; add the volunteer shifts manually or contact <a href="mailto:{{ DEFAULT_EMAIL_ADDRESSES.support }}">technical support</a> for assistance in automating the process.
     </p>
     {% end_inline_program_qsd_block %}
 
@@ -35,7 +35,7 @@ function toggle(source) {
             <input type="hidden" name="program" value="{{ past_program.id }}" />
             <input type="hidden" name="start_date" value="{{ start_date }}" />
             <table align="center" cellpadding="0" cellspacing="0" width="550">
-                <tr><th colspan="3">Proposed volunteer requests for {{ prog.niceName }}</th></tr>
+                <tr><th colspan="3">Proposed volunteer shifts for {{ prog.niceName }}</th></tr>
                 <tr><td colspan="3"><table cellpadding="0" cellspacing="0" width="100%">
                 <tr>
                     <td width="30%"><b>Time</b></td>
@@ -60,12 +60,12 @@ function toggle(source) {
 
 {% else %}
 
-    <h2>Volunteer Request Import Not Available</h2>
+    <h2>Volunteer Shift Import Not Available</h2>
 
     {% load render_qsd %}
     {% inline_program_qsd_block program "volunteer_import_empty" %}
     <p>
-    You have chosen to import the volunteer requests from {{ past_program.niceName }}, but this program does not have any volunteer requests to import. Please <a href="/manage/{{ prog.getUrlBase }}/volunteering">go back</a> and add volunteer requests manually or select a different program from which to import volunteer requests.
+    You have chosen to import the volunteer shifts from {{ past_program.niceName }}, but this program does not have any volunteer shifts to import. Please <a href="/manage/{{ prog.getUrlBase }}/volunteering">go back</a> and add volunteer shifts manually or select a different program from which to import volunteer shifts.
     </p>
     {% end_inline_program_qsd_block %}
 


### PR DESCRIPTION
This adds a confirmation page (like those for importing resources) for when importing volunteer shifts from another program.

![image](https://user-images.githubusercontent.com/7232514/130327471-7ae4010d-7ebe-465c-afc9-d7b581abf00d.png)

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3327.