### PR TITLE
Add undo button to student lottery management

### DIFF
--- a/esp/esp/program/modules/handlers/studentregphasezeromanage.py
+++ b/esp/esp/program/modules/handlers/studentregphasezeromanage.py
@@ -174,7 +174,15 @@ class StudentRegPhaseZeroManage(ProgramModuleObj):
         # Run lottery if requested
         if request.POST:
             if Tag.getBooleanTag('student_lottery_run', prog):
-                context['error'] = "You've already run the student lottery!"
+                if request.POST.get('mode') == 'undo':
+                    if "confirm" in request.POST:
+                        Group.objects.filter(name=role).delete()
+                        Tag.unSetTag('student_lottery_run', prog)
+                        context['lottery_messages'] = ["The student lottery has been undone."]
+                    else:
+                        context['error'] = "You did not confirm that you would like to undo the lottery."
+                else:
+                    context['error'] = "You've already run the student lottery!"
             else:
                 if "confirm" in request.POST:
                     role = request.POST['rolename']

--- a/esp/templates/program/modules/studentregphasezero/status.html
+++ b/esp/templates/program/modules/studentregphasezero/status.html
@@ -109,8 +109,8 @@ td {
             You must set the <i>program_size_by_grade</i> <a href="/manage/{{ program.getUrlBase }}/tags">tag</a>.
         {% endif %}
         <!--<b>Specify Role Name for Winners: </b>--><input type="hidden" name="rolename" value="{{role}}"></br></br>
-        <input type="checkbox" name="perms" checked>  Open all student registration deadlines for lottery winners.</br></br>
-        <input type="checkbox" name="confirm">  I confirm that I would like to run the default student lottery algorithm.</br></br>
+        <input type="checkbox" name="perms" id="perms_default_checkbox" checked>  <label for="perms_default_checkbox">Open all student registration deadlines for lottery winners.</label></br></br>
+        <input type="checkbox" name="confirm" id="confirm_default_checkbox">  <label for="confirm_default_checkbox">I confirm that I would like to run the default student lottery algorithm.<label></label></br></br>
         <input {% if lottery_run or not grade_caps or invalid_grades %}disabled {% endif %}{% if lottery_run %}title="Lottery has already been run" 
         {% elif invalid_grades %}title="Lottery can not be run with students with invalid grades" 
         {% elif not grade_caps %}title="The grade cap tag must be set to run the lottery" {% endif %}type="submit" style="float:none" value="Run Default Student Lottery Algorithm" />
@@ -127,9 +127,9 @@ td {
         <input type="hidden" name="mode" value="manual">
         <textarea name="usernames" rows="6" placeholder="Enter comma-separated or space-separated student usernames here"></textarea>
         <!--<b>Specify Role Name for Winners: </b>--><input type="hidden" name="rolename" value="{{role}}"></br></br>
-        <input type="checkbox" name="groups">  I would also like to accept any students in the same lottery groups.</br></br>
-        <input type="checkbox" name="perms" checked>  Open all student registration deadlines for lottery winners.</br></br>
-        <input type="checkbox" name="confirm">  I confirm that I would like to use the above list of students for a manual student lottery.</br></br>
+        <input type="checkbox" name="groups" id="groups_checkbox">  <label for="groups_checkbox">I would also like to accept any students in the same lottery groups.</label></br></br>
+        <input type="checkbox" name="perms" id="perms_manual_checkbox" checked>  <label for="perms_manual_checkbox">Open all student registration deadlines for lottery winners.</label></br></br>
+        <input type="checkbox" name="confirm" id="confirm_manual_checkbox">  <label for="confirm_manual_checkbox">I confirm that I would like to use the above list of students for a manual student lottery.</label></br></br>
         <input {% if lottery_run or invalid_grades %}disabled {% endif %}{% if lottery_run %}title="Lottery has already been run" 
         {% elif invalid_grades %}title="Lottery can not be run with students with invalid grades" {% endif %}type="submit" style="float:none" value="Run Manual Student Lottery" />
     </form>
@@ -143,7 +143,7 @@ td {
     This will UNDO the student lottery, which will delete the winners group and remove any permissions that were created for the group. This can NOT be undone.<br/><br/>
     <form action="#" method="POST">
         <input type="hidden" name="mode" value="undo">
-        <input type="checkbox" name="confirm">  I confirm that I would like to UNDO the student lottery.</br></br>
+        <input type="checkbox" name="confirm" id="confirm_undo_checkbox">  <label for="confirm_undo_checkbox">I confirm that I would like to UNDO the student lottery.</label></br></br>
         <input type="submit" style="float:none" value="Undo the Student Lottery" />
     </form>
 </div>

--- a/esp/templates/program/modules/studentregphasezero/status.html
+++ b/esp/templates/program/modules/studentregphasezero/status.html
@@ -111,7 +111,9 @@ td {
         <!--<b>Specify Role Name for Winners: </b>--><input type="hidden" name="rolename" value="{{role}}"></br></br>
         <input type="checkbox" name="perms" checked>  Open all student registration deadlines for lottery winners.</br></br>
         <input type="checkbox" name="confirm">  I confirm that I would like to run the default student lottery algorithm.</br></br>
-        <input {% if lottery_run or not grade_caps %}disabled {% endif %}{% if lottery_run %} title="Lottery has already been run" {% endif %}type="submit" style="float:none" value="Run Default Student Lottery Algorithm" />
+        <input {% if lottery_run or not grade_caps or invalid_grades %}disabled {% endif %}{% if lottery_run %}title="Lottery has already been run" 
+        {% elif invalid_grades %}title="Lottery can not be run with students with invalid grades" 
+        {% elif not grade_caps %}title="The grade cap tag must be set to run the lottery" {% endif %}type="submit" style="float:none" value="Run Default Student Lottery Algorithm" />
     </form>
 </div>
 
@@ -128,9 +130,24 @@ td {
         <input type="checkbox" name="groups">  I would also like to accept any students in the same lottery groups.</br></br>
         <input type="checkbox" name="perms" checked>  Open all student registration deadlines for lottery winners.</br></br>
         <input type="checkbox" name="confirm">  I confirm that I would like to use the above list of students for a manual student lottery.</br></br>
-        <input {% if lottery_run %}disabled title="Lottery has already been run" {% endif %}type="submit" style="float:none" value="Run Manual Student Lottery" />
+        <input {% if lottery_run or invalid_grades %}disabled {% endif %}{% if lottery_run %}title="Lottery has already been run" 
+        {% elif invalid_grades %}title="Lottery can not be run with students with invalid grades" {% endif %}type="submit" style="float:none" value="Run Manual Student Lottery" />
     </form>
 </div>
+
+{% if lottery_run %}
+<button class="dsphead">
+    <b><u>Undo the Student Lottery:</u></b>
+</button>
+<div class="dspcont">
+    This will UNDO the student lottery, which will delete the winners group and remove any permissions that were created for the group. This can NOT be undone.<br/><br/>
+    <form action="#" method="POST">
+        <input type="hidden" name="mode" value="undo">
+        <input type="checkbox" name="confirm">  I confirm that I would like to UNDO the student lottery.</br></br>
+        <input type="submit" style="float:none" value="Undo the Student Lottery" />
+    </form>
+</div>
+{% endif %}
 
 </center>
 


### PR DESCRIPTION
This adds an undo button to the student lottery management page if the lottery has already been run. Selecting this option will delete the tag, the winners group, and the associated permissions.

While I was at it, I added in some more protections to make sure the lottery isn't run if there are users with invalid grades. I also changed all of the checkbox text to `<label>`s so you can click the text to toggle the checkboxes.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3415.

![image](https://user-images.githubusercontent.com/7232514/135764828-b97a4718-2a9c-44af-8505-63effc75572c.png)