### PR TITLE
Filter teacher availability to only class time blocks

### DIFF
--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -568,12 +568,13 @@ class BaseESPUser(object):
     def getAvailableTimes(self, program, ignore_classes=False, ignore_moderation=False):
         """ Return a list of the Event objects representing the times that a particular user
             can teach for a particular program. """
-        from esp.cal.models import Event
+        from esp.cal.models import Event, EventType
 
         #   Detect whether the program has the availability module, and assume
         #   the user is always available if it isn't there.
         if program.hasModule('AvailabilityModule'):
-            valid_events = Event.objects.filter(useravailability__user=self, program=program).order_by('start')
+            et = EventType.get_from_desc('Class Time Block')
+            valid_events = Event.objects.filter(useravailability__user=self, program=program, event_type=et).order_by('start')
         else:
             valid_events = program.getTimeSlots()
 


### PR DESCRIPTION
Before, teacher availability included events of any `EventType`. Now, we only use "Class Time Block" events (which are the events for the actual program). This means that we no longer will include training events, etc as part of a teacher's availability. I believe this will actually fix some weird edge cases that we've encountered in the past where teachers could register more sections of a class than they should have been able to register (I remember lots of weird instances of this at Stanford).

Fixes https://github.com/learning-unlimited/ESP-Website/issues/2436.