### PR TITLE
Swap sections in the ajax scheduler

### DIFF
--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -927,7 +927,7 @@ class ClassSection(models.Model):
             return False
         # otherwise, check if all teachers are available
         for t in self.teachers:
-            available = t.getAvailableTimes(self.parent_program, ignore_classes=ignore_classes)
+            available = t.getAvailableTimes(self.parent_program, ignore_classes=ignore_classes, ignore_sections=[self])
             for e in meeting_times:
                 if e not in available:
                     return u"The teacher %s has not indicated availability during %s." % (t.name(), e.pretty_time())

--- a/esp/esp/program/modules/handlers/ajaxschedulingmodule.py
+++ b/esp/esp/program/modules/handlers/ajaxschedulingmodule.py
@@ -168,21 +168,21 @@ class AJAXSchedulingModule(ProgramModuleObj):
             retval = self.ajax_schedule_deletereg(prog, cls, user)
             if not json.loads(retval.content)['ret']:
                 return retval
-        
+
         # Schedule the section(s) from room 2 into room 1
         for asmt in assignments2:
             cls = ClassSection.objects.get(id=asmt['section'])
             retval = self.ajax_schedule_assignreg(prog, cls, asmt['timeslots'], [asmt['room_id']], user, override)
             if not json.loads(retval.content)['ret']:
                 return retval
-        
+
         # Schedule the section(s) from room 1 into room 2
         for asmt in assignments1:
             cls = ClassSection.objects.get(id=asmt['section'])
             retval = self.ajax_schedule_assignreg(prog, cls, asmt['timeslots'], [asmt['room_id']], user, override)
             if not json.loads(retval.content)['ret']:
                 return retval
-            
+
         return self.makeret(prog, ret=True, msg="Class sections successfully swapped")
 
     @aux_call

--- a/esp/esp/program/modules/handlers/jsondatamodule.py
+++ b/esp/esp/program/modules/handlers/jsondatamodule.py
@@ -227,7 +227,7 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
     @no_auth
     @cached_module_view
     def timeslots(prog):
-        timeslots = list(prog.getTimeSlots().extra({'label': """to_char("start", 'Dy HH:MI -- ') || to_char("end", 'HH:MI AM')"""}).values('id', 'short_description', 'label', 'start', 'end'))
+        timeslots = list(prog.getTimeSlots().extra({'label': """to_char("start", 'Dy MM/DD HH:MI -- ') || to_char("end", 'HH:MI AM')"""}).values('id', 'short_description', 'label', 'start', 'end'))
         for i in range(len(timeslots)):
             timeslot_start = Event.objects.get(pk=timeslots[i]['id']).start
             timeslots_before = Event.objects.filter(start__lt=timeslot_start)

--- a/esp/esp/program/modules/handlers/jsondatamodule.py
+++ b/esp/esp/program/modules/handlers/jsondatamodule.py
@@ -352,6 +352,7 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
                 'parent_class': cls.id,
                 'category': cls.category.symbol,
                 'category_id': cls.category.id,
+                'class_style': cls.class_style,
                 'grade_max': cls.grade_max,
                 'grade_min': cls.grade_min,
                 'title': cls.title,

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -569,7 +569,7 @@ class BaseESPUser(object):
             return ESPUser.objects.filter(Q_useroftype)
 
     @cache_function
-    def getAvailableTimes(self, program, ignore_classes=False, ignore_moderation=False):
+    def getAvailableTimes(self, program, ignore_classes=False, ignore_moderation=False, ignore_sections=[]):
         """ Return a list of the Event objects representing the times that a particular user
             can teach for a particular program. """
         from esp.cal.models import Event, EventType
@@ -585,7 +585,7 @@ class BaseESPUser(object):
         if not ignore_classes:
             #   Subtract out the times that they are already teaching.
             other_sections = self.getTaughtSections(program)
