### PR TITLE
Improve login redirect

### DIFF
--- a/esp/esp/tagdict/__init__.py
+++ b/esp/esp/tagdict/__init__.py
@@ -422,6 +422,20 @@ all_global_tags = {
         'category': 'manage',
         'is_setting': True,
     },
+    'teacher_home_page': {
+        'is_boolean': False,
+        'help_text': 'The page to which teachers get redirected after logging in (can be a relative or absolute page)',
+        'default': "/teach/index.html",
+        'category': 'teach',
+        'is_setting': True,
+    },
+    'student_home_page': {
+        'is_boolean': False,
+        'help_text': 'The page to which students get redirected after logging in (can be a relative or absolute page)',
+        'default': "/learn/index.html",
+        'category': 'learn',
+        'is_setting': True,
+    },
     'default_restypes': {
         'is_boolean': False,
         'help_text': 'A JSON list of the resource types (by name) to create when making a new program',

--- a/esp/esp/users/views/__init__.py
+++ b/esp/esp/users/views/__init__.py
@@ -30,27 +30,31 @@ def HttpMetaRedirect(location='/'):
     """ % (location, location)
     return response
 
-def pick_redirect(user, next):
-    mask_locations = ['/', '/myesp/signout', '/myesp/signout/', '/admin/logout/']
-    if next in mask_locations:
-        # We're getting redirected to somewhere undesirable.
-        # Let's try to do something smarter.
-        admin_home_url = Tag.getTag('admin_home_page')
-        teacher_home_url = Tag.getTag('teacher_home_page')
-        student_home_url = Tag.getTag('student_home_page')
-        if user.isAdmin() and admin_home_url:
-            return HttpMetaRedirect(admin_home_url)
-        elif user.isTeacher() and teacher_home_url:
-            return HttpMetaRedirect(teacher_home_url)
-        elif user.isStudent() and student_home_url:
-            return HttpMetaRedirect(student_home_url)
-    elif next:
-        return HttpMetaRedirect(next)
-    return HttpMetaRedirect('/')
+mask_locations = ['/', '/myesp/signout', '/myesp/signout/', '/admin/logout/']
+def mask_redirect(user, next):
+    # We're getting redirected to somewhere undesirable.
+    # Let's try to do something smarter.
+    admin_home_url = Tag.getTag('admin_home_page')
+    teacher_home_url = Tag.getTag('teacher_home_page')
+    student_home_url = Tag.getTag('student_home_page')
+    if user.isAdmin() and admin_home_url:
+        return HttpMetaRedirect(admin_home_url)
+    elif user.isTeacher() and teacher_home_url:
+        return HttpMetaRedirect(teacher_home_url)
+    elif user.isStudent() and student_home_url:
+        return HttpMetaRedirect(student_home_url)
+    else:
+        return HttpMetaRedirect('/')
 
 def login_checked(request, *args, **kwargs):
     if request.user.is_authenticated():
-        reply = pick_redirect(request.user, request.GET.get('next', ''))
+        next = request.GET.get('next', '')
+        if next in mask_locations:
+            reply = mask_redirect(request.user, next)
+        elif next:
+            reply = HttpMetaRedirect(next)
+        else:
+            reply = HttpMetaRedirect('/')
         #   Set response cookies in case of repeat login
         reply._new_user = request.user
         reply.no_set_cookies = False
@@ -88,7 +92,13 @@ def login_checked(request, *args, **kwargs):
                     context['next_title'] = 'the home page'
                 return render_to_response('users/login_duplicate_warning.html', request, context)
 
-    reply = pick_redirect(request.user, reply.get('Location', ''))
+    next = reply.get('Location', '')
+    if next in mask_locations:
+        reply = mask_redirect(request.user, next)
+    elif reply.status_code == 302:
+        #   Even if the redirect was going to a reasonable place, we need to
+        #   turn it into a 200 META redirect in order to set the cookies properly.
+        reply = HttpMetaRedirect(next)
 
     #   Stick the user in the response in order to set cookies if necessary
     reply._new_user = request.user


### PR DESCRIPTION
This makes the following improvements to the login redirect logic:

- Admins can now set custom landing pages for students and teachers with global tags (`teacher_home_page` and `student_home_page`) (this only works if a user isn't already being redirected to some other page)
- If a user is already logged in, they will be redirected properly to the "next" param (Fixes https://github.com/learning-unlimited/ESP-Website/issues/1777)