### PR TITLE
Theme editor fixes

### DIFF
--- a/esp/esp/themes/controllers.py
+++ b/esp/esp/themes/controllers.py
@@ -533,6 +533,11 @@ class ThemeController(object):
         for match in re.findall(r'@(\w+):\s*(.*?);', data):
             vars[match[0]] = match[1]
 
+        #   Substitute LESS variables
+        for key, val in vars.items():
+            if val[1:len(val)] in vars.keys():
+                vars[key] = vars[val[1:len(val)]]
+
         #   Collect save name stored in file
         save_name_match = re.search(r'// Theme Name: (.+?)\n', data)
         if save_name_match:

--- a/esp/esp/themes/settings.py
+++ b/esp/esp/themes/settings.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 
 from os import path
+from collections import OrderedDict
 
 # can we avoid hardcoding this?
 less_dir = path.join(settings.PROJECT_ROOT, 'public','media','theme_editor','less') #directory containing less files used by theme editor
@@ -10,22 +11,35 @@ variables_less = path.join(less_dir, 'variables.less')
 palette_dir = path.join(settings.PROJECT_ROOT, 'public','media','theme_editor')
 
 # and this...
-sans_serif_fonts = {"Impact":"Impact, Charcoal, sans-serif",
-                    "Palatino Linotype":"'Palatino Linotype', 'Book Antiqua', Palatino, serif",
-                    "Tahoma":"Tahoma, Geneva, sans-serif",
-                    "Century Gothic":"'Century Gothic', sans-serif",
-                    "Lucida Sans Unicode":"'Lucida Sans Unicode', 'Lucida Grande', sans-serif",
-                    "Arial Black":"'Arial Black', Gadget, sans-serif",
-                    "Times New Roman":"'Times New Roman', Times, serif",
-                    "Arial Narrow":"'Arial Narrow', sans-serif",
-                    "Verdana":"Verdana, Geneva, sans-serif",
-                    "Copperplate Gothic Light":"'Copperplate Gothic Light', Copperplate, sans-serif",
-                    "Lucida Console":"'Lucida Console', Monaco, monospace",
-                    "Gill Sans":"'Gill Sans', 'Gill Sans MT', sans-serif",
-                    "Trebuchet MS":"'Trebuchet MS', Helvetica', sans-serif",
-                    "Courier New":"'Courier New', Courier, monospace",
-                    "Arial":"Arial, Helvetica, sans-serif",
-                    "Georgia":"Georgia, serif"}
+sans_serif_fonts = OrderedDict([("Arial", "Arial, sans-serif"),
+                    ("Arial Black", "'Arial Black', sans-serif"),
+                    ("Arial Narrow", "'Arial Narrow', sans-serif"),
+                    ("Century Gothic", "'Century Gothic', sans-serif"),
+                    ("Gill Sans", "'Gill Sans', sans-serif"),
+                    ("Helvetica",  "Helvetica, sans-serif"),
+                    ("Impact", "Impact, Charcoal, sans-serif"),
+                    ("Lucida Sans Unicode", "'Lucida Sans Unicode', sans-serif"),
+                    ("Optima", "Optima, sans-serif"),
+                    ("Tahoma", "Tahoma, Geneva, sans-serif"),
+                    ("Trebuchet MS", "'Trebuchet MS', sans-serif"),
+                    ("Verdana", "Verdana, Geneva, sans-serif"),
+                    ("American Typewriter", "'American Typewriter', serif"),
+                    ("Bookman", "Bookman, serif"),
+                    ("Copperplate Gothic Light", "'Copperplate Gothic Light', serif"),
+                    ("Didot", "Didot, serif"),
+                    ("Georgia", "Georgia, serif"),
+                    ("Palatino Linotype", "'Palatino Linotype', serif"),
+                    ("Times", "Times, serif"),
+                    ("Times New Roman", "'Times New Roman', serif"),
+                    ("Andale Mono", "'Andale Mono', monospace"),
+                    ("Courier New", "'Courier New', monospace"),
+                    ("Lucida Console", "'Lucida Console', monospace"),
+                    ("Monaco", "Monaco, monospace"),
+                    ("Apple Chancery", "'Apple Chancery', cursive"),
+                    ("Bradley Hand", "'Bradley Hand', cursive"),
+                    ("Brush Script MT", "'Brush Script MT', cursive"),
+                    ("Comic Sans MS", "'Comic Sans MS', cursive"),
+                    ])
 
 THEME_DEBUG = False
 COMPILED_CSS_FILE = "theme_compiled.css"

