### PR TITLE
Only remove visible registrations when unenrolling students

### DIFF
--- a/esp/esp/program/controllers/classchange.py
+++ b/esp/esp/program/controllers/classchange.py
@@ -697,7 +697,7 @@ class ClassChangeController(object):
         relationship, created = RegistrationType.objects.get_or_create(name='Enrolled')
 
         for (student_ind,section_ind) in removals:
-            self.sections[section_ind].unpreregister_student(self.students[student_ind], prereg_verb = "Enrolled")
+            self.sections[section_ind].unpreregister_student(self.students[student_ind], prereg_verbs = ["Enrolled"])
             self.changed[student_ind] = True
         for (student_ind,section_ind) in assignments:
             self.sections[section_ind].preregister_student(self.students[student_ind], overridefull=False, prereg_verb = "Enrolled", fast_force_create=False)

--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -1264,17 +1264,17 @@ class ClassSection(models.Model):
         else:
             return [v.relationship for v in qs.filter(relationship__name__in=allowed_verbs).distinct()]
 
-    def unpreregister_student(self, user, prereg_verb = None):
-        #   New behavior: prereg_verb should be a string matching the name of
-        #   RegistrationType to match (if you want to use it)
+    def unpreregister_student(self, user, prereg_verbs = []):
+        #   New behavior: prereg_verbs should be a list of strings matching the names of
+        #   RegistrationTypes to match (if you want to use it)
 
         from esp.program.models.app_ import StudentAppQuestion
 
         now = datetime.datetime.now()
 
         #   Stop all active or pending registrations
-        if prereg_verb:
-            qs = StudentRegistration.valid_objects(now).filter(relationship__name=prereg_verb, section=self, user=user)
+        if prereg_verbs:
+            qs = StudentRegistration.valid_objects(now).filter(relationship__name__in=prereg_verbs, section=self, user=user)
             qs.update(end_date=now)
         else:
             qs = StudentRegistration.valid_objects(now).filter(section=self, user=user)
@@ -1950,11 +1950,11 @@ was approved! Please go to http://esp.mit.edu/teach/%s/class_status/%s to view y
         if best_section:
             best_section.preregister_student(user, overridefull, automatic)
 
-    def unpreregister_student(self, user):
+    def unpreregister_student(self, user, prereg_verbs = []):
         """ Find the student's registration for the class and expire it.
         Also update the cache on each of the sections.  """
         for s in self.sections.all():
-            s.unpreregister_student(user)
+            s.unpreregister_student(user, prereg_verbs)
 
     def getArchiveClass(self):
         result = ArchiveClass.objects.filter(original_id=self.id)

--- a/esp/esp/program/modules/handlers/adminclass.py
+++ b/esp/esp/program/modules/handlers/adminclass.py
@@ -45,7 +45,7 @@ from esp.program.modules.forms.management import ClassManageForm, SectionManageF
 
 from django.http import HttpResponseRedirect, HttpResponse
 from esp.middleware import ESPError
-
+from esp.program.controllers.studentclassregmodule import RegistrationTypeController as RTC
 
 """ Module in the middle of a rewrite. -Michael """
 
@@ -242,6 +242,7 @@ class AdminClass(ProgramModuleObj):
                 valid = (valid and sf.is_valid())
 
             if valid:
+                verbs = RTC.getVisibleRegistrationTypeNames(prog)
                 # Leave a loophole:  You can set a class to "Unreviewed" (ie., status = 0),
                 # then cancel it, and it won't kick all the students out
                 cls_alter = ClassSubject.objects.get(id=cls_form.cleaned_data['clsid'])
@@ -261,7 +262,7 @@ class AdminClass(ProgramModuleObj):
                     # Kick all the students out of a class if it was rejected
                     if int(sec_alter.status) < 0 and int(orig_sec_status) > 0:
                         for student in sec_alter.students():
-                            sec_alter.unpreregister_student(student)
+                            sec_alter.unpreregister_student(student, verbs)
 
                 #   Save class info after section info so that cls_form.save_data()
                 #   can override section information if it's supposed to.

--- a/esp/esp/program/modules/handlers/onsitecheckoutmodule.py
+++ b/esp/esp/program/modules/handlers/onsitecheckoutmodule.py
@@ -40,6 +40,7 @@ from esp.users.forms.generic_search_form import StudentSearchForm
 from esp.users.models    import ESPUser, Record
 from esp.program.modules.handlers.studentclassregmodule import StudentClassRegModule
 from esp.middleware.esperrormiddleware import ESPError
