### PR TITLE
Fix deadlines link on volunteer signup and teacher availability

### DIFF
--- a/esp/esp/program/modules/base.py
+++ b/esp/esp/program/modules/base.py
@@ -619,6 +619,8 @@ def _checkDeadline_helper(method, extension, moduleObj, request, tl, *args, **kw
             #   Give administrators additional information
             if user.isAdministrator(program=program):
                 request.show_perm_info = True
+                request.one = program.program_type
+                request.two = program.program_instance
                 if getattr(request, 'perm_names', None) is not None:
                     request.perm_names.append(perm_name)
                 else:

--- a/esp/esp/program/modules/handlers/availabilitymodule.py
+++ b/esp/esp/program/modules/handlers/availabilitymodule.py
@@ -231,6 +231,8 @@ class AvailabilityModule(ProgramModuleObj):
         context['conflict_found'] = conflict_found
         context['teacher_user'] = teacher
         context['isAdmin'] = isAdmin
+        context['one'] = one
+        context['two'] = two
 
         if isAdmin:
             form = TeacherSearchForm(initial={'target_user': teacher.id})

--- a/esp/esp/program/modules/handlers/volunteersignup.py
+++ b/esp/esp/program/modules/handlers/volunteersignup.py
@@ -69,8 +69,8 @@ class VolunteerSignup(ProgramModuleObj, CoreModule):
     @staticmethod
     def signupForm(request, tl, one, two, prog, volunteer, isAdmin=False):
         context = {}
-	context['one'] = one
-	context['two'] = two
+        context['one'] = one
+        context['two'] = two
 
         if request.method == 'POST':
             form = VolunteerOfferForm(request.POST, program=prog)

--- a/esp/esp/program/modules/handlers/volunteersignup.py
+++ b/esp/esp/program/modules/handlers/volunteersignup.py
@@ -69,6 +69,8 @@ class VolunteerSignup(ProgramModuleObj, CoreModule):
     @staticmethod
     def signupForm(request, tl, one, two, prog, volunteer, isAdmin=False):
         context = {}
+	context['one'] = one
+	context['two'] = two
 
         if request.method == 'POST':
             form = VolunteerOfferForm(request.POST, program=prog)

--- a/esp/esp/themes/theme_data/fruitsalad/templates/main.html
+++ b/esp/esp/themes/theme_data/fruitsalad/templates/main.html
@@ -213,7 +213,7 @@ var currentPrograms = [
           {% if request.show_perm_info %}
           <div class="alert alert-info">
               <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
-              <a href="/manage/{{ one }}/{{ two }}/deadline_management/">Permission/deadline</a> required to view this page: {{ request.perm_names|join:", " }}
+              <a href="/manage/{{ request.one }}/{{ request.two }}/deadline_management/">Permission/deadline</a> required to view this page: {{ request.perm_names|join:", " }}
               <br />
               {% if request.roles_with_perm %}
                   Roles with permission to view this page: {{ request.roles_with_perm|join:", " }}


### PR DESCRIPTION
Fixes #3335 by adding one and two to the context on the volunteer signup handler, which is the only broken link i could spot.