-            other_times = [sec.meeting_times.values_list('id', flat=True) for sec in other_sections]
+            other_times = [sec.meeting_times.values_list('id', flat=True) for sec in other_sections if sec not in ignore_sections]
             for lst in other_times:
                 valid_events = valid_events.exclude(id__in=lst)
         if not ignore_moderation:

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/ApiClient.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/ApiClient.js
@@ -101,8 +101,7 @@ function ApiClient() {
         var req = {
             action: 'swap',
             csrfmiddlewaretoken: csrf_token(),
-            assignments1: JSON.stringify(assignments1),
-            assignments2: JSON.stringify(assignments2),
+            assignments: JSON.stringify(assignments1.concat(assignments2)),
             override: override
         };
         this.send_request('ajax_schedule_class', req, callback, errorReporter);

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/ApiClient.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/ApiClient.js
@@ -89,6 +89,26 @@ function ApiClient() {
     };
 
     /**
+     * Swap two sets of sections on the server.
+     *
+     * @param assignments1: List of new assignments for the section(s) in room 1
+     * @param assignments2: List of new assignments for the section(s) in room 2
+     * @param callback: If successful, this function will be called. Takes no params.
+     * @param errorReporter: If server reports an error, this function will be called.
+     *                       Takes one param msg with an error message.
+     */
+    this.swap_sections = function(assignments1, assignments2, override, callback, errorReporter){
+        var req = {
+            action: 'swap',
+            csrfmiddlewaretoken: csrf_token(),
+            assignments1: JSON.stringify(assignments1),
+            assignments2: JSON.stringify(assignments2),
+            override: override
+        };
+        this.send_request('ajax_schedule_class', req, callback, errorReporter);
+    };
+
+    /**
      * Assign a moderator to a section on the server.
      *
      * @param section_id: The ID of the section to which to assign a moderator.

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Cell.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Cell.js
@@ -324,6 +324,7 @@ function Cell(el, section, room_id, timeslot_id, matrix) {
         tooltip_parts['Category'] = this.matrix.categories[this.section.category_id || this.ghostSection.category_id].name;
         tooltip_parts['Teachers'] = this.matrix.sections.getTeachersString(this.section);
         if(has_moderator_module === "True") tooltip_parts[moderator_title + 's'] = this.matrix.sections.getModeratorsString(this.section);
+        tooltip_parts['Style'] = this.section.class_style;
         tooltip_parts['Class size max'] = this.section.class_size_max;
         var length_str = '';
         if(Math.floor(this.section.length) > 0){

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Matrix.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Matrix.js
@@ -387,8 +387,9 @@ function Matrix(
      * @param section: The section to validate.
      * @param room_id: The name of the room we want to put the section into.
      * @param schedule_timeslots: The array of timeslots we want to put the section into.
+     * @param ignore_sections: An optional array of sections to ignore
      */
-    this.validateAssignment = function(section, room_id, schedule_timeslots){
+    this.validateAssignment = function(section, room_id, schedule_timeslots, ignore_sections = []){
         var result = {
             valid: true,
             reason: null,
@@ -403,7 +404,7 @@ function Matrix(
 
         var availableTimeslots = this.sections.getAvailableTimeslots(section)[0];
         var validateIndividualCell = function(index, cell) {
-            return !(cell.disabled || (cell.section && cell.section !== section) ||
+            return !(cell.disabled || (cell.section && cell.section !== section && !ignore_sections.includes(cell.section)) ||
                     availableTimeslots.indexOf(schedule_timeslots[index]) == -1);
         };
 

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Matrix.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Matrix.js
@@ -402,7 +402,7 @@ function Matrix(
             return result;
         }
 
-        var availableTimeslots = this.sections.getAvailableTimeslots(section)[0];
+        var availableTimeslots = this.sections.getAvailableTimeslots(section, ignore_sections)[0];
         var validateIndividualCell = function(index, cell) {
             return !(cell.disabled || (cell.section && cell.section !== section && !ignore_sections.includes(cell.section)) ||
                     availableTimeslots.indexOf(schedule_timeslots[index]) == -1);

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Matrix.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Matrix.js
@@ -118,6 +118,15 @@ function Matrix(
     this.moderatorDirectory = moderatorDirectory;
     if(has_moderator_module === "True") this.moderatorDirectory.bindMatrix(this);
 
+    /**
+     * Bind a scheduler to the matrix to access various functions
+     *
+     * @param scheduler: The scheduler to bind
+     */
+    this.bindScheduler = function(scheduler) {
+        this.scheduler = scheduler;
+    }
+
     // Set up scheduling checks
     this.updateCells = function(){
         $j.each(this.cells, function(index, room) {

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Matrix.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Matrix.js
@@ -404,24 +404,24 @@ function Matrix(
 
         var availableTimeslots = this.sections.getAvailableTimeslots(section, ignore_sections)[0];
         var validateIndividualCell = function(index, cell) {
-            return !(cell.disabled || (cell.section && cell.section !== section && !ignore_sections.includes(cell.section)) ||
-                    availableTimeslots.indexOf(schedule_timeslots[index]) == -1);
-        };
-
-        var firstCell = this.getCell(room_id, schedule_timeslots[0]);
-        if (section.length <= 1 && !validateIndividualCell(0, firstCell)) {
-            result.valid = false;
-            result.reason = "first cell is not valid"
-            return result;
-        }
+            if(cell.disabled){
+                return "Error: " + this.rooms[cell.room_id].text + " is not available during timeslot " + (this.timeslots.get_by_id(cell.timeslot_id).order + 1).toString();
+            } else if (cell.section && cell.section !== section && !ignore_sections.includes(cell.section)) {
+                return "Error: There is already a class scheduled in " + this.rooms[cell.room_id].text + " during timeslot " + (this.timeslots.get_by_id(cell.timeslot_id).order + 1).toString();
+            } else if (availableTimeslots.indexOf(schedule_timeslots[index]) == -1){
+                return "Error: The teachers of " + cell.section.emailcode + " are not available during timeslot " + (this.timeslots.get_by_id(cell.timeslot_id).order + 1).toString();
+            } else {
+                return true;
+            }
+        }.bind(this);
 
         // Check to make sure all the cells are available
         for(var timeslot_index in schedule_timeslots){
             var cell = this.getCell(room_id, schedule_timeslots[timeslot_index]);
-            if (!validateIndividualCell(timeslot_index, cell)){
+            var valid = validateIndividualCell(timeslot_index, cell);
+            if (valid != true){
                 result.valid = false;
-                result.reason = "Error: timeslot" +  schedule_timeslots[timeslot_index] +
-                    " already has a class in " + room_id + "."
+                result.reason = valid;
                 return result;
             }
         }

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Matrix.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Matrix.js
@@ -418,7 +418,7 @@ function Matrix(
             } else if (cell.section && cell.section !== section && !ignore_sections.includes(cell.section)) {
                 return "Error: There is already a class scheduled in " + this.rooms[cell.room_id].text + " during timeslot " + (this.timeslots.get_by_id(cell.timeslot_id).order + 1).toString();
             } else if (availableTimeslots.indexOf(schedule_timeslots[index]) == -1){
-                return "Error: The teachers of " + cell.section.emailcode + " are not available during timeslot " + (this.timeslots.get_by_id(cell.timeslot_id).order + 1).toString();
+                return "Error: The teachers of " + section.emailcode + " are not available during timeslot " + (this.timeslots.get_by_id(cell.timeslot_id).order + 1).toString();
             } else {
                 return true;
             }

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Scheduler.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Scheduler.js
@@ -144,20 +144,6 @@ function Scheduler(
             }
         });
 
-        // set up handlers for selecting/scheduling classes and assigning/unassigning moderators
-        $j("body").on("click", "td.matrix-cell > a", function(evt, ui) {
-            var cell = $j(evt.currentTarget.parentElement).data("cell");
-            if((evt.ctrlKey || evt.metaKey) && has_moderator_module === "True" && this.moderatorDirectory.selectedModerator) {
-                if(this.moderatorDirectory.selectedModerator.sections.includes(cell.section.id)) {
-                    this.moderatorDirectory.unassignModerator(cell.section);
-                } else {
-                    this.moderatorDirectory.assignModerator(cell.section);
-                }
-            } else {
-                this.sections.selectSection(cell.section);
-            }
-        }.bind(this));
-
         // set up handler for selecting moderators
         $j("body").on("click", "td.moderator-cell", function(evt, ui) {
             var moderatorCell = $j(evt.currentTarget).data("moderatorCell");
@@ -166,7 +152,7 @@ function Scheduler(
 
         // prevent above handler if clicking a link within a moderator cell
         $j("body").on("click", "td.moderator-cell > a", function(evt){
-             evt.stopPropagation();
+            evt.stopPropagation();
         });
 
         // set up handler for selecting moderators from section info panel
@@ -175,8 +161,21 @@ function Scheduler(
             this.moderatorDirectory.selectModerator(this.moderatorDirectory.moderators[modID]);
         }.bind(this));
 
-        $j("body").on("mouseleave click", "td.teacher-available-cell", function(evt, ui) {
-            this.sections.unscheduleAsGhost();
+        // set up handlers for selecting/scheduling classes and assigning/unassigning moderators
+        $j("body").on("click", "td.matrix-cell > a", function(evt, ui) {
+            var cell = $j(evt.currentTarget.parentElement).data("cell");
+            if((evt.ctrlKey || evt.metaKey) && this.sections.selectedSection){
+                // attempt to swap the previously selected section with the section in the newly clicked cell
+                this.sections.swapSections(this.sections.selectedSection, cell.section);
+            } else if((evt.ctrlKey || evt.metaKey) && has_moderator_module === "True" && this.moderatorDirectory.selectedModerator) {
+                if(this.moderatorDirectory.selectedModerator.sections.includes(cell.section.id)) {
+                    this.moderatorDirectory.unassignModerator(cell.section);
+                } else {
+                    this.moderatorDirectory.assignModerator(cell.section);
+                }
+            } else {
+                this.sections.selectSection(cell.section);
+            }
         }.bind(this));
 
         $j("body").on("click", "td.teacher-available-cell", function(evt, ui) {
@@ -191,6 +190,7 @@ function Scheduler(
             this.sections.unselectSection();
         }.bind(this));
 
+        // set up handlers to schedule and unschedule ghost sections while hovering over empty cells
         $j("body").on("mouseenter", "td.teacher-available-cell", function(evt, ui) {
             if(this.sections.selectedSection){
                 var cell = $j(evt.currentTarget).data("cell");
@@ -198,6 +198,11 @@ function Scheduler(
             }
         }.bind(this));
 
+        $j("body").on("mouseleave click", "td.teacher-available-cell", function(evt, ui) {
+            this.sections.unscheduleAsGhost();
+        }.bind(this));
+
+        // set up handler from print button
         $j("body").on("click", "#print_button", function(evt, ui) {
             printJS({
                 printable: "matrix-div",

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Scheduler.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Scheduler.js
@@ -105,6 +105,8 @@ function Scheduler(
             this.moderatorDirectory
         );
 
+        this.matrix.bindScheduler(this);
+
         this.directory = new Directory(this.sections,
                                        directoryEl,
                                        data.schedule_assignments,

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Scheduler.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Scheduler.js
@@ -81,6 +81,7 @@ function Scheduler(
         this.messagePanel = new MessagePanel(messageEl,
                                              "<i>Welcome to the Ajax Scheduler!</i><br><br>" +
                                              "<strong>Delete</strong>: unschedule the selected section<br>" +
+                                             "<strong>Ctrl/Cmd + Click</strong>: swap the clicked section with the selected section<br>" +
                                              "<strong>Escape</strong>: unselect the selected section" + (has_moderator_module === "True" ? "/moderator": "") + "<br>" +
                                              "<strong>F1</strong>: open the 'Classes' tab<br>" +
                                              "<strong>F2</strong>: open the 'Room Filters' tab<br>" +

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/SectionInfoPanel.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/SectionInfoPanel.js
@@ -167,6 +167,7 @@ function SectionInfoPanel(el, sections, togglePanel, sectionCommentDialog) {
             partDiv.append(content_parts[header]);
             contentDiv.append(partDiv);
         }
+        contentDiv.append($j('<br><div><b>Click on another section while holding down "Ctrl"/"Cmd" to swap it with this section</b>'));
 
         return contentDiv;
     }.bind(this);

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/SectionInfoPanel.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/SectionInfoPanel.js
@@ -140,6 +140,7 @@ function SectionInfoPanel(el, sections, togglePanel, sectionCommentDialog) {
         content_parts['Category'] = this.sections.categories_data[section.category_id].name;
         content_parts['Teachers'] = teacher_links;
         if(has_moderator_module === "True") content_parts[moderator_title + 's'] = getModeratorLinks(section);
+        content_parts['Style'] = section.class_style;
         content_parts['Class size max'] = section.class_size_max;
         var length_str = '';
         if(Math.floor(section.length) > 0){

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
@@ -654,7 +654,9 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
             new_assignments1,
             new_assignments2,
             override,
-            function(){},
+            function() {
+                this.matrix.scheduler.changelogFetcher.getChanges();
+            }.bind(this),
             // If there's an error, locally reschedule the sections in their old locations
             function(msg) {
                 this.swapSectionsLocal(old_assignments1, old_assignments2);

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
@@ -611,7 +611,7 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
                     var valid = this.matrix.validateAssignment(sec, room2, new_timeslots, ignore_sections);
                     if(!valid.valid){
                         console.log(valid.reason);
-                        this.matrix.messagePanel.addMessage("Error: can not swap those classes.", color = "red");
+                        this.matrix.messagePanel.addMessage(valid.reason, color = "red");
                         this.unselectSection();
                         return;
                     }
@@ -633,7 +633,7 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
                     var valid = this.matrix.validateAssignment(sec, room1, new_timeslots, ignore_sections);
                     if(!valid.valid){
                         console.log(valid.reason);
-                        this.matrix.messagePanel.addMessage("Error: can not swap those classes.", color = "red");
+                        this.matrix.messagePanel.addMessage(valid.reason, color = "red");
                         this.unselectSection();
                         return;
                     }

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
@@ -579,7 +579,9 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
         if (room1 === null){
             // If section 1 is unscheduled, section 2 will become unscheduled
             var new_timeslots2 = [];
-            var swapping_sections1 = [section1];
+            // Repeat section 1 for each timeslot it needs
+            var temp_timeslots = this.matrix.timeslots.get_timeslots_to_schedule_section(section1, old_timeslots2[0]);
+            var swapping_sections1 = Array(temp_timeslots.length).fill(section1);
         } else {
             // Get timeslots to schedule section 2 in classroom 1
             var new_timeslots2 = this.matrix.timeslots.get_timeslots_to_schedule_section(section2, old_timeslots1[0]);
@@ -597,7 +599,9 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
         if (room2 === null){
             // If section 2 is unscheduled, section 1 will become unscheduled
             var new_timeslots1 = [];
-            var swapping_sections2 = [section2];
+            // Repeat section 2 for each timeslot it needs
+            var temp_timeslots = this.matrix.timeslots.get_timeslots_to_schedule_section(section2, old_timeslots1[0]);
+            var swapping_sections2 = Array(temp_timeslots.length).fill(section2);
         } else {
             // Get timeslots to schedule section 1 in classroom 2
             var new_timeslots1 = this.matrix.timeslots.get_timeslots_to_schedule_section(section1, old_timeslots2[0]);
@@ -629,22 +633,26 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
         var start_slot = this.matrix.timeslots.get_by_id(old_timeslots2[0]);
         for(var sec of swapping_sections1){
             if(room2 === null) {
-                new_assignments1.push({"section": sec.id, "timeslots": [], "room_id": room2});
-            } else if(sec){
-                if(new_assignments1.length == 0 || sec.id !== new_assignments1[new_assignments1.length - 1].section){
-                    var new_timeslots = this.matrix.timeslots.get_timeslots_to_schedule_section(sec, start_slot.id);
-                    var valid = this.matrix.validateAssignment(sec, room2, new_timeslots, ignore_sections);
-                    if(!valid.valid){
-                        console.log(valid.reason);
-                        this.matrix.messagePanel.addMessage(valid.reason, color = "red");
-                        this.unselectSection();
-                        return;
-                    }
-                    new_assignments1.push({"section": sec.id, "timeslots": new_timeslots, "room_id": room2});
-                    start_slot = this.matrix.timeslots.get_by_order(this.matrix.timeslots.get_by_id(new_timeslots[new_timeslots.length - 1]).order + 1);
+                if(sec){
+                    new_assignments1.push({"section": sec.id, "timeslots": [], "room_id": room2});
                 }
             } else {
-                start_slot = this.matrix.timeslots.get_by_order(start_slot.order + 1);
+                if(sec){
+                    if(new_assignments1.length == 0 || sec.id !== new_assignments1[new_assignments1.length - 1].section){
+                        var new_timeslots = this.matrix.timeslots.get_timeslots_to_schedule_section(sec, start_slot.id);
+                        var valid = this.matrix.validateAssignment(sec, room2, new_timeslots, ignore_sections);
+                        if(!valid.valid){
+                            console.log(valid.reason);
+                            this.matrix.messagePanel.addMessage(valid.reason, color = "red");
+                            this.unselectSection();
+                            return;
+                        }
+                        new_assignments1.push({"section": sec.id, "timeslots": new_timeslots, "room_id": room2});
+                        start_slot = this.matrix.timeslots.get_by_order(this.matrix.timeslots.get_by_id(new_timeslots[new_timeslots.length - 1]).order + 1);
+                    }
+                } else {
+                    start_slot = this.matrix.timeslots.get_by_order(start_slot.order + 1);
+                }
             }
         }
 
@@ -653,22 +661,26 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
         var start_slot = this.matrix.timeslots.get_by_id(old_timeslots1[0])
         for(var sec of swapping_sections2){
             if(room1 === null) {
-                new_assignments2.push({"section": sec.id, "timeslots": [], "room_id": room1});
-            } else if(sec){
-                if(new_assignments2.length == 0 || sec.id !== new_assignments2[new_assignments2.length - 1].section){
-                    var new_timeslots = this.matrix.timeslots.get_timeslots_to_schedule_section(sec, start_slot.id);
-                    var valid = this.matrix.validateAssignment(sec, room1, new_timeslots, ignore_sections);
-                    if(!valid.valid){
-                        console.log(valid.reason);
-                        this.matrix.messagePanel.addMessage(valid.reason, color = "red");
-                        this.unselectSection();
-                        return;
-                    }
-                    new_assignments2.push({"section": sec.id, "timeslots": new_timeslots, "room_id": room1});
-                    start_slot = this.matrix.timeslots.get_by_order(this.matrix.timeslots.get_by_id(new_timeslots[new_timeslots.length - 1]).order + 1);
+                if(sec){
+                    new_assignments2.push({"section": sec.id, "timeslots": [], "room_id": room1});
                 }
             } else {
-                start_slot = this.matrix.timeslots.get_by_order(start_slot.order + 1);
+                if(sec){
+                    if(new_assignments2.length == 0 || sec.id !== new_assignments2[new_assignments2.length - 1].section){
+                        var new_timeslots = this.matrix.timeslots.get_timeslots_to_schedule_section(sec, start_slot.id);
+                        var valid = this.matrix.validateAssignment(sec, room1, new_timeslots, ignore_sections);
+                        if(!valid.valid){
+                            console.log(valid.reason);
+                            this.matrix.messagePanel.addMessage(valid.reason, color = "red");
+                            this.unselectSection();
+                            return;
+                        }
+                        new_assignments2.push({"section": sec.id, "timeslots": new_timeslots, "room_id": room1});
+                        start_slot = this.matrix.timeslots.get_by_order(this.matrix.timeslots.get_by_id(new_timeslots[new_timeslots.length - 1]).order + 1);
+                    }
+                } else {
+                    start_slot = this.matrix.timeslots.get_by_order(start_slot.order + 1);
+                }
             }
         }
 
@@ -711,12 +723,16 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
         for(var asmt of assignments2){
             if(asmt.room_id !== null){
                 this.scheduleSectionLocal(this.getById(asmt.section), asmt.room_id, asmt.timeslots);
+            } else {
+                this.unscheduleSectionLocal(this.getById(asmt.section));
             }
         }
         // Schedule the section(s) from room 1 into room 2
         for(var asmt of assignments1){
             if(asmt.room_id !== null){
                 this.scheduleSectionLocal(this.getById(asmt.section), asmt.room_id, asmt.timeslots);
+            } else {
+                this.unscheduleSectionLocal(this.getById(asmt.section));
             }
         }
     }

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
@@ -578,7 +578,6 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
         }
         if (room1 === null){
             // If section 1 is unscheduled, section 2 will become unscheduled
-            var new_timeslots2 = [];
             // Repeat section 1 for each timeslot it needs
             var temp_timeslots = this.matrix.timeslots.get_timeslots_to_schedule_section(section1, old_timeslots2[0]);
             var swapping_sections1 = Array(temp_timeslots.length).fill(section1);
@@ -598,7 +597,6 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
         }
         if (room2 === null){
             // If section 2 is unscheduled, section 1 will become unscheduled
-            var new_timeslots1 = [];
             // Repeat section 2 for each timeslot it needs
             var temp_timeslots = this.matrix.timeslots.get_timeslots_to_schedule_section(section2, old_timeslots1[0]);
             var swapping_sections2 = Array(temp_timeslots.length).fill(section2);

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
@@ -600,8 +600,6 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
         $j(".ui-tooltip").hide() // There seems to be a bug or something caused by the confirm box that causes the tooltip to get stuck
         var old_assignments1 = _.uniq(swapping_sections1.filter(Boolean)).map(sec => ({"section": sec, "timeslots": this.scheduleAssignments[sec.id].timeslots, "room_id": room1}));
         var old_assignments2 = _.uniq(swapping_sections2.filter(Boolean)).map(sec => ({"section": sec, "timeslots": this.scheduleAssignments[sec.id].timeslots, "room_id": room2}));
-        console.log(old_assignments1)
-        console.log(old_assignments2)
         var ignore_sections = _.uniq(_.union(swapping_sections1, swapping_sections2));
 
         // Determine new schedule for room 1 sections and validate assignments
@@ -625,7 +623,7 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
                 start_slot = this.matrix.timeslots.get_by_order(start_slot.order + 1);
             }
         }
-        console.log(new_assignments1)
+
         // Determine new schedule for room 2 sections and validate assignments
         var new_assignments2 = [];
         var start_slot = this.matrix.timeslots.get_by_id(old_timeslots1[0])
@@ -647,7 +645,6 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
                 start_slot = this.matrix.timeslots.get_by_order(start_slot.order + 1);
             }
         }
-        console.log(new_assignments2)
 
         // Unschedule the section(s) in room 1
         window.swappedSections = 0;
@@ -659,6 +656,7 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
         (async() => {
             while(window.swappedSections < old_assignments1.length) 
                 await new Promise(resolve => setTimeout(resolve, 1000));
+            await new Promise(resolve => setTimeout(resolve, 1000)); // A little extra breathing room
             // Schedule the section(s) from room 2 into room 1
             window.swappedSections = 0;
             for(var asmt of new_assignments2){
@@ -667,6 +665,7 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
             (async() => {
                 while(window.swappedSections < new_assignments2.length) 
                     await new Promise(resolve => setTimeout(resolve, 1000));
+                await new Promise(resolve => setTimeout(resolve, 1000)); // A little extra breathing room
                 // Schedule the section(s) from room 1 into room 2
                 for(var asmt of new_assignments1){
                     this.scheduleSection(asmt.section, room2, asmt.timeslots[0]);

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
@@ -20,6 +20,7 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
     this.selectedSection = null;
     this.ghostScheduleAssignment = {};
     this.availableTimeslots = [];
+    this.swappedSections = 0;
 
     // Set up filtering
     this.filter = {
@@ -396,8 +397,9 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
      * @param section: The section to schedule
      * @param room_id: The name of the room to schedule it in
      * @param first_timeslot_id: The ID of the first timeslot to schedule the section in
+     * @param callback: A function to run upon success
      */
-    this.scheduleSection = function(section, room_id, first_timeslot_id){
+    this.scheduleSection = function(section, room_id, first_timeslot_id, callback = function() {}){
         var old_assignment = this.scheduleAssignments[section.id];
         var schedule_timeslots = this.matrix.timeslots.
             get_timeslots_to_schedule_section(section, first_timeslot_id);
@@ -422,7 +424,7 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
             schedule_timeslots,
             room_id,
             override,
-            function() {},
+            callback,
             // If there's an error, reschedule the section in its old location
             function(msg) {
                 this.scheduleSectionLocal(section,
@@ -515,7 +517,7 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
      *
      * @param section: the section to unschedule
      */
-    this.unscheduleSection = function(section){
+    this.unscheduleSection = function(section, callback = function(){}){
         // Make sure section not locked
         if (section.schedulingLocked){
             this.matrix.messagePanel.addMessage("Error: the specified section is locked (" + section.schedulingComment + ")! Unlock it first.", color = "red");
@@ -531,7 +533,7 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
         this.unscheduleSectionLocal(section);
         this.apiClient.unschedule_section(
             section.id,
-            function(){},
+            callback,
             // If the server returns an error, put the class back in its original spot
             function(msg){
                 this.scheduleSectionLocal(section, old_room_id, old_schedule_timeslots);
@@ -539,6 +541,132 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
                 console.log(msg);
             }.bind(this)
         );
+    };
+
+    /**
+     * Update the local interface to reflect unscheduling a class
+     *
+     * @param section: the section to unschedule
+     */
+    this.unscheduleSectionLocal = function(section) {
+        this.scheduleSectionLocal(section, null, [])
+    };
+
+    this.swapSections = function(section1, section2) {
+        // Abort if either section is locked
+        if (section1.schedulingLocked){
+            this.matrix.messagePanel.addMessage("Error: the first selected section is locked (" + section1.schedulingComment + ")! Unlock it first.", color = "red");
+            this.unselectSection();
+            return;
+        } else if (section2.schedulingLocked){
+            this.matrix.messagePanel.addMessage("Error: the second selected section is locked (" + section2.schedulingComment + ")! Unlock it first.", color = "red");
+            this.unselectSection();
+            return;
+        }
+
+        // Get the current assignments for the sections
+        var old_assignment1 = this.scheduleAssignments[section1.id];
+        var old_assignment2 = this.scheduleAssignments[section2.id];
+        // Extract room and timeslots from assignments
+        var room1 = old_assignment1.room_id;
+        var room2 = old_assignment2.room_id;
+        var old_timeslots1 = old_assignment1.timeslots;
+        var old_timeslots2 = old_assignment2.timeslots;
+        var new_timeslots1 = this.matrix.timeslots.get_timeslots_to_schedule_section(section1, old_timeslots2[0]);
+        var new_timeslots2 = this.matrix.timeslots.get_timeslots_to_schedule_section(section2, old_timeslots1[0]);
+
+        // Abort if there isn't enough time for either section in their new classroom
+        if(new_timeslots1 === null){
+            this.matrix.messagePanel.addMessage("Error: not enough time to swap the first section to the new room.", color = "red");
+            this.unselectSection();
+            return;
+        }
+        if(new_timeslots2 === null){
+            this.matrix.messagePanel.addMessage("Error: not enough time to swap the second section to the new room.", color = "red");
+            this.unselectSection();
+            return;
+        }
+
+        // Get the sections you'll be swapping with (might be different than section1/section2)
+        var swapping_sections1 = new_timeslots2.map(ts => this.matrix.getCell(room1, ts).section);
+        var swapping_sections2 = new_timeslots1.map(ts => this.matrix.getCell(room2, ts).section);
+        // If there's more than one swapping section, confirm the user is OK with this
+        if(_.uniq(swapping_sections1.filter(Boolean)).length > 1 && !confirm("More than one section will need to be swapped from the old room. Is this OK?")){
+            return;
+        } else if(_.uniq(swapping_sections2.filter(Boolean)).length > 1 && !confirm("More than one section will need to be swapped from the new room. Is this OK?")){
+            return;
+        }
+        $j(".ui-tooltip").hide() // There seems to be a bug or something caused by the confirm box that causes the tooltip to get stuck
+        var old_assignments1 = _.uniq(swapping_sections1.filter(Boolean)).map(sec => ({"section": sec, "timeslots": this.scheduleAssignments[sec.id].timeslots, "room_id": room1}));
+        var old_assignments2 = _.uniq(swapping_sections2.filter(Boolean)).map(sec => ({"section": sec, "timeslots": this.scheduleAssignments[sec.id].timeslots, "room_id": room2}));
+        console.log(old_assignments1)
+        console.log(old_assignments2)
+
+        // Determine new schedule for room 1 sections and validate assignments
+        var new_assignments1 = [];
+        var start_slot = this.matrix.timeslots.get_by_id(old_timeslots2[0]);
+        for(var sec of swapping_sections1){
+            if(sec){
+                if(new_assignments1.length == 0 || sec !== new_assignments1[new_assignments1.length - 1].section){
+                    var new_timeslots = this.matrix.timeslots.get_timeslots_to_schedule_section(sec, start_slot.id);
+                    var valid = this.matrix.validateAssignment(sec, room2, new_timeslots, swapping_sections2);
+                    if(!valid.valid){
+                        console.log(valid.reason);
+                        return;
+                    }
+                    new_assignments1.push({"section": sec, "timeslots": new_timeslots, "room_id": room2});
+                    start_slot = this.matrix.timeslots.get_by_order(this.matrix.timeslots.get_by_id(new_timeslots[new_timeslots.length - 1]).order + 1);
+                }
+            } else {
+                start_slot = this.matrix.timeslots.get_by_order(start_slot.order + 1);
+            }
+        }
+        console.log(new_assignments1)
+        // Determine new schedule for room 2 sections and validate assignments
+        var new_assignments2 = [];
+        var start_slot = this.matrix.timeslots.get_by_id(old_timeslots1[0])
+        for(var sec of swapping_sections2){
+            if(sec){
+                if(new_assignments2.length == 0 || sec !== new_assignments2[new_assignments2.length - 1].section){
+                    var new_timeslots = this.matrix.timeslots.get_timeslots_to_schedule_section(sec, start_slot.id);
+                    var valid = this.matrix.validateAssignment(sec, room1, new_timeslots, swapping_sections1);
+                    if(!valid.valid){
+                        console.log(valid.reason);
+                        return;
+                    }
+                    new_assignments2.push({"section": sec, "timeslots": new_timeslots, "room_id": room1});
+                    start_slot = this.matrix.timeslots.get_by_order(this.matrix.timeslots.get_by_id(new_timeslots[new_timeslots.length - 1]).order + 1);
+                }
+            } else {
+                start_slot = this.matrix.timeslots.get_by_order(start_slot.order + 1);
+            }
+        }
+        console.log(new_assignments2)
+
+        // Unschedule the section(s) in room 1
+        window.swappedSections = 0;
+        for(var asmt of old_assignments1){
+            this.unscheduleSection(asmt.section, function() {window.swappedSections++});
+        }
+
+        // We need to wait to reschedule things until the backend changes have taken effect
+        (async() => {
+            while(window.swappedSections < old_assignments1.length) 
+                await new Promise(resolve => setTimeout(resolve, 1000));
+            // Schedule the section(s) from room 2 into room 1
+            window.swappedSections = 0;
+            for(var asmt of new_assignments2){
+                this.scheduleSection(asmt.section, room1, asmt.timeslots[0], function() {window.swappedSections++});
+            }
+            (async() => {
+                while(window.swappedSections < new_assignments2.length) 
+                    await new Promise(resolve => setTimeout(resolve, 1000));
+                // Schedule the section(s) from room 1 into room 2
+                for(var asmt of new_assignments1){
+                    this.scheduleSection(asmt.section, room2, asmt.timeslots[0], function() {window.swappedSections++});
+                }
+            })();
+        })();
     };
 
     /**
@@ -588,15 +716,6 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
             this.unselectSection();
         }
     }
-
-    /**
-     * Update the local interface to reflect unscheduling a class
-     *
-     * @param section: the section to unschedule
-     */
-    this.unscheduleSectionLocal = function(section) {
-        this.scheduleSectionLocal(section, null, [])
-    };
 
 
     this.getBaseUrlString = function() {


### PR DESCRIPTION
This allows you to swap two sections in the ajax scheduler by selecting one and then holding CTRL/CMD and clicking on the other one. If one is longer than the other, it will attempt to swap any other sections necessary to perform the full swap (after a confirmation is provided from the user). If the swap is not possible (due to teacher availability or temporal fitting), an error message is provided.

~~The swapping appears to work very cleanly for almost all cases (e.g., same room, same times, different lengths, etc.) EXCEPT when you try to swap a single section with multiple sections that partially overlap in time. I'm not sure what the issue is, but I have a hunch it has to do with availability caching, but I'm going to wait until this has been reviewed to see if there are any other edge cases that need to be fixed. Also, sometimes the sections are unscheduled after swapping, but they should always be rescheduled automatically once the site double-checks the change log (every 5 seconds).~~

~~In hindsight, I'm wondering if I maybe should have performed the swap as a single back-end action, instead of as 3 discrete actions (unschedule, reschedule, schedule). If the issues described above persist, I might need to change to this behavior instead.~~

I also fixed a bug that prevented scheduled sections from being rescheduled to an overlapping time (e.g., from 10-12 to 9-11) even if there was the proper availability.

Finally, I've also cherry-picked (with some modification) a couple of commits from the MIT branch that looked useful (but are not necessarily relevant to this PR).

Fixes https://github.com/learning-unlimited/ESP-Website/issues/1405.