### PR TITLE
Python3: change '== None' / '!= None' to 'is None' / 'is not None'

### DIFF
--- a/esp/esp/cal/models.py
+++ b/esp/esp/cal/models.py
@@ -140,7 +140,7 @@ class Event(models.Model):
                 sortedList[i]   = Event(start=sortedList[i-1].start, end=sortedList[i].end)
                 sortedList[i-1] = None
 
-        newList = [ x for x in sortedList if x != None ]
+        newList = [ x for x in sortedList if x is not None ]
 
         return newList
 

--- a/esp/esp/db/forms.py
+++ b/esp/esp/db/forms.py
@@ -256,7 +256,7 @@ class AjaxForeignKeyNewformField(forms.IntegerField):
 
         if hasattr(self, "field"):
             # If we couldn't grab an ID, ask the target's autocompleter.
-            if id == None:
+            if id is None:
                 objs = self.field.rel.to.ajax_autocomplete(value)
                 if len( objs ) == 1:
                     id = objs[0]['id']

--- a/esp/esp/miniblog/views/__init__.py
+++ b/esp/esp/miniblog/views/__init__.py
@@ -50,7 +50,7 @@ def preview_miniblog(request, section = None):
     """this function will return the last n miniblog entries from preview_miniblog """
     # last update: Axiak
 
-    if request.user != None:
+    if request.user is not None:
         curUser = request.user
     else:
         curUser = AnonymousESPUser()

--- a/esp/esp/program/controllers/classreg.py
+++ b/esp/esp/program/controllers/classreg.py
@@ -252,7 +252,7 @@ class ClassCreationController(object):
             teacher_ctxt = {'teacher': teacher}
             # Provide information about whether or not teacher's from MIT.
             last_profile = teacher.getLastProfile()
-            if last_profile.teacher_info != None:
+            if last_profile.teacher_info is not None:
                 teacher_ctxt['from_here'] = last_profile.teacher_info.from_here
                 teacher_ctxt['college'] = last_profile.teacher_info.college
             else: # This teacher never filled out their teacher profile!

