### PR TITLE
Convert errors and successes to banners

### DIFF
--- a/esp/esp/program/modules/handlers/onsitecheckoutmodule.py
+++ b/esp/esp/program/modules/handlers/onsitecheckoutmodule.py
@@ -91,7 +91,7 @@ class OnSiteCheckoutModule(ProgramModuleObj):
 
             # Get most recent check-in record
             if not prog.isCheckedIn(student):
-                context['checkout_message'] = "Caution: %s (%s) is not currently checked in for this program!" % (student.name(), student.username)
+                context['checkout_message_warning'] = "Caution: %s (%s) is not currently checked in for this program!" % (student.name(), student.username)
 
             if 'checkout_student' in request.POST:
                 # Make checked_out record
@@ -100,7 +100,7 @@ class OnSiteCheckoutModule(ProgramModuleObj):
                 # Unenroll student from selected classes
                 for sec in ClassSection.objects.filter(id__in=filter(None, request.POST.getlist('unenroll'))).distinct():
                     sec.unpreregister_student(student, prereg_verb = "Enrolled")
-                context['checkout_message'] = "Successfully checked out %s (%s)" % (student.name(), student.username)
+                context['checkout_message_success'] = "Successfully checked out %s (%s)" % (student.name(), student.username)
 
             context.update(StudentClassRegModule.prepare_static(student, prog))
         else:

--- a/esp/templates/admin/cache_flush.html
+++ b/esp/templates/admin/cache_flush.html
@@ -22,8 +22,18 @@ it doesn't get out-of-date next time.  (Out-of-date data indicates a bug.
 Flushing the cache may patch the bug for now, but it'll very likely come up
 later, possibly in a more annoying way.)</p>
 
-{% if error %}<p><font color="red">{{ error }}</font></p>{% endif %}
-{% if success %}<p><font color="blue">{{ success }}</font></p>{% endif %}
+{% if error %}
+    <div class="alert alert-danger">
+        <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+        {{ error }}
+    </div>
+{% endif %}
+{% if success %}
+    <div class="alert alert-success">
+        <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+        {{ success }}
+    </div>
+{% endif %}
 <p>
 <form action="/manage/flushcache/" method="POST">
 <textarea name="reason" placeholder="Reason for flushing cache"></textarea>

--- a/esp/templates/miniblog.html
+++ b/esp/templates/miniblog.html
@@ -4,7 +4,10 @@
 
 {% block content %}
 
-<h1><font color='red'>{{ extramsg }}</font></h1>
+<div class="alert alert-danger">
+    <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+        {{ extramsg }}
+</div>
 
 {% for entry in entries %}
 <h1>{{ entry.title }}</h1>

