### PR TITLE
Add a user interface for permissions

### DIFF
--- a/esp/esp/program/modules/handlers/admincore.py
+++ b/esp/esp/program/modules/handlers/admincore.py
@@ -42,10 +42,11 @@ from django.http import HttpResponseRedirect
 
 from esp.accounting.controllers import ProgramAccountingController
 from esp.cal.models import Event
+from esp.db.forms import AjaxForeignKeyNewformField
 from esp.program.modules.base import ProgramModuleObj, needs_admin, CoreModule, main_call, aux_call
 from esp.program.modules.module_ext import ClassRegModuleInfo, StudentClassRegModuleInfo
 from esp.tagdict.models import Tag
-from esp.users.models import Permission
+from esp.users.models import Permission, ESPUser
 from esp.utils.web import render_to_response
 from esp.utils.widgets import DateTimeWidget
 
@@ -59,16 +60,23 @@ class EditPermissionForm(forms.Form):
     id = forms.IntegerField(required=True, widget=forms.HiddenInput)
     skip = forms.BooleanField(required=False, widget=forms.HiddenInput)
 
-class NewPermissionForm(forms.Form):
-    permission_type = forms.ChoiceField(choices=filter(lambda x: isinstance(x[1], tuple) and "Deadline" in x[0], Permission.PERMISSION_CHOICES))
+class NewDeadlineForm(forms.Form):
+    deadline_type = forms.ChoiceField(choices=filter(lambda x: isinstance(x[1], tuple) and "Deadline" in x[0], Permission.PERMISSION_CHOICES))
     role = forms.ChoiceField(choices = [("Student","Students"),("Teacher","Teachers"),("Volunteer","Volunteers")])
     start_date = forms.DateTimeField(label='Opening date/time', initial=datetime.now, widget=DateTimeWidget(), required=False)
     end_date = forms.DateTimeField(label='Closing date/time', initial=None, widget=DateTimeWidget(), required=False)
 
     def __init__(self, *args, **kwargs):
         extra_roles = kwargs.pop('extra_roles', [])
-        super(NewPermissionForm, self).__init__(*args, **kwargs)
+        super(NewDeadlineForm, self).__init__(*args, **kwargs)
         self.fields['role'].choices = self.fields['role'].choices + [(role, role) for role in extra_roles]
+
+class NewPermissionForm(forms.Form):
+    permission_type = forms.ChoiceField(choices=Permission.PERMISSION_CHOICES)
+    user = AjaxForeignKeyNewformField(key_type=ESPUser, field_name='user', label='User',
+        help_text='Start typing a username or "Last Name, First Name", then select the user from the dropdown.')
+    perm_start_date = forms.DateTimeField(label='Opening date/time', initial=datetime.now, widget=DateTimeWidget(), required=False)
+    perm_end_date = forms.DateTimeField(label='Closing date/time', initial=None, widget=DateTimeWidget(), required=False)
 
 class AdminCore(ProgramModuleObj, CoreModule):
     doc = """Includes the core views for managing a program (e.g. settings, dashboard)."""
@@ -282,47 +290,79 @@ class AdminCore(ProgramModuleObj, CoreModule):
         message_good = ''
         message_bad = ''
 
-        #   Handle 'open' / 'close' actions
-        if extra == 'open' and 'group' in request.GET and 'perm' in request.GET:
+        #   Handle 'open' / 'close' / 'delete' actions
+        if extra == 'open':
             #   If there are no permissions for this permission type, create one and open it now (open ended)
             #   If there are permission(s) for this type, take the most recent(?) and open it (open ended)
-            group = Group.objects.get(id = request.GET['group'])
-            perms = Permission.objects.filter(role = group, permission_type = request.GET['perm'], program = prog).order_by('-end_date')
-            if perms.count() > 0:
-                perms[0].unexpire()
-            else:
-                Permission.objects.create(role = group, permission_type = request.GET['perm'], start_date = datetime.now(), program = prog)
-            message_good = 'Deadline opened for %ss: %s.' % (group, Permission.nice_name_lookup(request.GET['perm']))
+            if 'group' in request.GET and 'perm' in request.GET:
+                group = Group.objects.get(id = request.GET['group'])
+                perms = Permission.objects.filter(role = group, permission_type = request.GET['perm'], program = prog).order_by('-end_date')
+                if perms.count() > 0:
+                    perms[0].unexpire()
+                else:
+                    Permission.objects.create(role = group, permission_type = request.GET['perm'], start_date = datetime.now(), program = prog)
+                message_good = 'Deadline opened for %ss: %s.' % (group, Permission.nice_name_lookup(request.GET['perm']))
+            elif 'perm_id' in request.GET:
+                perms = Permission.objects.filter(id=request.GET['perm_id'])
+                if perms.count() == 1:
+                    perm = perms[0]
+                    perm.unexpire()
+                    message_good = 'Permission opened for %s: %s.' % (perm.user, perm.nice_name())
+                else:
+                    message_bad = 'No permission with ID %s.' % (request.GET['perm_id'])
 
