### PR TITLE
Fix registration/profile forms for new users

### DIFF
--- a/esp/esp/web/views/myesp.py
+++ b/esp/esp/web/views/myesp.py
@@ -252,6 +252,7 @@ def profile_editor(request, prog_input=None, responseuponCompletion = True, role
             state_tag_map[field] = 'local_state'
         form = FormClass(curUser, initial=new_data, tag_map=state_tag_map)
 
+    context['new_user'] = regProf.id is None
     context['request'] = request
     context['form'] = form
     context['require_student_phonenum'] = Tag.getBooleanTag('require_student_phonenum')

--- a/esp/templates/registration/newuser.html
+++ b/esp/templates/registration/newuser.html
@@ -40,7 +40,7 @@
 <p>
   Welcome to {{ settings.ORGANIZATION_SHORT_NAME }}!
   To do almost anything with us, you first need to register
-  an account with us. After you register account, you will be allowed to register
+  an account with us. After you register an account, you will be allowed to register
   for programs, sign up for classes, among other things.
   By creating an account, you agree to the <a href="https://www.learningu.org/about/privacy/" target="_blank">Privacy Policy</a>
   set forth by Learning Unlimited, the umbrella organization of which we are a member.

--- a/esp/templates/users/profile.html
+++ b/esp/templates/users/profile.html
@@ -26,9 +26,11 @@ div.required label.control-label:after {
     <div class="span12">
       {% load render_qsd %}
       {% inline_qsd_block "account_creation_basic_info" %}
-<p>First, please tell us a bit about yourself!  The fields with red asterisks are required.  After you have filled out everything, click the "update" button at the bottom of the page to continue.</p>
+<p>First, please tell us a bit about yourself!  The fields with red asterisks are required.  After you have filled out everything, click the "{% if new_user %}submit{% else %}update{% endif %}" button at the bottom of the page to continue.</p>
 
-<p>Email addresses have a tendency to change regularly, so we are asking that you re-enter your email address each time you visit this form.  Please take the time to also correct any other information that may be old or incorrect.  Thanks!</p>
+{% if not new_user %}
+<p>Email addresses have a tendency to change regularly, so we are asking that you re-enter your email address each time you visit this form. Please take the time to also correct any other information that may be old or incorrect.  Thanks!</p>
+{% endif %}
       {% end_inline_qsd_block %}
     </div>
   </div>
@@ -89,7 +91,7 @@ div.required label.control-label:after {
         {% endifequal %}
         {% endifequal %}
 
-        <div class="form-actions"><input type="submit" class="btn btn-primary" value="Update your Information!" /></div>
+        <div class="form-actions"><input type="submit" class="btn btn-primary" value="{% if new_user %}Submit{% else %}Update{% endif %} Your Information!" /></div>
 
         </fieldset>
     </form>


### PR DESCRIPTION
This makes minor changes to the registration and profile forms for new users, including:

- Change the wording when a user hasn't submitted a profile before
- Minor grammar fixes

I decided not to hide the fields as requested in https://github.com/learning-unlimited/ESP-Website/issues/3275 because:

1. There's potentially an edge case where a user might want to edit these after the previous registration form
2. The fields are already filled in, so the user doesn't need to fill them in again
3. I couldn't figure out an easy way to identify within the view the specific case where a user has come from the new user registration form (we could hide the fields whenever the user doesn't have a profile, but this seems to make #1 a more likely edge case)

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3275.