--- a/esp/templates/program/modules/adminclass/classavailability.html
+++ b/esp/templates/program/modules/adminclass/classavailability.html
@@ -26,15 +26,17 @@ $j(document).ready(function() {
 <h1>Availability for <u>{{ class|escape }}</u></h1>
 
 {% if is_overbooked %}
-<p style="color: red;">
+<div class="alert alert-danger">
+    <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
 This class is registered for more hours than the number of hours for which the teachers are jointly availabile.
-</p>
+</div>
 {% endif %}
 
 {% if conflict_found %}
-<p style="color: red;">
+<div class="alert alert-danger">
+    <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
 This class is scheduled during at least one timeslot in which at least one teacher is not marked as available (indicated with a red border).
-</p>
+</div>
 {% endif %}
 
 <h2>Length:</h2>

--- a/esp/templates/program/modules/adminclass/classedit.html
+++ b/esp/templates/program/modules/adminclass/classedit.html
@@ -16,7 +16,10 @@ Thank you for teaching for {{ one }}. Please fill out/update the form below.
 <br />
 
 {% if form.has_errors %}
-<h2 style="color:red">Please fix the error{{ form.error_dict|pluralize }} in the form.</h2>
+<div class="alert alert-danger">
+    <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+        Please fix the error{{ form.error_dict|pluralize }} in the form.
+</div>
 {% endif %}
 
 <form action="{{request.path}}" name="clsform" method="post">

--- a/esp/templates/program/modules/adminclass/coteachers.html
+++ b/esp/templates/program/modules/adminclass/coteachers.html
@@ -27,19 +27,22 @@
 <p>Please list all teachers that will be helping teach this class.  They will need to create accounts and mark their available times through the teacher registration page (for scheduling purposes).</p>
 
 {% if conflict %}
-    <p>
-    <b><font color="red">{% if program|hasModule:"CheckAvailabilityModule" %}<a href="/manage/{{ program.getUrlBase }}/edit_availability?user={{ conflict.username }}">{{ conflict.name }}</a>{% else %}{{ conflict.name }}{% endif %} has a conflicting schedule.</b></font><br />
-    </p>
+    <div class="alert alert-danger">
+        <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+            {% if program|hasModule:"CheckAvailabilityModule" %}<a href="/manage/{{ program.getUrlBase }}/edit_availability?user={{ conflict.username }}">{{ conflict.name }}</a>{% else %}{{ conflict.name }}{% endif %} has a conflicting schedule.</b></font><br />
+    </div>
 {% elif unavailableuser %}
-    <p>
-    <b><font color="red">{% if program|hasModule:"CheckAvailabilityModule" %}<a href="/manage/{{ program.getUrlBase }}/edit_availability?user={{ unavailableuser.username }}">{{ unavailableuser.name }}</a>{% else %}{{ unavailableuser.name }}{% endif %} is not available when this class is scheduled ({{ unavailabletimes|join:", " }}).</b></font><br />
-    </p>
+    <div class="alert alert-danger">
+        <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+            {% if program|hasModule:"CheckAvailabilityModule" %}<a href="/manage/{{ program.getUrlBase }}/edit_availability?user={{ unavailableuser.username }}">{{ unavailableuser.name }}</a>{% else %}{{ unavailableuser.name }}{% endif %} is not available when this class is scheduled ({{ unavailabletimes|join:", " }}).</b></font><br />
+    </div>
 {% endif %}
 
 {% if error %}
-<p style="color:red; font-weight: bold;">
-{{ error }}
-</p>
+<div class="alert alert-danger">
+    <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+        {{ error }}
+</div>
 {% endif %}
 
 <div id="program_form">

--- a/esp/templates/program/modules/admincore/deadlines.html
+++ b/esp/templates/program/modules/admincore/deadlines.html
@@ -23,10 +23,16 @@
 <p><h1>Deadline Management</h1></p>
 
 {% if message_good %}
-    <p><span style="color: green;"><b>{{ message_good }}</b></span></p>
+    <div class="alert alert-success">
+        <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+            {{ message_good }}
+    </div>
 {% endif %}
 {% if message_bad %}
-    <p><span style="color: red;"><b>{{ message_bad }}</b></span></p>
+    <div class="alert alert-danger">
+        <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+            {{ message_bad }}
+    </div>
 {% endif %}
 
 <p>Access to each program's Web pages (including registration pages) is controlled by a set of deadlines, each of which prescribes when a certain set of activities can be performed.  "Recursive" deadlines can control a range of activities jointly; you may open all registration features using a single recursive deadline (e.g., "All student deadlines"), or specify several non-recursive deadlines ("Register for classes", "Access to survey", etc.) for finer control.</p>

--- a/esp/templates/program/modules/admincore/lunch_constraints.html
+++ b/esp/templates/program/modules/admincore/lunch_constraints.html
@@ -9,9 +9,21 @@
 
 {% block content %}
     <h1>{{program.niceName}} Lunch Constraints</h1>
-    <br />
     <p>Please select the timeslots you would like to be used for lunch.</p>
     <p>You can also use this page to setup lunch scheduling constraints, which will enforce that each student have at least one lunch block per day.</p>
+
+    {% if POST and saved %}
+        <div class="alert alert-success">
+        <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+            Settings successfully saved.
+        </div>
+    {% endif %}
+    {% if POST and not saved %}
+        <div class="alert alert-danger">
+            <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+                There was an error with saving your settings. Please try again.
+        </div><br />
+    {% endif %}
 
     <div id="program_form">
     <form action="/manage/{{ program.getUrlBase }}/lunch_constraints/" method="post">
@@ -21,19 +33,6 @@
     <tr><td colspan="2" align="center"><input type="submit" value="Submit" class="btn btn-primary" /></td></tr>
     </table>
     </form>
-    <br /><br />
-    {% if POST and saved %}
-            <div class="alert alert-success">
-            <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
-                Settings successfully saved.
-            </div>
-    {% endif %}
-    {% if POST and not saved %}
-        <div class="alert alert-danger">
-            <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
-                There was an error with saving your settings. Please try again.
-        </div><br />
-    {% endif %}
     </div>
 
 {% include "program/modules/admincore/returnlink.html" %}

--- a/esp/templates/program/modules/admincore/lunch_constraints.html
+++ b/esp/templates/program/modules/admincore/lunch_constraints.html
@@ -23,10 +23,16 @@
     </form>
     <br /><br />
     {% if POST and saved %}
-        <h3 style="font-weight:bold;">Settings successfully saved.</h3><br /><br />
+            <div class="alert alert-success">
+            <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+                Settings successfully saved.
+            </div>
     {% endif %}
     {% if POST and not saved %}
-        <h3 style="font-weight:bold; color:red;">There was an error with saving your settings. Please try again.</h3><br /><br />
+        <div class="alert alert-danger">
+            <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+                There was an error with saving your settings. Please try again.
+        </div><br />
     {% endif %}
     </div>
 

--- a/esp/templates/program/modules/admincore/registrationtype_management.html
+++ b/esp/templates/program/modules/admincore/registrationtype_management.html
@@ -20,10 +20,16 @@
     </form>
     <br /><br />
     {% if POST and saved %}
-        <h3 style="font-weight:bold;">Settings successfully saved.</h3><br /><br />
+        <div class="alert alert-success">
+            <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+                Settings successfully saved.
+        </div><br />
     {% endif %}
     {% if POST and not saved %}
-        <h3 style="font-weight:bold; color:red;">There was an error with saving your settings. Please try again.</h3><br /><br />
+        <div class="alert alert-danger">
+            <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+                There was an error with saving your settings. Please try again.
+        </div><br />
     {% endif %}
     <p>If you know what you're doing and you have reason to do so, you may manually manipulate RegistrationTypes in <a href="/admin/program/registrationtype/">the admin panel</a>.</p>
     

--- a/esp/templates/program/modules/availabilitymodule/availability_form.html
+++ b/esp/templates/program/modules/availabilitymodule/availability_form.html
@@ -43,26 +43,29 @@ You can click on individual timeblocks, highlight multiple timeblocks, and even 
 {% end_inline_program_qsd_block %}
 
 {% if is_overbooked %}
-{% inline_program_qsd_block prog "teacher_overbooked" %}
-<p style="color: red;">
-We have detected that you are currently signed up to teach more hours of class than you have hours of availability.  This makes it impossible to schedule your classes.  Please add to your available times in order to continue with registration.
-</p>
-{% end_inline_program_qsd_block %}
+    <div class="alert alert-danger">
+        <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+            We have detected that you are currently signed up to teach more hours of class than you have hours of availability.  This makes it impossible to schedule your classes.  Please add to your available times in order to continue with registration.
+    </div>
+    {% inline_program_qsd_block prog "teacher_overbooked" %}
+    {% end_inline_program_qsd_block %}
 {% endif %}
 
 {% if conflict_found %}
 {% inline_program_qsd_block prog "teacher_conflict" %}
-<p style="color: red;">
-You are scheduled to teach a class during at least one timeslot in which you are not marked as available (indicated with a red border below).  Please <a href="mailto:{{ prog.director_email }}">contact the directors</a> immediately to resolve this conflict.
-</p>
+<div class="alert alert-danger">
+    <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+        You are scheduled to teach a class during at least one timeslot in which you are not marked as available (indicated with a red border below).  Please <a href="mailto:{{ prog.director_email }}">contact the directors</a> immediately to resolve this conflict.
+</div>
 {% end_inline_program_qsd_block %}
 {% endif %}
 
 {% if submitted_blank %}
 {% inline_program_qsd_block prog "teacher_blank_availability" %}
-<p style="color: red;">
-You submitted a schedule with no available times.  You can't register a class without first telling us when you are free!  Please add your available times in order to continue with registration.
-</p>
+<div class="alert alert-danger">
+    <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+        You submitted a schedule with no available times.  You can't register a class without first telling us when you are free!  Please add your available times in order to continue with registration.
+</div>
 {% end_inline_program_qsd_block %}
 {% endif %}
 

--- a/esp/templates/program/modules/bulkcreateaccountmodule/bulk_create_response.html
+++ b/esp/templates/program/modules/bulkcreateaccountmodule/bulk_create_response.html
@@ -8,8 +8,11 @@
 
     <p>Your accounts have been created with the following passwords for each prefix.<p>
 
-    <div style="color: red"><b>Please save this list somewhere yourself, as the website
-        does NOT save these anywhere once you navigate away from this page.</b></div>
+    <div class="alert alert-danger">
+        <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+            Please save this list somewhere yourself, as the website
+            does NOT save these anywhere once you navigate away from this page.
+    </div>
 
     <br/>
 

--- a/esp/templates/program/modules/classchangerequestmodule/classchangerequest.html
+++ b/esp/templates/program/modules/classchangerequestmodule/classchangerequest.html
@@ -5,7 +5,10 @@
 
 {% block content %}
 {% if success %}
-<p style='color:red; font-weight:bold; font-size:medium;'>Your class change requests have successfully been saved.</p>
+<div class="alert alert-success">
+    <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+        Your class change requests have successfully been saved.
+</div>
 {% else %}
 <h3>Current Enrollments</h3>
 <ol>

--- a/esp/templates/program/modules/creditcardmodule_stripe/failure.html
+++ b/esp/templates/program/modules/creditcardmodule_stripe/failure.html
@@ -12,7 +12,10 @@
 
 {% block content %}
 <div class="error_background">
-<h1>Credit Card Payment for {{ program.niceName }} <font color="red">FAILED</font></h1>
+<div class="alert alert-danger">
+    <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+        Credit Card Payment for {{ program.niceName }} FAILED.
+</div>
 
 {% load render_qsd %}
 

--- a/esp/templates/program/modules/onsitecheckoutmodule/checkout.html
+++ b/esp/templates/program/modules/onsitecheckoutmodule/checkout.html
@@ -113,8 +113,17 @@ $j(function() {
 
 {% if student %}
 <br />
-{% if checkout_message %}
-<h3 style="color:red;">{{ checkout_message }}</h3>
+{% if checkout_message_warning %}
+    <div class="alert alert-warning">
+        <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+            {{ checkout_message_warning }}
+    </div>
+{% endif %}
+{% if checkout_message_success %}
+    <div class="alert alert-success">
+        <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+            {{ checkout_message_success }}
+    </div>
 {% endif %}
 <div id="return_options">
     <h2>

--- a/esp/templates/program/modules/splashinfomodule/splashinfo.html
+++ b/esp/templates/program/modules/splashinfomodule/splashinfo.html
@@ -16,7 +16,12 @@
 
 <div id="program_form">
 
-{% if form.errors or missing_siblingname %}<p align="center" style="color: red;">Please correct the form below before continuing. <br />{{ form.errors }}</p>{% endif %}
+{% if form.errors or missing_siblingname %}
+    <div class="alert alert-danger">
+        <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+            Please correct the form below before continuing. <br />{{ form.errors }}
+    </div>
+{% endif %}
 
 {% inline_program_qsd_block program "splashinfo_lunch" %}
 <h2>Lunch Preferences</h2>

--- a/esp/templates/program/modules/studentlunchselection/select_lunch.html
+++ b/esp/templates/program/modules/studentlunchselection/select_lunch.html
@@ -16,7 +16,12 @@
 
 <div id="program_form">
 
-{% if errors %}<p align="center" style="color: red;">Please correct the form below before continuing.</p>{% endif %}
+{% if errors %}
+    <div class="alert alert-danger">
+        <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+            Please correct the form below before continuing.
+    </div>
+{% endif %}
 
 {% inline_program_qsd_block program "studentlunchinstructions" %}
 <h2>Directions</h2>
@@ -26,7 +31,10 @@
 
 {% if messages %}
 {% for msg in messages %}
-<p><span style="color: red; font-weight: bold;">{{ msg }}</span></p>
+    <div class="alert alert-danger">
+        <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+            {{ msg }}
+    </div>
 {% endfor %}
 {% endif %}
 

--- a/esp/templates/program/modules/studentregphasezero/status.html
+++ b/esp/templates/program/modules/studentregphasezero/status.html
@@ -74,8 +74,18 @@ td {
 
 <center>
 <hr>
-{% if error %}<p><font color="red">{{ error }}</font></p>{% endif %}
-{% if invalid_grades %}<p><font color="red">The following students have invalid grades:</br>{% for student in invalid_grades %}{{ student }}</br>{% endfor %}</font></p>{% endif %}
+{% if error %}
+    <div class="alert alert-danger">
+        <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+            {{ error }}
+    </div>
+{% endif %}
+{% if invalid_grades %}
+    <div class="alert alert-danger">
+        <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+            The following students have invalid grades:</br>{% for student in invalid_grades %}{{ student }}</br>{% endfor %}
+    </div>
+{% endif %}
 {% autoescape off %}
 {% if lottery_messages %}<p><font color="blue">{{ lottery_messages|join:"<br/>" }}</font></p>{% endif %}
 {% endautoescape %}

--- a/esp/templates/program/modules/teacherclassregmodule/classedit.html
+++ b/esp/templates/program/modules/teacherclassregmodule/classedit.html
@@ -57,7 +57,10 @@
 
 {% if form.errors %}
 <p align="center">
-<font color="red" size="+1">Please fix the errors in the form below.</font>
+<div class="alert alert-danger">
+    <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+        Please fix the errors in the form below.
+</div>
 </p>
 {% endif %}
 

--- a/esp/templates/program/modules/teacherclassregmodule/coteachers.html
+++ b/esp/templates/program/modules/teacherclassregmodule/coteachers.html
@@ -34,19 +34,22 @@
 </ol>
 
 {% if conflict %}
-    <p>
-    <b><font color="red">{{ conflict.name }}</font> has a conflicting schedule.</b><br />
-    </p>
+    <div class="alert alert-danger">
+        <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+            {{ conflict.name }} has a conflicting schedule.
+    </div>
 {% elif unavailableuser %}
-    <p>
-    <b><font color="red">{{ unavailableuser.name }}</font> is not available when this class is scheduled ({{ unavailabletimes|join:", " }}).</b><br />
-    </p>
+    <div class="alert alert-danger">
+        <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+            {{ unavailableuser.name }}</font> is not available when this class is scheduled ({{ unavailabletimes|join:", " }}).
+    </div>
 {% endif %}
 
 {% if error %}
-<p style="color:red; font-weight: bold;">
-{{ error }}
-</p>
+<div class="alert alert-danger">
+    <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+        {{ error }}
+</div>
 {% endif %}
 <div id="program_form">
 {% if not coteachers|length %}

--- a/esp/templates/program/modules/volunteersignup/signup.html
+++ b/esp/templates/program/modules/volunteersignup/signup.html
@@ -96,7 +96,10 @@ The directors have been notified that you are no longer able to volunteer at {{ 
     <center>
       <p>{% if request.user.email %}Since you are logged in, your information is pre-filled but you can change it for the purposes of contacting you about volunteering.{% else %}If you have an account, please <a href="/myesp/login?next={{ request.path }}">click here</a> to log in and return to this page.{% endif %}</p>
       {% if form.errors %}
-      <p><span style="color: red;">Please correct the errors in the form.</span></p>
+        <div class="alert alert-danger">
+            <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+                Please correct the errors in the form.
+        </div>
       {% endif %}
       <div class="noclick">
         {{ form.name.label_tag }}

--- a/esp/templates/survey/choose_survey.html
+++ b/esp/templates/survey/choose_survey.html
@@ -11,7 +11,10 @@
 <h1>Please Select a Survey:</h1>
 
 {% if error %}
-<font color="red"><p>Error: We lost track of your survey!  Please try again.</p></font>
+<div class="alert alert-danger">
+    <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+        Error: We lost track of your survey!  Please try again.
+</div>
 {% else %}
 <p> Several surveys were found for this program:</p>
 {% endif %}

--- a/esp/templates/survey/review.html
+++ b/esp/templates/survey/review.html
@@ -26,7 +26,10 @@ td, th {
 <form method="POST" action="{{ request.get_full_path }}">
 <h2>Search for a teacher to retrieve their specific survey results:</h2>
 {% for error in teacher_form.target_user.errors %}
-<span style="color:red;">{{ error|escape }}</span></br>
+<div class="alert alert-danger">
+    <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+        {{ error|escape }}
+</div>
 {% endfor %}
 {{ teacher_form.target_user }}
 <input type="submit" value="Search" />

--- a/esp/templates/survey/survey_form.html
+++ b/esp/templates/survey/survey_form.html
@@ -4,12 +4,18 @@
     {% if section_surveys or general_survey %}
         <p class="message">
         {% if submitted or completed %}
-        <span style="color: red; font-weight: bold;">
-        {% if submitted %}Your survey responses for {% if section %}{{ section }}{% elif general %}the general program survey{% endif %} have been saved.
-        {% elif completed %}You've already completed the {% if section %}survey for {{ section }}{% elif general %}general program survey{% endif %}.{% endif %}
+        {% if submitted %}
+            <div class="alert alert-success">
+                <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+                    Your survey responses for {% if section %}{{ section }}{% elif general %}the general program survey{% endif %} have been saved.
+            </div>
+        {% elif completed %}
+            <div class="alert alert-danger">
+                <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+                    You've already completed the {% if section %}survey for {{ section }}{% elif general %}general program survey{% endif %}.
+            </div>
+        {% endif %}
         Please select another survey component below or come back later.
-        </span>
-        <br /><br />
         {% endif %}
         This survey consists of{% if section_surveys %} a survey component for each class you are registered for{% endif %}{% if section_surveys and general_survey %} and{% endif %}{% if general_survey %} a general program survey component{% endif %}.{% if section_surveys %} You may fill out a class survey once the class has begun.{% endif %}{% if general_survey %} You may fill out the general program survey once your first class has begun.{% endif %} If no survey components are available, please come back later.
         </p>

--- a/esp/templates/users/profile.html
+++ b/esp/templates/users/profile.html
@@ -36,7 +36,10 @@ div.required label.control-label:after {
 <div class="row-fluid">
   <div class="span10">
       {% if form.errors %}
-      <h4 style="color:red">Please fix the following error{{ form.errors|pluralize }} in the form.</h4>
+            <div class="alert alert-danger">
+                <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+                    Please fix the following error{{ form.errors|pluralize }} in the form.
+            </div>
       <ul>
 	{% for error in form.errors.items %}
 	{% ifequal error.0 '__all__' %}

--- a/esp/templates/users/studentprofile.html
+++ b/esp/templates/users/studentprofile.html
@@ -12,7 +12,10 @@
 
 
 {% if form.has_errors %}
-<h2 style="color:red">Please make sure to fill in all the required fields.  Thanks! </h2>
+    <div class="alert alert-danger">
+        <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+            Please make sure to fill in all the required fields.  Thanks!
+    </div>
 {% endif %}
 
 <form action='/learn/{{one}}/{{two}}/profile/' method="post">

--- a/esp/templates/users/teacherbioedit.html
+++ b/esp/templates/users/teacherbioedit.html
@@ -29,7 +29,10 @@ Please complete the form below to update your biography.  We'd appreciate a pict
 </p>
 
 {% if form.errors %}
-<h2 style="color:red">Please fix the error{{ form.errors|pluralize }} in the form.<h2>
+    <div class="alert alert-danger">
+        <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+            Please fix the error{{ form.errors|pluralize }} in the form.
+    </div>
 {% endif %}
 
 <div id="program_form">


### PR DESCRIPTION
Change many errors and successes to banners. I checked all the ones I could, but some errors are hard to get to so I didn't do those. There are definitely more messages that should be banners, but less easily searchable and will need to get updated as folks notice them. Fixes #3434