-        elif extra == 'close' and 'group' in request.GET and 'perm' in request.GET:
+        elif extra == 'close':
             #   If there are open permission(s) for this type, close them all
-            group = Group.objects.get(id = request.GET['group'])
-            perms = Permission.valid_objects().filter(permission_type = request.GET['perm'], program = prog, role = group)
-            perms.update(end_date = datetime.now())
-            message_good = 'Deadline closed for %ss: %s.' % (group, Permission.nice_name_lookup(request.GET['perm']))
+            if 'group' in request.GET and 'perm' in request.GET:
+                group = Group.objects.get(id = request.GET['group'])
+                perms = Permission.valid_objects().filter(permission_type = request.GET['perm'], program = prog, role = group)
+                perms.update(end_date = datetime.now())
+                message_good = 'Deadline closed for %ss: %s.' % (group, Permission.nice_name_lookup(request.GET['perm']))
+            if 'perm_id' in request.GET:
+                perms = Permission.objects.filter(id=request.GET['perm_id'])
+                if perms.count() == 1:
+                    perm = perms[0]
+                    perm.expire()
+                    message_good = 'Permission closed for %s: %s.' % (perm.user, perm.nice_name())
+                else:
+                    message_bad = 'No permission with ID %s.' % (request.GET['perm_id'])
 
         elif extra == 'delete' and 'perm_id' in request.GET:
             #   Delete the specified permission if it exists
             perms = Permission.objects.filter(id=request.GET['perm_id'])
             if perms.count() == 1:
                 perm = perms[0]
-                message_good = 'Deadline deleted for %ss: %s.' % (perm.role, perm.nice_name())
+                if 'deadline' in request.GET:
+                    message_good = 'Deadline deleted for %ss: %s.' % (perm.role, perm.nice_name())
+                else:
+                    message_good = 'Permission deleted for %s: %s.' % (perm.user, perm.nice_name())
                 perm.delete()
             else:
-                message_bad = 'Error while deleting permission with ID %s.' % request.GET['perm_id']
+                if 'deadline' in request.GET:
+                    message_bad = 'Error while deleting deadline with ID %s.' % request.GET['perm_id']
+                else:
+                    message_bad = 'Error while deleting permission with ID %s.' % request.GET['perm_id']
 
         #   Check incoming form data
-        if request.method == 'POST' and 'submit' in request.POST:
-            if request.POST['submit'] == 'Create Deadline':
-                create_form = NewPermissionForm(request.POST.copy())
+        if request.method == 'POST' and 'action' in request.POST:
+            if request.POST['action'] == 'add_deadline':
+                create_form = NewDeadlineForm(request.POST.copy())
                 if create_form.is_valid():
