### PR TITLE
Fix forms with submit buttons named "submit"

### DIFF
--- a/esp/templates/program/modules/admincore/deadlines.html
+++ b/esp/templates/program/modules/admincore/deadlines.html
@@ -93,7 +93,7 @@
                     {% if perm.implied %}
                         Implied by {{ perm.implied_by.permission_type }}
                     {% else %}
-                        <input class="btn btn-primary" type="Submit" name="submit" value="Save" />
+                        <input class="btn btn-primary" type="Submit" name="submit_btn" value="Save" />
                         {% if details.perms|length > 1 %}
                             <a href="/manage/{{ program.getUrlBase }}/deadlines/delete?perm_id={{ perm.id }}"><button type="button" class="btn btn-danger btn-small">Delete</button></a>
                         {% endif %}
@@ -125,7 +125,7 @@
 {{ create_form }}
 <tr>
     <td align="center" valign="center" colspan="2">
-        <input class="button" type="Submit" name="submit" value="Create Deadline" />
+        <input class="button" type="Submit" name="submit_btn" value="Create Deadline" />
     </td>
 </tr>
 </table>

--- a/esp/templates/program/modules/adminreviewapps/review.html
+++ b/esp/templates/program/modules/adminreviewapps/review.html
@@ -48,7 +48,7 @@ Added your class: {{ student.added_class|date:"m/d/Y @ h:i:s" }}
 {{ form }}
 <tr>
  <th colspan="2" class="submit"> 
-  <input type="submit" value="Submit" name="submit" />
+  <input type="submit" value="Submit" name="submit_btn" />
  </th>
 </tr>
 </tbody>

--- a/esp/templates/program/modules/mailinglabels/mailinglabel_badzips.html
+++ b/esp/templates/program/modules/mailinglabels/mailinglabel_badzips.html
@@ -27,7 +27,7 @@ For example:
 {{ form }}
 <tr>
   <th colspan="2">
-    <input type="submit" value="Submit" name="submit" />
+    <input type="submit" value="Submit" name="submit_btn" />
   </th>
 </tr>
 </table>

--- a/esp/templates/program/modules/programprintables/refund_receipt_form.html
+++ b/esp/templates/program/modules/programprintables/refund_receipt_form.html
@@ -27,7 +27,7 @@ Transaction Amount: {{ transaction.amount }}
 <input type="hidden" name="payer_post" value="true" />
 <tr>
   <th colspan="2">
-    <input type="submit" value="Submit" name="submit" />
+    <input type="submit" value="Submit" name="submit_btn" />
   </th>
 </tr>
 </table>

--- a/esp/templates/program/modules/teachereventsmanagemodule/teacher_events.html
+++ b/esp/templates/program/modules/teachereventsmanagemodule/teacher_events.html
@@ -26,7 +26,7 @@ Teacher Events include (for now) <a href="#training">teacher training</a> and <a
 <table align="center" cellpadding="0" cellspacing="0" width="450">
      <tr><th colspan="2" class="small">Add a Training or Interview</th></tr>
     {{ timeslot_form }}
-    <tr><td colspan="2" align="center"><input class="btn btn-primary" type="submit" name = "submit" value="Add Training" /> <input class="btn btn-primary" type="submit" name="submit" value="Add Interview" /></td></tr>
+    <tr><td colspan="2" align="center"><input class="btn btn-primary" type="submit" name = "submit_btn" value="Add Training" /> <input class="btn btn-primary" type="submit" name="submit_btn" value="Add Interview" /></td></tr>
 </table>
 </form>
 

--- a/esp/templates/program/modules/teacherreviewapps/review.html
+++ b/esp/templates/program/modules/teacherreviewapps/review.html
@@ -64,7 +64,7 @@ Please review the student's biographical information and responses to our questi
 {{ form }}
 <tr>
  <th colspan="2" class="submit"> 
-  <input type="submit" class="fancybutton" value="Submit, and stay on page" name="submit" />
+  <input type="submit" class="fancybutton" value="Submit, and stay on page" name="submit_btn" />
   <input type="submit" class="fancybutton" value="Submit, and review next student" name="submit_next" />
   <input type="submit" class="fancybutton" value="Submit, and return to roster" name="submit_return" />
  </th>

--- a/esp/templates/registration/duplicate_accounts.html
+++ b/esp/templates/registration/duplicate_accounts.html
@@ -58,7 +58,7 @@ are errors{% endif %} in the below form. Please fix and resubmit.
 {{ form }}
 <tr>
   <th colspan="2" class="submit">
-    <input type="submit" value="Create account, proceed to profile creation" name="submit" />
+    <input type="submit" value="Create account, proceed to profile creation" name="submit_btn" />
   </th>
 </tr>
 </tbody>

