### PR TITLE
Add UI for class categories and flag types

### DIFF
--- a/esp/esp/program/forms.py
+++ b/esp/esp/program/forms.py
@@ -37,7 +37,7 @@ import re
 import unicodedata
 
 from esp.users.models import StudentInfo, K12School
-from esp.program.models import Program, ProgramModule, ClassFlag
+from esp.program.models import Program, ProgramModule, ClassFlag, ClassFlagType, ClassCategories
 from esp.utils.widgets import DateTimeWidget
 from django import forms
 from django.core import validators
@@ -412,6 +412,16 @@ class ClassFlagForm(forms.ModelForm):
     class Meta:
         model = ClassFlag
         fields = ['subject','flag_type','comment']
+
+class FlagTypeForm(forms.ModelForm):
+    class Meta:
+        model = ClassFlagType
+        fields = ['name','color','seq','show_in_scheduler','show_in_dashboard']
+
+class CategoryForm(forms.ModelForm):
+    class Meta:
+        model = ClassCategories
+        fields = ['category','symbol','seq']
 
 class TagSettingsForm(BetterForm):
     """ Form for changing global tags. """

--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -260,16 +260,11 @@ class Program(models.Model, CustomFormsLinkModel):
                          'the documentation</a> for details.')
     class_categories = models.ManyToManyField('ClassCategories',
                                               blank=True,
-                                              help_text=format_lazy('You can add new categories or modify existing ones from <a href="%s">the admin panel</a>.',
-                                                                    urlresolvers.reverse_lazy('admin:program_classcategories_changelist')))
+                                              help_text='You can add new categories or modify existing ones <a href="/manage/categoriesandflags/categories">here</a>.')
 
     flag_types = models.ManyToManyField('ClassFlagType',
                     blank=True,
-                    help_text=format_lazy(
-                    'The set of flags that can be used ' +
-                    'to tag classes for this program. ' +
-                    'Add flag types in <a href="%s">the admin panel</a>.',
-                    urlresolvers.reverse_lazy('admin:program_classflagtype_changelist')))
+                    help_text='The set of flags that can be used to tag classes for this program. You can add and modify flag types <a href="/manage/categoriesandflags/flagtypes">here</a>.')
 
     documents = GenericRelation(Media, content_type_field='owner_type', object_id_field='owner_id')
 

--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -2042,12 +2042,12 @@ was approved! Please go to http://esp.mit.edu/teach/%s/class_status/%s to view y
 class ClassCategories(models.Model):
     """ A list of all possible categories for an ESP class
 
-    Categories include 'Mathematics', 'Science', 'Zocial Zciences', etc.
+    Categories include 'Mathematics', 'Science', 'Social Sciences', etc.
     """
 
-    category = models.TextField(blank=False)
-    symbol = models.CharField(max_length=1, default='?', blank=False)
-    seq = models.IntegerField(default=0)
+    category = models.TextField(blank=False, help_text='The name of the category')
+    symbol = models.CharField(max_length=1, default='?', blank=False, help_text='A single character to represent the category')
+    seq = models.IntegerField(default=0, help_text='Categories will be ordered by this.  Smaller is earlier; the default is 0.')
 
     class Meta:
         verbose_name_plural = 'Class categories'

--- a/esp/esp/program/models/flags.py
+++ b/esp/esp/program/models/flags.py
@@ -42,9 +42,9 @@ from esp.users.models import ESPUser
 from esp.program.models import Program
 
 class ClassFlagType(models.Model):
-    name = models.CharField(max_length=255, unique=True)
-    show_in_scheduler = models.BooleanField(default=False)
-    show_in_dashboard = models.BooleanField(default=False)
+    name = models.CharField(max_length=255, unique=True, help_text='The name of the flag type')
+    show_in_scheduler = models.BooleanField(default=False, help_text='Should this flag type be shown in the scheduler?')
+    show_in_dashboard = models.BooleanField(default=False, help_text='Should this flag type be shown in the dashboard?')
     seq = models.SmallIntegerField(default=0, help_text='Flag types will be ordered by this.  Smaller is earlier; the default is 0.')
     color = models.CharField(blank=True, max_length=20, help_text='A color for displaying this flag type.  Should be a valid CSS color, for example "red", "#ff0000", or "rgb(255, 0, 0)".  If blank, an arbitrary one will be chosen.')
 