--- a/esp/esp/program/controllers/lottery.py
+++ b/esp/esp/program/controllers/lottery.py
@@ -709,14 +709,14 @@ class LotteryAssignmentController(object):
         You might want to crosscheck this file before accepting it."""
         import csv
 
-        if directory == None:
+        if directory is None:
             directory = self.options['directory']
 
-        if stats == None:
+        if stats is None:
             stats = self.compute_stats(display=False) #Calculate stats if I didn't get any
 
         studentlist = stats['students_by_screwedness']
-        if n != None: studentlist = studentlist[:n]
+        if n is not None: studentlist = studentlist[:n]
         tday = datetime.today().strftime('%Y-%m-%d')
 
         fullfilename = directory + '/screwed_csv_' + tday + '.csv'

--- a/esp/esp/program/forms.py
+++ b/esp/esp/program/forms.py
@@ -452,7 +452,7 @@ class TagSettingsForm(BetterForm):
                 self.fields[key].initial = tag_info.get('default')
                 self.fields[key].required = False
                 set_val = Tag.getBooleanTag(key) if tag_info.get('is_boolean', False) else Tag.getTag(key)
-                if set_val != None and set_val != self.fields[key].initial:
+                if set_val is not None and set_val != self.fields[key].initial:
                     if isinstance(self.fields[key], forms.MultipleChoiceField):
                         set_val = set_val.split(",")
                     self.fields[key].initial = set_val

--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -1479,7 +1479,7 @@ class RegistrationProfile(models.Model):
             except RegistrationProfile.DoesNotExist:
                 pass
 
-        if regProf != None:
+        if regProf is not None:
             return regProf
 
         regProf = RegistrationProfile()
@@ -1567,7 +1567,7 @@ class RegistrationProfile(models.Model):
     getLastForProgram = staticmethod(getLastForProgram)
 
     def __unicode__(self):
-        if self.program_id == None:
+        if self.program_id is None:
             return u'<Registration for %s>' % six.text_type(self.user)
         if self.user is not None:
             return u'<Registration for %s in %s>' % (six.text_type(self.user), six.text_type(self.program))

--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -190,7 +190,7 @@ class ClassManager(Manager):
 
         classes = classes.select_related('category')
 
-        if program != None:
+        if program is not None:
             classes = classes.filter(parent_program = program)
 
         if ts is not None:
@@ -417,7 +417,7 @@ class ClassSection(models.Model):
 
     def _get_room_capacity(self, rooms = None):
         # rooms should be a queryset
-        if rooms == None:
+        if rooms is None:
             rooms = self.classrooms()
 
         # Take the summed classroom capacity for each timeblock, then take the minimum of those sums
@@ -443,7 +443,7 @@ class ClassSection(models.Model):
                 ans = min(self.parent_class.class_size_max, self._get_room_capacity(rooms))
 
         #hacky fix for classes with no max size
-        if ans == None or ans == 0:
+        if ans is None or ans == 0:
             # New class size capacity condition set for Splash 2010.  In code
             # because it seems like a fairly reasonable metric.
             if self.parent_class.allowable_class_size_ranges.all() and len(rooms) != 0:
@@ -1267,7 +1267,7 @@ class ClassSection(models.Model):
 
     def getRegistrations(self, user = None):
         """Gets all StudentRegistrations for this section and a particular user. If no user given, gets all StudentRegistrations for this section"""
-        if user == None:
+        if user is None:
             return StudentRegistration.valid_objects().filter(section=self).order_by('start_date')
         else:
             return StudentRegistration.valid_objects().filter(section=self, user=user).order_by('start_date')
@@ -1316,7 +1316,7 @@ class ClassSection(models.Model):
             remove_list_member(list_name, user.email)
 
     def preregister_student(self, user, overridefull=False, priority=1, prereg_verb = None, fast_force_create=False, webapp=False):
-        if prereg_verb == None:
+        if prereg_verb is None:
             scrmi = self.parent_program.studentclassregmoduleinfo
             if scrmi and scrmi.use_priority:
                 prereg_verb = 'Priority/%d' % priority
@@ -1505,7 +1505,7 @@ class ClassSubject(models.Model, CustomFormsLinkModel):
                 if not hasattr(s, "_events"):
                     did_search = False
                     break
-                if timeslot in s._events or timeslot == None:
+                if timeslot in s._events or timeslot is None:
                     return s
 
             if did_search: # If we did successfully search all sections, but found none in this timeslot
@@ -1722,7 +1722,7 @@ class ClassSubject(models.Model, CustomFormsLinkModel):
     get_capacity_factor = staticmethod(get_capacity_factor)
 
     def is_nearly_full(self, capacity_factor = None):
-        if capacity_factor == None:
+        if capacity_factor is None:
             capacity_factor = ClassSubject.get_capacity_factor()
         return len([x for x in self.get_sections() if x.num_students() > capacity_factor*x.capacity]) > 0
 
@@ -1935,7 +1935,7 @@ was approved! Please go to http://esp.mit.edu/teach/%s/class_status/%s to view y
 
     def getRegistrations(self, user=None):
         """Gets all non-expired StudentRegistrations associated with this class. If user is given, will also filter to that particular user only."""
-        if user == None:
+        if user is None:
             return StudentRegistration.valid_objects().filter(section__in=self.sections.all()).order_by('start_date')
         else:
             return StudentRegistration.valid_objects().filter(section__in=self.sections.all(), user=user).order_by('start_date')

--- a/esp/esp/program/modules/forms/admincore.py
+++ b/esp/esp/program/modules/forms/admincore.py
@@ -137,7 +137,7 @@ class ProgramTagSettingsForm(BetterForm):
                 self.fields[key].initial = tag_info.get('default')
                 self.fields[key].required = False
                 set_val = Tag.getBooleanTag(key, program = self.program) if tag_info.get('is_boolean', False) else Tag.getProgramTag(key, program = self.program)
-                if set_val != None and set_val != self.fields[key].initial:
+                if set_val is not None and set_val != self.fields[key].initial:
                     if isinstance(self.fields[key], forms.MultipleChoiceField):
                         set_val = set_val.split(",")
                     self.fields[key].initial = set_val

--- a/esp/esp/program/modules/forms/resources.py
+++ b/esp/esp/program/modules/forms/resources.py
@@ -62,7 +62,7 @@ class ResourceTypeForm(forms.Form):
         self.fields['name'].initial = res_type.name
         self.fields['description'].initial = res_type.description
         self.fields['priority'].initial = res_type.priority_default
-        self.fields['is_global'].initial = (res_type.program == None)
+        self.fields['is_global'].initial = (res_type.program is None)
         self.fields['only_one'].initial = res_type.only_one
         self.fields['hidden'].initial = res_type.hidden
         self.fields['id'].initial = res_type.id

--- a/esp/esp/program/modules/handlers/jsondatamodule.py
+++ b/esp/esp/program/modules/handlers/jsondatamodule.py
@@ -262,7 +262,7 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
     def sections(extra, prog):
         if extra == 'catalog':
             catalog = True
-        elif extra == None:
+        elif extra is None:
             catalog = False
         else:
             raise Http404
@@ -443,7 +443,7 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
     def class_subjects(extra, prog):
         if extra == 'catalog':
             catalog = True
-        elif extra == None:
+        elif extra is None:
             catalog = False
         else:
             raise Http404
@@ -568,14 +568,14 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
         if 'return_key' in request.GET:
             return_key = request.GET['return_key']
         if 'section_id' in request.GET:
-            if return_key == None: return_key = 'sections'
+            if return_key is None: return_key = 'sections'
             section_id = int(request.GET['section_id'])
             if return_key == 'sections':
                 section = ClassSection.objects.get(pk=section_id)
             else:
                 matching_classes = ClassSubject.objects.filter(sections=section_id)
         elif 'class_id' in request.GET:
-            if return_key == None: return_key = 'classes'
+            if return_key is None: return_key = 'classes'
             class_id = int(request.GET['class_id'])
             matching_classes = ClassSubject.objects.filter(id=class_id)
         else:
@@ -630,14 +630,14 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
             return_key = request.GET['return_key']
 
         if 'section_id' in request.GET:
-            if return_key == None: return_key = 'sections'
+            if return_key is None: return_key = 'sections'
             section_id = int(request.GET['section_id'])
             if return_key == 'sections':
                 section = ClassSection.objects.get(pk=section_id)
             else:
                 target_qs = ClassSubject.objects.filter(sections=section_id)
         elif 'class_id' in request.GET:
-            if return_key == None: return_key = 'classes'
+            if return_key is None: return_key = 'classes'
             class_id = int(request.GET['class_id'])
             target_qs = ClassSubject.objects.filter(id=class_id)
         else:
@@ -679,14 +679,14 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
             return_key = request.GET['return_key']
 
         if 'section_id' in request.GET:
-            if return_key == None: return_key = 'sections'
+            if return_key is None: return_key = 'sections'
             section_id = int(request.GET['section_id'])
             if return_key == 'sections':
                 section = ClassSection.objects.get(pk=section_id)
             else:
                 matching_classes = ClassSubject.objects.filter(sections=section_id)
         elif 'class_id' in request.GET:
-            if return_key == None: return_key = 'classes'
+            if return_key is None: return_key = 'classes'
             class_id = int(request.GET['class_id'])
             matching_classes = ClassSubject.objects.filter(id=class_id)
         else:

--- a/esp/esp/program/modules/handlers/mailinglabels.py
+++ b/esp/esp/program/modules/handlers/mailinglabels.py
@@ -161,7 +161,7 @@ class MailingLabels(ProgramModuleObj):
 
             infos = [user.getLastProfile().contact_user for user in ESPUser.objects.filter(filterObj.get_Q()).distinct()]
 
-            infos_filtered = [ info for info in infos if (info != None and info.undeliverable != True) ]
+            infos_filtered = [ info for info in infos if (info is not None and info.undeliverable != True) ]
 
         output = MailingLabels.gen_addresses(infos, combine)
 
@@ -186,7 +186,7 @@ class MailingLabels(ProgramModuleObj):
         addresses = {}
         ids_zipped = []
 
-        infos = [i for i in infos if i != None]
+        infos = [i for i in infos if i is not None]
 
         if len(infos) > 0 and infos[0].k12school_set.all().count() > 0:
             use_title = True
@@ -194,7 +194,7 @@ class MailingLabels(ProgramModuleObj):
             use_title = False
 
         for info in infos:
-            if info == None:
+            if info is None:
                 continue
 
             schools = info.k12school_set.all()
@@ -212,7 +212,7 @@ class MailingLabels(ProgramModuleObj):
             else:
                 name = '%s %s' % (info.first_name.strip(), info.last_name.strip())
 
-            if info.address_postal != None:
+            if info.address_postal is not None:
                 key = info.address_postal
             else:
 

--- a/esp/esp/program/modules/handlers/programprintables.py
+++ b/esp/esp/program/modules/handlers/programprintables.py
@@ -105,7 +105,7 @@ class ProgramPrintables(ProgramModuleObj):
                 ids = None
                 single_select = False
 
-            if ids == None:
+            if ids is None:
                 transfers = pac.all_transfers(optional_only=True).order_by('line_item','user').select_related()
             else:
                 lineitems = pac.all_transfers(optional_only=True).filter(line_item__id__in=ids).order_by('line_item','user').select_related()

--- a/esp/esp/program/modules/handlers/studentclassregmodule.py
+++ b/esp/esp/program/modules/handlers/studentclassregmodule.py
@@ -260,7 +260,7 @@ class StudentClassRegModule(ProgramModuleObj):
         for i in range(len(timeslots)):
             timeslot = timeslots[i]
             daybreak = False
-            if prevTimeSlot != None:
+            if prevTimeSlot is not None:
                 if not Event.contiguous(prevTimeSlot, timeslot):
                     blockCount += 1
                     daybreak = True

--- a/esp/esp/program/modules/handlers/studentregtwophase.py
+++ b/esp/esp/program/modules/handlers/studentregtwophase.py
@@ -146,7 +146,7 @@ class StudentRegTwoPhase(ProgramModuleObj):
 
         for i in range(len(timeslots)):
             timeslot = timeslots[i]
-            if prevTimeSlot != None:
+            if prevTimeSlot is not None:
                 if not Event.contiguous(prevTimeSlot, timeslot):
                     blockCount += 1
 

--- a/esp/esp/program/modules/tests/adminclass.py
+++ b/esp/esp/program/modules/tests/adminclass.py
@@ -53,8 +53,8 @@ class CancelClassTest(ProgramFrameworkTest):
                     studentEmail = m
                     break
 
-        self.assertTrue(directorEmail != None and cancelMsg in directorEmail.body)
-        self.assertTrue(studentEmail != None and cancelMsg in studentEmail.body)
+        self.assertTrue(directorEmail is not None and cancelMsg in directorEmail.body)
+        self.assertTrue(studentEmail is not None and cancelMsg in studentEmail.body)
 
         # Check that classes show up in the cancelled classes printable
         r = self.client.get("/manage/"+self.program.url+"/classesbytime?cancelled")

--- a/esp/esp/program/modules/tests/support/program_manager.py
+++ b/esp/esp/program/modules/tests/support/program_manager.py
@@ -11,15 +11,15 @@ class TestProgramManager():
         self.schedule_class_url = '/manage/%s/' % self.program.getUrlBase() + 'ajax_schedule_class'
 
     def getClassToSchedule(self, section=None, teacher=None, timeslots=None, rooms=None):
-        if section == None:
-            if teacher == None:
+        if section is None:
+            if teacher is None:
                 teacher = self.teachers[0]
             section = teacher.getTaughtSections(self.program)[0]
 
-        if rooms == None:
+        if rooms is None:
             rooms = self.rooms[0].identical_resources().filter(event__in=self.timeslots).order_by('event__start')
 
-        if timeslots == None:
+        if timeslots is None:
             timeslots = self.program.getTimeSlots().order_by('start')
 
         return (section, timeslots, rooms)

--- a/esp/esp/qsd/views.py
+++ b/esp/esp/qsd/views.py
@@ -87,7 +87,7 @@ def qsd(request, url):
     # Fetch the QSD object
     try:
         qsd_rec = QuasiStaticData.objects.get_by_url(base_url)
-        if qsd_rec == None:
+        if qsd_rec is None:
             raise QuasiStaticData.DoesNotExist
         if qsd_rec.disabled:
             raise QuasiStaticData.DoesNotExist

--- a/esp/esp/tagdict/models.py
+++ b/esp/esp/tagdict/models.py
@@ -82,7 +82,7 @@ class Tag(models.Model):
                            key)
 
         try:
-            if target != None:
+            if target is not None:
                 ct = ContentType.objects.get_for_model(target)
                 return cls.objects.get(key=key, content_type=ct, object_id=target.id).value
             else:
@@ -170,7 +170,7 @@ class Tag(models.Model):
         that the tag has been set (or not).
         """
 
