### PR TITLE
Unit test that loads all views

### DIFF
--- a/esp/esp/program/controllers/confirmation.py
+++ b/esp/esp/program/controllers/confirmation.py
@@ -37,7 +37,7 @@ from esp.program.models import Program, ClassSection, ClassSubject
 from esp.users.models import ESPUser, Record
 from esp.program.modules.module_ext import DBReceipt
 
-from django.template import Template, Context
+from django.template import Template
 from django.template.loader import select_template
 from esp.dbmail.models import send_mail
 
@@ -55,7 +55,7 @@ class ConfirmationEmailController(object):
             except:
                 receipt_template = select_template(['program/confemails/%s_confemail.txt' %(program.id),'program/confirm_email.txt'])
             send_mail("Thank you for registering for %s!" %(program.niceName()), \
-                      receipt_template.render(Context({'user': user, 'program': program}, autoescape=False)), \
+                      receipt_template.render({'user': user, 'program': program}), \
                       (ESPUser.email_sendto_address(program.director_email, program.niceName() + " Directors")), \
                       [user.email], True)
 

--- a/esp/esp/program/modules/handlers/admissionsdashboard.py
+++ b/esp/esp/program/modules/handlers/admissionsdashboard.py
@@ -123,9 +123,9 @@ class AdmissionsDashboard(ProgramModuleObj):
         try:
             classapp = StudentClassApp.objects.get(id=extra)
         except StudentClassApp.DoesNotExist:
-            return # XXX: more useful error here
+            return self.goToCore(tl) # XXX: more useful error here
         if not (request.user.isAdmin(prog) or classapp.subject in request.user.getTaughtClassesFromProgram(prog)):
-            return
+            return self.goToCore(tl)
         content = classapp.get_teacher_view(prog)
         return HttpResponse(content)
 

--- a/esp/esp/program/modules/handlers/creditcardmodule_cybersource.py
+++ b/esp/esp/program/modules/handlers/creditcardmodule_cybersource.py
@@ -115,6 +115,9 @@ class CreditCardModule_Cybersource(ProgramModuleObj):
 
         return render_to_response(self.baseDir() + 'cardpay.html', request, context)
 
+    def isStep(self):
+        return settings.CYBERSOURCE_CONFIG['post_url'] and settings.CYBERSOURCE_CONFIG['merchant_id']
+
     class Meta:
         proxy = True
         app_label = 'modules'

