### PR TITLE
Add interfaces to add and remove students to/from the student lottery

### DIFF
--- a/esp/esp/program/modules/handlers/studentregphasezero.py
+++ b/esp/esp/program/modules/handlers/studentregphasezero.py
@@ -205,7 +205,7 @@ class StudentRegPhaseZero(ProgramModuleObj):
 
     @aux_call
     @needs_student
-    def studentlookup(self, request, tl, one, two, module, extra, prog, newclass = None):
+    def studentlookup(self, request, tl, one, two, module, extra, prog):
 
         # Search for students with names that start with search string
         if not 'username' in request.GET or 'username' in request.POST:

--- a/esp/esp/program/modules/handlers/studentregphasezeromanage.py
+++ b/esp/esp/program/modules/handlers/studentregphasezeromanage.py
@@ -145,6 +145,7 @@ class StudentRegPhaseZeroManage(ProgramModuleObj):
         context = {}
         role = str(prog) + " Winner"
         context['role'] = role
+        num_allowed_users = int(Tag.getProgramTag("student_lottery_group_max", prog))
 
         if request.POST:
             if request.POST.get('mode') == 'addnew':
@@ -221,8 +222,6 @@ class StudentRegPhaseZeroManage(ProgramModuleObj):
         timess_data, start = BigBoardModule.make_graph_data(timess)
         context["left_axis_data"] = [{"axis_name": "#", "series_data": timess_data}]
         context["first_hour"] = start
-
-        num_allowed_users = int(Tag.getProgramTag("student_lottery_group_max", prog))
 
         grades = range(prog.grade_min, prog.grade_max + 1)
         stats = {}

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -241,6 +241,14 @@ class BaseESPUser(object):
             QObject = Q(classsubject__status__gt=0)
         return cls.ajax_autocomplete(data, QObject)
 
+    @classmethod
+    def ajax_autocomplete_student_lottery(cls, data, prog = None):
+        if prog:
+            QObject = Q(phasezerorecord__program=prog)
+        else:
+            QObject = Q(phasezerorecord__program__isnull=False)
+        return cls.ajax_autocomplete(data, QObject)
+
     def ajax_str(self):
         return "%s, %s (%s)" % (self.last_name, self.first_name, self.username)
 

--- a/esp/public/media/scripts/program/modules/studentregphasezero.js
+++ b/esp/public/media/scripts/program/modules/studentregphasezero.js
@@ -1,25 +1,86 @@
 function setup_autocomplete()
 {
-    $j("#student_username").autocomplete({
-	source: function(request, response) {
+    // Autocomplete for student page which only searches by and shows username
+    $j("[name=student_username]").autocomplete({
+        source: function(request, response) {
+                $j.ajax({
+            url: "/learn/"+base_url+"/studentlookup/",
+            dataType: "json",
+            data: {username: request.term},
+            success: function(data) {
+                var output = $j.map(data, function(item) {
+                return {
+                    label: item.username + " (grade " + item.grade + ")",
+                    value: item.username,
+                    id: item.id
+                };
+                });
+                response(output);
+            }
+            });
+        },
+        select: function(event, ui) {
+            $j(this).next("[name=student_selected]").val(ui.item.id);
+        }
+    });
+    
+    // Autocomplete for admin page which searches by and shows username and name
+    $j(".student_search").autocomplete({
+        source: function(request, response) {
             $j.ajax({
-		url: "/learn/"+base_url+"/studentlookup/",
-		dataType: "json",
-		data: {username: request.term},
-		success: function(data) {
-		    var output = $j.map(data, function(item) {
-			return {
-			    label: item.username + " (grade " + item.grade + ")",
-			    value: item.username,
-			    id: item.id
-			};
-		    });
-		    response(output);
-		}
-	    });
-	},
-	select: function(event, ui) {
-	    $j("#student_id").val(ui.item.id);
-	}
+                url: "/admin/ajax_autocomplete/",
+                dataType: "json",
+                data: {
+                    model_module: "esp.users.models",
+                    model_name: "ESPUser",
+                    ajax_func: "ajax_autocomplete_student",
+                    ajax_data: request.term,
+                    prog: "",
+                },
+                success: function(data) {
+                    var output = $j.map(data.result, function(item) {
+                        return {
+                            label: item.ajax_str,
+                            value: item.ajax_str,
+                            id: item.id
+                        };
+                    });
+                    response(output);
+                }
+            });
+        },
+        select: function(event, ui) {
+            $j(this).next(".student_selected").val(ui.item.id);
+        }
+    });
+    
+    // Same as above, but filters only to students already in the lottery
+    $j(".lottery_student_search").autocomplete({
+        source: function(request, response) {
+            $j.ajax({
+                url: "/admin/ajax_autocomplete/",
+                dataType: "json",
+                data: {
+                    model_module: "esp.users.models",
+                    model_name: "ESPUser",
+                    ajax_func: "ajax_autocomplete_student_lottery",
+                    ajax_data: request.term,
+                    prog: prog_id,
+                },
+                success: function(data) {
+                    var output = $j.map(data.result, function(item) {
+                        return {
+                            label: item.ajax_str,
+                            value: item.ajax_str,
+                            id: item.id
+                        };
+                    });
+                    response(output);
+                }
+            });
+        },
+        select: function(event, ui) {
+            $j(this).next(".student_selected").val(ui.item.id);
+        }
     });
 }