--- a/esp/templates/registration/emailuser.html
+++ b/esp/templates/registration/emailuser.html
@@ -48,7 +48,7 @@ are errors{% endif %} in the below form. Please fix and resubmit.
 <tfoot>
 <tr>
   <th colspan="2" class="submit">
-    <input type="submit" value="Join our email list" name="submit" />
+    <input type="submit" value="Join our email list" name="submit_btn" />
   </th>
 </tr>
 </tfoot>

--- a/esp/templates/registration/newuser.html
+++ b/esp/templates/registration/newuser.html
@@ -75,7 +75,7 @@
     {% if accounts %}<input type="hidden" name="do_reg_no_really" value="true" />{% endif %}
 
     <div class="form-actions">
-    <input type="submit" value="{% if accounts %}Confirm: Create another account for this email{% else %}Create account{% endif %}" name="submit" class="btn btn-primary" />
+    <input type="submit" value="{% if accounts %}Confirm: Create another account for this email{% else %}Create account{% endif %}" name="submit_btn" class="btn btn-primary" />
     </div>
   </fieldset>
 </form>

--- a/esp/templates/registration/newuser_phase1.html
+++ b/esp/templates/registration/newuser_phase1.html
@@ -85,7 +85,7 @@ are errors{% endif %} in the below form. Please fix and resubmit.
 
 <tr>
   <th colspan="2" class="submit">
-    <input type="submit" value="Proceed to Account Creation" name="submit" class="btn btn-default" />
+    <input type="submit" value="Proceed to Account Creation" name="submit_btn" class="btn btn-default" />
   </th>
 </tr>
 </tbody>

--- a/esp/templates/registration/resend.html
+++ b/esp/templates/registration/resend.html
@@ -38,7 +38,7 @@ are errors{% endif %} in the below form. Please fix and resubmit.
 
 <tr>
   <th colspan="2" class="submit">
-    <input type="submit" value="Send" name="submit" />
+    <input type="submit" value="Send" name="submit_btn" />
   </th>
 </tr>
 </tbody>

--- a/esp/templates/users/make_admin.html
+++ b/esp/templates/users/make_admin.html
@@ -21,7 +21,7 @@
 	<th align="center" colspan="2">Grant Administrator Privileges</th>
       </tr>
       {{ form.as_table }}
-      <tr><td align="center" colspan="2"><button class="button" type="submit" name="submit" onclick="return confirm('Are you sure you want to make this user an admin?');">Submit</button></td></tr>
+      <tr><td align="center" colspan="2"><button class="button" type="submit" name="submit_btn" onclick="return confirm('Are you sure you want to make this user an admin?');">Submit</button></td></tr>
     </table>
 </div>
 </form>

--- a/esp/templates/users/merge_accounts.html
+++ b/esp/templates/users/merge_accounts.html
@@ -17,7 +17,7 @@
   <h3>Please select two accounts to merge:</h3>
   <table width="550">
   {{ form.as_table }}
-  <tr><td colspan="2"><br><br><input class="btn btn-primary" type="submit" value="Merge!" name="submit" onclick="return confirm('Account merges cannot be undone. Proceed?');" /></td></tr>
+  <tr><td colspan="2"><br><br><input class="btn btn-primary" type="submit" value="Merge!" name="submit_btn" onclick="return confirm('Account merges cannot be undone. Proceed?');" /></td></tr>
   </table>
 </div></form>
 

--- a/esp/templates/users/recovery_email.html
+++ b/esp/templates/users/recovery_email.html
@@ -43,7 +43,7 @@ title="Contact Form">contact us</a>.
 {{ form }}
 <tr>
   <th colspan="2" class="submit">
-    <input type="submit" value="Set password and login!" name="submit" class="btn btn-primary" />
+    <input type="submit" value="Set password and login!" name="submit_btn" class="btn btn-primary" />
   </th>
 </tr>
 </tbody>

--- a/esp/templates/users/recovery_request.html
+++ b/esp/templates/users/recovery_request.html
@@ -50,7 +50,7 @@ title="Contact Form">contact us</a>.
 </tr>
 <tr>
   <th colspan="2" class="submit">
-    <input type="submit" value="Get recovery email" name="submit" class="btn btn-primary" />
+    <input type="submit" value="Get recovery email" name="submit_btn" class="btn btn-primary" />
   </th>
 </tr>
 </tbody>


### PR DESCRIPTION
The change in https://github.com/learning-unlimited/ESP-Website/pull/3482 broke any forms where the submit button had `name="submit"` (see [this stackoverflow answer](https://stackoverflow.com/a/834197/4660582) for why). This changes all of those submit buttons' names to "submit_btn". I double-checked, and I couldn't find any javascript that specifies these elements based on their names, so this shouldn't break anything.