-                    perm = Permission.objects.create(user=None, permission_type=create_form.cleaned_data['permission_type'],
+                    perm = Permission.objects.create(user=None, permission_type=create_form.cleaned_data['deadline_type'],
                                                      role=Group.objects.get(name=create_form.cleaned_data['role']),program=prog,
                                                      start_date = create_form.cleaned_data['start_date'], end_date = create_form.cleaned_data['end_date'])
                     message_good = 'Deadline created for %ss: %s.' % (create_form.cleaned_data['role'], perm.nice_name())
                 else:
+                    message_bad = 'Error(s) while creating deadline: %s' % create_form.errors
+            elif request.POST['action'] == "add_permission":
+                create_form = NewPermissionForm(request.POST.copy())
+                if create_form.is_valid():
+                    perm = Permission.objects.create(user=create_form.cleaned_data['user'], permission_type=create_form.cleaned_data['permission_type'], program=prog,
+                                                     start_date = create_form.cleaned_data['perm_start_date'], end_date = create_form.cleaned_data['perm_end_date'])
+                    message_good = 'Permission created for %s: %s.' % (create_form.cleaned_data['user'], perm.nice_name())
+                else:
                     message_bad = 'Error(s) while creating permission: %s' % create_form.errors
-            elif request.POST['submit'] == 'Save':
+            elif request.POST['action'] == 'save_deadlines':
                 edit_formset = EditPermissionFormset(request.POST.copy(), prefix='edit')
                 if edit_formset.is_valid():
                     num_forms = 0
@@ -335,14 +375,27 @@ class AdminCore(ProgramModuleObj, CoreModule):
                             perm.end_date = form.cleaned_data['end_date']
                             perm.save()
                     if num_forms > 0:
-                        message_good = 'Changes saved.'
+                        message_good = 'Deadlines saved.'
+                else:
+                    message_bad = 'Error(s) while saving deadline(s): %s' % edit_formset.errors
+            elif request.POST['action'] == 'save_permissions':
+                edit_formset = EditPermissionFormset(request.POST.copy(), prefix='edit_perms')
+                if edit_formset.is_valid():
+                    num_forms = 0
+                    for form in edit_formset.forms:
+                        #   Check if the permission with the specified ID exists.
+                        if 'id' in form.cleaned_data and not form.cleaned_data['skip'] and Permission.objects.filter(id=form.cleaned_data['id']).exists():
+                            num_forms += 1
+                            perm = Permission.objects.get(id=form.cleaned_data['id'])
+                            perm.start_date = form.cleaned_data['start_date']
+                            perm.end_date = form.cleaned_data['end_date']
+                            perm.save()
+                    if num_forms > 0:
+                        message_good = 'Permissions saved.'
                 else:
                     message_bad = 'Error(s) while saving permission(s): %s' % edit_formset.errors
 
-        #   find all the existing permissions with this program
-        #   Only consider global permissions -- those that apply to all users
-        #   of a particular role.  Permissions added for individual users
-        #   should be managed in the admin interface.
+        #   find all the existing user group permissions for this program
         perms = Permission.deadlines().filter(program=self.program, user__isnull=True)
         #   Get roles associated with those permissions, plus the normal roles (if not already selected)
         groups = list(Group.objects.filter(Q(id__in=perms.values_list('role', flat = True).distinct()) | Q(name__in=["Student", "Teacher", "Volunteer"])))
@@ -367,9 +420,6 @@ class AdminCore(ProgramModuleObj, CoreModule):
                     group_perms[group].setdefault(perm_copy.permission_type, {'is_open': False, 'perms': []})['perms'].append(perm_copy)
             group_perms[group] = OrderedDict([(key, group_perms[group][key]) for key in sorted(group_perms[group].keys(), key = Permission.PERMISSION_CHOICES_FLAT.index)])
 
-        #   Populate template context to render page with forms
-        context = {}
-
         initial_data = [perm.__dict__ for group, perm_types in group_perms.items() for perm_type, details in perm_types.items() for perm in details['perms']]
         #   Supply initial data for forms
         formset = EditPermissionFormset(initial = initial_data, prefix = 'edit')
@@ -391,12 +441,26 @@ class AdminCore(ProgramModuleObj, CoreModule):
                 # Sort by validity and start/end dates
                 group_perms[group][perm_type]['perms'].sort(key=lambda perm: (perm.is_valid(), perm.end_date or datetime.max, perm.start_date or datetime.min), reverse=True)
 
+        #   find all the existing user permissions for this program
+        ind_perms = Permission.objects.filter(program=self.program, user__isnull=False).order_by('user__username', 'permission_type')
+
+        perm_initial_data = [perm.__dict__ for perm in ind_perms]
+        perm_formset = EditPermissionFormset(initial = perm_initial_data, prefix = 'edit_perms')
+        idx = 0
+        for perm in ind_perms:
+            perm.form = perm_formset.forms[idx]
+            idx += 1
+
+        #   Populate template context to render page with forms
+        context = {}
         context['message_good'] = message_good
         context['message_bad'] = message_bad
         context['manage_form'] = formset.management_form
-        context['group_perms'] = group_perms
-        context['perms'] = perms
-        context['create_form'] = NewPermissionForm(extra_roles = [group.name for group in groups if group.name not in ["Student", "Teacher", "Volunteer"]])
+        context['deadlines'] = group_perms
+        context['perm_manage_form'] = perm_formset.management_form
+        context['permissions'] = ind_perms
+        context['create_form'] = NewDeadlineForm(extra_roles = [group.name for group in groups if group.name not in ["Student", "Teacher", "Volunteer"]])
+        context['create_perm_form'] = NewPermissionForm()
 
         return render_to_response(self.baseDir()+'deadlines.html', request, context)
 

--- a/esp/esp/program/modules/handlers/admincore.py
+++ b/esp/esp/program/modules/handlers/admincore.py
@@ -62,11 +62,14 @@ class EditPermissionForm(forms.Form):
 
 class NewDeadlineForm(forms.Form):
     deadline_type = forms.ChoiceField(choices=filter(lambda x: "Administer" not in x[0], Permission.PERMISSION_CHOICES))
-    role = forms.ChoiceField(choices = [("Student","Students"),("Teacher","Teachers"),("Volunteer","Volunteers")] +
-                                        [(role, role + "s") for role in Group.objects.exclude(name__in=["Student", "Teacher", "Volunteer"]
-                                                                                      ).order_by('name').values_list('name', flat = True)])
+    role = forms.ChoiceField(choices = [("Student","Students"),("Teacher","Teachers"),("Volunteer","Volunteers")])
     start_date = forms.DateTimeField(label='Opening date/time', initial=datetime.now, widget=DateTimeWidget(), required=False)
     end_date = forms.DateTimeField(label='Closing date/time', initial=None, widget=DateTimeWidget(), required=False)
+
+    def __init__(self, *args, **kwargs):
+        super(NewDeadlineForm, self).__init__(*args, **kwargs)
+        self.fields['role'].choices = self.fields['role'].choices + [(role, role + "s") for role in Group.objects.exclude(name__in=["Student", "Teacher", "Volunteer"]
+                                                                                                                          ).order_by('name').values_list('name', flat = True)]
 
 class NewPermissionForm(forms.Form):
     permission_type = forms.ChoiceField(choices=filter(lambda x: "Administer" not in x[0], Permission.PERMISSION_CHOICES))

--- a/esp/public/media/default_styles/deadlines.css
+++ b/esp/public/media/default_styles/deadlines.css
@@ -120,6 +120,15 @@
     font-weight: normal;
 }
 
