### PR TITLE
Add test coverage stats

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,12 +50,9 @@ jobs:
       env:
         TRAVIS_JOB: ${{ matrix.travis_job }}
       run: deploy/travis/script
-  codecov:
-    name: Upload Coverage to Codecov
-    needs: build
-    runs-on: ubuntu-20.04
-    steps:
-    - name: 
+    - name: Upload Coverage to Codecov
+      if: ${{ matrix.travis_job == 'test' }}
       uses: codecov/codecov-action@v2
       with:
         fail_ci_if_error: true
+    

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,4 +55,5 @@ jobs:
       uses: codecov/codecov-action@v2
       with:
         fail_ci_if_error: true
+        verbose: true
     

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,3 +50,7 @@ jobs:
       env:
         TRAVIS_JOB: ${{ matrix.travis_job }}
       run: deploy/travis/script
+    - name: Upload Coverage to Codecov
+      uses: codecov/codecov-action@v2
+      with:
+        fail_ci_if_error: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,12 @@ jobs:
       env:
         TRAVIS_JOB: ${{ matrix.travis_job }}
       run: deploy/travis/script
-    - name: Upload Coverage to Codecov
+  codecov:
+    name: Upload Coverage to Codecov
+    needs: build
+    runs-on: ubuntu-20.04
+    steps:
+    - name: 
       uses: codecov/codecov-action@v2
       with:
         fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.com/learning-unlimited/ESP-Website.svg?branch=main)](https://travis-ci.com/learning-unlimited/ESP-Website)
+[![codecov](https://codecov.io/gh/learning-unlimited/ESP-Website/branch/main/graph/badge.svg?token=eY0C5a1Lju)](https://codecov.io/gh/learning-unlimited/ESP-Website)
 # ESP Website
 A website to help manage the logistics of large short-term educational programs
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/deploy/travis/install
+++ b/deploy/travis/install
@@ -5,6 +5,7 @@ if [ "$TRAVIS_JOB" = "test" ]; then
     sudo apt-get install -y $(cat esp/packages_base.txt | grep -v ^memcached | grep -v ^postgres | grep -v ^libpq-dev | grep -v ^.*pip)
     esp/packages_base_manual_install.sh
     pip2 install -r esp/requirements.txt -q --log pip.log || (tail pip.log && exit 1)
+    pip2 install coverage
 elif [ "$TRAVIS_JOB" = "lint" ]; then
     pip2 install flake8
 else

--- a/deploy/travis/script
+++ b/deploy/travis/script
@@ -4,7 +4,7 @@ set -euf -o pipefail
 if [ "$TRAVIS_JOB" = "test" ]; then
     cd esp
     ./manage.py collectstatic --noinput -v 0
-    ./manage.py test
+    coverage run --source=. ./manage.py test
 elif [ "$TRAVIS_JOB" = "lint" ]; then
     deploy/lint
 else

--- a/deploy/travis/script
+++ b/deploy/travis/script
@@ -5,6 +5,7 @@ if [ "$TRAVIS_JOB" = "test" ]; then
     cd esp
     ./manage.py collectstatic --noinput -v 0
     coverage run --source=. ./manage.py test
+    coverage xml
 elif [ "$TRAVIS_JOB" = "lint" ]; then
     deploy/lint
 else


### PR DESCRIPTION
This modifies a github action to assess the codebase coverage of our tests using the [coverage.py](http://coverage.readthedocs.io/) package. It then uploads the results to codecov.io. By default the coverage is posted as a comment to every PR, but I turned that off.

Fixes #989.