### PR TITLE
Various improvements to the user search controller interface

### DIFF
--- a/esp/public/media/scripts/commpanel.js
+++ b/esp/public/media/scripts/commpanel.js
@@ -112,7 +112,8 @@ function populate_get()
     var items = location.search.substr(1).split("&").filter(Boolean);
     for (var index = 0; index < items.length; index++) {
         var key_val = items[index].split("=");
-        $j("[name=" + key_val[0] + "]").val(key_val[1].split(",")).change();
+        $j("[name=" + key_val[0] + "]").val(key_val[1].split(","));
+        if(key_val[0] == "recipient_type") recipient_type_change(clear = false);
     }
 }
 
@@ -122,15 +123,21 @@ function clear_filters()
     var $form = $j("#filter_accordion");
     var form_fields = $form.find(':input');
     form_fields.each(function(i, form_field) {
-        switch (form_field.type) {
-            case 'checkbox':
-                form_field.checked = false;
-                break;
-            case 'radio':
-                form_field.checked = false;
-                break;
-            default:
-                $j(form_field).val('');
+        if(form_field.name == "grade_min"){
+            $j(form_field).val(program_grade_min);
+        } else if(form_field.name == "grade_max"){
+            $j(form_field).val(program_grade_max);
+        } else{
+            switch (form_field.type) {
+                case 'checkbox':
+                    form_field.checked = false;
+                    break;
+                case 'radio':
+                    form_field.checked = false;
+                    break;
+                default:
+                    $j(form_field).val('');
+            }
         }
     });
     $j("#filter_accordion").accordion("option", "active", false);
@@ -166,7 +173,7 @@ function initialize()
     });
 
     //  Handle changes in the recipient type
