### PR TITLE
Python 3: a few small fixes

### DIFF
--- a/deploy/travis/before_script
+++ b/deploy/travis/before_script
@@ -7,6 +7,7 @@ if [ "$TRAVIS_JOB" = "test" ]; then
     ln -f -s `pwd`/esp/public/media/default_styles esp/public/media/styles
     # the postgres service in Github Actions sets up the database for us
     if [ "$GITHUB_ACTIONS" != true ]; then
+        psql -c "DROP DATABASE IF EXISTS test_test_django;" -U postgres
         psql -c "DROP DATABASE IF EXISTS test_django;" -U postgres
         psql -c "DROP ROLE IF EXISTS testuser;" -U postgres
         psql -c "CREATE ROLE testuser PASSWORD 'testpassword' LOGIN CREATEDB;" -U postgres

--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -2148,7 +2148,7 @@ class RegistrationType(models.Model):
     def get_map(include=None, category=None):
         #   If 'include' is specified, make sure we have keys named in that list
         if include:
-            if not isinstance(category, str):
+            if not isinstance(category, str) and not isinstance(category, six.text_type):
                 raise ESPError('Need to supply category to RegistrationType.get_map() when passing include arguments', log=True)
             for name in include:
                 type, created = RegistrationType.objects.get_or_create(name=name, category=category)

--- a/esp/esp/program/modules/tests/jsondatamodule.py
+++ b/esp/esp/program/modules/tests/jsondatamodule.py
@@ -102,7 +102,7 @@ class JSONDataModuleTest(ProgramFrameworkTest):
         ## Statistics in the "grades" section of the dashboard
         ## Note: Depends on add_user_profiles() always creating 10th graders
         ## and all classes being open to all grades in the program
-        expected_response = {"data": [], "id": "grades"}
+        expected_response = {"id": "grades", "data": []}
         for g in range(self.program.grade_min, self.program.grade_max + 1):
             expected_response["data"].append({"grade": g,
                                               "num_subjects": 10,

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -924,7 +924,7 @@ class BaseESPUser(object):
         """
         def _new_method(user):
             return user.is_user_type(user_class)
-        _new_method.__name__    = 'is%s' % str(user_class)
+        _new_method.__name__    = str('is%s' % str(user_class))
         _new_method.__doc__     = "Returns ``True`` if the user is a %s and False otherwise." % user_class
         return _new_method
 

--- a/esp/esp/utils/__init__.py
+++ b/esp/esp/utils/__init__.py
@@ -23,7 +23,7 @@ def force_str(x):
     '\\xc3\\x85ngstrom'
 
     """
-    if isinstance(x, str):
+    if isinstance(x, str) or isinstance(x, six.text_type):
         return x
     return six.text_type(x).encode('utf8')
 

--- a/esp/esp/utils/latex.py
+++ b/esp/esp/utils/latex.py
@@ -197,7 +197,7 @@ def _gen_latex(texcode, stdout, stderr, type='pdf'):
         raise ESPError("Postprocessing failed; try downloading as PDF.")
 
     out_file = file_base + '.' + type
-    if type is 'png' and not os.path.isfile(out_file):
+    if type == 'png' and not os.path.isfile(out_file):
         # If the schedule is multiple pages (such as a schedule if the program
         # is using barcode check-in), ImageMagick will generate files of the
         # form file_base-n.png.  In this case, we will just return the first


### PR DESCRIPTION
1. Change 'is' to '==' when used with a literal 'png'
2. drop database test_test_django in the before_script
3. fix dictionary ordering in expected test result
4. Use six.text_type for Python 2/3 compatibility
5. Add str() conversion for `__name__` in `create_membership_methods`

For item 2:
If the tests fail at the wrong time (or you use Ctrl-C to interrupt them early), sometimes the database `test_test_django` doesn't get dropped and it will cause an error the next time you run the tests.

For item 3:
 In Python 2, when you json.dumps a dictionary, the keys are sorted according to some internal ordering, but in Python 3, json.dumps maintains the key order that was initially defined.