### PR TITLE
Add button for bulk download of custom form response files

### DIFF
--- a/esp/esp/customforms/urls.py
+++ b/esp/esp/customforms/urls.py
@@ -17,4 +17,5 @@ urlpatterns = [
     url(r'^/getmodules/$', views.get_modules),
     url(r'^/builddata/$', views.formBuilderData),
     url(r'^/exceldata/(?P<form_id>\d{1,6})/$', views.getExcelData),
+    url(r'^/bulkdownloadfiles/?', views.bulkDownloadFiles)
 ]

--- a/esp/esp/utils/web.py
+++ b/esp/esp/utils/web.py
@@ -149,4 +149,3 @@ def zip_download(files = [], zipname = 'files'):
     response = HttpResponse(file_like.getvalue(), content_type='application/zip')
     response['Content-Disposition']='attachment; filename=%s.zip' % zipname
     return response
-    

--- a/esp/esp/utils/web.py
+++ b/esp/esp/utils/web.py
@@ -32,7 +32,10 @@ Learning Unlimited, Inc.
   Phone: 617-379-0178
   Email: web-team@learningu.org
 """
+import os
 import re
+import zipfile
+from io import BytesIO as StringIO
 from django.template import Template, loader, RequestContext
 from django.conf import settings
 from django import http
@@ -133,3 +136,17 @@ def secure_required(view_fn):
         return view_fn(request, *args, **kwargs)
     return _wrapped_view
 
+def zip_download(files = [], zipname = 'files'):
+    """
+    Zips a list of files together and returns it as a download
+    """
+    file_like = StringIO()
+    zf = zipfile.ZipFile(file_like, 'w')
+    for file in files:
+        if file:
+            zf.write(file, os.path.basename(os.path.normpath(file)))
+    zf.close()
+    response = HttpResponse(file_like.getvalue(), content_type='application/zip')
+    response['Content-Disposition']='attachment; filename=%s.zip' % zipname
+    return response
+    

--- a/esp/public/media/scripts/customforms_response.js
+++ b/esp/public/media/scripts/customforms_response.js
@@ -67,32 +67,43 @@ function file_link_formatter(cellvalue, options, rowObject)
 
 var createGrid=function(form_data){
     $j("#jqGrid").jqGrid({
-	datatype: "local",
-	height: 250,
-	colNames: $j.map(form_data['questions'], function(val, index) {
-	    return val[1];
-	}),
-	colModel: $j.map(form_data['questions'], function(val, index) {
-	    var result = {name: val[0], index: val[0]};
-        //  Substitute in custom formatter defined above in order to link to uploaded files.
-        if (val[2] == "file")
-        {
-            result['formatter'] = file_link_formatter;
-        }
-        return result;
-	}),
-	caption: "Form responses",
-	rowNum: 10,
-	pager: "#jqGridPager"
+        datatype: "local",
+        height: 250,
+        colNames: $j.map(form_data['questions'], function(val, index) {
+            return val[1];
+        }),
+        colModel: $j.map(form_data['questions'], function(val, index) {
+            var result = {name: val[0], index: val[0]};
+            //  Substitute in custom formatter defined above in order to link to uploaded files.
+            if (val[2] == "file")
+            {
+                result['formatter'] = file_link_formatter;
+                result['classes'] = "file_column"
+            }
+            return result;
+        }),
+        caption: "Form responses",
+        rowNum: 10,
+        pager: "#jqGridPager"
     });
     $j("#jqGrid").jqGrid('navGrid', '#jqGridPager',
 			{view: true, edit: false, add: false, del: false},
 			{}, {}, {}, 
 			{multipleSearch: true, closeOnEscape: true},
-		        {closeOnEscape: true});
+		        {closeOnEscape: true}
+    );
+    $j.each(form_data['questions'], function(index, val) {
+        //  Substitute in custom formatter defined above in order to link to uploaded files.
+        if (val[2] == "file") {
+            $j("#jqGrid_" + val[0] + " div").prepend("<a title='Bulk Download All Files' href='/customforms/bulkdownloadfiles?form_id="+$j('#form_id').val()+"&question_name="+val[0]+"'><span class='ui-icon  ui-icon-circle-arrow-s'></span></a> ");
+            $j("#jqGrid_" + val[0] + " div a").click(function(e) {
+                e.stopPropagation();
+            });
+        }
+    });
     $j.each(form_data['answers'], function(index, val) {
-	delete val.id;
-	$j("#jqGrid").jqGrid('addRowData', index+1, val);
+        delete val.id;
+        $j("#jqGrid").jqGrid('addRowData', index+1, val);
     });
 };
 


### PR DESCRIPTION
This adds a button to the custom form response interface to bulk download files that have been uploaded in response to an individual as a zip file/folder:
![image](https://user-images.githubusercontent.com/7232514/147422265-1ad5903f-2c86-4b31-83c8-7be97a49c62a.png)

The code to make the zip folder is pulled out so it can be utilized for other things in the future (e.g., for the filebrowser, for program files).

Fixes #3441?