+#userbitforms ul.errorlist, #userbitforms ul.errorlist li
+{
+    list-style-type: none;
+    margin: 0px;
+    text-indent: 0px;
+    font-style: italic !important;
+    color: #c00 !important;
+}
+
 .hasDatepicker:disabled + .ui-datepicker-trigger {
     display: none;
 }

--- a/esp/templates/program/modules/admincore/deadlines.html
+++ b/esp/templates/program/modules/admincore/deadlines.html
@@ -1,6 +1,6 @@
 {% extends "main.html" %}
 
-{% block title %}Set Deadlines{% endblock %}
+{% block title %}Set Deadlines and Permissions{% endblock %}
 
 {% block keywords %}{% endblock %}
 {% block description %}{% endblock %}
@@ -20,7 +20,7 @@
 {% block content %}
 {% load users %}
 <div id="userbitforms">
-<p><h1>Deadline Management</h1></p>
+<p><h1>Deadline and Permission Management</h1></p>
 
 {% if message_good %}
     <div class="alert alert-success">
@@ -35,24 +35,28 @@
     </div>
 {% endif %}
 
-<p>Access to each program's Web pages (including registration pages) is controlled by a set of deadlines, each of which prescribes when a certain set of activities can be performed.  "Recursive" deadlines can control a range of activities jointly; you may open all registration features using a single recursive deadline (e.g., "All student deadlines"), or specify several non-recursive deadlines ("Register for classes", "Access to survey", etc.) for finer control.</p>
+<p>Access to each program's Web pages (including registration pages) is controlled by a set of <b>deadlines</b>, which prescribe when a certain set of activities can be performed by a certain group of users (e.g., Students), and <b>permissions</b>, which prescribe when a certain set of activities can be performed by an individual user.</p>
 