+from esp.program.controllers.studentclassregmodule import RegistrationTypeController as RTC
 
 class OnSiteCheckoutModule(ProgramModuleObj):
     doc = """Check students out (temporarily or indefinitely) from a program."""
@@ -98,8 +99,9 @@ class OnSiteCheckoutModule(ProgramModuleObj):
                 Record.objects.create(user=student, event="checked_out", program=prog)
 
                 # Unenroll student from selected classes
+                verbs = RTC.getVisibleRegistrationTypeNames(prog)
                 for sec in ClassSection.objects.filter(id__in=filter(None, request.POST.getlist('unenroll'))).distinct():
-                    sec.unpreregister_student(student, prereg_verb = "Enrolled")
+                    sec.unpreregister_student(student, verbs)
                 context['checkout_message_success'] = "Successfully checked out %s (%s)" % (student.name(), student.username)
 
             context.update(StudentClassRegModule.prepare_static(student, prog))

--- a/esp/esp/program/modules/handlers/onsiteclasslist.py
+++ b/esp/esp/program/modules/handlers/onsiteclasslist.py
@@ -57,6 +57,7 @@ from esp.utils.models import Printer, PrintRequest
 from esp.utils.query_utils import nest_Q
 from esp.tagdict.models import Tag
 from esp.accounting.controllers import IndividualAccountingController
+from esp.program.controllers.studentclassregmodule import RegistrationTypeController as RTC
 
 class OnSiteClassList(ProgramModuleObj):
     doc = """Display lists of classes for onsite registration purposes."""
@@ -270,9 +271,10 @@ class OnSiteClassList(ProgramModuleObj):
                     failed_add_sections.append(sec.id)
 
             if len(failed_add_sections) == 0:
+                verbs = RTC.getVisibleRegistrationTypeNames(prog)
                 #   Remove sections the student wants out of
                 for sec in sections_to_remove:
-                    sec.unpreregister_student(user)
+                    sec.unpreregister_student(user, verbs)
                     result['messages'].append('Removed %s (%s) from %s: %s (%s)' % (user.name(), user.id, sec.emailcode(), sec.title(), sec.id))
 
                 #   Remove sections that conflict with those the student wants into
@@ -284,7 +286,7 @@ class OnSiteClassList(ProgramModuleObj):
                         #   We found something we need to remove
                         for sm_sec in sm.map[ts]:
                             if sm_sec.id not in sections_to_add:
-                                sm_sec.unpreregister_student(user)
+                                sm_sec.unpreregister_student(user, verbs)
                                 result['messages'].append('Removed %s (%s) from %s: %s (%s)' % (user.name(), user.id, sm_sec.emailcode(), sm_sec.title(), sm_sec.id))
                             else:
                                 existing_sections.append(sm_sec)

--- a/esp/esp/program/modules/handlers/studentclassregmodule.py
+++ b/esp/esp/program/modules/handlers/studentclassregmodule.py
@@ -51,6 +51,7 @@ from django.core.cache import cache
 
 from esp.program.modules.base import ProgramModuleObj, needs_teacher, needs_student, needs_admin, usercheck_usetl, meets_deadline, meets_any_deadline, main_call, aux_call, meets_cap, no_auth
 from esp.program.modules.handlers.onsiteclasslist import OnSiteClassList
+from esp.program.controllers.studentclassregmodule import RegistrationTypeController as RTC
 from esp.program.models  import ClassSubject, ClassSection, ClassCategories, RegistrationProfile, StudentRegistration, StudentSubjectInterest
 from esp.utils.web import render_to_response
 from esp.middleware      import ESPError, AjaxError, ESPError_Log, ESPError_NoLog
@@ -616,7 +617,7 @@ class StudentClassRegModule(ProgramModuleObj):
     @staticmethod
     def clearslot_logic(request, tl, one, two, module, extra, prog):
         """ Clear the specified timeslot from a student registration and return True if there are no errors """
-
+        verbs = RTC.getVisibleRegistrationTypeNames(prog)
         #   Get the sections that the student is registered for in the specified timeslot.
         oldclasses = request.user.getSections(prog).filter(meeting_times=extra)
         #   Narrow this down to one class if we're using the priority system.
@@ -628,7 +629,7 @@ class StudentClassRegModule(ProgramModuleObj):
             if result and not hasattr(request.user, "onsite_local"):
                 return result
             else:
-                sec.unpreregister_student(request.user)
+                sec.unpreregister_student(request.user, verbs)
         #   Return the ID of classes that were removed.
         return oldclasses.values_list('id', flat=True)
 

