### PR TITLE
Use GET parameters for USC printable links

### DIFF
--- a/esp/public/media/scripts/commpanel.js
+++ b/esp/public/media/scripts/commpanel.js
@@ -112,8 +112,23 @@ function populate_get()
     var items = location.search.substr(1).split("&").filter(Boolean);
     for (var index = 0; index < items.length; index++) {
         var key_val = items[index].split("=");
-        $j("[name=" + key_val[0] + "]").val(key_val[1].split(","));
-        if(key_val[0] == "recipient_type") recipient_type_change(clear = false);
+        var field = $j("[name=" + key_val[0] + "]");
+        if(field.length >= 1){
+            switch (field[0].type) {
+                case 'checkbox':
+                    // don't need a value for a checkbox, just check it
+                    field[0].checked = true;
+                    break;
+                default:
+                    if(key_val.length == 2){
+                        field.val(key_val[1].split(","));
+                        if(key_val[0] == "recipient_type") recipient_type_change(clear = false);
+                    } else {
+                        // skip it and keep going if a value wasn't specified
+                        break;
+                    }
+            }
+        }
     }
 }
 

--- a/esp/templates/program/modules/programprintables/options.html
+++ b/esp/templates/program/modules/programprintables/options.html
@@ -65,7 +65,7 @@ Please select from options below.
     <a href="./studentschedules/png/?recipient_type=Student&base_list=enrolled">PNG (1 schedule max)</a>
 </li>
 <li><a href="./flatstudentschedules?recipient_type=Student&base_list=enrolled" title="Student Schedules">Flat Student Schedules</a> (by students)</li>
-<li><a href="./teacherschedules?recipient_type=Teacher&base_list=approved" title="Teacher Schedules">Teacher Schedules</a> (by teachers)</li>
+<li><a href="./teacherschedules?recipient_type=Teacher&base_list=class_approved" title="Teacher Schedules">Teacher Schedules</a> (by teachers)</li>
 {% if program|hasModule:"TeacherModeratorModule" %}
     <li><a href="./teachermoderatorschedules?combo_base_list=Teacher:class_approved&checkbox_or_assigned_moderator#tab_combo" title="Teacher and Moderator Schedules">Combined Teacher and {{ program.getModeratorTitle }} Schedules</a> (by teachers)</li>
     <li><a href="./moderatorschedules?recipient_type=Teacher&base_list=assigned_moderator" title="Moderator Schedules">{{ program.getModeratorTitle }} Schedules</a> (by teachers)</li>
@@ -87,17 +87,17 @@ Please select from options below.
 {% if program|hasModule:"TeacherModeratorModule" %}
     <li>Class Rosters</li>
     <ul>
-        <li><a href="./classrosters?recipient_type=Teacher&base_list=approved" title="Class Rosters">By teachers</a></li>
+        <li><a href="./classrosters?recipient_type=Teacher&base_list=class_approved" title="Class Rosters">By teachers</a></li>
         <li><a href="./classrostersbymoderator?recipient_type=Teacher&base_list=assigned_moderator" title="Class Rosters">By {{ program.getModeratorTitle|lower }}s</a></li>
     </ul>
     <li>Attendance Sheets</li>
     <ul>
-        <li><a href="./classrosters/attendance?recipient_type=Teacher&base_list=approved" title="Attendance Sheets">By teachers</a></li>
+        <li><a href="./classrosters/attendance?recipient_type=Teacher&base_list=class_approved" title="Attendance Sheets">By teachers</a></li>
         <li><a href="./classrostersbymoderator/attendance?recipient_type=Teacher&base_list=assigned_moderator" title="Attendance Sheets">By {{ program.getModeratorTitle|lower }}s</a></li>
     </ul>
 {% else %}
