### PR TITLE
Prevent combination list with only NOT

### DIFF
--- a/esp/public/media/default_styles/commpanel.css
+++ b/esp/public/media/default_styles/commpanel.css
@@ -84,6 +84,16 @@ div #combo_list_form li {
     margin-bottom: 8px;
 }
 
+#combo_list_form .checkbox_wrapper {
+    float: left;
+    margin-right: 5px;
+}
+
+#combo_list_form .checkbox_label {
+    display: table-cell;
+    padding-top: 2px;
+}
+
 #combo_list_form label.ui-button {
     margin: 0px;
     margin-left: 2px;
@@ -108,6 +118,7 @@ div #combo_list_form li {
 
 div .combo_list_separator {
     font-weight: bold;
+    padding-top: 10px;
 }
 
 div #msgreq_info_area {

--- a/esp/public/media/scripts/commpanel.js
+++ b/esp/public/media/scripts/commpanel.js
@@ -252,11 +252,11 @@ function initialize()
         $j("#bool_options_" + list_names[i]).buttonset();
     }
 
-    //  Make the ANDs turn off the ORs and vice versa
     for (var i = 0; i < list_names.length; i++)
     {
         with ({list_name: list_names[i]})
         {
+            //  Make the ANDs turn off the ORs and vice versa
             $j("input[name=checkbox_and_" + list_name + "]").change(function () {
                 if ($j("input[name=checkbox_and_" + list_name + "]").prop("checked")
                     && $j("input[name=checkbox_or_" + list_name + "]").prop("checked"))
@@ -265,6 +265,13 @@ function initialize()
             $j("input[name=checkbox_or_" + list_name + "]").change(function () {
                 if ($j("input[name=checkbox_and_" + list_name + "]").prop("checked")
                     && $j("input[name=checkbox_or_" + list_name + "]").prop("checked"))
+                    $j("input[name=checkbox_and_" + list_name + "]").click();
+            });
+            //  NOT can't be selected by itself
+            $j("input[name=checkbox_not_" + list_name + "]").change(function () {
+                if ($j("input[name=checkbox_not_" + list_name + "]").prop("checked")
+                    && !$j("input[name=checkbox_and_" + list_name + "]").prop("checked")
+                    && !$j("input[name=checkbox_or_" + list_name + "]").prop("checked"))
                     $j("input[name=checkbox_and_" + list_name + "]").click();
             });
         }

--- a/esp/templates/users/usersearch/list_selector.html
+++ b/esp/templates/users/usersearch/list_selector.html
@@ -148,12 +148,12 @@ $j(document).ready(function() {
             {% for item in kv.1 %}{% if not item.all_flag %}
             {% ifchanged kv.0 %}<li><div class="combo_list_separator">Category: {{ kv.0 }}</div></li>{% endifchanged %}
             <li>
-                <span id="bool_options_{{ item.name }}">
+                <span class="checkbox_wrapper" id="bool_options_{{ item.name }}">
                 <input type="checkbox" id="checkbox_and_{{ item.name }}" name="checkbox_and_{{ item.name }}" /><label for="checkbox_and_{{ item.name }}">AND</label>
                 <input type="checkbox" id="checkbox_or_{{ item.name }}" name="checkbox_or_{{ item.name }}" /><label for="checkbox_or_{{ item.name }}">OR</label>
                 <input type="checkbox" id="checkbox_not_{{ item.name }}"  name="checkbox_not_{{ item.name }}"/><label for="checkbox_not_{{ item.name }}">NOT</label>
                 </span>
-                {{ item.description }}
+                <span class="checkbox_label">{{ item.description }}</span>
             </li>
             {% endif %}{% endfor %}{% endfor %}
             </ul>


### PR DESCRIPTION
When a NOT checkbox is selected for a combination list, we now automatically select AND as well (if neither AND nor OR is already selected).

While I was at it, I cleaned up some of the styling of the checkbox interface:
![image](https://user-images.githubusercontent.com/7232514/153529665-50bfe10b-9c36-4a29-aeda-d2578d7262ed.png)

Fixes https://github.com/learning-unlimited/ESP-Website/issues/1664.