-        if target != None:
+        if target is not None:
             ct = ContentType.objects.get_for_model(target)
             tag, created = cls.objects.get_or_create(key=key, content_type=ct, object_id=target.id)
         else:
@@ -193,7 +193,7 @@ class Tag(models.Model):
         """
         tag_counter = 0
 
-        if target != None:
+        if target is not None:
             ct = ContentType.objects.get_for_model(target)
             items = cls.objects.filter(key=key, content_type=ct, object_id=target.id)
         else:

--- a/esp/esp/themes/views.py
+++ b/esp/esp/themes/views.py
@@ -217,7 +217,7 @@ def editor(request):
         #   Re-generate the CSS for the current theme given the supplied settings
         if vars:
             tc.customize_theme(vars)
-        if palette != None:
+        if palette is not None:
             tc.set_palette(palette)
 
     #   Get current theme and customization settings

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -1078,7 +1078,7 @@ class BaseESPUser(object):
 
     @staticmethod
     def gradeFromYOG(yog, schoolyear=None):
-        if schoolyear == None:
+        if schoolyear is None:
             schoolyear = ESPUser.current_schoolyear()
         try:
             yog        = int(yog)
@@ -1473,7 +1473,7 @@ class StudentInfo(models.Model):
 
     def __unicode__(self):
         username = "N/A"
-        if self.user != None:
+        if self.user is not None:
             username = self.user.username
         return u'ESP Student Info (%s) -- %s' % (username, six.text_type(self.school))
 
@@ -1589,7 +1589,7 @@ class TeacherInfo(models.Model, CustomFormsLinkModel):
 
     def __unicode__(self):
         username = ""
-        if self.user != None:
+        if self.user is not None:
             username = self.user.username
         return u'ESP Teacher Info (%s)' % username
 
@@ -1653,7 +1653,7 @@ class GuardianInfo(models.Model):
 
     def __unicode__(self):
         username = ""
-        if self.user != None:
+        if self.user is not None:
             username = self.user.username
         return u'ESP Guardian Info (%s)' % username
 
@@ -1730,7 +1730,7 @@ class EducatorInfo(models.Model):
 
     def __unicode__(self):
         username = ""
-        if self.user != None:
+        if self.user is not None:
             username = self.user.username
         return u'ESP Educator Info (%s)' % username
 
@@ -1939,7 +1939,7 @@ class ContactInfo(models.Model, CustomFormsLinkModel):
         return form_data
 
     def save(self, *args, **kwargs):
-        if self.id != None:
+        if self.id is not None:
             try:
                 old_self = ContactInfo.objects.get(id = self.id)
                 if old_self.address_zip != self.address_zip or \
@@ -1950,7 +1950,7 @@ class ContactInfo(models.Model, CustomFormsLinkModel):
                     self.undeliverable = False
             except:
                 pass
-        if self.address_postal != None:
+        if self.address_postal is not None:
             self.address_postal = str(self.address_postal)
 
         super(ContactInfo, self).save(*args, **kwargs)
@@ -1959,7 +1959,7 @@ class ContactInfo(models.Model, CustomFormsLinkModel):
     def __unicode__(self):
         username = ""
         last_name, first_name = '', ''
-        if self.user != None:
+        if self.user is not None:
             username = self.user.username
         if self.first_name is not None:
             first_name = self.first_name

--- a/esp/esp/varnish/varnish.py
+++ b/esp/esp/varnish/varnish.py
@@ -13,7 +13,7 @@ def get_varnish_host():
         return None
 
 def purge_page(url, host=None):
-    if host == None:
+    if host is None:
         host = get_varnish_host()
         if host is None:
             return None

--- a/esp/esp/web/views/archives.py
+++ b/esp/esp/web/views/archives.py
@@ -68,7 +68,7 @@ def compute_range(postvars, num_records):
         results_start = int(postvars['results_start'])
     if 'results_end' in postvars:
         results_end = int(postvars['results_end'])
-    if (num_records > default_num_records) and results_end == None:
+    if (num_records > default_num_records) and results_end is None:
         if postvars.get('max_num_results') == "Show all":
             results_end = num_records
         elif postvars.get('max_num_results'):
@@ -116,7 +116,7 @@ def archive_classes(request, category, options, sortorder = None):
     context['options'] = options
 
     #    Take filtering criteria both from form and from URL
-    if category != None and options != None:
+    if category is not None and options is not None:
         url_criterion = ArchiveFilter(category = category, options = options)
         criteria_list = [url_criterion]
     else:

--- a/esp/useful_scripts/export_all_surveys.py
+++ b/esp/useful_scripts/export_all_surveys.py
@@ -333,9 +333,9 @@ def build_workbook_data():
 
                 for ans in resp:
                     ans_dict[ans.question_id] = auto_cell_type(ans.answer)
-                    ans_dict[-1] = ans._class.emailcode() if ans._class != None else ans_dict[-1]
-                    ans_dict[-2] = ans._section.title() if ans._section != None else ans_dict[-2]
-                    ans_dict[-3] = ", ".join("%s %s" % (x.first_name, x.last_name) for x in ans._class._teachers) if ans._class != None else ans_dict[-3]
+                    ans_dict[-1] = ans._class.emailcode() if ans._class is not None else ans_dict[-1]
+                    ans_dict[-2] = ans._section.title() if ans._section is not None else ans_dict[-2]
+                    ans_dict[-3] = ", ".join("%s %s" % (x.first_name, x.last_name) for x in ans._class._teachers) if ans._class is not None else ans_dict[-3]
 
                 this_answers = [ans_dict[q] for q in this_question_ids]
 


### PR DESCRIPTION
change `== None` to `is None`
change `!= None` to `is not None`

Now that the comparison functions like `__eq__` have been defined in some places in the code, sometimes `== None` can fail. This also explains the sudden appearance of Python 2 test failures in the `python3` branch.  