-    <li><a href="./classrosters?recipient_type=Teacher&base_list=approved" title="Class Rosters">Class Rosters</a> (by teachers)</li>
-    <li><a href="./classrosters/attendance?recipient_type=Teacher&base_list=approved" title="Attendance Sheets">Attendance Sheets</a> (by teachers)</li>
+    <li><a href="./classrosters?recipient_type=Teacher&base_list=class_approved" title="Class Rosters">Class Rosters</a> (by teachers)</li>
+    <li><a href="./classrosters/attendance?recipient_type=Teacher&base_list=class_approved" title="Attendance Sheets">Attendance Sheets</a> (by teachers)</li>
 {% endif %}
 <li><a href="./classchecklists" title="Class Checlists">Class Checklists</a> (all confirmed students)</li>
 <li><a href="./studentchecklist?recipient_type=Student&base_list=enrolled" title="Student Checklist">Student Checklist</a> (by students)</li>
@@ -117,8 +117,8 @@ Please select from options below.
 
 <h3>Teacher Lists</h3>
 <ul>
-<li><a href="./teachersbyname?recipient_type=Teacher&base_list=approved" title="Teacher List">Teacher List</a> (can be sorted by name, class, or start time) (<a href="./teachersbyname/csv?recipient_type=Teacher&base_list=approved">CSV</a>)
-<ul><li><a href="./teachersbyname/secondday?recipient_type=Teacher&base_list=approved">Teachers for second day of classes only</a> (<a href="./teachersbyname/seconddaycsv?recipient_type=Teacher&base_list=approved">CSV</a>)</li></ul></li>
+<li><a href="./teachersbyname?recipient_type=Teacher&base_list=class_approved" title="Teacher List">Teacher List</a> (can be sorted by name, class, or start time) (<a href="./teachersbyname/csv?recipient_type=Teacher&base_list=class_approved">CSV</a>)
+<ul><li><a href="./teachersbyname/secondday?recipient_type=Teacher&base_list=class_approved">Teachers for second day of classes only</a> (<a href="./teachersbyname/seconddaycsv?recipient_type=Teacher&base_list=class_approved">CSV</a>)</li></ul></li>
 </ul>
 {% if program|hasModule:"TeacherModeratorModule" %}
     <ul>

--- a/esp/templates/program/modules/programprintables/options.html
+++ b/esp/templates/program/modules/programprintables/options.html
@@ -57,20 +57,20 @@ Please select from options below.
 
 <h3>Schedules</h3>
 <ul>
-<li><a href="./studentschedules" title="Student Schedules">Student Schedules</a> (by students) -- multiple formats available: 
-    <a href="./studentschedules/tex/">TEX</a>
-    <a href="./studentschedules/ps/">PS</a>
-    <a href="./studentschedules/pdf/">PDF</a>
-    <a href="./studentschedules/svg/">SVG (1 schedule max)</a> 
-    <a href="./studentschedules/png/">PNG (1 schedule max)</a>
+<li><a href="./studentschedules?recipient_type=Student&base_list=enrolled" title="Student Schedules">Student Schedules</a> (by students) -- multiple formats available: 
+    <a href="./studentschedules/tex/?recipient_type=Student&base_list=enrolled">TEX</a>
+    <a href="./studentschedules/ps/?recipient_type=Student&base_list=enrolled">PS</a>
+    <a href="./studentschedules/pdf/?recipient_type=Student&base_list=enrolled">PDF</a>
+    <a href="./studentschedules/svg/?recipient_type=Student&base_list=enrolled">SVG (1 schedule max)</a> 
+    <a href="./studentschedules/png/?recipient_type=Student&base_list=enrolled">PNG (1 schedule max)</a>
 </li>
-<li><a href="./flatstudentschedules" title="Student Schedules">Flat Student Schedules</a> (by students)</li>
-<li><a href="./teacherschedules" title="Teacher Schedules">Teacher Schedules</a> (by teachers)</li>
+<li><a href="./flatstudentschedules?recipient_type=Student&base_list=enrolled" title="Student Schedules">Flat Student Schedules</a> (by students)</li>
+<li><a href="./teacherschedules?recipient_type=Teacher&base_list=approved" title="Teacher Schedules">Teacher Schedules</a> (by teachers)</li>
 {% if program|hasModule:"TeacherModeratorModule" %}
