### PR TITLE
Python 3 migration - sort related changes

### DIFF
--- a/esp/esp/cal/models.py
+++ b/esp/esp/cal/models.py
@@ -132,7 +132,7 @@ class Event(models.Model):
         """ this method will return a list of new collapsed events """
         from copy import copy
         sortedList = copy(eventList)
-        sortedList.sort()
+        sortedList.sort(key=lambda e: e.start)
 
         for i in range(1,len(sortedList)):
             if (sortedList[i-1].end+tol) >= sortedList[i].start:
@@ -158,7 +158,7 @@ class Event(models.Model):
         """ Takes a list of events and returns a list of lists where each sublist is a contiguous group. """
         from copy import copy
         sorted_list = copy(event_list)
-        sorted_list.sort()
+        sorted_list.sort(key=lambda e: e.start)
 
         grouped_list = []
         current_group = []

--- a/esp/esp/cal/models.py
+++ b/esp/esp/cal/models.py
@@ -211,6 +211,18 @@ class Event(models.Model):
             return cmp(self.start, other.start)
         except:
             return 0
+    def __lt__(self, other):
+        return self.__cmp__(other) < 0
+    def __gt__(self, other):
+        return self.__cmp__(other) > 0
+    def __eq__(self, other):
+        return self.__cmp__(other) == 0
+    def __le__(self, other):
+        return self.__cmp__(other) <= 0
+    def __ge__(self, other):
+        return self.__cmp__(other) >= 0
+    def __ne__(self, other):
+        return self.__cmp__(other) != 0
 
 def install():
     """

--- a/esp/esp/cal/models.py
+++ b/esp/esp/cal/models.py
@@ -41,6 +41,7 @@ logger = logging.getLogger(__name__)
 from django.db import models
 from datetime import datetime, timedelta
 from argcache import cache_function
+from esp.utils import cmp
 
 # Create your models here.
 

--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -174,6 +174,18 @@ class ArchiveClass(models.Model):
         if test != 0:
             return test
         return 0
+    def __lt__(self, other):
+        return self.__cmp__(other) < 0
+    def __gt__(self, other):
+        return self.__cmp__(other) > 0
+    def __eq__(self, other):
+        return self.__cmp__(other) == 0
+    def __le__(self, other):
+        return self.__cmp__(other) <= 0
+    def __ge__(self, other):
+        return self.__cmp__(other) >= 0
+    def __ne__(self, other):
+        return self.__cmp__(other) != 0
 
     def heading(self):
         if len(self.date) > 1:

--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -1070,12 +1070,6 @@ class Program(models.Model, CustomFormsLinkModel):
         """ Gets a list of modules for this program. """
         from esp.program.modules import base
 
-        def cmpModules(mod1, mod2):
-            """ comparator function for two modules """
-            try:
-                return cmp(mod1.seq, mod2.seq)
-            except AttributeError:
-                return 0
         if tl:
             modules =  [ base.ProgramModuleObj.getFromProgModule(self, module)
                  for module in self.program_modules.filter(module_type = tl)]
@@ -1083,7 +1077,7 @@ class Program(models.Model, CustomFormsLinkModel):
             modules =  [ base.ProgramModuleObj.getFromProgModule(self, module, old_prog)
                  for module in self.program_modules.all()]
 
-        modules.sort(cmpModules)
+        modules.sort(key=lambda m: m.seq)
         return modules
     getModules_cached.depend_on_row('program.Program', lambda prog: {'self': prog})
     getModules_cached.depend_on_model('program.ProgramModule')

--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -268,11 +268,11 @@ class ClassManager(Manager):
 
         for c in classes:
             c._teachers = list(c.teachers.all())
-            c._teachers.sort(cmp=lambda t1, t2: cmp(t1.last_name, t2.last_name))
+            c._teachers.sort(key=lambda t: t.last_name)
             c._sections = sections_by_parent_id[c.id]
             for s in c._sections:
                 s.parent_class = c
-            c._sections.sort(cmp=lambda s1, s2: cmp(s1.id, s2.id))
+            c._sections.sort(key=lambda s:s.id)
             c.parent_program = p # So that if we set attributes on one instance of the program,
                                  # they show up for all instances.
 
@@ -365,7 +365,7 @@ class ClassSection(models.Model):
 
         for s in sections:
             s._events = list(s.meeting_times.all())
-            s._events.sort(cmp=lambda e1, e2: cmp(e1.start, e2.start))
+            s._events.sort(key=lambda e:e.start)
 
         return sections
 

--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -64,6 +64,7 @@ from django_extensions.db.fields.json import JSONField
 from esp.db.fields import AjaxForeignKey
 from esp.utils.property import PropertyDict
 from esp.utils.query_utils import nest_Q
+from esp.utils import cmp
 from esp.tagdict.models import Tag
 from esp.mailman import add_list_member, remove_list_member
 

--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -1141,6 +1141,18 @@ class ClassSection(models.Model):
                 return cmpresult
 
         return cmp(self.title(), other.title())
+    def __lt__(self, other):
+        return self.__cmp__(other) < 0
+    def __gt__(self, other):
+        return self.__cmp__(other) > 0
+    def __eq__(self, other):
+        return self.__cmp__(other) == 0
+    def __le__(self, other):
+        return self.__cmp__(other) <= 0
+    def __ge__(self, other):
+        return self.__cmp__(other) >= 0
+    def __ne__(self, other):
+        return self.__cmp__(other) != 0
 
 
     def firstBlockEvent(self):

--- a/esp/esp/program/modules/handlers/programprintables.py
+++ b/esp/esp/program/modules/handlers/programprintables.py
@@ -50,6 +50,7 @@ from esp.tagdict.models import Tag
 from esp.cal.models import Event
 from esp.middleware import ESPError
 from esp.utils.query_utils import nest_Q
+from esp.utils import cmp
 from esp.program.models import VolunteerOffer
 from esp.survey.views import _encode_ascii
 

--- a/esp/esp/program/modules/handlers/programprintables.py
+++ b/esp/esp/program/modules/handlers/programprintables.py
@@ -62,6 +62,7 @@ from django.template.loader import render_to_string, get_template
 from django.utils.encoding import smart_str
 from django.utils.html import mark_safe
 
+from functools import cmp_to_key
 from datetime import timedelta
 from decimal import Decimal
 import json
@@ -114,13 +115,8 @@ class ProgramPrintables(ProgramModuleObj):
         for lineitem in lineitems:
             lineitem.has_financial_aid = lineitem.user.hasFinancialAid(prog)
 
-        def sort_fn(a,b):
-            if a.user.last_name.lower() > b.user.last_name.lower():
-                return 1
-            return -1
-
         lineitems_list = list(lineitems)
-        lineitems_list.sort(sort_fn)
+        lineitems_list.sort(key=lambda li: li.user.last_name.lower())
 
         context = { 'lineitems': lineitems_list,
                     'hide_paid': request.GET.get('hide_paid') == 'True',
@@ -239,7 +235,7 @@ class ProgramPrintables(ProgramModuleObj):
         sort_list_reversed = sort_list
         sort_list_reversed.reverse()
         for sort_fn in sort_list_reversed:
-            classes.sort(sort_fn)
+            classes.sort(key=cmp_to_key(sort_fn))
 
         clsids = ','.join([str(cls.id) for cls in classes])
 
@@ -440,7 +436,7 @@ class ProgramPrintables(ProgramModuleObj):
                     classes_temp.append(cls_split)
             classes = classes_temp
 
-        classes.sort(sort_exp)
+        classes.sort(key=cmp_to_key(sort_exp))
 
         context = {'classes': classes, 'program': self.program}
 
@@ -483,7 +479,7 @@ class ProgramPrintables(ProgramModuleObj):
 
         sections = list(filter(filt_exp, sections))
 
-        sections.sort(sort_exp)
+        sections.sort(key=cmp_to_key(sort_exp))
 
         context = {'sections': sections, 'program': self.program}
 
@@ -639,7 +635,7 @@ class ProgramPrintables(ProgramModuleObj):
                                'res_values': [classes[0].resourcerequest_set.filter(res_type__name=x).values_list('desired_value', flat=True) for x in resource_types]})
 
         scheditems = list(filter(filt_exp, scheditems))
-        scheditems.sort(sort_exp)
+        scheditems.sort(key=cmp_to_key(sort_exp))
 
         context['res_types'] = resource_types
         context['scheditems'] = scheditems
@@ -740,7 +736,7 @@ class ProgramPrintables(ProgramModuleObj):
             extra_dict = extra_func(s)
             for key in extra_dict:
                 setattr(s, key, extra_dict[key])
-        rooms.sort(sort_exp)
+        rooms.sort(key=cmp_to_key(sort_exp))
 
         context = {'rooms': rooms, 'program': self.program}
 
@@ -772,7 +768,7 @@ class ProgramPrintables(ProgramModuleObj):
             extra_dict = extra_func(s)
             for key in extra_dict:
                 setattr(s, key, extra_dict[key])
-        students.sort(sort_exp)
+        students.sort(key=cmp_to_key(sort_exp))
         context['students'] = students
 
         return render_to_response(self.baseDir()+template_file, request, context)
@@ -1652,7 +1648,7 @@ class ProgramPrintables(ProgramModuleObj):
             classes = [cls for cls in self.program.classes()
                        if cls.isAccepted()                   ]
 
-            classes.sort(ClassSubject.idcmp)
+            classes.sort(key=cmp_to_key(ClassSubject.idcmp))
 
             for cls in classes:
                 for teacher in cls.get_teachers():

--- a/esp/esp/program/modules/handlers/teacherreviewapps.py
+++ b/esp/esp/program/modules/handlers/teacherreviewapps.py
@@ -108,7 +108,7 @@ class TeacherReviewApps(ProgramModuleObj):
                         student.app_completed = True
 
         students = list(students)
-        students.sort(lambda x,y: cmp(x.added_class,y.added_class))
+        students.sort(key=lambda s: s.added_class)
 
         if 'prev' in request.GET:
             prev_id = int(request.GET.get('prev'))

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -81,6 +81,7 @@ from esp.utils.decorators import enable_with_setting
 from esp.utils.expirable_model import ExpirableModel
 from esp.utils.widgets import NullRadioSelect, NullCheckboxSelect
 from esp.utils.query_utils import nest_Q
+from esp.utils import cmp
 
 from six.moves.urllib.parse import quote
 

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -284,6 +284,18 @@ class BaseESPUser(object):
         if lastname == 0:
            return cmp(self.first_name.upper(), other.first_name.upper())
         return lastname
+    def __lt__(self, other):
+        return self.__cmp__(other) < 0
+    def __gt__(self, other):
+        return self.__cmp__(other) > 0
+    def __eq__(self, other):
+        return self.__cmp__(other) == 0
+    def __le__(self, other):
+        return self.__cmp__(other) <= 0
+    def __ge__(self, other):
+        return self.__cmp__(other) >= 0
+    def __ne__(self, other):
+        return self.__cmp__(other) != 0
 
     def getLastProfile(self):
         # caching is handled in RegistrationProfile.getLastProfile
@@ -2256,6 +2268,18 @@ class DBList(object):
     def __cmp__(self, other):
         """ We are going to order by the size of our lists. """
         return cmp(self.count(), other.count())
+    def __lt__(self, other):
+        return self.__cmp__(other) < 0
+    def __gt__(self, other):
+        return self.__cmp__(other) > 0
+    def __eq__(self, other):
+        return self.__cmp__(other) == 0
+    def __le__(self, other):
+        return self.__cmp__(other) <= 0
+    def __ge__(self, other):
+        return self.__cmp__(other) >= 0
+    def __ne__(self, other):
+        return self.__cmp__(other) != 0
 
     def __unicode__(self):
         return self.key

--- a/esp/esp/utils/__init__.py
+++ b/esp/esp/utils/__init__.py
@@ -42,3 +42,15 @@ def ascii(x):
 
     """
     return quote_plus(force_str(x))
+
+# copied from: https://portingguide.readthedocs.io/en/latest/comparisons.html
+def cmp(x, y):
+    """
+    Replacement for built-in function cmp that was removed in Python 3
+
+    Compare the two objects x and y and return an integer according to
+    the outcome. The return value is negative if x < y, zero if x == y
+    and strictly positive if x > y.
+    """
+
+    return (x > y) - (x < y)


### PR DESCRIPTION
1. Convert all cmp parameters to key for sort() calls
      If I could see directly that the cmp was comparing f(a) with f(b) for some function f, then I replaced it with `key=f`. 
      Otherwise I used `cmp_to_key` to do the conversion.
2. add cmp function to utils and import everywhere cmp is used
3. define `__lt__`, etc. everywhere `__cmp__` is defined
    Python 3 no longer supports `__cmp__` directly. Instead, you have to define 6 separate comparison functions. I defined them in terms of the existing `__cmp__` to minimize the risk of errors.

A lot of the code for 2 and 3 was copied from here: https://portingguide.readthedocs.io/en/latest/comparisons.html