--- a/esp/templates/program/modules/studentregphasezero/status.html
+++ b/esp/templates/program/modules/studentregphasezero/status.html
@@ -15,39 +15,26 @@
   height: 250px;
 }
 
-#applicants
-{
-    list-style-type: none;
-    counter-reset: section;
-
-    -moz-column-count: 3;
-    -moz-column-gap: 20px;
-    -webkit-column-count: 3;
-    -webkit-column-gap: 20px;
-    column-count: 3;
-    column-gap: 20px;
-    margin: 0px;
-}
-
-#record
-{
-    padding-left: 30px;
-    position: relative;
-}
-
-#lotteryentries{
-  display:none;
-}
-#lotteryentries.show{
-  display:block;
-}
-
 table {
     border-collapse: collapse;
 }
 
-table, th, td {
+table, th, td, .option {
     border: 1px solid black;
+}
+
+.option th {
+    padding-top: 10px;
+}
+
+.option tr:last-child td:last-child {
+    padding-bottom: 10px;
+}
+
+.addstudent,
+.addstudent th,
+.addstudent td {
+    border: none;
 }
 
 td {
@@ -63,6 +50,15 @@ td {
   <script type="text/javascript" src="//code.highcharts.com/highcharts.js"></script>
   <script type="text/javascript" src="//code.highcharts.com/highcharts-more.js"></script>
   <script type="text/javascript" src="//code.highcharts.com/modules/no-data-to-display.js"></script>
+  <script type="text/javascript">base_url = "{{ program.getUrlBase }}"</script>
+  <script type="text/javascript">prog_id = "{{ program.id }}"</script>
+  <script type="text/javascript" src="/media/scripts/program/modules/studentregphasezero.js"></script>
+  <script type="text/javascript">
+    // Set up the student input autocomplete
+    $j(document).ready(function() {
+      setup_autocomplete();
+    });
+  </script>
 {% endblock xtrajs %}
 
 {% block content %}
@@ -78,6 +74,12 @@ td {
     <div class="alert alert-danger">
         <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
             {{ error }}
+    </div>
+{% endif %}
+{% if success %}
+    <div class="alert alert-success">
+        <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+            {{ success }}
     </div>
 {% endif %}
 {% if invalid_grades %}
@@ -198,7 +200,99 @@ td {
         </tr>
     {% endfor %}
 </table>
+<br/><br/>
 {% endif %}
+
+<button class="dsphead">
+    <b><u>Manually Add a Student to the Lottery:</u></b>
+</button>
+<div class="dspcont">
+    <table width=100% cellpadding="0" cellspacing="0" class="addstudent">
+        <td width=46% class="option">
+            <form action="#" method="POST">
+                <table width="100%">
+                    <tr>
+                        <th>{% if num_allowed_users > 1 %}Create a New Lottery Group{% else %}Add a Student to the Lottery{% endif %}</th>
+                    </tr>
+                    {% if num_allowed_users > 1 %}
+                    <tr>
+                        <td>(Use this option if you want to start a new lottery group for a student)<br><br></td>
+                    </tr>
+                    {% endif %}
+                    <tr>
+                        <td>
+                            <input type="hidden" name="mode" value="addnew">
+                            <label for="student_search1">Student to be added to {% if num_allowed_users > 1 %}new lottery group{% else %}the lottery{% endif %}:</label>
+                            <input type="text" class="student_search" name="student_search1" id="student_search1" placeholder="username/name" />
+                            <input type="hidden" class="student_selected" name="student_selected1" id="student_selected1" /><br><br>
+                            <input type="submit" class="button" value="{% if num_allowed_users > 1 %}Create New Lottery Group{% else %}Add Student to Lottery{% endif %}" {% if lottery_run %}disabled title="Lottery has already been run"{% endif %} />
+                        </td>
+                    </tr>
+                </table>
+            </form>
+        </td>
+
+        {% if num_allowed_users > 1 %}
+        <td width=8%><b><i>OR</i></b></td>
+
+        <td width=46% class="option">
+            <form action="#" method="POST">
+                <table width="100%">
+                    <tr>
+                        <th>Add To Existing Lottery Group</th>
+                    </tr>
+                    <tr>
+                        <td>(Use this option if you want to add a student to an existing lottery group)<br><br></td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <input type="hidden" name="mode" value="addtoexisting">
+                            <label for="student_search2">Student to be added to existing lottery group:</label>
+                            <input type="text" class="student_search" name="student_search2" id="student_search2" placeholder="username/name" />
+                            <input type="hidden" class="student_selected" name="student_selected2" id="student_selected2" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <label for="student_search3">Student in existing lottery group:</label>
+                            <input type="text" class="lottery_student_search" name="student_search3" id="student_search3" placeholder="username/name" />
+                            <input type="hidden" class="student_selected" name="student_selected3" id="student_selected3" /><br><br>
+                            <input type="submit" class="button" value="Add to Existing Lottery Group" {% if lottery_run %}disabled title="Lottery has already been run"{% endif %} />
+                        </td>
+                    </tr>
+                </table>
+            </form>
+        </td>
+        {% endif %}
+    </table>
+</div>
+
+<button class="dsphead">
+    <b><u>Manually Remove a Student from the Lottery:</u></b>
+</button>
+<div class="dspcont">
+    <table width=50% cellpadding="0" cellspacing="0" class="addstudent" style="margin: auto;">
+        <td width=46% class="option">
+            <form action="#" method="POST">
+                <table width="100%">
+                    <tr>
+                        <th>Remove a Student from the Lottery</th>
+                    </tr>
+                    <tr>
+                        <td>
+                            <input type="hidden" name="mode" value="remove">
+                            <label for="student_search4">Student in the lottery:</label>
+                            <input type="text" class="lottery_student_search" name="student_search4" id="student_search4" placeholder="username/name" />
+                            <input type="hidden" class="student_selected" name="student_selected4" id="student_selected4" /><br><br>
+                            <input type="submit" class="button" value="Remove from Lottery" {% if lottery_run %}disabled title="Lottery has already been run"{% endif %} />
+                        </td>
+                    </tr>
+                </table>
+            </form>
+        </td>
+    </table>
+</div>
+
 {% include "program/modules/admincore/returnlink.html" %}
 <script type="text/javascript" src="/media/scripts/expand_display.js"></script>
 {% endblock %}

--- a/esp/templates/program/modules/studentregphasezero/submit.html
+++ b/esp/templates/program/modules/studentregphasezero/submit.html
@@ -89,9 +89,6 @@ Welcome to Phase Zero, or the Student Lottery, for {{program.niceName}}. Any stu
                     <th>Join An Existing Lottery Ticket</th>
                 </tr>
                 <tr>
-                    <td>(Use this option if you want to join a ticket that someone else has already made)<br><br>1) Begin typing another student's <u>username</u> below<br>2) Select the correct username<br>3) Click the button<br><br>Note: the student must already have a lottery ticket and the maximum allowed group size is <b>{{ num_allowed_users }}</b> students</td>
-                </tr>
-                <tr>
                     <td>
                         <input type="text" name="student_username" id="student_username" />
                         <input type="hidden" name="student_selected" id="student_id" />

--- a/esp/templates/program/modules/studentregphasezero/submit.html
+++ b/esp/templates/program/modules/studentregphasezero/submit.html
@@ -89,6 +89,9 @@ Welcome to Phase Zero, or the Student Lottery, for {{program.niceName}}. Any stu
                     <th>Join An Existing Lottery Ticket</th>
                 </tr>
                 <tr>
+                    <td>(Use this option if you want to join a ticket that someone else has already made)<br><br>1) Begin typing another student's <u>username</u> below<br>2) Select the correct username<br>3) Click the button<br><br>Note: the student must already have a lottery ticket and the maximum allowed group size is <b>{{ num_allowed_users }}</b> students</td>
+                </tr>
+                <tr>
                     <td>
                         <input type="text" name="student_username" id="student_username" />
                         <input type="hidden" name="student_selected" id="student_id" />


### PR DESCRIPTION
This adds an interface on the Phase Zero Management page to add students to and remove students from the student lottery:
![image](https://user-images.githubusercontent.com/7232514/167750178-50135b52-7fed-4e66-bf1b-498049f58cb4.png)

This is another step towards #3497.