### PR TITLE
Add class category ajax scheduling "check"

### DIFF
--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Cell.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Cell.js
@@ -140,10 +140,14 @@ function Cell(el, section, room_id, timeslot_id, matrix) {
                 if(this.matrix.rooms[this.room_id].num_students < .5 * section.class_size_max) { // Class size is too big, make cell red
                     return this.cellColors.HSLToRGB(0,100,50 + 50 * (this.matrix.rooms[this.room_id].num_students / section.class_size_max));
                 } else if(this.matrix.rooms[this.room_id].num_students > 1.5 * section.class_size_max) { // Class size is too small, make cell red
-                    return this.cellColors.HSLToRGB(0,100,50 + 50 * (section.class_size_max / this.matrix.rooms[this.room_id].num_students));
+                    return this.cellColors.HSLToRGB(240,100,50 + 50 * (section.class_size_max / this.matrix.rooms[this.room_id].num_students));
                 } else { // Class size is good, make cell green
                     return this.cellColors.HSLToRGB(120,100,100 - 50 * (Math.min(section.class_size_max, this.matrix.rooms[this.room_id].num_students) / Math.max(section.class_size_max, this.matrix.rooms[this.room_id].num_students)));
                 }
+            case "category":
+                // Color cell based on the class category
+                var cat_ind = Object.keys(this.matrix.categories).indexOf(section.category_id.toString());
+                return this.cellColors.hexToRGB(this.cellColors.colors[Math.round(cat_ind / Object.keys(this.matrix.categories).length * 100)]);
             case "lunch":
                 // Check if section overlaps with all lunch timeslots for a single day
                 for(var day in this.matrix.timeslots.lunch_timeslots){

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Cell.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Cell.js
@@ -139,7 +139,7 @@ function Cell(el, section, room_id, timeslot_id, matrix) {
                 // Color cell based on how well room capacity matches section capacity
                 if(this.matrix.rooms[this.room_id].num_students < .5 * section.class_size_max) { // Class size is too big, make cell red
                     return this.cellColors.HSLToRGB(0,100,50 + 50 * (this.matrix.rooms[this.room_id].num_students / section.class_size_max));
-                } else if(this.matrix.rooms[this.room_id].num_students > 1.5 * section.class_size_max) { // Class size is too small, make cell red
+                } else if(this.matrix.rooms[this.room_id].num_students > 1.5 * section.class_size_max) { // Class size is too small, make cell blue
                     return this.cellColors.HSLToRGB(240,100,50 + 50 * (section.class_size_max / this.matrix.rooms[this.room_id].num_students));
                 } else { // Class size is good, make cell green
                     return this.cellColors.HSLToRGB(120,100,100 - 50 * (Math.min(section.class_size_max, this.matrix.rooms[this.room_id].num_students) / Math.max(section.class_size_max, this.matrix.rooms[this.room_id].num_students)));

--- a/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
+++ b/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
@@ -209,6 +209,8 @@
                         <br />
                         <input type="radio" name="scheduling-checks" value="capacity" id="scheduling-checks-capacity"></input><label for="scheduling-checks-capacity"> Room Capacity Mismatch</label>
                         <br />
+                        <input type="radio" name="scheduling-checks" value="category" id="scheduling-checks-category"></input><label for="scheduling-checks-category"> Color by Class Category</label>
+                        <br />
                         <input type="radio" name="scheduling-checks" value="unapproved" id="scheduling-checks-unapproved"></input><label for="scheduling-checks-unapproved"> Unapproved Classes</label>
                         <br />
                         <input type="radio" name="scheduling-checks" value="requests" id="scheduling-checks-requests"></input><label for="scheduling-checks-requests"> Unfulfilled Resource Requests</label>


### PR DESCRIPTION
This adds a scheduling "check" to the ajax scheduler that colors classes by their category. This can be used to check the distribution of different class categories across time/space (like the category check in the scheduling checks module). The coloration is flexible to the total number of categories and evenly splits up the full rainbow palette across the categories (i.e., the more categories there are, the closer in color they will be).

While I was at it, I also fixed the capacity mismatch check to distinguish between "class too small" (blue, because not that bad) and "class too big" (red, because very bad). This fixes #3498.