-    <li><a href="./teachermoderatorschedules" title="Teacher and Moderator Schedules">Combined Teacher and {{ program.getModeratorTitle }} Schedules</a> (by teachers)</li>
-    <li><a href="./moderatorschedules" title="Moderator Schedules">{{ program.getModeratorTitle }} Schedules</a> (by teachers)</li>
+    <li><a href="./teachermoderatorschedules?combo_base_list=Teacher:class_approved&checkbox_or_assigned_moderator#tab_combo" title="Teacher and Moderator Schedules">Combined Teacher and {{ program.getModeratorTitle }} Schedules</a> (by teachers)</li>
+    <li><a href="./moderatorschedules?recipient_type=Teacher&base_list=assigned_moderator" title="Moderator Schedules">{{ program.getModeratorTitle }} Schedules</a> (by teachers)</li>
 {% endif %}
-<li><a href="./volunteerschedules" title="Volunteer Schedules">Volunteer Schedules</a> (by volunteers)</li>
+<li><a href="./volunteerschedules?recipient_type=Volunteer&base_list=volunteer_all" title="Volunteer Schedules">Volunteer Schedules</a> (by volunteers)</li>
 <li><a href="./roomschedules" title="Room Schedules">Room Schedules</a> (<a href="./roomschedules/all_blocks" title="Room Schedules with All Blocks">with all blocks</a>)</li>
 {% if program|hasModule:"TeacherModeratorModule" %}
     <li><a href="./moderator_rooms_spr" title="Complete Moderator Schedule by Room">Complete Moderator Schedule by Room</a> (CSV format)</li>
@@ -87,23 +87,23 @@ Please select from options below.
 {% if program|hasModule:"TeacherModeratorModule" %}
     <li>Class Rosters</li>
     <ul>
-        <li><a href="./classrosters" title="Class Rosters">By teachers</a></li>
-        <li><a href="./classrostersbymoderator" title="Class Rosters">By {{ program.getModeratorTitle|lower }}s</a></li>
+        <li><a href="./classrosters?recipient_type=Teacher&base_list=approved" title="Class Rosters">By teachers</a></li>
+        <li><a href="./classrostersbymoderator?recipient_type=Teacher&base_list=assigned_moderator" title="Class Rosters">By {{ program.getModeratorTitle|lower }}s</a></li>
     </ul>
     <li>Attendance Sheets</li>
     <ul>
-        <li><a href="./classrosters/attendance" title="Attendance Sheets">By teachers</a></li>
-        <li><a href="./classrostersbymoderator/attendance" title="Attendance Sheets">By {{ program.getModeratorTitle|lower }}s</a></li>
+        <li><a href="./classrosters/attendance?recipient_type=Teacher&base_list=approved" title="Attendance Sheets">By teachers</a></li>
+        <li><a href="./classrostersbymoderator/attendance?recipient_type=Teacher&base_list=assigned_moderator" title="Attendance Sheets">By {{ program.getModeratorTitle|lower }}s</a></li>
     </ul>
 {% else %}
-    <li><a href="./classrosters" title="Class Rosters">Class Rosters</a> (by teachers)</li>
-    <li><a href="./classrosters/attendance" title="Attendance Sheets">Attendance Sheets</a> (by teachers)</li>
+    <li><a href="./classrosters?recipient_type=Teacher&base_list=approved" title="Class Rosters">Class Rosters</a> (by teachers)</li>
+    <li><a href="./classrosters/attendance?recipient_type=Teacher&base_list=approved" title="Attendance Sheets">Attendance Sheets</a> (by teachers)</li>
 {% endif %}
 <li><a href="./classchecklists" title="Class Checlists">Class Checklists</a> (all confirmed students)</li>