--- a/esp/esp/program/modules/handlers/creditcardmodule_stripe.py
+++ b/esp/esp/program/modules/handlers/creditcardmodule_stripe.py
@@ -113,8 +113,7 @@ class CreditCardModule_Stripe(ProgramModuleObj):
 
     def check_setup(self):
         """ Validate the keys specified in the stripe_settings Tag.
-            If something is wrong, provide an error message which will hopefully
-            only be seen by admins during setup. """
+            If something is wrong, return False, otherwise return True. """
 
         self.apply_settings()
 
@@ -133,7 +132,8 @@ class CreditCardModule_Stripe(ProgramModuleObj):
         valid_pk_re = r'pk_(test|live)_([A-Za-z0-9+/=]){24}'
         valid_sk_re = r'sk_(test|live)_([A-Za-z0-9+/=]){24}'
         if not re.match(valid_pk_re, self.settings['publishable_key']) or not re.match(valid_sk_re, self.settings['secret_key']):
-            raise ESPError('The site has not yet been properly set up for credit card payments. Administrators should contact the <a href="mailto:{{settings.SUPPORT}}">websupport team to get it set up.', True)
+            return False
+        return True
 
     @main_call
     @needs_student
@@ -154,7 +154,8 @@ class CreditCardModule_Stripe(ProgramModuleObj):
             raise ESPError("Please go back and ensure that you have completed all required steps of registration before paying by credit card.", log=False)
 
         #   Check for setup of module.  This is also required to initialize settings.
-        self.check_setup()
+        if not self.check_setup():
+            raise ESPError('The site has not yet been properly set up for credit card payments. Administrators should contact the <a href="mailto:{{settings.SUPPORT}}">websupport team to get it set up.', True)
 
         user = request.user
 
@@ -220,7 +221,8 @@ class CreditCardModule_Stripe(ProgramModuleObj):
     @needs_student
     def charge_payment(self, request, tl, one, two, module, extra, prog):
         #   Check for setup of module.  This is also required to initialize settings.
-        self.check_setup()
+        if not self.check_setup():
+            raise ESPError('The site has not yet been properly set up for credit card payments. Administrators should contact the <a href="mailto:{{settings.SUPPORT}}">websupport team to get it set up.', True)
 
         context = {'postdata': request.POST.copy()}
 
@@ -331,11 +333,7 @@ class CreditCardModule_Stripe(ProgramModuleObj):
         return render_to_response(self.baseDir() + 'success.html', request, context)
 
     def isStep(self):
-        try:
-            self.check_setup()
-        except ESPError:
-            return False
-        return True
+        return self.check_setup()
 
     class Meta:
         proxy = True

--- a/esp/esp/program/modules/handlers/creditcardmodule_stripe.py
+++ b/esp/esp/program/modules/handlers/creditcardmodule_stripe.py
@@ -330,6 +330,13 @@ class CreditCardModule_Stripe(ProgramModuleObj):
         context['can_confirm'] = self.deadline_met('/Confirm')
         return render_to_response(self.baseDir() + 'success.html', request, context)
 
+    def isStep(self):
+        try:
+            self.check_setup()
+        except ESPError:
+            return False
+        return True
+
     class Meta:
         proxy = True
         app_label = 'modules'

--- a/esp/esp/program/modules/handlers/formstackappmodule.py
+++ b/esp/esp/program/modules/handlers/formstackappmodule.py
@@ -103,7 +103,7 @@ class FormstackAppModule(ProgramModuleObj):
     def finaidapp(self, request, tl, one, two, module, extra, prog):
         fsas = prog.formstackappsettings
         if not fsas.finaid_form():
-            return # no finaid form
+            return self.goToCore(tl) # no finaid form
         app = FormstackStudentProgramApp.objects.filter(user=request.user, program=prog)
         if not (app or request.user.isAdmin(prog)): # student has not applied for the program
             return # XXX: more useful error here

--- a/esp/esp/program/modules/handlers/studentregcore.py
+++ b/esp/esp/program/modules/handlers/studentregcore.py
@@ -128,7 +128,7 @@ class StudentRegCore(ProgramModuleObj, CoreModule):
         self.request = request
 
         if prog.user_can_join(request.user):
-            raise ESPError("You can't subscribe to the waitlist of a program that isn't full yet!  Please click 'Back' and refresh the page to see the button to confirm your registration.", log=False)
+            return self.goToCore(tl)
 
         waitlist = Record.objects.filter(event="waitlist",
                                          user=request.user,

--- a/esp/esp/program/modules/handlers/teacherreviewapps.py
+++ b/esp/esp/program/modules/handlers/teacherreviewapps.py
@@ -186,6 +186,9 @@ class TeacherReviewApps(ProgramModuleObj):
         scrmi = prog.studentclassregmoduleinfo
         reg_nodes = scrmi.reg_verbs()
 
+        if not extra:
+            return self.goToCore(tl)
+
         try:
             cls = ClassSubject.objects.get(id = extra)
         except ClassSubject.DoesNotExist:

--- a/esp/esp/program/modules/tests/__init__.py
+++ b/esp/esp/program/modules/tests/__init__.py
@@ -50,3 +50,4 @@ from esp.program.modules.tests.adminclass import CancelClassTest
 from esp.program.modules.tests.classsearchmodule import ClassSearchModuleTest
 from esp.program.modules.tests.auth import ProgramModuleAuthTest
 from esp.program.modules.tests.unenrollmodule import UnenrollModuleTest
+from esp.program.modules.tests.testallviews import AllViewsTest

--- a/esp/esp/program/modules/tests/programprintables.py
+++ b/esp/esp/program/modules/tests/programprintables.py
@@ -79,7 +79,7 @@ class ProgramPrintablesModuleTest(ProgramFrameworkTest):
             'use_checklist': 0,
         }
         response = self.client.post('/manage/%s/%s' % (self.program.getUrlBase(), view_name), post_data)
-        self.assertTrue(response.status_code, 200)
+        self.assertEquals(response.status_code, 200)
         return response
 
     def get_userlist_views(self):

--- a/esp/esp/program/modules/tests/testallviews.py
+++ b/esp/esp/program/modules/tests/testallviews.py
@@ -1,0 +1,205 @@
+__author__    = "Individual contributors (see AUTHORS file)"
+__date__      = "$DATE$"
+__rev__       = "$REV$"
+__license__   = "AGPL v.3"
+__copyright__ = """
+This file is part of the ESP Web Site
+Copyright (c) 2011 by the individual contributors
+  (see AUTHORS file)
+
+The ESP Web Site is free software; you can redistribute it and/or
+modify it under the terms of the GNU Affero General Public License
+as published by the Free Software Foundation; either version 3
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public
+License along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+Contact information:
+MIT Educational Studies Program
+  84 Massachusetts Ave W20-467, Cambridge, MA 02139
+  Phone: 617-253-4882
+  Email: esp-webmasters@mit.edu
+Learning Unlimited, Inc.
+  527 Franklin St, Cambridge, MA 02139
+  Phone: 617-379-0178
+  Email: web-team@learningu.org
+"""
+
+from django.conf import settings
+
+from esp.customforms.models import Form
+from esp.program.tests import ProgramFrameworkTest
+from esp.program.models import ProgramModule
+from esp.program.modules.base import ProgramModuleObj
+from esp.survey.models import Survey, Question, QuestionType
+from esp.tagdict.models import Tag
+from esp.users.models import ESPUser
+
+import json
+
+class AllViewsTest(ProgramFrameworkTest):
+    def setUp(self):
+        # Set up the program framework and randomly schedule classes
+        super(AllViewsTest, self).setUp(modules = ProgramModule.objects.all())
+
+        # We don't want to get stuck in registration
+        scrmi = self.program.studentclassregmoduleinfo
+        scrmi.force_show_required_modules = False
+        scrmi.save()
+
+        # So we can confirm registration without errors
+        for pmo in self.program.getModules():
+            pmo.__class__ = ProgramModuleObj
+            pmo.required = False
+            pmo.save()
+
+        # Create an admin account so we have access to every view
+        self.adminUser, created = ESPUser.objects.get_or_create(username='admin', first_name = 'Admin', last_name = 'Admin')
+        self.adminUser.set_password('password')
+        self.adminUser.makeAdmin()
+        self.adminUser.makeRole('Student')
+        self.adminUser.makeRole('Teacher')
+        self.adminUser.makeRole('Volunteer')
+
+        # Login with the admin account
+        self.client.login(username='admin', password='password')
+
+        # Set up a schedule for the program and enroll students
+        self.add_user_profiles()
+        self.schedule_randomly()
+        self.classreg_students()
+
+        # Set up surveys for the program
+        (survey1, created) = Survey.objects.get_or_create(name='Test Survey', program=self.program, category='learn')
+        (text_qtype, created) = QuestionType.objects.get_or_create(name='yes-no response')
+        (number_qtype, created) = QuestionType.objects.get_or_create(name='numeric rating', is_numeric=True, is_countable=True)
+        (question_base, created) = Question.objects.get_or_create(survey=survey1, name='Question1', question_type=text_qtype, per_class=False, seq=0)
+        (question_perclass, created) = Question.objects.get_or_create(survey=survey1, name='Question2', question_type=text_qtype, per_class=True, seq=1)
+        (question_number, created) = Question.objects.get_or_create(survey=survey1, name='Question3', question_type=number_qtype, per_class=True, seq=2)
+        (survey2, created) = Survey.objects.get_or_create(name='Test Survey', program=self.program, category='teach')
+        (text_qtype, created) = QuestionType.objects.get_or_create(name='yes-no response')
+        (number_qtype, created) = QuestionType.objects.get_or_create(name='numeric rating', is_numeric=True, is_countable=True)
+        (question_base, created) = Question.objects.get_or_create(survey=survey2, name='Question1', question_type=text_qtype, per_class=False, seq=0)
+        (question_perclass, created) = Question.objects.get_or_create(survey=survey2, name='Question2', question_type=text_qtype, per_class=True, seq=1)
+        (question_number, created) = Question.objects.get_or_create(survey=survey2, name='Question3', question_type=number_qtype, per_class=True, seq=2)
+
+        # Set up custom forms for the program
+        form_data = {
+            'title': 'Test Form',
+            'perms': u'',
+            'link_id': -1,
+            'success_url': '/formsuccess.html',
+            'success_message': 'Thank you!',
+            'anonymous': False,
+            'pages': [{
+                'parent_id': -1,
+                'sections': [{
+                    'fields': [
+                        {'data': {'field_type': 'textField', 'question_text': 'ShortText', 'seq': 0, 'required': True, 'parent_id': -1, 'attrs':{'correct_answer': 'Smart', 'charlimits': '0,100'}, 'help_text': 'Instructions'}},
+                        {'data': {'field_type': 'phone', 'question_text': 'Your phone no.', 'seq': 1, 'required': True, 'parent_id': -1, 'attrs': {}, 'help_text': u''}},
+                        {'data': {'field_type': 'gender', 'question_text': 'Your gender', 'seq': 2, 'required': True, 'parent_id': -1, 'attrs': {}, 'help_text': u''}},
+                        {'data': {'field_type': 'radio', 'question_text': 'Choose an option', 'seq': 3, 'required': True, 'parent_id': -1, 'attrs': {'correct_answer': '1', 'options': 'A|B|C|'}, 'help_text': u''}},
+                        {'data': {'field_type': 'boolean', 'question_text': 'True/false', 'seq': 4, 'required': True, 'parent_id': -1, 'attrs': {}, 'help_text':u''}},
+                        {'data': {'field_type': 'textField', 'question_text': 'NonRequired', 'seq': 5, 'required': False, 'parent_id': -1, 'attrs': {'correct_answer': u'', 'charlimits': ','}, 'help_text': u''}}
+                    ],
+                'data': {'help_text': u'', 'question_text': u'', 'seq': 0}
+                }],
+                'seq': 0
+            }],
+            'link_type': '-1',
+            'desc': 'Test'
+        }
+
+        response = self.client.post("/customforms/submit/", json.dumps(form_data), content_type='application/json', HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        form = Form.objects.filter(title='Test Form')[0]
+        Tag.setTag(key='learn_extraform_id', value=form.id, target=self.program)
+        Tag.setTag(key='teach_extraform_id', value=form.id, target=self.program)
+        Tag.setTag(key='quiz_form_id', value=form.id, target=self.program)
+
+        # Set up credit card test keys
+        settings.STRIPE_CONFIG = {
+            'secret_key': 'sk_test_4eC39HqLyjWDarjtT1zdp7dc',
+            'publishable_key': 'pk_test_TYooMQauvdEDq54NiTphI7jx',
+        }
+        settings.CYBERSOURCE_CONFIG = {
+            'post_url': 'https://apitest.cybersource.com/pts/v2/payments',
+            'merchant_id': 'test',
+        }
+
+    def testAllViews(self):
+        # Check all views of all modules
+        failed_modules = []
+        cls = self.program.classes()[0]
+        cls_id = str(cls.id)
+        sec = cls.get_sections()[0]
+        sec_id = str(sec.id)
+        event = self.program.getTimeSlots()[0]
+        event_id = str(event.id)
+        for tl in ['learn', 'teach', 'admin', 'volunteer']:
+            modules = self.program.getModules(tl = tl)
+            for module in modules:
+                views = module.get_all_views()
+                for view in views:
+                    self.program.classes()[0].get_sections()[0].preregister_student(self.adminUser)
+                    # Some views are expecting an "extra" argument; some are expecting "GET" variables; some are expecting "POST" variables
+                    try:
+                        print("GET")
+                        response = self.client.get('/' + tl + '/' + self.program.getUrlBase() + '/' + view + '?cls=' + cls_id + '&clsid=' + cls_id + '&name=Admin&username=admin')
+                        if response.status_code in [200, 302]:
+                            continue
+                    except Exception, e:
+                        print(e)
+                    try:
+                        print("Extra Class")
+                        response = self.client.get('/' + tl + '/' + self.program.getUrlBase() + '/' + view + '/' + cls_id + '?student=' + self.adminUser.id)
+                        if response.status_code in [200, 302]:
+                            continue
+                    except Exception, e:
+                        print(e)
+                    try:
+                        print("Extra Section")
+                        response = self.client.get('/' + tl + '/' + self.program.getUrlBase() + '/' + view + '/' + sec_id)
+                        if response.status_code in [200, 302]:
+                            continue
+                    except Exception, e:
+                        print(e)
+                    try:
+                        print("Extra Event")
+                        response = self.client.get('/' + tl + '/' + self.program.getUrlBase() + '/' + view + '/' + event_id)
+                        if response.status_code in [200, 302]:
+                            continue
+                    except Exception, e:
+                        print(e)
+                    try:
+                        print("POST1")
+                        self.program.classes()[0].get_sections()[0].unpreregister_student(self.adminUser)
+                        response = self.client.post('/' + tl + '/' + self.program.getUrlBase() + '/' + view, {'class_id': cls_id,  'section_id': sec_id, 'json_data': '{}'})
+                        if response.status_code in [200, 302]:
+                            continue
+                    except Exception, e:
+                        print(e)
+                    try:
+                        print("POST2")
+                        response = self.client.post('/' + tl + '/' + self.program.getUrlBase() + '/' + view, {'json_data': '{"interested": [1, 5, 3, 9], "not_interested": [4, 6, 10]}'})
+                        if response.status_code in [200, 302]:
+                            continue
+                    except Exception, e:
+                        print(e)
+                    try:
+                        print("POST3")
+                        response = self.client.post('/' + tl + '/' + self.program.getUrlBase() + '/' + view, {'json_data': '{"' + event_id + '": {}}'})
+                        if response.status_code in [200, 302]:
+                            continue
+                    except Exception, e:
+                        print(e)
+                    failed_modules.append((module, view))
+
+        # Check if any failed
+        self.assertTrue(len(failed_modules) == 0, '\n'.join(['The "' + view + '" view from the "' + module.module.handler + '" module is broken.' for (module, view) in failed_modules]))

--- a/esp/esp/program/modules/tests/testallviews.py
+++ b/esp/esp/program/modules/tests/testallviews.py
@@ -147,53 +147,49 @@ class AllViewsTest(ProgramFrameworkTest):
             for module in modules:
                 views = module.get_all_views()
                 for view in views:
+                    # In case the user has been unregistered, reregister them
                     self.program.classes()[0].get_sections()[0].preregister_student(self.adminUser)
-                    # Some views are expecting an "extra" argument; some are expecting "GET" variables; some are expecting "POST" variables
-                    try:
-                        print("GET")
+                    # Try a whole bunch of different requests (because different views have different expectations)
+                    # Skip to the next view if this view ever properly serves a page (or redirects to another page)
+                    try: # Various GET arguments
                         response = self.client.get('/' + tl + '/' + self.program.getUrlBase() + '/' + view + '?cls=' + cls_id + '&clsid=' + cls_id + '&name=Admin&username=admin')
                         if response.status_code in [200, 302]:
                             continue
                     except Exception, e:
                         print(e)
-                    try:
-                        print("Extra Class")
+                    try: # Use a class ID as the extra argument
                         response = self.client.get('/' + tl + '/' + self.program.getUrlBase() + '/' + view + '/' + cls_id + '?student=' + self.adminUser.id)
                         if response.status_code in [200, 302]:
                             continue
                     except Exception, e:
                         print(e)
-                    try:
-                        print("Extra Section")
+                    try: # Use a section ID as the extra argument
                         response = self.client.get('/' + tl + '/' + self.program.getUrlBase() + '/' + view + '/' + sec_id)
                         if response.status_code in [200, 302]:
                             continue
                     except Exception, e:
                         print(e)
-                    try:
-                        print("Extra Event")
+                    try: # Use an event ID as the extra argument
                         response = self.client.get('/' + tl + '/' + self.program.getUrlBase() + '/' + view + '/' + event_id)
                         if response.status_code in [200, 302]:
                             continue
                     except Exception, e:
                         print(e)
-                    try:
-                        print("POST1")
+                    try: # Various POST data
+                        # Mostly used for registering for classes, so unregister for the class in advance
                         self.program.classes()[0].get_sections()[0].unpreregister_student(self.adminUser)
                         response = self.client.post('/' + tl + '/' + self.program.getUrlBase() + '/' + view, {'class_id': cls_id,  'section_id': sec_id, 'json_data': '{}'})
                         if response.status_code in [200, 302]:
                             continue
                     except Exception, e:
                         print(e)
-                    try:
-                        print("POST2")
+                    try: # Student lottery POST data
                         response = self.client.post('/' + tl + '/' + self.program.getUrlBase() + '/' + view, {'json_data': '{"interested": [1, 5, 3, 9], "not_interested": [4, 6, 10]}'})
                         if response.status_code in [200, 302]:
                             continue
                     except Exception, e:
                         print(e)
-                    try:
-                        print("POST3")
+                    try: # Different student lottery POST data
                         response = self.client.post('/' + tl + '/' + self.program.getUrlBase() + '/' + view, {'json_data': '{"' + event_id + '": {}}'})
                         if response.status_code in [200, 302]:
                             continue

--- a/esp/templates/program/modules/lotterystudentregmodule/student_reg_splash.html
+++ b/esp/templates/program/modules/lotterystudentregmodule/student_reg_splash.html
@@ -34,12 +34,12 @@ var open_class_registration = {{ open_class_registration }};
 
 
 {% block content %} 
-    {% inline_program_qsd_block prog "lsr_title" request.user %}Class Lottery for {{prog.niceName}}{% end_inline_program_qsd_block %}
+    {% inline_program_qsd_block prog "lsr_title" %}Class Lottery for {{prog.niceName}}{% end_inline_program_qsd_block %}
 
     <div id="lsr_content">
         <h3 class="header"><a href="#">Instructions</a></h3>
         <div id="instructions">
-            {% inline_program_qsd_block prog "lsr_instructions" request.user %}Write instructions here!{% end_inline_program_qsd_block %}
+            {% inline_program_qsd_block prog "lsr_instructions" %}Write instructions here!{% end_inline_program_qsd_block %}
 	</div>
 
 	<br/>


### PR DESCRIPTION
This adds a unit test that loads every single view (`main_call` and `aux_call`) from every single program module. Unfortunately, we aren't terribly consistent in how our views work, so I had to brute force a whole bunch of different ways of loading the views (e.g., GET variables, POST data, various `extra` arguments). After writing the test, I then fixed any of the views that it identified as broken (e.g., Fixes #3438). I also changed some views to redirect to the main registration page if the incorrect data was provided (e.g., `waitlist_subscribe` when there isn't a waitlist).

While I was at it, I realized that the two credit card modules displayed an error if they weren't configured. Now, if they aren't configured, they aren't shown as steps in registration.

Fixes #1900.