### PR TITLE
Webapp map and directions changes

### DIFF
--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -40,6 +40,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 import random
+import re
 
 # django Util
 from django.conf import settings
@@ -529,6 +530,14 @@ class ClassSection(models.Model):
             return self.classrooms().filter(event=initial_time).order_by('id')
         else:
             return Resource.objects.none()
+
+    def initial_lat_long(self):
+        classroom = self.initial_rooms().first()
+        if classroom:
+            res = classroom.associated_resources().filter(res_type__name='Lat/Long')
+            if res.count() == 1 and re.match("^[-+]?([1-8]?\d(\.\d+)?|90(\.0+)?),\s*[-+]?(180(\.0+)?|((1[0-7]\d)|([1-9]?\d))(\.\d+)?)$", res[0].attribute_value):
+                return res[0].attribute_value
+        return None
 
     def prettyrooms(self):
         """ Return the pretty name of the rooms. """

--- a/esp/esp/program/modules/handlers/studentonsite.py
+++ b/esp/esp/program/modules/handlers/studentonsite.py
@@ -35,7 +35,6 @@ import datetime
 
 from esp.program.modules.base import ProgramModuleObj, needs_student, meets_deadline, meets_grade, CoreModule, main_call, aux_call, meets_cap
 from esp.program.models  import ClassSubject, ClassSection, StudentRegistration
-from esp.resources.models import Resource
 from esp.utils.web import render_to_response
 from esp.users.models    import Record
 from esp.cal.models import Event

--- a/esp/esp/program/modules/handlers/studentonsite.py
+++ b/esp/esp/program/modules/handlers/studentonsite.py
@@ -199,6 +199,7 @@ class StudentOnsite(ProgramModuleObj, CoreModule):
         context['program'] = prog
         context['one'] = one
         context['two'] = two
+        context['map_tab'] = bool(Tag.getTag('google_cloud_api_key').strip())
         return context
 
     def isStep(self):

--- a/esp/esp/program/modules/handlers/studentonsite.py
+++ b/esp/esp/program/modules/handlers/studentonsite.py
@@ -110,23 +110,9 @@ class StudentOnsite(ProgramModuleObj, CoreModule):
         context = self.onsitecontext(request, tl, one, two, prog)
         context['webapp_page'] = 'map'
         context['center'] = Tag.getProgramTag('program_center', program = prog)
+        context['zoom'] = Tag.getProgramTag('program_center_zoom', program = prog)
         context['API_key'] = Tag.getTag('google_cloud_api_key')
 
-        #extra should be a classroom id
-        if extra:
-            #gets lat/long of classroom and adds it to context
-            try:
-                classroom = Resource.objects.get(id=extra)
-            except:
-                res = None
-            else:
-                try:
-                    res = classroom.associated_resources().get(res_type__name='Lat/Long')
-                except:
-                    res = None
-            if res and res.attribute_value:
-                classroom = res.attribute_value.split(",")
-                context['classroom'] = '{lat: ' + classroom[0].strip() + ', lng: ' + classroom[1].strip() + '}'
         return render_to_response(self.baseDir()+'map.html', request, context)
 
     @aux_call

--- a/esp/esp/program/modules/handlers/teacheronsite.py
+++ b/esp/esp/program/modules/handlers/teacheronsite.py
@@ -179,6 +179,7 @@ class TeacherOnsite(ProgramModuleObj, CoreModule):
         context['program'] = prog
         context['one'] = one
         context['two'] = two
+        context['map_tab'] = bool(Tag.getTag('google_cloud_api_key').strip())
         return context
 
     def isStep(self):

--- a/esp/esp/program/modules/handlers/teacheronsite.py
+++ b/esp/esp/program/modules/handlers/teacheronsite.py
@@ -83,23 +83,9 @@ class TeacherOnsite(ProgramModuleObj, CoreModule):
         context = self.onsitecontext(request, tl, one, two, prog)
         context['webapp_page'] = 'map'
         context['center'] = Tag.getProgramTag('program_center', program = prog)
+        context['zoom'] = Tag.getProgramTag('program_center_zoom', program = prog)
         context['API_key'] = Tag.getTag('google_cloud_api_key')
 
-        #extra should be a classroom id
-        if extra:
-            #gets lat/long of classroom and adds it to context
-            try:
-                classroom = Resource.objects.get(id=extra)
-            except:
-                res = None
-            else:
-                try:
-                    res = classroom.associated_resources().get(res_type__name='Lat/Long')
-                except:
-                    res = None
-            if res and res.attribute_value:
-                classroom = res.attribute_value.split(",")
-                context['classroom'] = '{lat: ' + classroom[0].strip() + ', lng: ' + classroom[1].strip() + '}'
         return render_to_response(self.baseDir()+'map.html', request, context)
 
     @aux_call