--- a/esp/esp/themes/views.py
+++ b/esp/esp/themes/views.py
@@ -228,7 +228,7 @@ def editor(request):
     context['last_used_setting'] = tc.get_current_customization()
 
     #   Load a bunch of preset fonts
-    context['sans_fonts'] = sorted(themes_settings.sans_serif_fonts.iteritems())
+    context['sans_fonts'] = themes_settings.sans_serif_fonts.iteritems()
 
     #   Load the theme-specific options
     adv_vars = tc.find_less_variables(current_theme, theme_only=True)

--- a/esp/public/media/theme_editor/themes/Default.less
+++ b/esp/public/media/theme_editor/themes/Default.less
@@ -52,7 +52,7 @@
 
 // Typography
 // -------------------------
-@sansFontFamily: "Copperplate Gothic Light", "Helvetica Neue", Helvetica, Arial, sans-serif;
+@sansFontFamily:        Helvetica, Arial, sans-serif;
 @serifFontFamily:       Georgia, "Times New Roman", Times, serif;
 @monoFontFamily:        Menlo, Monaco, Consolas, "Courier New", monospace;
 

--- a/esp/public/media/theme_editor/themes/Rupaa.less
+++ b/esp/public/media/theme_editor/themes/Rupaa.less
@@ -53,7 +53,7 @@
 
 // Typography
 // -------------------------
-@sansFontFamily: 'Century Gothic', "Copperplate Gothic Light", "Helvetica Neue", Helvetica, Arial, sans-serif;
+@sansFontFamily:        Helvetica, Arial, sans-serif;
 @serifFontFamily:       Georgia, "Times New Roman", Times, serif;
 @monoFontFamily:        Menlo, Monaco, Consolas, "Courier New", monospace;
 

--- a/esp/templates/themes/editor.html
+++ b/esp/templates/themes/editor.html
@@ -46,6 +46,9 @@ var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% 
   .sp-palette .sp-thumb-inner {
       border: 1px solid black;
   }
+  .control-label {
+    padding-right: 10px;
+  }
 </style>
 {% endblock %}
 {% block title %}Theme Editor{% endblock %}
@@ -112,7 +115,7 @@ var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% 
                     </div>
                     <div class="collapse" id="scaffolding">
                         <div class="control-group">
-                            <label class="control-label" for="bodybg">Background :</label>
+                            <label class="control-label" for="bodybg">Background:</label>
                             <div class="controls">
                                 <input type="text" id="bodybg" name="bodyBackground" class="color" value="{{bodyBackground}}"/>
                             </div>
@@ -133,7 +136,7 @@ var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% 
                         </div>
 
                         <div class="control-group">
-                            <label class="control-label" for="textColor">Text :</label>
+                            <label class="control-label" for="textColor">Text:</label>
                             <div class="controls">
                                 <input type="text" class="color" id="textColor" name="textColor" value="{{ textColor }}"/>
                             </div>
@@ -147,7 +150,7 @@ var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% 
                     </div>
                     <div class="collapse" id="links">
                         <div class="control-group">
-                            <label class="control-label" for="linkColor">Links :</label>
+                            <label class="control-label" for="linkColor">Links:</label>
                             <div class="controls">
                                 <input type="text" class="color" id="linkColor" name="linkColor" value="{{ linkColor }}"/>
                             </div>
@@ -205,28 +208,28 @@ var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% 
                     </div>
                     <div class="collapse" id="navbar_edit_group">
                         <div class="control-group">
-                            <label class="control-label" for="navbarBackground">Background :</label>
+                            <label class="control-label" for="navbarBackground">Background:</label>
                             <div class="controls">
                                 <input type="text" class="color" id="navbarBackground" name="navbarBackground" value="{{ navbarBackground }}"/>
                             </div>
                         </div>
 
                         <div class="control-group">
-                            <label class="control-label" for="navbarBackgroundHighlight">Highlight :</label>
+                            <label class="control-label" for="navbarBackgroundHighlight">Highlight:</label>
                             <div class="controls">
                                 <input type="text" class="color" id="navbarBackgroundHighlight" name="navbarBackgroundHighlight" value="{{ navbarBackgroundHighlight }}"/>
                             </div>
                         </div>
 
                         <div class="control-group">