--- a/esp/esp/program/modules/handlers/studentregcore.py
+++ b/esp/esp/program/modules/handlers/studentregcore.py
@@ -36,6 +36,7 @@ from esp.program.modules.base import ProgramModuleObj, needs_student, meets_dead
 from esp.program.modules import module_ext
 from esp.program.models  import Program
 from esp.program.controllers.confirmation import ConfirmationEmailController
+from esp.program.controllers.studentclassregmodule import RegistrationTypeController as RTC
 from esp.tagdict.models import Tag
 from esp.utils.web import render_to_response
 from esp.users.models    import ESPUser, Record
@@ -239,10 +240,11 @@ class StudentRegCore(ProgramModuleObj, CoreModule):
 
         #   If the appropriate flag is set, remove the student from their classes.
         scrmi = prog.studentclassregmoduleinfo
+        verbs = RTC.getVisibleRegistrationTypeNames(prog)
         if scrmi.cancel_button_dereg:
             sections = request.user.getSections()
             for sec in sections:
-                sec.unpreregister_student(request.user)
+                sec.unpreregister_student(request.user, verbs)
 
         #   If a cancel receipt template is there, use it.  Otherwise, return to the main studentreg page.
         try:

--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -38,6 +38,7 @@ from esp.program.modules.base    import ProgramModuleObj, needs_teacher, meets_d
 from esp.program.modules.forms.teacherreg   import TeacherClassRegForm, TeacherOpenClassRegForm
 from esp.program.models          import ClassSubject, ClassSection, Program, ProgramModule, StudentRegistration, RegistrationType, ClassFlagType, RegistrationProfile, ScheduleMap
 from esp.program.controllers.classreg import ClassCreationController, ClassCreationValidationError, get_custom_fields
+from esp.program.controllers.studentclassregmodule import RegistrationTypeController as RTC
 from esp.resources.models        import ResourceRequest
 from esp.tagdict.models          import Tag
 from esp.utils.web               import render_to_response
@@ -260,6 +261,7 @@ class TeacherClassRegModule(ProgramModuleObj):
         enrolled = RegistrationType.objects.get_or_create(name='Enrolled', category = "student")[0]
         onsite = RegistrationType.objects.get_or_create(name='OnSite/AttendedClass', category = "student")[0]
         not_found = []
+        verbs = RTC.getVisibleRegistrationTypeNames(prog)
         if request.POST and 'submitted' in request.POST:
             # split with delimiters comma, semicolon, and space followed by any amount of extra whitespace
             misc_students = filter(None, re.split(r'[;,\s]\s*', request.POST.get('misc_students')))
@@ -285,7 +287,7 @@ class TeacherClassRegModule(ProgramModuleObj):
                             for ts in [ts.id for ts in section.get_meeting_times()]:
                                 if ts in sm.map and len(sm.map[ts]) > 0:
                                     for sm_sec in sm.map[ts]:
-                                        sm_sec.unpreregister_student(student)
+                                        sm_sec.unpreregister_student(student, verbs)
                         if 'enroll' in request.POST:
                             for rt in [enrolled, onsite]:
                                 srs = StudentRegistration.objects.filter(user = student, section = section, relationship = rt)
@@ -334,6 +336,7 @@ class TeacherClassRegModule(ProgramModuleObj):
         attended = RegistrationType.objects.get_or_create(name = 'Attended', category = "student")[0]
         enrolled = RegistrationType.objects.get_or_create(name='Enrolled', category = "student")[0]
         onsite = RegistrationType.objects.get_or_create(name='OnSite/AttendedClass', category = "student")[0]
+        verbs = RTC.getVisibleRegistrationTypeNames(prog)
         if 'student' in request.POST and 'secid' in request.POST:
             students = ESPUser.objects.filter(username=request.POST['student'])
             if not students.exists():
@@ -370,7 +373,7 @@ class TeacherClassRegModule(ProgramModuleObj):
                                 for ts in [ts.id for ts in section.get_meeting_times()]:
                                     if ts in sm.map and len(sm.map[ts]) > 0:
                                         for sm_sec in sm.map[ts]:
-                                            sm_sec.unpreregister_student(student)
+                                            sm_sec.unpreregister_student(student, verbs)
                             if request.POST.get('enroll', 'true').lower() == 'true':
                                 for rt in [enrolled, onsite]:
                                     srs = StudentRegistration.objects.filter(user = student, section = section, relationship = rt)


### PR DESCRIPTION
This uses the RegistrationTypeController to determine which registration types should be expired when a student is removed from a class. Usually this is only "Enrolled", but it can be other types as well for certain setups. The most important effect of this is that when a student is removed from a class their lottery preferences will no longer be expired. This also allows for multiple verbs to be expired at once.

Fixes #258.