-<li><a href="./studentchecklist" title="Student Checklist">Student Checklist</a> (by students)</li>
-<li><a href="./student_financial_spreadsheet">Student Financial Spreadsheet</a> (used by the check-scanning app)</li>
-<li><a href="./studentsbyname" title="Student List">Students by Name</a> (by students)</li>
-<li><a href="./emergencycontacts" title="Student List">Students' Emergency Contact Info</a> (by students)</li>
+<li><a href="./studentchecklist?recipient_type=Student&base_list=enrolled" title="Student Checklist">Student Checklist</a> (by students)</li>
+<li><a href="./student_financial_spreadsheet?recipient_type=Student&base_list=enrolled">Student Financial Spreadsheet</a> (used by the check-scanning app)</li>
+<li><a href="./studentsbyname?recipient_type=Student&base_list=enrolled" title="Student List">Students by Name</a> (by students)</li>
+<li><a href="./emergencycontacts?recipient_type=Student&base_list=enrolled" title="Student List">Students' Emergency Contact Info</a> (by students)</li>
 {% if not li_types|length_is:0 %}
 <li>Students who have ordered/reserved line items:
     <ul>
@@ -117,23 +117,23 @@ Please select from options below.
 
 <h3>Teacher Lists</h3>
 <ul>
-<li><a href="./teachersbyname" title="Teacher List">Teacher List</a> (can be sorted by name, class, or start time) (<a href="./teachersbyname/csv">CSV</a>)
-<ul><li><a href="./teachersbyname/secondday">Teachers for second day of classes only</a> (<a href="./teachersbyname/seconddaycsv">CSV</a>)</li></ul></li>
+<li><a href="./teachersbyname?recipient_type=Teacher&base_list=approved" title="Teacher List">Teacher List</a> (can be sorted by name, class, or start time) (<a href="./teachersbyname/csv?recipient_type=Teacher&base_list=approved">CSV</a>)
+<ul><li><a href="./teachersbyname/secondday?recipient_type=Teacher&base_list=approved">Teachers for second day of classes only</a> (<a href="./teachersbyname/seconddaycsv?recipient_type=Teacher&base_list=approved">CSV</a>)</li></ul></li>
 </ul>
 {% if program|hasModule:"TeacherModeratorModule" %}
     <ul>
-    <li><a href="./teachermoderatorsbyname" title="Teacher and Moderator List">Combined Teacher and {{ program.getModeratorTitle }} List</a> (can be sorted by name, class, or start time) (<a href="./teachermoderatorsbyname/csv">CSV</a>)
-    <ul><li><a href="./teachermoderatorsbyname/secondday">{{ program.getModeratorTitle }}s and teachers for second day of classes only</a> (<a href="./teachermoderatorsbyname/seconddaycsv">CSV</a>)</li></ul></li>
+    <li><a href="./teachermoderatorsbyname?combo_base_list=Teacher:class_approved&checkbox_or_assigned_moderator#tab_combo" title="Teacher and Moderator List">Combined Teacher and {{ program.getModeratorTitle }} List</a> (can be sorted by name, class, or start time) (<a href="./teachermoderatorsbyname/csv?combo_base_list=Teacher:class_approved&checkbox_or_assigned_moderator#tab_combo">CSV</a>)
+    <ul><li><a href="./teachermoderatorsbyname/secondday?combo_base_list=Teacher:class_approved&checkbox_or_assigned_moderator#tab_combo">{{ program.getModeratorTitle }}s and teachers for second day of classes only</a> (<a href="./teachermoderatorsbyname/seconddaycsv?combo_base_list=Teacher:class_approved&checkbox_or_assigned_moderator#tab_combo">CSV</a>)</li></ul></li>
     </ul>
     <ul>
