### PR TITLE
Fix scheduling and lottery caching

### DIFF
--- a/esp/esp/program/controllers/lottery.py
+++ b/esp/esp/program/controllers/lottery.py
@@ -742,7 +742,10 @@ class LotteryAssignmentController(object):
 
         relationship, created = RegistrationType.objects.get_or_create(name='Enrolled')
         self.now = datetime.now()   # The time that all the registrations start at, in case all lottery registrations need to be manually reverted later
-        StudentRegistration.objects.bulk_create([StudentRegistration(user_id=student_ids[i], section_id=section_ids[i], relationship=relationship, start_date=self.now) for i in range(student_ids.shape[0])])
+        srs = StudentRegistration.objects.bulk_create([StudentRegistration(user_id=student_ids[i], section_id=section_ids[i], relationship=relationship, start_date=self.now) for i in range(student_ids.shape[0])])
+        # Trigger any relevant caches
+        for sr in srs:
+            sr.save()
         if self.options['stats_display']:
             logger.info("StudentRegistration enrollments all created to start at %s", self.now)
             logger.info('Created %d registrations', student_ids.shape[0])

--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -249,10 +249,7 @@ class ClassManager(Manager):
         class_ids = map(lambda x: x.id, classes)
 
         # Now to get the sections corresponding to these classes...
-
         sections = ClassSection.objects.filter(parent_class__in=class_ids)
-
-        sections = ClassSection.prefetch_catalog_data(sections.distinct())
 
         sections_by_parent_id = defaultdict(list)
         for s in sections:

--- a/esp/esp/program/modules/handlers/jsondatamodule.py
+++ b/esp/esp/program/modules/handlers/jsondatamodule.py
@@ -666,7 +666,7 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
 
     # This is separate from class_info because students shouldn't see it
     @aux_call
-    @cache_control(public=True, max_age=300)
+    @cache_control(public=True, max_age=30)
     @json_response()
     @needs_admin
     def class_admin_info(self, request, tl, one, two, module, extra, prog):

--- a/esp/esp/program/modules/handlers/studentclassregmodule.py
+++ b/esp/esp/program/modules/handlers/studentclassregmodule.py
@@ -91,7 +91,7 @@ def json_encode(obj):
         return { 'id': obj.id,
                  'status': obj.status,
                  'duration': obj.duration,
-                 'get_meeting_times': obj._events,
+                 'get_meeting_times': sorted(list(obj.get_meeting_times()), cmp=lambda e1, e2: cmp(e1.start, e2.start)),
                  'num_students': obj.num_students(),
                  'capacity': obj.capacity
                  }

--- a/esp/public/media/scripts/program/modules/adminclass.js
+++ b/esp/public/media/scripts/program/modules/adminclass.js
@@ -1,6 +1,5 @@
 //  Global variables for storing the class and section data
 var classes_global = {};
-var sections_global = {};
 
 function deleteClass() {
     if (confirm('Are you sure you would like to delete this class? \n Since you are an admin, you can delete this class with students. \n Deleting is hard to undo, so consider instead marking it unreviewed or rejected.')) {
@@ -193,7 +192,6 @@ function update_class(clsid, statusId) {
 function fillClasses(data)
 {
     // First pull out the data
-    var sections = data.sections;
     var classes = data.classes;
 
     // Clear the current classes list (most likely just "Loading...")
@@ -207,7 +205,6 @@ function fillClasses(data)
 
     //  Save the data for later if we need it
     classes_global = classes;
-    sections_global = sections;
 }
 
 function createClassTitleTd(clsObj) {

--- a/esp/templates/program/modules/adminclass/listclasses.html
+++ b/esp/templates/program/modules/adminclass/listclasses.html
@@ -23,7 +23,7 @@ json_data = {};
   $j(document).ready(setup_sort_control);
 
   // Start the AJAX request to get the class data and display it
-  json_fetch(["sections", "class_subjects"], fillClasses, json_data, function() { alert("Error loading class data"); });
+  json_fetch(["class_subjects"], fillClasses, json_data, function() { alert("Error loading class data"); });
 
 /* ]]> */
 </script>


### PR DESCRIPTION
This fixes two instances of caching issues:

1. Catalog and dashboard caching when scheduling classes (fixes #3138 and fixes #2198). This may cause a slight performance drop when first loading the catalog, but all subsequent loads should be just as fast. Only individual classes within the catalog should update their caches when their scheduling is changed (like on the survey results page).
2. Enrollment caching when running the lottery (fixes #3126 and fixes #1840). This may cause a very minor performance hit, but it shouldn't matter since saving lottery preferences already takes a while.

While I was at it, I also cleaned up some of the code for the dashboard which may perhaps give a slight performance boost.