### PR TITLE
Some changes for python 3 migration unrelated to strings and bytes

### DIFF
--- a/deploy/travis/before_script
+++ b/deploy/travis/before_script
@@ -3,10 +3,12 @@ set -euf -o pipefail
 
 if [ "$TRAVIS_JOB" = "test" ]; then
     cp esp/esp/local_settings.py.travis esp/esp/local_settings.py
-    ln -s `pwd`/esp/public/media/default_images esp/public/media/images
-    ln -s `pwd`/esp/public/media/default_styles esp/public/media/styles
+    ln -f -s `pwd`/esp/public/media/default_images esp/public/media/images
+    ln -f -s `pwd`/esp/public/media/default_styles esp/public/media/styles
     # the postgres service in Github Actions sets up the database for us
     if [ "$GITHUB_ACTIONS" != true ]; then
+        psql -c "DROP DATABASE IF EXISTS test_django;" -U postgres
+        psql -c "DROP ROLE IF EXISTS testuser;" -U postgres
         psql -c "CREATE ROLE testuser PASSWORD 'testpassword' LOGIN CREATEDB;" -U postgres
         psql -c "CREATE DATABASE test_django OWNER testuser;" -U postgres
     fi

--- a/esp/esp/program/controllers/autoscheduler/consistency_checks.py
+++ b/esp/esp/program/controllers/autoscheduler/consistency_checks.py
@@ -170,12 +170,12 @@ class ConsistencyChecker:
                             "Roomslot index for room {} was {} instead of {}."
                     ).format(room.name, roomslot.index(), i))
                 if i < len(room.availability) - 1:
-                    if room.availability[i + 1] != next(roomslot):
+                    if room.availability[i + 1] != roomslot.next():
                         raise ConsistencyError(
                             "Roomslot next for room {} was wrong.".format(
                                 room.name))
                 else:
-                    if next(roomslot) is not None:
+                    if roomslot.next() is not None:
                         raise ConsistencyError((
                                 "Last roomslot next for room {} was not None."
                         ).format(room.name))

--- a/esp/esp/program/controllers/autoscheduler/data_model.py
+++ b/esp/esp/program/controllers/autoscheduler/data_model.py
@@ -228,7 +228,7 @@ class AS_Classroom(object):
         This is mostly for testing purposes."""
         for roomslot in self.availability:
             roomslot.index()
-            next(roomslot)
+            roomslot.next()
 
     def flush_roomslot_caches(self):
         """Flush each roomslot's caches for their next_roomslot and index

--- a/esp/esp/program/controllers/autoscheduler/scoring.py
+++ b/esp/esp/program/controllers/autoscheduler/scoring.py
@@ -851,7 +851,7 @@ class RoomConsecutivityScorer(BaseScorer):
                                 avoid_doublecount=False):
         """The boundary-after a roomslit is complete if either there's no
         roomslot after or there's another class scheduled after it."""
-        next_roomslot = next(roomslot)
+        next_roomslot = roomslot.next()
         return next_roomslot is None \
             or (not avoid_doublecount
                 and next_roomslot.assigned_section is not None

--- a/esp/esp/program/modules/handlers/grouptextmodule.py
+++ b/esp/esp/program/modules/handlers/grouptextmodule.py
@@ -44,8 +44,8 @@ from esp.middleware import ESPError
 
 from django.conf import settings
 
-from twilio import TwilioRestException
-from twilio.rest import TwilioRestClient
+from twilio.rest import Client
+from twilio.base.exceptions import TwilioRestException
 
 class GroupTextModule(ProgramModuleObj):
     doc = """Text users that match specific search criteria."""
@@ -165,7 +165,7 @@ class GroupTextModule(ProgramModuleObj):
             if not contactInfo.receive_txt_message and not override:
                 send_log.append(str(user)+" does not want text messages, fine")
                 continue
-            client = TwilioRestClient(account_sid, auth_token)
+            client = Client(account_sid, auth_token)
 
             # format the number for Twilio
             formattedNumber = contactInfo.phone_cell.replace("-", "").replace(" ", "")
@@ -176,7 +176,7 @@ class GroupTextModule(ProgramModuleObj):
 
                 send_log.append("Sending text message to "+formattedNumber)
                 try:
-                    client.sms.messages.create(body=body,
+                    client.messages.create(body=body,
                                            to=formattedNumber,
                                            from_=ourNumbers[numberIndex])
                 except TwilioRestException as error:

--- a/esp/requirements.txt
+++ b/esp/requirements.txt
@@ -33,6 +33,6 @@ raven # Required for Sentry error reporting
 selenium==2.44.0 # Runs selenium tests which probably don't work anymore
 shortuuid==0.4.2 # django-extensions dependency
 stripe==1.19.1 # Required for credit card processing
-twilio==3.6.5 # Required for text messaging support
+twilio==6.63.2 # Required for text messaging support
 werkzeug # Required for runserver_plus (alternative to runserver provided by django-extensions)
 xlwt==1.0.0 # Does form and survey exporting

--- a/esp/requirements3.txt
+++ b/esp/requirements3.txt
@@ -33,6 +33,6 @@ raven # Required for Sentry error reporting
 selenium==2.44.0 # Runs selenium tests which probably don't work anymore
 shortuuid==0.4.2 # django-extensions dependency
 stripe==1.19.1 # Required for credit card processing
-twilio==3.6.5 # Required for text messaging support
+twilio==6.63.2 # Required for text messaging support
 werkzeug # Required for runserver_plus (alternative to runserver provided by django-extensions)
 xlwt==1.3.0 # Does form and survey exporting

--- a/esp/useful_scripts/send_text_messages.py
+++ b/esp/useful_scripts/send_text_messages.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 import sys
-from twilio.rest import TwilioRestClient
+from twilio.rest import Client
 
 # TODO(jmoldow): Use Python built-in argparse module.
 if len(sys.argv) < 6:
@@ -17,10 +17,10 @@ body = sys.argv[5]
 numberIndex = 0
 
 for number in recipients:
-    client = TwilioRestClient(account_sid, auth_token)
+    client = Client(account_sid, auth_token)
 
     print("Sending text message to "+number)
-    client.sms.messages.create(body=body,
+    client.messages.create(body=body,
                                to=number,
                                from_=ourNumbers[numberIndex])
     numberIndex = (numberIndex + 1) % len(ourNumbers)


### PR DESCRIPTION
- Upgraded Twilio client to latest (old version only works up to Python 3.7 and not 3.8+)  (Followed [this documentation](https://www.twilio.com/docs/libraries/reference/twilio-python/index.html))
- next(roomslot) changed to roomslot.next()
- Updated Travis scripts so tests can run locally

The roomslot.next() change got rid of the errors saying that AS_RoomSlot is not an iterator.