### PR TITLE
Priority settings changes

### DIFF
--- a/esp/esp/program/modules/forms/admincore.py
+++ b/esp/esp/program/modules/forms/admincore.py
@@ -104,7 +104,7 @@ class StudentRegSettingsForm(BetterModelForm):
     class Meta:
         fieldsets = [
                      ('Capacity Settings', {'fields': ['enforce_max', 'class_cap_multiplier', 'class_cap_offset', 'apply_multiplier_to_room_cap']}),
-                     ('Priority Registration Settings', {'fields': ['use_priority', 'priority_limit']}),
+                     ('Priority Registration Settings', {'fields': ['priority_limit']}), # use_priority is not included here to prevent confusion; to my knowledge, only HSSP uses this setting - WG
                      ('Enrollment Settings', {'fields': ['use_grade_range_exceptions', 'register_from_catalog', 'visible_enrollments', 'visible_meeting_times', 'show_emailcodes']}),
                      ('Button Settings', {'fields': ['confirm_button_text', 'view_button_text', 'cancel_button_text', 'temporarily_full_text', 'cancel_button_dereg', 'send_confirmation']}),
                      ('Visual Options', {'fields': ['progress_mode','force_show_required_modules']}),

--- a/esp/esp/program/modules/module_ext.py
+++ b/esp/esp/program/modules/module_ext.py
@@ -79,9 +79,11 @@ class StudentClassRegModuleInfo(models.Model):
     apply_multiplier_to_room_cap = models.BooleanField(default=False, help_text='Apply class cap multipler and offset to room capacity instead of class capacity.')
 
     #   Whether to use priority
-    use_priority         = models.BooleanField(default=False, help_text='Check this box to enable priority registration.')
+    use_priority         = models.BooleanField(default=False, help_text='Check this box to enable priority registration. Note, this is NOT for the two-phase student registration module. This will remove \
+                                                                         the ability for students to enroll in classes during normal student registration (i.e., first-come first-served).')
     #   Number of choices a student can make for each time block (1st choice, 2nd choice, ...Nth choice.)
-    priority_limit       = models.IntegerField(default=3, help_text='The maximum number of choices a student can make per timeslot when priority registration is enabled.')
+    priority_limit       = models.IntegerField(default=3, help_text='The maximum number of choices a student can make per timeslot when priority registration is enabled. Also, the \
+                                                                     number of priority slots listed in the rank classes interface for the two-phase student registration module.')
     #   Whether to use grade range exceptions
     use_grade_range_exceptions = models.BooleanField(default=False, help_text='Check this box to enable grade range exceptions.')
 


### PR DESCRIPTION
This does the following:

1. Updates the help text for the priority settings in the SCRMI to clarify that `use_priority` is NOT related to the two-phase student registration module and that `priority_limit` has two purposes (one of which IS for the two-phase student registration module).
2. Remove the `use_priority` setting from the program settings UI (since it is only used for MIT's HSSP program, to my knowledge).

Fixes #3513.