--- a/esp/esp/program/modules/handlers/teacheronsite.py
+++ b/esp/esp/program/modules/handlers/teacheronsite.py
@@ -29,7 +29,6 @@ Learning Unlimited, Inc.
 """
 from esp.program.modules.base import ProgramModuleObj, needs_teacher, meets_deadline, CoreModule, main_call, aux_call
 from esp.program.models  import ClassSection
-from esp.resources.models import Resource
 from esp.utils.web import render_to_response
 from esp.users.models    import Record
 from esp.survey.views   import survey_view, survey_review

--- a/esp/esp/tagdict/__init__.py
+++ b/esp/esp/tagdict/__init__.py
@@ -445,7 +445,7 @@ all_global_tags = {
     },
     'google_cloud_api_key': {
         'is_boolean': False,
-        'help_text': 'An API key for use with the Google Cloud Platform. Used for the student and teacher onsite webapps.',
+        'help_text': 'An API key for use with the Google Cloud Platform. Used for the maps in the student and teacher onsite webapps.',
         'default': '',
         'category': 'manage',
         'is_setting': True,

--- a/esp/esp/tagdict/__init__.py
+++ b/esp/esp/tagdict/__init__.py
@@ -445,7 +445,7 @@ all_global_tags = {
     },
     'google_cloud_api_key': {
         'is_boolean': False,
-        'help_text': 'An API key for use with the Google Cloud Platform. Used for the maps in the student and teacher onsite webapps.',
+        'help_text': 'An API key for use with the Google Cloud Platform. Used for the maps in the student and teacher onsite webapps. The embedded map is entirely free but requires an API key. If not set, the map tab will be hidden.',
         'default': '',
         'category': 'manage',
         'is_setting': True,
@@ -951,10 +951,19 @@ all_program_tags = {
     },
     'program_center': {
         'is_boolean': False,
-        'help_text': 'The geographic center for a program, following the form {lat: 37.427490, lng: -122.170267}. Used for the teacher and student onsite webapps.',
-        'default': '{lat: 37.427490, lng: -122.170267}',
+        'help_text': 'The geographic center for a program, following the form "lat, long". Used for the maps in the teacher and student onsite webapps.',
+        'default': '37.427490, -122.170267',
         'category': 'manage',
         'is_setting': True,
+        'field': forms.CharField(validators=[RegexValidator(r'^[-+]?([1-8]?\d(\.\d+)?|90(\.0+)?),\s*[-+]?(180(\.0+)?|((1[0-7]\d)|([1-9]?\d))(\.\d+)?)$', 'Enter a valid location.')])
+    },
+    'program_center_zoom': {
+        'is_boolean': False,
+        'help_text': 'The initial zoom level of the map in the teacher and student onsite webapps.',
+        'default': '17',
+        'category': 'manage',
+        'is_setting': True,
+        'field': forms.IntegerField(min_value=0, max_value=21),
     },
     'student_webapp_isstep': {
         'is_boolean': True,

--- a/esp/templates/program/modules/studentonsite/map.html
+++ b/esp/templates/program/modules/studentonsite/map.html
@@ -6,7 +6,7 @@
 
     <div class="main">
         {% if API_key %}
-            <iframe width="100%" frameborder="0" style="border:0; height: 92vh;" src="https://www.google.com/maps/embed/v1/view?key={{ API_key }}&zoom=17&center={{ center }}"></iframe>
+            <iframe width="100%" frameborder="0" style="border:0; height: 92vh;" src="https://www.google.com/maps/embed/v1/view?key={{ API_key }}&zoom={{ zoom }}&center={{ center }}"></iframe>
         {% endif %}
     </div>
 

--- a/esp/templates/program/modules/studentonsite/map.html
+++ b/esp/templates/program/modules/studentonsite/map.html
@@ -1,120 +1,15 @@
 {% extends "program/modules/studentonsite/webapp.html" %}
 
-{% block head %}
-
-{% if classroom %}
-<meta http-equiv="refresh" content="30">
-
-<script>
-  function initDirections() {
-    var position;
-    navigator.geolocation.getCurrentPosition(onSuccess, onError);
-    function onSuccess(pos) {
-      position = {
-        lat: pos.coords.latitude,
-        lng: pos.coords.longitude
-      };
-      setupMap(position);
-    }
-    function onError(error) {
-      alert('code: '    + error.code    + '\n' +
-          'message: ' + error.message + '\n');
-      position = {{ center }};
-      setupMap(position);
-    }
-  }
-
-  function setupMap(position) {
-    var directionsService = new google.maps.DirectionsService;
-    var directionsDisplay = new google.maps.DirectionsRenderer;
-    var map = new google.maps.Map(document.getElementById('map'), {
-      zoom: 7,
-      center: position
-    });
-    directionsDisplay.setMap(map);
-    calculateAndDisplayRoute(directionsService, directionsDisplay, position);
-  }
-
-  function calculateAndDisplayRoute(directionsService, directionsDisplay, position) {
-    var classroom = {{ classroom }};
-    var dest = new google.maps.LatLng(classroom.lat, classroom.lng);
-    directionsService.route({
-      origin: position,
-      destination: dest,
-      travelMode: 'WALKING'
-    }, function(response, status) {
-      if (status === 'OK') {
-        directionsDisplay.setDirections(response);
-      } else {
-        window.alert('Directions request failed due to ' + status);
-      }
-    });
-  }
-</script>
-{% endif %}
-
-<script>
-  // Note: This example requires that you consent to location sharing when
-  // prompted by your browser. If you see the error "The Geolocation service
-  // failed.", it means you probably did not give permission for the browser to
-  // locate you.
-  var map, infoWindow;
-  function initMap() {
-    map = new google.maps.Map(document.getElementById('map'), {
-      center: {{ center }},
-      zoom: 17
-    });
-    infoWindow = new google.maps.InfoWindow;
-
-    // Try HTML5 geolocation.
-    if (navigator.geolocation) {
-      navigator.geolocation.getCurrentPosition(function(position) {
-        var pos = {
-          lat: position.coords.latitude,
-          lng: position.coords.longitude
-        };
-
-        var marker = new google.maps.Marker({
-          position: pos,
-          map: map,
-          title: 'Your location'
-        });
-      }, function() {
-        handleLocationError(true, infoWindow, map.getCenter());
-      });
-    } else {
-      // Browser doesn't support Geolocation
-      handleLocationError(false, infoWindow, map.getCenter());
-    }
-  }
-
-  function handleLocationError(browserHasGeolocation, infoWindow, pos) {
-    infoWindow.setPosition(pos);
-    infoWindow.setContent(browserHasGeolocation ?
-                          'Error: The Geolocation service failed.' :
-                          'Error: Your browser doesn\'t support geolocation.');
-    infoWindow.open(map);
-  }
-</script>
-
-{% endblock %}
-
 {% block body %}
 
 <center>
 
     <div class="main">
-        <div id="map"></div>
+        {% if API_key %}
+            <iframe width="100%" frameborder="0" style="border:0; height: 92vh;" src="https://www.google.com/maps/embed/v1/view?key={{ API_key }}&zoom=17&center={{ center }}"></iframe>
+        {% endif %}
     </div>
 
 </center>
-
-{% if API_key %}
-    {% if classroom %}
-        <script async defer src="https://maps.googleapis.com/maps/api/js?key={{ API_key }}&callback=initDirections"></script>
-    {% else %}
-        <script async defer src="https://maps.googleapis.com/maps/api/js?key={{ API_key }}&callback=initMap"></script>
-    {% endif %}
-{% endif %}
 
 {% endblock %}

--- a/esp/templates/program/modules/studentonsite/schedule.html
+++ b/esp/templates/program/modules/studentonsite/schedule.html
@@ -50,7 +50,7 @@ function togglePopup() {
                         <!--link to course details-->
                         <a class="no-dec" title="More Details" href="/learn/{{one}}/{{two}}/onsitedetails/{{ cls.section.id }}"><b>{{ cls.section.title }}&nbsp;<i class="material-icons md-3">list</i></a></b>
                         {% if checked_in and not cls.section.initial_rooms.count == 0 %}
-                        <br><a class="no-dec" title="Directions" href="/learn/{{one}}/{{two}}/onsitemap/{{ cls.section.initial_rooms.0.id }}">{{ cls.section.prettyrooms|join:", " }}&nbsp;<i class="material-icons md-3">directions</i></a>
+                        <br>{% if cls.section.initial_lat_long %}<a class="no-dec" title="Directions" target="_blank" href="https://www.google.com/maps/dir/?api=1&destination={{ cls.section.initial_lat_long }}&travelmode=walking">{% endif %}{{ cls.section.prettyrooms|join:", " }}{% if cls.section.initial_lat_long %}&nbsp;<i class="material-icons md-3">directions</i></a>{% endif %}
                         {% endif %}
                     </td>
                     {% endif %}

--- a/esp/templates/program/modules/studentonsite/webapp.html
+++ b/esp/templates/program/modules/studentonsite/webapp.html
@@ -17,8 +17,10 @@
     <tr>
       <td{% if webapp_page == "schedule" %} class="selected"{% endif %}><a class="no-dec" href="/learn/{{one}}/{{two}}/studentonsite/" style="display:block;"><i class="material-icons md-5">event_note</i>
         <br>Schedule</td>
+      {% if map_tab %}
       <td{% if webapp_page == "map" %} class="selected"{% endif %}><a class="no-dec" href="/learn/{{one}}/{{two}}/onsitemap" style="display:block;"><i class="material-icons md-5">map</i>
         <br>Map</a></td>
+      {% endif %}
       <td{% if webapp_page == "catalog" %} class="selected"{% endif %}><a class="no-dec" href="/learn/{{one}}/{{two}}/onsitecatalog" style="display:block;"><i class="material-icons md-5">event</i>
         <br>Catalog</td>
       {% if survey_status != "none" %}

--- a/esp/templates/program/modules/teacheronsite/map.html
+++ b/esp/templates/program/modules/teacheronsite/map.html
@@ -6,7 +6,7 @@
 
     <div class="main">
         {% if API_key %}
-            <iframe width="100%" frameborder="0" style="border:0; height: 92vh;" src="https://www.google.com/maps/embed/v1/view?key={{ API_key }}&zoom=17&center={{ center }}"></iframe>
+            <iframe width="100%" frameborder="0" style="border:0; height: 92vh;" src="https://www.google.com/maps/embed/v1/view?key={{ API_key }}&zoom={{ zoom }}&center={{ center }}"></iframe>
         {% endif %}
     </div>
 

--- a/esp/templates/program/modules/teacheronsite/map.html
+++ b/esp/templates/program/modules/teacheronsite/map.html
@@ -1,115 +1,15 @@
 {% extends "program/modules/teacheronsite/webapp.html" %}
 
-{% block head %}
-
-{% if classroom %}
-<meta http-equiv="refresh" content="30">
-
-<script>
-  function initDirections() {
-    var position;
-    navigator.geolocation.getCurrentPosition(onSuccess, onError);
-    function onSuccess(pos) {
-      position = {
-        lat: pos.coords.latitude,
-        lng: pos.coords.longitude
-      };
-      setupMap(position);
-    }
-    function onError(error) {
-      alert('code: '    + error.code    + '\n' +
-          'message: ' + error.message + '\n');
-      position = {{ center }};
-      setupMap(position);
-    }
-  }
-  function setupMap(position) {
-    var directionsService = new google.maps.DirectionsService;
-    var directionsDisplay = new google.maps.DirectionsRenderer;
-    var map = new google.maps.Map(document.getElementById('map'), {
-      zoom: 7,
-      center: position
-    });
-    directionsDisplay.setMap(map);
-    calculateAndDisplayRoute(directionsService, directionsDisplay, position);
-  }
-  function calculateAndDisplayRoute(directionsService, directionsDisplay, position) {
-    var classroom = {{ classroom }};
-    var dest = new google.maps.LatLng(classroom.lat, classroom.lng);
-    directionsService.route({
-      origin: position,
-      destination: dest,
-      travelMode: 'WALKING'
-    }, function(response, status) {
-      if (status === 'OK') {
-        directionsDisplay.setDirections(response);
-      } else {
-        window.alert('Directions request failed due to ' + status);
-      }
-    });
-  }
-</script>
-{% endif %}
-
-<script>
-  // Note: This example requires that you consent to location sharing when
-  // prompted by your browser. If you see the error "The Geolocation service
-  // failed.", it means you probably did not give permission for the browser to
-  // locate you.
-  var map, infoWindow;
-  function initMap() {
-    map = new google.maps.Map(document.getElementById('map'), {
-      center: {{ center }},
-      zoom: 17
-    });
-    infoWindow = new google.maps.InfoWindow;
-    // Try HTML5 geolocation.
-    if (navigator.geolocation) {
-      navigator.geolocation.getCurrentPosition(function(position) {
-        var pos = {
-          lat: position.coords.latitude,
-          lng: position.coords.longitude
-        };
-        var marker = new google.maps.Marker({
-          position: pos,
-          map: map,
-          title: 'Your location'
-        });
-      }, function() {
-        handleLocationError(true, infoWindow, map.getCenter());
-      });
-    } else {
-      // Browser doesn't support Geolocation
-      handleLocationError(false, infoWindow, map.getCenter());
-    }
-  }
-  function handleLocationError(browserHasGeolocation, infoWindow, pos) {
-    infoWindow.setPosition(pos);
-    infoWindow.setContent(browserHasGeolocation ?
-                          'Error: The Geolocation service failed.' :
-                          'Error: Your browser doesn\'t support geolocation.');
-    infoWindow.open(map);
-  }
-</script>
-
-{% endblock %}
-
 {% block body %}
 
 <center>
 
     <div class="main">
-        <div id="map"></div>
+        {% if API_key %}
+            <iframe width="100%" frameborder="0" style="border:0; height: 92vh;" src="https://www.google.com/maps/embed/v1/view?key={{ API_key }}&zoom=17&center={{ center }}"></iframe>
+        {% endif %}
     </div>
 
 </center>
-
-{% if API_key %}
-    {% if classroom %}
-        <script async defer src="https://maps.googleapis.com/maps/api/js?key={{ API_key }}&callback=initDirections"></script>
-    {% else %}
-        <script async defer src="https://maps.googleapis.com/maps/api/js?key={{ API_key }}&callback=initMap"></script>
-    {% endif %}
-{% endif %}
 
 {% endblock %}

--- a/esp/templates/program/modules/teacheronsite/schedule.html
+++ b/esp/templates/program/modules/teacheronsite/schedule.html
@@ -30,7 +30,7 @@
                 <td class="time">{{ cls.time_blocks.0.short_time }}</td>
                 <td class="cls">
                     <b>{{ cls.parent_class.title }}</b>{% if request.user in cls.get_moderators %}</br>({{ program.getModeratorTitle }}){% endif %}
-                    <br>{{ cls.prettyrooms|join:", " }}&nbsp;<a class="no-dec" title="Directions" href="/teach/{{one}}/{{two}}/onsitemap/{{ cls.initial_rooms.0.id }}"><i class="material-icons md-3">directions</i></a>
+                    <br>{% if cls.initial_lat_long %}<a class="no-dec" title="Directions" target="_blank" href="https://www.google.com/maps/dir/?api=1&destination={{ cls.initial_lat_long }}&travelmode=walking">{% endif %}{{ cls.prettyrooms|join:", " }}{% if cls.initial_lat_long %}&nbsp;<i class="material-icons md-3">directions</i></a>{% endif %}
                 </td>
                 <td class="list">
                     <a class="no-dec" title="More Details" href="/teach/{{one}}/{{two}}/onsitedetails/{{ cls.id }}"><i class="material-icons md-4">list</i></a>

--- a/esp/templates/program/modules/teacheronsite/webapp.html
+++ b/esp/templates/program/modules/teacheronsite/webapp.html
@@ -19,8 +19,10 @@
         <br>Schedule</td>
       <td{% if webapp_page == "details" %} class="selected"{% endif %}><a class="no-dec" href="/teach/{{one}}/{{two}}/onsitedetails" style="display:block;"><i class="material-icons md-5">list</i>
         <br>Class Details</td>
+      {% if map_tab %}
       <td{% if webapp_page == "map" %} class="selected"{% endif %}><a class="no-dec" href="/teach/{{one}}/{{two}}/onsitemap" style="display:block;"><i class="material-icons md-5">map</i>
         <br>Map</a></td>
+      {% endif %}
       {% if survey_status != "none" %}
       <td{% if webapp_page == "survey" %} class="selected"{% endif %}><a class="no-dec" href="/teach/{{one}}/{{two}}/onsitesurvey" style="display:block;"><i class="material-icons md-5">question_answer</i>
         <br>Surveys</td>


### PR DESCRIPTION
This makes the following changes to the webapp maps and directions:

1. If the `google_cloud_api_key` tag is not set, then the map will fail, so this hides the tab in the onsite interfaces if the tag is not set.
2. The links to directions in the student or teacher onsite schedule now link directly to google maps, which is both 1) free and 2) more feature rich than what I had originally designed for the webapp (why reinvent the wheel)
3. Cleanup of the schedule such that the link/icon don't appear if the classroom doesn't have a location set
4. Use an embedded iframe (which is free) for the map tab instead of using the javascript API (which costs money)
5. Allow for the map initial zoom to be adjusted with a tag
6. Validation of lat/long values that are associated with classrooms
7. Validation of the `program_center` tag (which now has a new format)