### PR TITLE
Show default values in the tag settings ui

### DIFF
--- a/esp/esp/program/forms.py
+++ b/esp/esp/program/forms.py
@@ -446,7 +446,7 @@ class TagSettingsForm(BetterForm):
                 else:
                     self.fields[key] = forms.CharField()
                 self.fields[key].help_text = tag_info.get('help_text', '')
-                self.fields[key].initial = tag_info.get('default')
+                self.fields[key].initial = self.fields[key].default = tag_info.get('default')
                 self.fields[key].required = False
                 set_val = Tag.getBooleanTag(key) if tag_info.get('is_boolean', False) else Tag.getTag(key)
                 if set_val != None and set_val != self.fields[key].initial:

--- a/esp/esp/program/modules/forms/admincore.py
+++ b/esp/esp/program/modules/forms/admincore.py
@@ -136,7 +136,7 @@ class ProgramTagSettingsForm(BetterForm):
                 else:
                     self.fields[key] = forms.CharField()
                 self.fields[key].help_text = tag_info.get('help_text', '')
-                self.fields[key].initial = tag_info.get('default')
+                self.fields[key].initial = self.fields[key].default = tag_info.get('default')
                 self.fields[key].required = False
                 set_val = Tag.getBooleanTag(key, program = self.program) if tag_info.get('is_boolean', False) else Tag.getProgramTag(key, program = self.program)
                 if set_val != None and set_val != self.fields[key].initial:

--- a/esp/templates/program/modules/admincore/tags.html
+++ b/esp/templates/program/modules/admincore/tags.html
@@ -65,6 +65,8 @@
         <br/>
         <span> {{ field.help_text }} </span>
       {% endif %}
+      <br/>
+      <span style="font-style:italic;">Default: </span>{% if field.field.default != None %}<span>{{ field.field.default }}</span>{% endif %}
       {% for error in field.errors %}
       <br/>
        <span class='form_error'> {{ error }} </span>


### PR DESCRIPTION
This displays the default value for each tag on the tag settings UI (to make it easy for an admin to reset a tag to its default value):
![image](https://user-images.githubusercontent.com/7232514/147491900-fc0cb9c7-9071-44bd-b189-1d8c393734f5.png)

Fixes #3440.