### PR TITLE
Do more work at the database level

### DIFF
--- a/esp/esp/program/views.py
+++ b/esp/esp/program/views.py
@@ -761,7 +761,7 @@ def get_email_data(start_date):
             req.num_rec = CommModule.approx_num_of_recipients(req.recipients, req.get_sendto_fn())
         req.num_sent = toes.filter(sent__isnull=False).count()
         if req.num_rec == req.num_sent:
-            req.finished_at = toes.aggregate(sent_last = Max('sent'))['sent_last']
+            req.finished_at = toes.order_by('-sent').first().sent
         else:
             req.finished_at = "(Not finished)"
         requests_list.append(req)

--- a/esp/esp/program/views.py
+++ b/esp/esp/program/views.py
@@ -52,7 +52,7 @@ from esp.users.models import ESPUser, Permission, admin_required, ZipCode, UserA
 from django.contrib.auth.decorators import login_required
 from django.contrib.contenttypes.models import ContentType
 from django.db.models.query import Q
-from django.db.models import Min
+from django.db.models import Min, Max
 from django.db import transaction
 from django.core.mail import mail_admins
 from django.core.cache import cache
@@ -754,14 +754,14 @@ def get_email_data(start_date):
     for req in requests:
         toes = TextOfEmail.objects.filter(created_at=req.created_at,
                                           subject = req.subject,
-                                          send_from = req.sender).order_by('-sent')
+                                          send_from = req.sender)
         if req.processed:
             req.num_rec = toes.count()
         else:
             req.num_rec = CommModule.approx_num_of_recipients(req.recipients, req.get_sendto_fn())
-        req.num_sent = sum(toe.sent is not None for toe in toes)
+        req.num_sent = toes.filter(sent__isnull=False).count()
         if req.num_rec == req.num_sent:
-            req.finished_at = toes[0].sent
+            req.finished_at = toes.aggregate(sent_last = Max('sent'))['sent_last']
         else:
             req.finished_at = "(Not finished)"
         requests_list.append(req)


### PR DESCRIPTION
I've been noticing that loading /manage/emails on some production sites can take quite a long time, and sometimes can even fail (or worse, crash the server). Therefore, this attempts to move a lot of the work for the view to the database level, which should generally be more efficient. Testing this on dev3 indicates that this causes slightly more SQL time, slightly less CPU time (this is good), and overall slightly more total time (not noticeable). I think the best benefit to this, though, is the reduction in memory usage (especially on the production server), since we are no longer iterating over lists of potentially tens of thousands of `TextOfEmail`s. It would probably be useful to also test this on one of the larger sites, like Yale or Stanford, to make sure this actually helps.