-<p>If you use recursive deadlines, keep in mind that the "implied" deadlines can only be used to open registration features when the recursive deadline is closed; you cannot close implied deadlines to override an open recursive deadline.  Hence it is wise to make the deadlines non-recursive when controlling individual registration features.</p>
+<p>"Recursive" deadlines can control a range of activities jointly; you may open all registration features using a single recursive deadline (e.g., "All student deadlines"), or specify several non-recursive deadlines ("Register for classes", "Access to survey", etc.) for finer control. If you use recursive deadlines, keep in mind that the "implied" deadlines can only be used to open registration features when the recursive deadline is closed; you cannot close implied deadlines to override an open recursive deadline.  Hence it is wise to make the deadlines non-recursive when controlling individual registration features.</p>
 
-<p>Please proceed to edit <a href="#existing">existing deadlines</a> or <a href="#new">create a new deadline</a> if necessary.</p>
+<p>Please proceed to edit <a href="#existing">existing deadlines for user groups</a> or <a href="#new">create a new deadline</a> if necessary.</p>
+
+<p>Alternatively, you can edit <a href="#permissions">existing permissions for individual users</a> or <a href="#new_perm">create a new permission</a>.</p>
 
 {% include "program/modules/admincore/returnlink.html" %}
 
+<br />
 <a name="existing"></a>
-<h2>Existing Deadlines</h2>
+<h2>Deadlines (for user groups)</h2>
 
 <form method="post" action="/manage/{{ program.getUrlBase }}/deadlines" id="manage_form">
 {% autoescape off %}
 {{ manage_form }}
+<input type="hidden" name="action" value="save_deadlines">
 
-{% for group, perm_types in group_perms.items %}
+{% for group, perm_types in deadlines.items %}
 <button type="button" class="dsphead">
-   <b>{{ group }}s</b> (click to expand/contract)
+   <b>Deadlines for {{ group }}s</b> (click to expand/contract)
 </button>
 <div class="dspcont">
     <table width="100%" cellspacing="0" cellpadding="3px">
@@ -78,7 +82,7 @@
                     <span class="bituri">{{ perm_type }}</span>
                     <br /><br />
                     {% if details.is_open %}
-                        <a {% if not details.implied_open %}href="/manage/{{ program.getUrlBase }}/deadlines/close?group={{ group.id }}&perm={{ perm_type|urlencode }}"{% endif %}><button {% if details.implied_open %}disabled title="Can not be closed due to implied permission" {% endif %}type="button" class="btn btn-danger">Close</button></a>
+                        <a {% if not details.implied_open %}href="/manage/{{ program.getUrlBase }}/deadlines/close?group={{ group.id }}&perm={{ perm_type|urlencode }}"{% endif %}><button {% if details.implied_open %}disabled title="Can not be closed due to implied deadline" {% endif %}type="button" class="btn btn-danger">Close</button></a>
                     {% else %}
                         <a href="/manage/{{ program.getUrlBase }}/deadlines/open?group={{ group.id }}&perm={{ perm_type|urlencode }}"><button type="button" class="btn btn-success">Open</button></a>
                     {% endif %}
@@ -95,13 +99,13 @@
                     {% else %}
                         <input class="btn btn-primary" type="Submit" name="submit_btn" value="Save" />
                         {% if details.perms|length > 1 %}
-                            <a href="/manage/{{ program.getUrlBase }}/deadlines/delete?perm_id={{ perm.id }}"><button type="button" class="btn btn-danger btn-small">Delete</button></a>
+                            <a href="/manage/{{ program.getUrlBase }}/deadlines/delete?perm_id={{ perm.id }}&deadline"><button type="button" class="btn btn-danger btn-small">Delete</button></a>
                         {% endif %}
                     {% endif %}
                 </td>
             </tr>
             {% empty %}
-                <td colspan="3">No permission set</td>
+                <td colspan="3">No deadline set</td>
             </tr>
             {% endfor %}
         {% endfor %}
@@ -116,15 +120,16 @@
 <form method="post" action="/manage/{{ program.getUrlBase }}/deadlines" id="create_form">
 
 <a name="new"></a>
-<h2>Create new deadlines</h2>
+<h3>Create new deadlines</h3>
 
-<p>If you have made changes to the current deadlines, please click "Save Changes" above before creating a new deadline.</p>
+<p>If you have made changes to the current deadlines, please click "Save" above before creating a new deadline.</p>
 
 {% autoescape off %}
 <table cellspacing="0" width="550px" cellpadding="3">
 {{ create_form }}
 <tr>
     <td align="center" valign="center" colspan="2">
