### PR TITLE
Add anonymous option to the contact form

### DIFF
--- a/esp/esp/web/forms/contact_form.py
+++ b/esp/esp/web/forms/contact_form.py
@@ -56,11 +56,14 @@ hear_about = (
     )
 
 class ContactForm(forms.Form):
-    sender  = forms.EmailField(label=_("Your Email"), required = True,
+    anonymous = forms.BooleanField(label=_("Anonymous"), required = False,
+                                   help_text=_("(By checking this, we will make your submission anonymous by removing all identifying information from your submission.)") )
+
+    sender  = forms.EmailField(label=_("Your Email"), required = False,
                                help_text=_("(e.g.: john.doe@domain.xyz)"))
 
-    cc_myself = forms.BooleanField(label=_("Copy me"), required = False,
-                                   help_text=_("(By checking this, we will send you a carbon-copy (cc) of this email.)") )
+    cc_myself = forms.BooleanField(label=_("Copy me"), required = False, initial = True,
+                                   help_text=_("(By checking this, we will send a carbon-copy (cc) of this email to the address listed above. If you checked the 'Anonymous' box, we will send a blind carbon-copy (bcc) of this email.)") )
 
     name      = forms.CharField(max_length=100, label="Your Name", required=False)
 

--- a/esp/templates/contact.html
+++ b/esp/templates/contact.html
@@ -7,6 +7,18 @@
   <link rel="stylesheet" type="text/css" href="/media/styles/forms.css" />
 {% endblock %}
 
+{% block javascript %}
+  {{ block.super }}
+  <script>
+    $j(document).ready(function() {
+      $j("#id_sender").attr('required', true);
+      $j("#id_anonymous").change(function() {
+        $j("#id_sender").attr('required', !this.checked);
+      });
+    });
+  </script>
+{% endblock %}
+
 {% block content %}
 {% load render_qsd %}
 

--- a/esp/templates/email/comment
+++ b/esp/templates/email/comment
@@ -1,9 +1,14 @@
 {% autoescape off %}
 Someone filled a form out on {{ domain }}:
 
+{% if anonymous %}
+(The form was submitted anonymously)
+
+{% else %}
 Name: {{ form.cleaned_data.name }}
 Usernames with this email address: {{ usernames|join:', ' }}
 Logged in as: {{ logged_in_as }}
+{% endif %}
 I am a: {{ form.cleaned_data.person_type }}
 How did you hear about us?: {{ form.cleaned_data.hear_about }}
 Topic of interest: {{ form.cleaned_data.topic }}


### PR DESCRIPTION
This adds an anonymous option to the contact form:
![image](https://user-images.githubusercontent.com/7232514/145136913-4a40e1a4-108f-44ec-97a9-d84c0fd29a8d.png)

If the box is checked, the email address field is no longer required. It will not put any personal information in the email, it will set the given email address to the bcc (if the copy me option is checked), and it will set the "from" email address as the same as the "to" email address.

It seems to work on my dev server, but it never actually sent emails, so it might be good to test this on dev3 (or even on cloud since they requested it).

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3419.