-                            <label class="control-label" for="navbarText">Text :</label>
+                            <label class="control-label" for="navbarText">Text:</label>
                             <div class="controls">
                                 <input type="text" class="color" id="navbarText" name="navbarText" value="{{ navbarText }}"/>
                             </div>
                         </div>
 
                         <div class="control-group">
-                            <label class="control-label" for="navbarLinkColor">Links :</label>
+                            <label class="control-label" for="navbarLinkColor">Links:</label>
                             <div class="controls">
                                 <input type="text" class="color" id="navbarLinkColor" name="navbarLinkColor" value="{{ navbarLinkColor }}"/>
                             </div>
@@ -261,7 +264,7 @@ var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% 
                         </div>
 
                         <div class="control-group">
-                            <label class="control-label" for="sidebarBackground">Background :</label>
+                            <label class="control-label" for="sidebarBackground">Background:</label>
                             <div class="controls">
                                 <input type="text" class="color" id="sidebarBackground" name="sidebarBackground" value="{{ sidebarBackground }}"/>
                             </div>
@@ -299,7 +302,7 @@ var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% 
 
                         {% comment %}
                         <div class="control-group">
-                            <label class="control-label" for="navbarLinkColor">Links :</label>
+                            <label class="control-label" for="navbarLinkColor">Links:</label>
                             <div class="controls">
                                 <input type="text" class="color" id="navbarLinkColor" name="navbarLinkColor" value="{{ navbarLinkColor }}"/>
                             </div>

--- a/esp/templates/themes/editor.html
+++ b/esp/templates/themes/editor.html
@@ -57,7 +57,7 @@ var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% 
     <div class="span12">
         <h1>Theme Editor</h1>
         <div class="alert alert-info">
-            <p>New to the theme editor?<a href="#help-modal" data-toggle="modal">Click here</a>.</p>
+            <p>New to the theme editor? <a href="#help-modal" data-toggle="modal">Click here</a>.</p>
         </div>
         <div id="help-modal" class="modal hide fade">
             <div class="modal-header">

--- a/esp/templates/themes/editor.html
+++ b/esp/templates/themes/editor.html
@@ -62,15 +62,15 @@ var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% 
         <div id="help-modal" class="modal hide fade">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal">x</button>
-                <h3>Welcome to the theme editor! It's easy to get started</h3>
+                <h3>Welcome to the theme editor! It's easy to get started!</h3>
             </div>
             <div class="modal-body">
                 <ol>
-                    <li><strong>Add colors</strong>to your Palette.</li>
-                    <li>Dive into the sections and<strong>customize</strong>at will. Press<strong>Test</strong>often to see your changes in action.</li>
-                    <li>When you're happy with your changes, just enter a name under Theme Properties and press<strong>Save</strong>!</li>
+                    <li><strong>Add colors</strong> to your Palette.</li>
+                    <li>Dive into the sections and <strong>customize</strong> at will. Press <strong>Test</strong> often to see your changes in action.</li>
+                    <li>When you're happy with your changes, just enter a name under Theme Properties and press <strong>Save</strong>!</li>
                 </ol>
-                <p>For even more<strong>color picking power</strong>, we recommend using a full featured colour picker like<a href='http://colorschemedesigner.com' target="_blank">this one</a>to decide your colours, and enter the hex values when adding to your palette.</p>
+                <p>For even more <strong>color picking power</strong>, we recommend using a full featured colour picker like <a href='http://colorschemedesigner.com' target="_blank">this one</a> to decide your colours, and enter the hex values when adding to your palette.</p>
             </div>
             <div class="modal-footer"></div>
         </div>


### PR DESCRIPTION
This fixes the following:

1. When loading one of the default theme customizations ("Default" or "Rupaa"), various theme colors were not loaded properly. When you then saved, this caused lots of things to turn black (including buttons and the background).
2. The default font for both default theme customizations was Copperplate Gothic (ewww).
3. Many fonts secretly had different font families as backups (now they all just have serif/sans-serif as backups).
4. Fonts were sorted alphabetically, which is nice if you know what you are looking for, but if you want to compare different fonts it's not terribly useful. Now they are sorted alphabetically within category (e.g., serif).
5. There wasn't any spacing between the color labels and the color pickers (and there were stray spaces).

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3406.