-    <li><a href="./moderatorsbyname" title="Moderator List">{{ program.getModeratorTitle }} List</a> (can be sorted by name, class, or start time) (<a href="./moderatorsbyname/csv">CSV</a>)
-    <ul><li><a href="./moderatorsbyname/secondday">{{ program.getModeratorTitle }}s for second day of classes only</a> (<a href="./moderatorsbyname/seconddaycsv">CSV</a>)</li></ul></li>
+    <li><a href="./moderatorsbyname?recipient_type=Teacher&base_list=assigned_moderator" title="Moderator List">{{ program.getModeratorTitle }} List</a> (can be sorted by name, class, or start time) (<a href="./moderatorsbyname/csv?recipient_type=Teacher&base_list=assigned_moderator">CSV</a>)
+    <ul><li><a href="./moderatorsbyname/secondday?recipient_type=Teacher&base_list=assigned_moderator">{{ program.getModeratorTitle }}s for second day of classes only</a> (<a href="./moderatorsbyname/seconddaycsv?recipient_type=Teacher&base_list=assigned_moderator">CSV</a>)</li></ul></li>
     </ul>
 {% endif %}
 
 <h3>Receipts</h3>
 <ul>
-<li><a href="./certificate" title="Completion Certificate">Completion Certificate</a> (by students)</li>
+<li><a href="./certificate?recipient_type=Student&base_list=enrolled" title="Completion Certificate">Completion Certificate</a> (by students)</li>
 <li><a href="./paid_list_filter" title="Purchase Lists">Lists of Purchased Items</a></li>
 </ul>
 

--- a/esp/templates/users/usersearch/list_selector.html
+++ b/esp/templates/users/usersearch/list_selector.html
@@ -7,12 +7,12 @@ $j(document).ready(function() {
 <h3>Commonly used searches:</h3>
 <div id="common_searches">
     <ul>
-        <li><a href="./commpanel?recipient_type=Student&base_list=all_Student&grade_min={{ program.grade_min }}&grade_max={{ program.grade_max }}">All students within the age range of the program</a></li>
-        <li><a href="./commpanel?recipient_type=Student&base_list=enrolled">All students enrolled in at least one class</a></li>
-        <li><a href="./commpanel?recipient_type=Teacher&base_list=all_Teacher&gradyear_min={% now 'Y' %}">All teachers who have not graduated</a></li>
-        <li><a href="./commpanel?recipient_type=Teacher&base_list=class_approved">All teachers teaching at least one approved class</a></li>
-        <li><a href="./commpanel?recipient_type=Volunteer&base_list=all_Volunteer">All volunteers in the database</a></li>
-        <li><a href="./commpanel?recipient_type=Volunteer&base_list=volunteer_all">All volunteers signed up for this program</a></li>
+        <li><a href="?recipient_type=Student&base_list=all_Student&grade_min={{ program.grade_min }}&grade_max={{ program.grade_max }}">All students within the age range of the program</a></li>
+        <li><a href="?recipient_type=Student&base_list=enrolled">All students enrolled in at least one class</a></li>
+        <li><a href="?recipient_type=Teacher&base_list=all_Teacher&gradyear_min={% now 'Y' %}">All teachers who have not graduated</a></li>
+        <li><a href="?recipient_type=Teacher&base_list=class_approved">All teachers teaching at least one approved class</a></li>
+        <li><a href="?recipient_type=Volunteer&base_list=all_Volunteer">All volunteers in the database</a></li>
+        <li><a href="?recipient_type=Volunteer&base_list=volunteer_all">All volunteers signed up for this program</a></li>
     </ul>
 </div>
 


### PR DESCRIPTION
This uses GET parameters for the links to the printables that use the UserSearchController to make it slightly easier for admins to output these printables with the correct sets of users. As part of this, the GET parameters can now specify any of the AND/OR/NOT checkboxes to be checked.

While I was at it, I fixed a bug introduced in #3424 where the USC links always directed to the commpanel, instead of staying in the module.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3403.