### PR TITLE
Prevent non-admins from accessing manage QSD pages

### DIFF
--- a/esp/esp/qsd/views.py
+++ b/esp/esp/qsd/views.py
@@ -77,7 +77,7 @@ def qsd(request, url):
         page_name_base = page_name
     base_url = '/'.join(url_parts[:-1] + [page_name_base])
 
-    # Detect edit authorizations
+    # Detect read authorizations
     have_read = True
     if url_parts[0] == 'manage' and not request.user.isAdministrator():
         have_read = False

--- a/esp/esp/qsd/views.py
+++ b/esp/esp/qsd/views.py
@@ -79,6 +79,8 @@ def qsd(request, url):
 
     # Detect edit authorizations
     have_read = True
+    if url_parts[0] == 'manage' and not request.user.isAdministrator():
+        have_read = False
 
     if not have_read and action == 'read':
         raise Http403, "You do not have permission to access this page."
@@ -122,8 +124,6 @@ def qsd(request, url):
 
     # Detect the standard read verb
     if action == 'read':
-        if not have_read:
-            raise Http403, 'You do not have permission to read this page.'
 
         # Render response
         response = render_to_response('qsd/qsd.html', request, {


### PR DESCRIPTION
This prevents non-admins from accessing QSD pages that have a 'manage' url.

Fixes #194.