### PR TITLE
Fix errors for emails with weird characters

### DIFF
--- a/esp/esp/dbmail/models.py
+++ b/esp/esp/dbmail/models.py
@@ -198,7 +198,7 @@ class MessageRequest(models.Model):
     public = models.BooleanField(default=False) # Should the subject and msgtext of this request be publicly viewable at /email/<id>?
 
     def public_url(self):
-        return '%s/email/%s' % (Site.objects.get_current().domain, self.id)
+        return '%s/email/%s' % (Site.objects.get_current().domain, self.id or "{ID will be here}")
 
     def __unicode__(self):
         return unicode(self.subject)
@@ -224,7 +224,6 @@ class MessageRequest(models.Model):
 
         if var_dict is not None:
             new_request.save()
-            var_dict['request'] = new_request
             MessageVars.createMessageVars(new_request, var_dict) # create the message Variables
         return new_request
 
@@ -519,6 +518,9 @@ class MessageVars(models.Model):
 
         for msgvar in msgvars:
             context.update(msgvar.getDict(user))
+
+        context['request'] = ActionHandler(msgrequest, user) # add the request so the public url is accessible
+
         return Context(context)
 
     @staticmethod

--- a/esp/esp/program/modules/handlers/commmodule.py
+++ b/esp/esp/program/modules/handlers/commmodule.py
@@ -112,7 +112,8 @@ class CommModule(ProgramModuleObj):
             body = '<html>' + body + '</html>'
 
         contextdict = {'user'   : ActionHandler(firstuser, firstuser),
-                       'program': ActionHandler(self.program, firstuser) }
+                       'program': ActionHandler(self.program, firstuser),
+                       'request': ActionHandler(MessageRequest(), firstuser)}
 
         renderedtext = Template(body).render(DjangoContext(contextdict))
 

--- a/esp/templates/program/modules/commmodule/step2.html
+++ b/esp/templates/program/modules/commmodule/step2.html
@@ -58,7 +58,7 @@ into the text of the message. You can use the {% templatetag openvariable %}{% t
   </label><br />
   <input type="text" size="30" name="subject" id="subject" value="{{subject}}" required />
   <br /><br />
-  <input type="checkbox" name="public_view" id="public_view" {% if public_view %}checked{% endif %}/> Should the email be public? (makes the non-user specific text viewable by anyone)
+  <input type="checkbox" name="public_view" id="public_view" {% if public_view %}checked{% endif %}/> <label for="public_view">Should the email be public? (makes the non-user specific text viewable by anyone)</label>
   <br /><br />
   <label for="emailbody">
   <strong>Body:</strong>


### PR DESCRIPTION
The root cause of this was that we were originally pickling the entire `MessageRequest` object, which assumed the email body was UTF-8. Now, we don't create a `MessageVars` for the `MessageRequest`, skipping the pickling, and then include it later when we go to create the context for the email rendering.

While I was at it, I also made it so that we include a dummy `MessageRequest` for the email preview and I fixed the text label for the public view checkbox (so clicking the text not checks the box).

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3446.