-    recipient_type_change = function () {
+    recipient_type_change = function (clear = true) {
         var rb_selected = $j("select[name=recipient_type]").val();
         $j("#recipient_type_name").html("Which set of " + rb_selected + " would you like to contact?");
         $j("#recipient_list_select").children("div").addClass("commpanel_hidden");
@@ -174,7 +181,7 @@ function initialize()
         $j("#recipient_list_options_" + rb_selected).removeClass("commpanel_hidden");
         $j(".sendto_fn_select").addClass("commpanel_hidden");
         $j("." + rb_selected + ".sendto_fn_select").removeClass("commpanel_hidden");
-        clear_filters();
+        if(clear) clear_filters();
         prepare_accordion(rb_selected);
     }
     $j("select[name=recipient_type]").change(recipient_type_change);

--- a/esp/templates/users/usersearch/filter_accordion.html
+++ b/esp/templates/users/usersearch/filter_accordion.html
@@ -35,8 +35,8 @@
 
 <h4 class="student"><a href="#">Grade</a></h4>
 <div>
-Min Grade: <input type="text" size="3" name="grade_min" value="" /><br />
-Max Grade: <input type="text" size="3" name="grade_max" value="" />
+Min Grade: <input type="text" size="3" name="grade_min" value="{{ program.grade_min }}" /><br />
+Max Grade: <input type="text" size="3" name="grade_max" value="{{ program.grade_max }}" />
 </div>
 
 <h4 class="teacher"><a href="#">Graduation year</a></h4>

--- a/esp/templates/users/usersearch/list_selector.html
+++ b/esp/templates/users/usersearch/list_selector.html
@@ -4,6 +4,18 @@ $j(document).ready(function() {
 });
 </script>
 
+<h3>Commonly used searches:</h3>
+<div id="common_searches">
+    <ul>
+        <li><a href="./commpanel?recipient_type=Student&base_list=all_Student&grade_min={{ program.grade_min }}&grade_max={{ program.grade_max }}">All students within the age range of the program</a></li>
+        <li><a href="./commpanel?recipient_type=Student&base_list=enrolled">All students enrolled in at least one class</a></li>
+        <li><a href="./commpanel?recipient_type=Teacher&base_list=all_Teacher&gradyear_min={% now 'Y' %}">All teachers who have not graduated</a></li>
+        <li><a href="./commpanel?recipient_type=Teacher&base_list=class_approved">All teachers teaching at least one approved class</a></li>
+        <li><a href="./commpanel?recipient_type=Volunteer&base_list=all_Volunteer">All volunteers in the database</a></li>
+        <li><a href="./commpanel?recipient_type=Volunteer&base_list=volunteer_all">All volunteers signed up for this program</a></li>
+    </ul>
+</div>
+
 <div id="list_descriptions" class="commpanel_hidden">
 {% for kv in lists.items %}{% for item in kv.1 %}
 <div id="list_description_{{ item.name }}">{{ item.description }}</div>
@@ -35,16 +47,16 @@ $j(document).ready(function() {
                 {% if include_prev_list %}
                 <div class="sendto_fn_select Student">
                     <div>
-                        <input type="checkbox" name="student_sendto_self" value="1" checked="checked" />
-                        <label for="student_sendto_self">Email the students</label>
+                        <input type="checkbox" id="student_sendto_self_basic" name="student_sendto_self" value="1" checked="checked" />
+                        <label for="student_sendto_self_basic">Email the students</label>
                     </div>
                     <div>
-                        <input type="checkbox" name="student_sendto_guardian" value="1" />
-                        <label for="student_sendto_guardian">Email the students' guardians</label>
+                        <input type="checkbox" id="student_sendto_guardian_basic" name="student_sendto_guardian" value="1" />
+                        <label for="student_sendto_guardian_basic">Email the students' guardians</label>
                     </div>
                     <div>
-                        <input type="checkbox" name="student_sendto_emergency" value="1" />
-                        <label for="student_sendto_emergency">Email the students' emergency contacts</label>
+                        <input type="checkbox" id="student_sendto_emergency_basic" name="student_sendto_emergency" value="1" />
+                        <label for="student_sendto_emergency_basic">Email the students' emergency contacts</label>
                     </div>
                 </div>
                 {% endif %}
@@ -108,16 +120,16 @@ $j(document).ready(function() {
             </select>
             <div class="sendto_fn_select Student">
                 <div>
-                    <input type="checkbox" name="student_sendto_self" value="1" checked="checked" />
-                    <label for="student_sendto_self">Email the students</label>
+                    <input type="checkbox" id="student_sendto_self_combo" name="student_sendto_self" value="1" checked="checked" />
+                    <label for="student_sendto_self_combo">Email the students</label>
                 </div>
                 <div>
-                    <input type="checkbox" name="student_sendto_guardian" value="1" />
-                    <label for="student_sendto_guardian">Email the students' guardians</label>
+                    <input type="checkbox" id="student_sendto_guardian_combo" name="student_sendto_guardian" value="1" />
+                    <label for="student_sendto_guardian_combo">Email the students' guardians</label>
                 </div>
                 <div>
-                    <input type="checkbox" name="student_sendto_emergency" value="1" />
-                    <label for="student_sendto_emergency">Email the students' emergency contacts</label>
+                    <input type="checkbox" id="student_sendto_emergency_combo" name="student_sendto_emergency" value="1" />
+                    <label for="student_sendto_emergency_combo">Email the students' emergency contacts</label>
                 </div>
             </div>
             <p>&nbsp;</p>

--- a/esp/templates/users/usersearch/support.html
+++ b/esp/templates/users/usersearch/support.html
@@ -11,6 +11,8 @@
     <script type="text/javascript" src="/media/scripts/commpanel.js"></script>
     <script type="text/javascript">
     var program_base_url = "/json/{{ program.getUrlBase }}/";
+    var program_grade_min = "{{ program.grade_min }}";
+    var program_grade_max = "{{ program.grade_max }}";
     //  Populate list names
     var list_names = [{% for name in all_list_names %}"{{ name }}"{% if not forloop.last %}, {% endif %}{% endfor %}];
     </script>


### PR DESCRIPTION
This makes the following improvements to the user search controller (comm panel, arbitrary user list, etc):

- The default min and max grade filters correspond to the min and max grades of the program
- There is now a list of commonly used searches (Fixes https://github.com/learning-unlimited/ESP-Website/issues/3269)
- Fixes a bug that would cause an infinite loop in the javascript if you specified "recipient_type" in the GET parameters
- Makes the labels for the student email options (students/guardians/emergency contacts) associated with the checkboxes, which enables clicking the text to toggle the checkbox