### PR TITLE
Add filters for expired vs unexpired permissions and student registrations

### DIFF
--- a/esp/esp/program/admin.py
+++ b/esp/esp/program/admin.py
@@ -54,6 +54,8 @@ from esp.accounting.models import FinancialAidGrant
 
 from esp.utils.admin_user_search import default_user_search
 
+from esp.users.admin import ExpiredListFilter
+
 class ProgramModuleAdmin(admin.ModelAdmin):
     list_display = ('link_title', 'admin_title', 'handler')
     search_fields = ['link_title', 'admin_title', 'handler']
@@ -232,7 +234,7 @@ class StudentRegistrationAdmin(admin.ModelAdmin):
     list_display = ('id', 'section', 'user', 'relationship', 'start_date', 'end_date',)
     actions = [ expire_student_registrations, renew_student_registrations ]
     search_fields = default_user_search() + ['id', 'section__id', 'section__parent_class__title', 'section__parent_class__id']
-    list_filter = ['section__parent_class__parent_program', 'relationship']
+    list_filter = ['section__parent_class__parent_program', 'relationship', ExpiredListFilter]
     date_hierarchy = 'start_date'
 admin_site.register(StudentRegistration, StudentRegistrationAdmin)
 

--- a/esp/esp/users/admin.py
+++ b/esp/esp/users/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.utils.translation import ugettext_lazy as _
 from esp.admin import admin_site
 from django import forms
 from django.db import models
@@ -58,10 +59,26 @@ class RecordAdmin(admin.ModelAdmin):
     date_hierarchy = 'time'
 admin_site.register(Record, RecordAdmin)
 
+class ExpiredListFilter(admin.SimpleListFilter):
+    title = _('expiration status')
+    parameter_name = 'status'
+
+    def lookups(self, request, model_admin):
+        return (
+            ('unexpired', _('Not expired')),
+            ('expired', _('Expired')),
+        )
+
+    def queryset(self, request, queryset):
+        if self.value() == 'unexpired':
+            return queryset.filter(end_date=None) | queryset.filter(end_date__gt=datetime.datetime.now())
+        elif self.value() == 'expired':
+            return queryset.filter(end_date__lte=datetime.datetime.now())
+
 class PermissionAdmin(admin.ModelAdmin):
     list_display = ['id', 'user', 'role', 'permission_type','program','start_date','end_date']
     search_fields = default_user_search() + ['permission_type', 'program__url']
-    list_filter = ['permission_type', 'program', 'role']
+    list_filter = ['permission_type', 'program', 'role', ExpiredListFilter]
     date_hierarchy = 'start_date'
     actions = [ 'expire', 'renew' ]
 


### PR DESCRIPTION
Fixes #1030 by adding filters for expired vs unexpired items for both permissions and student registrations in the admin pages. 