### PR TITLE
Add banner to required modules

### DIFF
--- a/esp/esp/program/modules/base.py
+++ b/esp/esp/program/modules/base.py
@@ -607,6 +607,8 @@ def _checkDeadline_helper(method, extension, moduleObj, request, tl, *args, **kw
         user = request.user
         program = request.program
         canView = user.updateOnsite(request)
+        request.mod_required = moduleObj.required
+        request.tl = tl
         if not canView:
             canView = Permission.user_has_perm(user,
                                                perm_name,

--- a/esp/esp/themes/theme_data/barebones/templates/main.html
+++ b/esp/esp/themes/theme_data/barebones/templates/main.html
@@ -69,6 +69,24 @@ Customize your title formatting here.  For example:
     {% endblock %}
 
     <div id="main" class="span12 resizable">
+      {% if request.mod_required %}
+      <div class="alert alert-danger">
+          <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+          This page is <b>required</b> for {% if request.tl == "teach" %}teacher{% elif request.tl == "learn" %}student{% elif request.tl == "volunteer" %}volunteer{% endif %} registration. You must complete it to proceed.
+      </div>
+      {% endif %}
+      {% if request.show_perm_info %}
+      <div class="alert alert-info">
+          <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+          <a href="/manage/{{ request.one }}/{{ request.two }}/deadline_management/">Permission/deadline</a> required to view this page: {{ request.perm_names|join:", " }}
+          <br />
+          {% if request.roles_with_perm %}
+              Roles with permission to view this page: {{ request.roles_with_perm|join:", " }}
+          {% else %}
+              <strong>No (non-admin) roles have permission to view this page!</strong>
+          {% endif %}
+      </div>
+      {% endif %}
       {% block content %}
       {% endblock %}
     </div>

--- a/esp/esp/themes/theme_data/bigpicture/templates/main.html
+++ b/esp/esp/themes/theme_data/bigpicture/templates/main.html
@@ -74,6 +74,24 @@
     {% endblock %}
 
     <div id="main" class="span9 resizable">
+      {% if request.mod_required %}
+      <div class="alert alert-danger">
+          <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+          This page is <b>required</b> for {% if request.tl == "teach" %}teacher{% elif request.tl == "learn" %}student{% elif request.tl == "volunteer" %}volunteer{% endif %} registration. You must complete it to proceed.
+      </div>
+      {% endif %}
+      {% if request.show_perm_info %}
+      <div class="alert alert-info">
+          <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+          <a href="/manage/{{ request.one }}/{{ request.two }}/deadline_management/">Permission/deadline</a> required to view this page: {{ request.perm_names|join:", " }}
+          <br />
+          {% if request.roles_with_perm %}
+              Roles with permission to view this page: {{ request.roles_with_perm|join:", " }}
+          {% else %}
+              <strong>No (non-admin) roles have permission to view this page!</strong>
+          {% endif %}
+      </div>
+      {% endif %}
       {% block content %}
       {% endblock content %}
     </div>

--- a/esp/esp/themes/theme_data/circles/templates/main.html
+++ b/esp/esp/themes/theme_data/circles/templates/main.html
@@ -129,7 +129,27 @@
 
 <div id="chicago_main_header">{% block welcome_message %}<!-- CSS2 doesn't allow vertical alignment without a table.  So, give it a table. --><table width="600px" height="30px"><tr><td valign="middle">{{ theme.welcome_message }}</td></tr></table>{% endblock %}</div>
 
-<div id="chicago_main_content">{% block content %}{% endblock %}</div>
+<div id="chicago_main_content">
+  {% if request.mod_required %}
+  <div class="alert alert-danger">
+      <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+      This page is <b>required</b> for {% if request.tl == "teach" %}teacher{% elif request.tl == "learn" %}student{% elif request.tl == "volunteer" %}volunteer{% endif %} registration. You must complete it to proceed.
+  </div>
+  {% endif %}
+  {% if request.show_perm_info %}
+  <div class="alert alert-info">
+      <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+      <a href="/manage/{{ request.one }}/{{ request.two }}/deadline_management/">Permission/deadline</a> required to view this page: {{ request.perm_names|join:", " }}
+      <br />
+      {% if request.roles_with_perm %}
+          Roles with permission to view this page: {{ request.roles_with_perm|join:", " }}
+      {% else %}
+          <strong>No (non-admin) roles have permission to view this page!</strong>
+      {% endif %}
+  </div>
+  {% endif %}
+  {% block content %}{% endblock %}
+</div>
 
 <div id="footer">{% block footer %}{% endblock %}</div>
 

--- a/esp/esp/themes/theme_data/floaty/templates/main.html
+++ b/esp/esp/themes/theme_data/floaty/templates/main.html
@@ -131,7 +131,24 @@
 </div>
 
 <div id="content_area">
-
+    {% if request.mod_required %}
+    <div class="alert alert-danger">
+        <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+        This page is <b>required</b> for {% if request.tl == "teach" %}teacher{% elif request.tl == "learn" %}student{% elif request.tl == "volunteer" %}volunteer{% endif %} registration. You must complete it to proceed.
+    </div>
+    {% endif %}
+    {% if request.show_perm_info %}
+    <div class="alert alert-info">
+        <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+        <a href="/manage/{{ request.one }}/{{ request.two }}/deadline_management/">Permission/deadline</a> required to view this page: {{ request.perm_names|join:", " }}
+        <br />
+        {% if request.roles_with_perm %}
+            Roles with permission to view this page: {{ request.roles_with_perm|join:", " }}
+        {% else %}
+            <strong>No (non-admin) roles have permission to view this page!</strong>
+        {% endif %}
+    </div>
+    {% endif %}
     {% block content %}
     {% endblock %}
 

--- a/esp/esp/themes/theme_data/fruitsalad/templates/main.html
+++ b/esp/esp/themes/theme_data/fruitsalad/templates/main.html
@@ -213,7 +213,7 @@ var currentPrograms = [
           {% if request.mod_required %}
           <div class="alert alert-danger">
               <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
-              This page is required for {% if request.tl == "teach" %}teacher{% elif request.tl == "learn" %}student{% elif request.tl == "volunteer" %}volunteer{% endif %} registration. You must complete it to proceed.
+              This page is <b>required</b> for {% if request.tl == "teach" %}teacher{% elif request.tl == "learn" %}student{% elif request.tl == "volunteer" %}volunteer{% endif %} registration. You must complete it to proceed.
           </div>
           {% endif %}
           {% if request.show_perm_info %}

--- a/esp/esp/themes/theme_data/fruitsalad/templates/main.html
+++ b/esp/esp/themes/theme_data/fruitsalad/templates/main.html
@@ -210,6 +210,12 @@ var currentPrograms = [
 {% endblock %}
 
       <div id="content">
+          {% if request.mod_required %}
+          <div class="alert alert-danger">
+              <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+              This page is required for {% if request.tl == "teach" %}teacher{% elif request.tl == "learn" %}student{% elif request.tl == "volunteer" %}volunteer{% endif %} registration. You must complete it to proceed.
+          </div>
+          {% endif %}
           {% if request.show_perm_info %}
           <div class="alert alert-info">
               <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>


### PR DESCRIPTION
This adds a banner at the top of modules that are required, to clarify why a page is being shown before the registration landing page:
![image](https://user-images.githubusercontent.com/7232514/138013029-0e410804-fb67-4450-8aa9-f5fae938bc38.png)

While I was at it, I also copied the deadlines banner to all non-fruitsalad themes (Fixes https://github.com/learning-unlimited/ESP-Website/issues/3431).

Fixes https://github.com/learning-unlimited/ESP-Website/issues/335.