+        <input type="hidden" name="action" value="add_deadline">
         <input class="button" type="Submit" name="submit_btn" value="Create Deadline" />
     </td>
 </tr>
@@ -132,7 +137,92 @@
 {% endautoescape %}
 </form>
 
+<hr>
+
+<a name="permissions"></a>
+<h2>Permissions (for individual users)</h2>
+
+<button type="button" class="dsphead">
+   <b>Existing Permissions</b> (click to expand/contract)
+</button>
+<div class="dspcont">
+
+<form method="post" action="/manage/{{ program.getUrlBase }}/deadlines" id="manage_perms_form">
+{{ perm_manage_form }}
+<input type="hidden" name="action" value="save_permissions">
+
+<table width="100%" cellspacing="0" cellpadding="3px">
+    <colgroup>
+       <col span="1" width="20%">
+       <col span="1" width="30%">
+       <col span="1">
+       <col span="1" width="15%">
+    </colgroup>
+    <tbody>
+    {% for perm in permissions %}
+    {% if forloop.counter0|divisibleby:"5" %}
+    <tr>
+        <th>User</th>
+        <th>Permission</th>
+        <th>Timing</th>
+        <th></th>
+    </tr>
+    {% endif %}
+    <tr style="border-top: 1px solid grey;{% if details.perms|length_is:1 %}border-bottom: 1px solid grey;{% endif %}">
+        <th>{{ perm.user }}</th>
+        <th class="{% if perm.is_valid %}is_open{% else %}is_closed{% endif %}">
+            {{ perm.permission_type|perm_nice_name }}<br>
+            <span class="bituri">{{ perm.permission_type }}</span>
+            <br /><br />
+            {% if perm.is_valid %}
+                <a href="/manage/{{ program.getUrlBase }}/deadlines/close?perm_id={{ perm.id }}"><button type="button" class="btn btn-danger">Close</button></a>
+            {% else %}
+                <a href="/manage/{{ program.getUrlBase }}/deadlines/open?perm_id={{ perm.id }}"><button type="button" class="btn btn-success">Open</button></a>
+            {% endif %}
+        </th>
+        <td>
+            {{ perm.form.id }}
+            <b>Start:</b><br>{{ perm.form.start_date }}<br>
+            <b>End:</b><br>{{ perm.form.end_date }}
+        </td>
+        <td align="center" valign="center">
+            <input class="btn btn-primary" type="Submit" name="submit_btn" value="Save" />
+            <a href="/manage/{{ program.getUrlBase }}/deadlines/delete?perm_id={{ perm.id }}&permission"><button type="button" class="btn btn-danger btn-small">Delete</button></a>
+        </td>
+    </tr>
+    {% empty %}
+        <td colspan="3">No permissions set</td>
+    </tr>
+    {% endfor %}
+    </tbody>
+</table>
 </div>
+
+</form>
+
+<form method="post" action="/manage/{{ program.getUrlBase }}/deadlines" id="create_perm_form">
+
+<a name="new_perm"></a>
+<h3>Create new permissions</h3>
+
+<p>If you have made changes to the current permissions, please click "Save" above before creating a new permission.</p>
+
+{% autoescape off %}
+<table cellspacing="0" width="550px" cellpadding="3">
+{{ create_perm_form }}
+<tr>
+    <td align="center" valign="center" colspan="2">
+        <input type="hidden" name="action" value="add_permission">
+        <input class="button" type="Submit" name="submit_btn" value="Create Permission" />
+    </td>
+</tr>
+</table>
+{% endautoescape %}
+</form>
+
+</div>
+
+<br /><br />
 
 <script type="text/javascript" src="/media/scripts/expand_display.js"></script>
 {% endblock %}


### PR DESCRIPTION
This adds a user interface for permissions for individual users to the "Deadline Management" page (now "Deadline and Permissions Management"). I've made a clear distinction between deadlines (for user ROLES) and permissions (for individual USERS), even though technically they are the same thing in the database. My thought is that this will hopefully reduce confusion around the terms "deadlines" and "permissions" (which we have tended to use interchangeably up to now). The interface works just like the deadlines interface (opening/closing/adding/deleting/editing), and the permission form has an autocomplete field for users.

Another step towards #3497