### PR TITLE
Download student schedules pdf to file

### DIFF
--- a/esp/esp/program/modules/handlers/programprintables.py
+++ b/esp/esp/program/modules/handlers/programprintables.py
@@ -1313,10 +1313,13 @@ class ProgramPrintables(ProgramModuleObj):
         if file_type == 'html':
             return render_to_response(basedir+'studentschedule.html', request, context)
         elif file_type == 'pdf':
-            response = HttpResponse(content_type='application/pdf')
-            response['Content-Disposition'] = 'attachment; filename="studentschedules.pdf"'
-            response.write(render_to_latex(basedir+'studentschedule.tex', context, file_type))
-            return response
+            if len(students) > 1:
+                response = HttpResponse(content_type='application/pdf')
+                response['Content-Disposition'] = 'attachment; filename="studentschedules.pdf"'
+                response.write(render_to_latex(basedir+'studentschedule.tex', context, 'pdf'))
+                return response
+            else:
+                return render_to_latex(basedir+'studentschedule.tex', context, 'pdf')
         else:
             return render_to_latex(basedir+'studentschedule.tex', context, file_type)
 

--- a/esp/esp/program/modules/handlers/programprintables.py
+++ b/esp/esp/program/modules/handlers/programprintables.py
@@ -1171,10 +1171,7 @@ class ProgramPrintables(ProgramModuleObj):
             elif 'img_format' in request.GET:
                 file_type = request.GET['img_format']
             else:
-                if onsite:
-                    file_type = 'png'
-                else:
-                    file_type = 'pdf'
+                file_type = 'pdf'
             filterObj, found = UserSearchController().create_filter(request, self.program, target_path = request.get_full_path(), add_to_context = {'module': "Student Schedules (" + file_type + ")"})
 
             if not found:

--- a/esp/esp/program/modules/handlers/programprintables.py
+++ b/esp/esp/program/modules/handlers/programprintables.py
@@ -1166,7 +1166,16 @@ class ProgramPrintables(ProgramModuleObj):
         if onsite:
             students = [ESPUser.objects.get(id=request.GET['userid'])]
         else:
-            filterObj, found = UserSearchController().create_filter(request, self.program, add_to_context = {'module': "Student Schedules"})
+            if extra:
+                file_type = extra.strip()
+            elif 'img_format' in request.GET:
+                file_type = request.GET['img_format']
+            else:
+                if onsite:
+                    file_type = 'png'
+                else:
+                    file_type = 'pdf'
+            filterObj, found = UserSearchController().create_filter(request, self.program, target_path = request.get_full_path(), add_to_context = {'module': "Student Schedules (" + file_type + ")"})
 
             if not found:
                 return filterObj
@@ -1306,7 +1315,12 @@ class ProgramPrintables(ProgramModuleObj):
         basedir = 'program/modules/programprintables/'
         if file_type == 'html':
             return render_to_response(basedir+'studentschedule.html', request, context)
-        else:  # elif format == 'pdf':
+        elif file_type == 'pdf':
+            response = HttpResponse(content_type='application/pdf')
+            response['Content-Disposition'] = 'attachment; filename="studentschedules.pdf"'
+            response.write(render_to_latex(basedir+'studentschedule.tex', context, file_type))
+            return response
+        else:
             return render_to_latex(basedir+'studentschedule.tex', context, file_type)
 
     @aux_call


### PR DESCRIPTION
This makes it so that the student schedules pdf is downloaded to the user's disk as opposed to being loaded within the browser. For larger pdfs, Chrome (and possibly other browsers) might have some trouble loading them, so this should help.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/1769.

This might also help with https://github.com/learning-unlimited/ESP-Website/issues/1198, but I haven't tested that at all.