### PR TITLE
Fix userview email address for some users

### DIFF
--- a/esp/templates/users/userview.html
+++ b/esp/templates/users/userview.html
@@ -135,13 +135,12 @@
 <tr><td class="key">Gender</td><td>{% if profile.student_info.gender %}{{ profile.student_info.gender }}{% else %}Not specified{% endif %}</td></tr>
 <tr><td class="key">Username</td><td>{{ user.username }}</td></tr>
 <tr><td class="key">User ID</td><td>{{ user.id }}</td></tr>
+<tr><td class="key">Email</td><td>{{ user.email }}</td></tr>
 {% if profile.contact_user %}
-    <tr><td class="key">Email</td><td><a href="mailto:{{ profile.contact_user.e_mail }}" target="_blank">{{ profile.contact_user.e_mail }}</a></td></tr>
     <tr><td class="key">Day Phone</td><td>{{ profile.contact_user.phone_day }}</td></tr>
     <tr><td class="key">Cell Phone</td><td>{{ profile.contact_user.phone_cell }}</td></tr>
     <tr><td class="key">Address</td><td>{{ profile.contact_user.address_street }}<br />{{ profile.contact_user.address_city }}, {{ profile.contact_user.address_state }} {{ profile.contact_user.address_zip }}{% if profile.contact_user.undeliverable %}<br /><font color="red">Mail has bounced!</font>{% endif %}</td></tr>
 {% else %}
-    <tr><td class="key">Email</td><td>{{ user.email }}</td></tr>
     <tr><td colspan="2"><font color="red">User account not fully created; please fill out a profile!</font></td></tr>
 {% endif %}
 </table>


### PR DESCRIPTION
Sometimes (I'm not entirely sure how), a `ContactInfo` will end up without an email address. If this is the most recent `ContactInfo` or the `ContactInfo` associated with the selected program, the userview page would previously show a blank email address. However, there is always an email address associated with each user, and it is always updated when a user's profile is updated:
https://github.com/learning-unlimited/ESP-Website/blob/4bba497d00446c650a918e3029562e9aa9ca6c48/esp/esp/web/views/myesp.py#L194-L196

Given that we probably always want the most up-to-date email address on the userview page (as opposed to the program-specific one), this seems like a reasonable minor change.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/1832.