### PR TITLE
Fix pdf survey responses styling

### DIFF
--- a/esp/templates/inclusion/survey/responses_for_program.tex
+++ b/esp/templates/inclusion/survey/responses_for_program.tex
@@ -1,13 +1,13 @@
 {% load latex %}
-\begin{center}
-\begin{longtable}{|p{0.48\linewidth}|p{0.48\linewidth}|} \hline
-\multicolumn{2}{|C{\linewidth}|}{\cellcolor{esphead} ~ } \\
-\multicolumn{2}{|C{\linewidth}|}{\cellcolor{esphead} \Large {Responses for {{ survey.name|texescape }}} } \\ 
-\multicolumn{2}{|C{\linewidth}|}{\cellcolor{esphead} ~ } \\\hline
+
+\begin{tcolorbox}[width=\textwidth,colback={esphead}]    
+ \begin{center}
+      \Large {Responses for {{ survey.name|texescape }}} 
+\end{center}
+\end{tcolorbox}  
+
 {% for q in display_data %}
     {% with survey.num_participants as num_participants %}
         {% include "survey/answers.tex" %}
     {% endwith %}
 {% endfor %}
-\end{longtable}
-\end{center}

--- a/esp/templates/inclusion/survey/responses_for_section.tex
+++ b/esp/templates/inclusion/survey/responses_for_section.tex
@@ -1,17 +1,14 @@
 {% load latex %}
-\begin{center}
-\begin{longtable}{|p{0.48\linewidth}|p{0.48\linewidth}|} \hline
-\multicolumn{2}{|C{\linewidth}|}{\cellcolor{esphead} ~ } \\
-\multicolumn{2}{|C{\linewidth}|}{\cellcolor{esphead} \Large {Responses for {{ sec.emailcode }}: {{ sec.title|texescape }}} } \\ 
-\multicolumn{2}{|C{\linewidth}|}{\cellcolor{esphead} ~ } \\\hline
-\multicolumn{2}{|C{\linewidth}|}{
-    \rule{0pt}{3ex}
-    Teachers: {{ sec.parent_class.getTeacherNames|join:", "|texescape }}
-    \rule[-1.5ex]{0pt}{0pt} } \\\hline
+
+\begin{tcolorbox}[width=\textwidth,colbacktitle={esphead}, colback=white, title = \strut\Large {Responses for {{ sec.emailcode }}: {{ sec.title|texescape }}}, center title, coltitle=black ]    
+ \begin{center}
+       Teachers: {{ sec.parent_class.getTeacherNames|join:", "|texescape }}
+\end{center}
+\end{tcolorbox}  
+\vspace{6pt}
+
 {% for q in class_data %}
     {% with sec.num_students as num_participants %}
         {% include "survey/answers.tex" %}
     {% endwith %}
 {% endfor %}
-\end{longtable}
-\end{center}

--- a/esp/templates/outlines/review_base.tex
+++ b/esp/templates/outlines/review_base.tex
@@ -11,8 +11,11 @@
 \usepackage{subfigure}
 \usepackage{boxedminipage}
 \usepackage{array}
+\usepackage{paracol}
+\usepackage{tcolorbox}
 
 {% block headers %}
+\setlength{\columnseprule}{.5pt}
 \definecolor{esphead}{rgb}{0.773,0.867,0.965}
 \newenvironment{itemize2}{
 \begin{itemize}
@@ -27,12 +30,6 @@
 
 \begin{document}
 
-\vspace{.1in}
-\begin{center}
-\begin{minipage}{7in}
-
-\end{minipage}
-\end{center}
 {% autoescape off %}
 {% block content %}
 

--- a/esp/templates/survey/answers.tex
+++ b/esp/templates/survey/answers.tex
@@ -3,12 +3,13 @@
 {% load latex %}
 
 {% if q.question.question_type.is_countable %}
-    \begin{minipage}[b]{3in}
+    \begin{paracol}{2}
+        \raggedright
+        \normalsize
         \vspace*{0.1in}
-        \textbf{ {{ q.question.name|texescape }}:} \\
+        \hspace{-\the\fontdimen2\font\space}\textbf{ {{q.question.name|texescape}}: } \\
         (Numerical responses)
-        \vspace*{0.1in}
-        
+        \vspace*{0.1in}       
         \textbf{Number of responses:} {{ q.answers|length }}/{{ num_participants }} \\
         {% if q.question.question_type.is_numeric %}
             \textbf{Average:} {{ q.answers|unpack_answers|average }} \\
@@ -43,7 +44,7 @@
                 {% endif %}
             {% endwith %}
         {% endif %}
-    \end{minipage} & 
+    \switchcolumn 
     {% if not q.answers|length_is:0 %}
         {% with q.question.get_params as params %}
             {% if q.question.question_type.is_numeric and params.number_of_ratings %}
@@ -67,16 +68,16 @@
     {% else %} There are no responses to this question.
     {% endif %}
     \vspace*{0.1in}
-    \\ \hline
+    \end{paracol} % \\ \hline
 {% else %}
-    \begin{minipage}{3in}
+    \begin{paracol}{2}
+        \raggedright
+        \normalsize
         \vspace*{0.1in}
-        \textbf{ {{ q.question.name|texescape }} }
-        \vspace*{0.1in}
-        
+        \hspace{-\the\fontdimen2\font\space}\textbf{ {{q.question.name|texescape}} }
+        \vspace*{0.1in}       
         \textbf{Number of responses:} {{ q.answers|length }}/{{ num_participants }} \\
-    \end{minipage} &
-    \begin{minipage}{3in}
+    \switchcolumn
     {% ifequal q.question.question_type.name "Favorite Class" %}
         \vspace*{0.1in} \small
         \begin{enumerate}
@@ -102,5 +103,8 @@
         {% endif %}
         \vspace*{0.1in}
     {% endifequal %}
-    \end{minipage} \\ \hline
+    \end{paracol} %\\ \hline
 {% endif %}
+\vspace{6pt}
+\hrule
+\vspace{6pt}

--- a/esp/templates/survey/review.tex
+++ b/esp/templates/survey/review.tex
@@ -9,7 +9,7 @@
 
 \normalsize {{ program.niceName|texescape }}: {{ program.date_range }} } \\
 
-\vspace{0.3in}
+\vspace{0.1in}
 
 {% if surveys %}
     {% for s in surveys %}
@@ -34,4 +34,3 @@ Students were asked a few questions about each of their classes.  The results fo
 {% endif %}
 
 {% endblock %}
-


### PR DESCRIPTION
Fixes #3316 so that long responses no longer get cut off in the survey responses pdf.

Unfortunately to fix this issue, I had to redo the styling of the whole pdf since minipages do not support spanning across pages. I think the restyling looks good, but am open to feedback!

![image](https://user-images.githubusercontent.com/7232514/135761234-0f0ed9ac-7166-498f-94d0-0b1e6d4dde29.png)