### PR TITLE
Fix (and unify) links for program and class documents

### DIFF
--- a/esp/esp/qsdmedia/models.py
+++ b/esp/esp/qsdmedia/models.py
@@ -96,6 +96,11 @@ class Media(models.Model):
 
         self.target_file.save(self.hashed_name, file)
 
+    # returns a download path for this file
+    def get_download_path(self):
+        return "/download/" + self.hashed_name + "/" + self.file_name
+    download_path = property(get_download_path)
+
     # returns an absolute path to this file
     def get_uploaded_filename(self):
         return os.path.join(settings.MEDIA_ROOT, "..", self.target_file.url.lstrip('/'))

--- a/esp/templates/inclusion/program/class_catalog_core.html
+++ b/esp/templates/inclusion/program/class_catalog_core.html
@@ -113,7 +113,7 @@
        <b>Materials for this class include:</b>
         <span class="doclist">
         {% for doc in class.docs_summary %}
-        <a href="/download/{{ doc.hashed_name }}/{{ doc.file_name }}">{{ doc.friendly_name }}</a>{% if not forloop.last %},{% endif %}
+        <a href="{{ doc.download_path }}">{{ doc.friendly_name }}</a>{% if not forloop.last %},{% endif %}
         {% endfor %}
         {% if class.media_count > class.docs_summary|length %}
         <b><a href="{{ class.parent_program.get_learn_url }}class_docs/{{ class.id }}">(view all {{ class.media_count }})</a></b>

--- a/esp/templates/program/modules/adminclass/manageclass.html
+++ b/esp/templates/program/modules/adminclass/manageclass.html
@@ -70,7 +70,7 @@
             {% if class.documents.exists %}
             <ul>
                 {% for doc in class.getDocuments %}
-                <li style="color: black;"><a href="/download/{{ doc.hashed_name }}/{{ doc.file_name }}">{{ doc.friendly_name }}</a></li>
+                <li style="color: black;"><a href="{{ doc.download_path }}">{{ doc.friendly_name }}</a></li>
                 {% endfor %}
             </ul>
             {% else %}

--- a/esp/templates/program/modules/adminmaterials/listmaterials.html
+++ b/esp/templates/program/modules/adminmaterials/listmaterials.html
@@ -49,7 +49,7 @@ From this page, you can view documents related to the program (in the first sect
 	{% endif %}
 	{% for doc in prog.getDocuments %}
 	<tr>
-            <td class="class_stuff"><a href="/download/{{ doc.hashed_name }}/{{ doc.file_name }}">{{ doc.friendly_name }}</a></td>
+            <td class="class_stuff"><a href="{{ doc.download_path }}">{{ doc.friendly_name }}</a></td>
 		<td class="clsmiddle">
 			<form method="post" action="/manage/{{ prog.url }}/get_materials" onsubmit="return confirm('Are you sure that you want to delete {{ doc.friendly_name|escapejs|escape }}?');">
 				<input type="hidden" name="docid" value="{{ doc.id }}">
@@ -75,7 +75,7 @@ From this page, you can view documents related to the program (in the first sect
 		</tr>
 			{% for doc in cls.getDocuments %}
 			<tr>
-				<td class="class_stuff"><a href="/download/{{ doc.hashed_name }}/{{ doc.file_name }}">{{ doc.friendly_name }}</a></td>
+				<td class="class_stuff"><a href="{{ doc.download_path }}">{{ doc.friendly_name }}</a></td>
 				<td class="clsmiddle">
 					<form method="post" action="/manage/{{ program.url }}/get_materials" onsubmit="return confirm('Are you sure that you want to delete {{ doc.friendly_name|escapejs|escape }}?');">
 						<input type="hidden" name="docid" value="{{ doc.id }}">

--- a/esp/templates/program/modules/studentclassregmodule/class_docs.html
+++ b/esp/templates/program/modules/studentclassregmodule/class_docs.html
@@ -40,7 +40,7 @@ The teachers of this class have provided the following materials for you.  We ho
 	{% endif %}
 	{% for doc in cls.getDocuments %}
 	<tr>
-		<td class="clsmiddle"><a href="/download/{{ doc.hashed_name }}/{{ doc.file_name }}">{{ doc.friendly_name }}</a></td>
+		<td class="clsmiddle"><a href="{{ doc.download_path }}">{{ doc.friendly_name }}</a></td>
 
 	</tr>
 	{% endfor %}

--- a/esp/templates/program/modules/studentonsite/sectioninfo.html
+++ b/esp/templates/program/modules/studentonsite/sectioninfo.html
@@ -37,7 +37,7 @@
                 <td>Document uploads:</td>
                 <td>
                     {% for doc in section.parent_class.documents.all %}
-                        <a href="/download/{{ doc.hashed_name }}/{{ doc.file_name }}">{{ doc.friendly_name }}</a><br />
+                        <a href="{{ doc.download_path }}">{{ doc.friendly_name }}</a><br />
                     {% endfor %}
                 </td>
             </tr>

--- a/esp/templates/program/modules/teacherclassregmodule/class_docs.html
+++ b/esp/templates/program/modules/teacherclassregmodule/class_docs.html
@@ -44,7 +44,7 @@ We would like you, as a teacher, to upload all documents and other materials rel
 	{% endif %}
 	{% for doc in cls.getDocuments %}
 	<tr>
-		<td class="clsmiddle"><a href="/download/{{ doc.hashed_name }}/{{ doc.file_name }}">{{ doc.friendly_name }}</a></td>
+		<td class="clsmiddle"><a href="{{ doc.download_path }}">{{ doc.friendly_name }}</a></td>
 		<td class="clsmiddle">
 			<form method="post" action="./{{ cls.id }}" onsubmit="return confirm('Are you sure that you want to delete {{ doc.friendly_name|escapejs|escape }}?');">
 				<input type="hidden" name="docid" value="{{ doc.id }}">

--- a/esp/templates/program/modules/teacheronsite/sectioninfo.html
+++ b/esp/templates/program/modules/teacheronsite/sectioninfo.html
@@ -50,7 +50,7 @@
                     <td>Document uploads:</td>
                     <td>
                         {% for doc in section.parent_class.documents.all %}
-                            <a href="/download/{{ doc.hashed_name }}/{{ doc.file_name }}">{{ doc.friendly_name }}</a><br />
+                            <a href="{{ doc.download_path }}">{{ doc.friendly_name }}</a><br />
                         {% empty %}
                             No documents uploaded<br />
                         {% endfor %}

--- a/esp/templates/program/modules/teacherpreviewmodule/handouts.html
+++ b/esp/templates/program/modules/teacherpreviewmodule/handouts.html
@@ -10,7 +10,7 @@
     </tr>
     {% for doc in prog.getDocuments %}
     <tr>
-        <td class="class_stuff"><a href="{{ doc.target_file.url }}">{{ doc.friendly_name }}</a></td>
+        <td class="class_stuff"><a href="{{ doc.download_path }}">{{ doc.friendly_name }}</a></td>
     </tr>
     {% endfor %}
     {% endif %}


### PR DESCRIPTION
This was originally driven by the incorrect download links in the handouts template, but then I also decided to use the same change for all of the other templates that have document download links.