### PR TITLE
Add ability to edit teacher events

### DIFF
--- a/esp/esp/program/modules/forms/teacherevents.py
+++ b/esp/esp/program/modules/forms/teacherevents.py
@@ -15,11 +15,20 @@ class TimeslotForm(forms.Form):
     minutes = forms.IntegerField(widget=forms.TextInput(attrs={'size':'6'}))
     description = forms.CharField(widget=forms.TextInput(attrs={'size':'100'}), required = False)
 
+    def load_timeslot(self, slot):
+        self.fields['start'].initial = slot.start
+        length = (slot.end - slot.start).seconds
+        self.fields['hours'].initial = int(length / 3600)
+        self.fields['minutes'].initial = int(length / 60 - 60 * self.fields['hours'].initial)
+        self.fields['description'].initial = slot.description
+
     def save_timeslot(self, program, slot, type):
         slot.start = self.cleaned_data['start']
         slot.end = slot.start + timedelta(hours=self.cleaned_data['hours'], minutes=self.cleaned_data['minutes'])
 
-        if type == "training":
+        if isinstance(type, EventType):
+            slot.event_type = type
+        elif type == "training":
             slot.event_type = EventType.get_from_desc('Teacher Training')
         elif type == "interview":
             slot.event_type = EventType.get_from_desc('Teacher Interview')

--- a/esp/esp/program/modules/handlers/teachereventsmanagemodule.py
+++ b/esp/esp/program/modules/handlers/teachereventsmanagemodule.py
@@ -74,8 +74,25 @@ class TeacherEventsManageModule(ProgramModuleObj):
                 ts = Event.objects.get(id=data['id'])
                 ts.delete()
 
+            elif data['command'] == 'load':
+                #   load timeslot for editing
+                ts = Event.objects.get(id=data['id'])
+                form = TimeslotForm()
+                form.load_timeslot(ts)
+                context['timeslot_form'] = form
+                context['editing_timeslot'] = ts
+
+            elif data['command'] == 'edit':
+                #   edit timeslot
+                ts = Event.objects.get(id=data['id'])
+                form = TimeslotForm(data)
+                if form.is_valid():
+                    form.save_timeslot(self.program, ts, ts.event_type)
+                else:
+                    context['timeslot_form'] = form
+
             elif data['command'] == 'add':
-                #   add/edit timeslot
+                #   add timeslot
                 form = TimeslotForm(data)
                 if form.is_valid():
                     new_timeslot = Event()

--- a/esp/templates/program/modules/teachereventsmanagemodule/event_row.html
+++ b/esp/templates/program/modules/teachereventsmanagemodule/event_row.html
@@ -12,12 +12,19 @@
                 <em>(None)</em>
             {% endif %}
         </td>
-        <td style="width:5%">
-            <form method="post" action="teacher_events">
-            <input type="hidden" name="id" value="{{ timeslot.id }}" />
-            <input type="hidden" name="command" value="delete" />
-            <input type="submit" value="Delete" class="btn btn-danger" />
-            </form>
+        <td style="width:10%">
+            <center>
+                <form method="post" action="teacher_events">
+                    <input type="hidden" name="id" value="{{ timeslot.id }}" />
+                    <input type="hidden" name="command" value="load" />
+                    <input type="submit" value="Edit" class="btn btn-primary" />
+                </form>
+                <form method="post" action="teacher_events" onsubmit="return deleteEvent()">
+                    <input type="hidden" name="id" value="{{ timeslot.id }}" />
+                    <input type="hidden" name="command" value="delete" />
+                    <input type="submit" value="Delete" class="btn btn-danger" />
+                </form>
+            </center>
         </td>
     </tr>
 {% endfor %}

--- a/esp/templates/program/modules/teachereventsmanagemodule/teacher_events.html
+++ b/esp/templates/program/modules/teachereventsmanagemodule/teacher_events.html
@@ -12,6 +12,18 @@
     </style>
 {% endblock %}
 
+{% block xtrajs %}
+<script type="text/javascript">
+{{ block.super }}
+function deleteEvent() {
+    if (confirm('Are you sure you would like to delete this event?')) {
+       return true;
+    }
+    return false;
+}
+</script>
+{% endblock %}
+
 {% block content %}
 
 <h1>Manage Teacher Events for {{ prog.niceName }}</h1>
@@ -22,20 +34,22 @@ Teacher Events include (for now) <a href="#training">teacher training</a> and <a
 
 <div id="program_form">
 <form method="post" action="/manage/{{ prog.url }}/teacher_events">
-<input type="hidden" name="command" value="add" />
+<input type="hidden" name="command" value="{% if editing_timeslot %}edit{% else %}add{% endif %}" />
+{% if editing_timeslot %}
+<input type="hidden" name="id" value="{{ editing_timeslot.id }}" />
+{% endif %}
 <table align="center" cellpadding="0" cellspacing="0" width="450">
      <tr><th colspan="2" class="small">Add a Training or Interview</th></tr>
     {{ timeslot_form }}
-    <tr><td colspan="2" align="center"><input class="btn btn-primary" type="submit" name = "submit_btn" value="Add Training" /> <input class="btn btn-primary" type="submit" name="submit_btn" value="Add Interview" /></td></tr>
+    <tr><td colspan="2" align="center">{% if editing_timeslot %}<input class="btn btn-primary" type="submit" name = "submit_btn" value="Edit {{ editing_timeslot.event_type }}" />{% else %}<input class="btn btn-primary" type="submit" name = "submit_btn" value="Add Training" /> <input class="btn btn-primary" type="submit" name="submit_btn" value="Add Interview" />{% endif %}</td></tr>
 </table>
 </form>
 
-<center>Training Session Descriptions can be edited <a href="/admin/cal/event/">here</a>.</center>
 </br></br>
 
 <table align="center" cellpadding="4" cellspacing="0"> 
     <tr><th colspan="5"><a name="interview"></a>Teacher Interviews</th></tr>
-    <tr><th style="width:25%">Description</th><th style="width:18%">Start</th><th style="width:7%">End</th><th style="width:45%">Teachers</th><th style="width:5%">Delete</th></tr>
+    <tr><th style="width:25%">Description</th><th style="width:18%">Start</th><th style="width:7%">End</th><th style="width:45%">Teachers</th><th style="width:10%"></th></tr>
     {% with interview_times as timeslots %}
         {% include "program/modules/teachereventsmanagemodule/event_row.html" %}
     {% endwith %}
@@ -43,7 +57,7 @@ Teacher Events include (for now) <a href="#training">teacher training</a> and <a
 <br><br>
 <table align="center" cellpadding="4" cellspacing="0"> 
     <tr><th colspan="5"><a name="training"></a>Teacher Training</th></tr>
-    <tr><th style="width:25%">Description</th><th style="width:18%">Start</th><th style="width:7%">End</th><th style="width:45%">Teachers</th><th style="width:5%">Delete</th></tr>
+    <tr><th style="width:25%">Description</th><th style="width:18%">Start</th><th style="width:7%">End</th><th style="width:40%">Teachers</th><th style="width:10%"></th></tr>
     {% with training_times as timeslots %}
         {% include "program/modules/teachereventsmanagemodule/event_row.html" %}
     {% endwith %}


### PR DESCRIPTION
This adds the ability to edit teacher events (i.e., training, interviews). This allows admins to adjust the timing and description of such events. I also added a confirmation popup for when an admin tries to delete a teacher event. This is another step towards https://github.com/learning-unlimited/ESP-Website/issues/3497.