--- a/esp/esp/program/urls.py
+++ b/esp/esp/program/urls.py
@@ -16,6 +16,7 @@ urlpatterns = [
     url(r'^manage/usersearch/?$', views.usersearch),
     url(r'^manage/flushcache/?$', views.flushcache),
     url(r'^manage/emails/?$', views.emails),
+    url(r'^manage/categoriesandflags/?(?P<section>[^/]*)/?$', views.categoriesandflags),
     url(r'^manage/tags/?(?P<section>[^/]*)/?$', views.tags),
     url(r'^manage/statistics/?$', views.statistics),
     url(r'^manage/preview/?$', views.template_preview),

--- a/esp/esp/program/views.py
+++ b/esp/esp/program/views.py
@@ -896,7 +896,6 @@ def categoriesandflags(request, section=""):
     context['flag_types'] = ClassFlagType.objects.all().order_by('seq')
 
     return render_to_response('program/categories_and_flags.html', request, context)
-    
 
 @admin_required
 def statistics(request, program=None):

--- a/esp/templates/program/categories_and_flags.html
+++ b/esp/templates/program/categories_and_flags.html
@@ -1,0 +1,173 @@
+{% extends "main.html" %}
+
+{% block title %}
+    Class Category and Flag Type Management
+{% endblock %}
+
+{% block stylesheets %}
+    {{ block.super }}
+    <link rel="stylesheet" href="/media/styles/forms.css" type="text/css" />
+    <link rel="stylesheet" href="/media/styles/expand_display.css" type="text/css" />
+{% endblock %}
+
+{% block xtrajs %}
+<script type="text/javascript">
+function deleteCategory() {
+    if (confirm('Are you sure you would like to delete this class category?')) {
+       return true;
+    }
+    return false;
+}
+
+function deleteFlagType() {
+    if (confirm('Are you sure you would like to delete this class flag type?')) {
+       return true;
+    }
+    return false;
+}
+</script>
+{% endblock %}
+
+{% block content %}
+
+<h2>
+    Class Category and Flag Type Management
+</h2>
+
+<div id="program_form">
+
+    {% if open_section == "categories" %}
+    <button class="dsphead active">
+       <b>Class Categories</b> (click to expand/contract)
+    </button>
+
+    <div class="dspcont active">
+    {% else %}
+    <button class="dsphead">
+       <b>Class Categories</b> (click to expand/contract)
+    </button>
+
+    <div class="dspcont">
+    {% endif %}
+
+    <form method="post">
+    <input type="hidden" name="command" value="{% if cat_form.instance.id %}edit{% else %}add{% endif %}" />
+    {% if cat_form.instance.id %}
+    <input type="hidden" name="id" value="{{ cat_form.instance.id }}" />
+    {% endif %}
+    <input type="hidden" name="object" value="category" />
+    <table align="center" cellpadding="0" cellspacing="0" width="100%">
+        <tr><th colspan="2" class="small">Add/Edit Class Categories</th></tr>
+        {{ cat_form }}
+        <tr><td colspan="2" align="center"><input class="fancybutton" type="submit" value="{% if cat_form.instance.id %}Edit{% else %}Add{% endif %} Class Category" /></td></tr>
+    </table>
+    </form>
+
+    <br />
+
+    <table align="center" cellpadding="0" cellspacing="0" width="100%">
+        <tr><th colspan="4">Class Categories</th></tr>
+        <tr>
+            <td><b>Category</b></td>
+            <td><b>Symbol</b></td>
+            <td><b>Seq</b></td>
+            <td><b>Options</b></td>
+        </tr>
+        {% for cat in categories %}
+        <tr>
+            <td>{{ cat.category }}</td>
+            <td>{{ cat.symbol }}</td>
+            <td>{{ cat.seq }}</td>
+            <td>
+                <center>
+                    <form method="post">
+                        <input type="hidden" name="id" value="{{ cat.id }}" />
+                        <input type="hidden" name="command" value="load" />
+                        <input type="hidden" name="object" value="category" />
+                        <input type="submit" value="Edit" class="btn btn-primary" />
+                    </form>
+                    <form method="post" onsubmit="return deleteCategory()">
+                        <input type="hidden" name="id" value="{{ cat.id }}" />
+                        <input type="hidden" name="command" value="delete" />
+                        <input type="hidden" name="object" value="category" />
+                        <input type="submit" value="Delete" class="btn btn-danger" />
+                    </form>
+                </center>
+            </td>
+        </tr>
+        {% endfor %}
+    </table>
+    </div>
+
+    {% if open_section == "flagtypes" %}
+    <button class="dsphead active">
+       <b>Class Flag Types</b> (click to expand/contract)
+    </button>
+
+    <div class="dspcont active">
+    {% else %}
+    <button class="dsphead">
+       <b>Class Flag Types</b> (click to expand/contract)
+    </button>
+
+    <div class="dspcont">
+    {% endif %}
+
+    <form method="post">
+    <input type="hidden" name="command" value="{% if flag_form.instance.id %}edit{% else %}add{% endif %}" />
+    {% if flag_form.instance.id %}
+    <input type="hidden" name="id" value="{{ flag_form.instance.id }}" />
+    {% endif %}
+    <input type="hidden" name="object" value="flag_type" />
+    <table align="center" cellpadding="0" cellspacing="0" width="100%">
+        <tr><th colspan="2" class="small">Add/Edit Class Flag Types</th></tr>
+        {{ flag_form }}
+        <tr><td colspan="2" align="center"><input class="fancybutton" type="submit" value="{% if flag_form.instance.id %}Edit{% else %}Add{% endif %} Class Flag Type" /></td></tr>
+    </table>
+    </form>
+
+    <br />
+
+    <table align="center" cellpadding="0" cellspacing="0" width="100%">
+        <tr><th colspan="6">Class Flag Types</th></tr>
+        <tr>
+            <td><b>Name</b></td>
+            <td><b>Color</b></td>
+            <td><b>Seq</b></td>
+            <td><b>Show in Scheduler?</b></td>
+            <td><b>Show in Dashboard?</b></td>
+            <td><b>Options</b></td>
+        </tr>
+        {% for ft in flag_types %}
+        <tr>
+            <td>{{ ft.name }}</td>
+            <td>{{ ft.color }}</td>
+            <td>{{ ft.seq }}</td>
+            <td>{{ ft.show_in_scheduler }}</td>
+            <td>{{ ft.show_in_dashboard }}</td>
+            <td>
+                <center>
+                    <form method="post">
+                        <input type="hidden" name="id" value="{{ ft.id }}" />
+                        <input type="hidden" name="command" value="load" />
+                        <input type="hidden" name="object" value="flag_type" />
+                        <input type="submit" value="Edit" class="btn btn-primary" />
+                    </form>
+                    <form method="post" onsubmit="return deleteFlagType()">
+                        <input type="hidden" name="id" value="{{ ft.id }}" />
+                        <input type="hidden" name="command" value="delete" />
+                        <input type="hidden" name="object" value="flag_type" />
+                        <input type="submit" value="Delete" class="btn btn-danger" />
+                    </form>
+                </center>
+            </td>
+        </tr>
+        {% endfor %}
+    </table>
+    </div>
+
+</div>
+
+<script type="text/javascript" src="/media/scripts/expand_display.js"></script>
+
+{% endblock %}

--- a/esp/templates/program/manage_programs.html
+++ b/esp/templates/program/manage_programs.html
@@ -28,6 +28,8 @@
           
           <li><a href="/manage/emails/">Monitor comm panel email status</a></li>
           
+          <li><a href="/manage/categoriesandflags/">Manage class categories and flag types</a></li>
+          
           <li><a href="/manage/tags/">Modify tag settings (generic miscellaneous settings, for experts only)</a></li>
         </ul>
         </p>


### PR DESCRIPTION
This adds a user interface for admins to add and manage class categories and class flag types (/manage/categoriesandflags). The interface looks pretty similar to that of the resources page, with collapsible sections, forms for each object type, and lists of the existing objects.

Another step towards https://github.com/learning-unlimited/ESP-Website/issues/3497.