### PR TITLE
Prevent forms from being submitted twice

### DIFF
--- a/esp/templates/elements/html
+++ b/esp/templates/elements/html
@@ -76,6 +76,16 @@
       });
     </script>
 
+    <!-- prevent forms from being submitted twice -->
+    <script text="text/javascript">
+      $j(function() {
+        $j('[type=submit]').click(function(){
+          $j(this).prop('disabled', true);
+          $j(this).parents('form').submit();
+        });
+      });
+    </script>
+
     <script type="text/javascript" src="/media/scripts/json2.js"></script>
     <script type="text/javascript" src="/media/scripts/qsd.js"></script>
     <script type="text/javascript" src="/media/scripts/jsprettify-all-latest.js"></script>


### PR DESCRIPTION
This makes it so that the submit buttons for the vast majority of forms on the site are disabled after being clicked, preventing the forms from being submitted twice, preventing "database things" from happening twice instead of just once. For the record, I wasn't able to reproduce the double program admission charge on my dev server or on dev3, but this is my best guess as to the root cause, so I'm hoping this will prevent future instances of this and other weird double "database things".

Hopefully fixes #2838 and fixes #2737.