### PR TITLE
Lunch constraint form fixes

### DIFF
--- a/esp/templates/program/modules/admincore/lunch_constraints.html
+++ b/esp/templates/program/modules/admincore/lunch_constraints.html
@@ -7,6 +7,22 @@
     <link rel="stylesheet" type="text/css" href="/media/styles/forms.css" />
 {% endblock %}
 
+{% block xtrajs %}
+<script type="text/javascript">
+    $j(function(){
+        function update_checkboxes() {
+            if(!$j("#id_generate_constraints").prop("checked")) {
+                $j("#id_autocorrect, #id_include_conditions").prop("checked", false).prop("disabled", true);
+            } else {
+                $j("#id_autocorrect, #id_include_conditions").prop("disabled", false);
+            }
+        }
+        $j("#id_generate_constraints").on("change", update_checkboxes);
+        update_checkboxes();
+    });
+</script>
+{% endblock %}
+
 {% block content %}
     <h1>{{program.niceName}} Lunch Constraints</h1>
     <p>Please select the timeslots you would like to be used for lunch.</p>


### PR DESCRIPTION
This PR makes the following fixes/changes to the lunch constraints form:

1. I made the form itself a little more user-friendly by making the last two checkboxes get unchecked and disabled whenever the "generate constraints" checkbox is unchecked.
2. The initial values are now properly set (including both which lunch blocks have already been made and which settings were used for constraints). In doing this, I also changed the default for the form to NOT make constraints (because honestly they don't seem to always work and are not super intuitive, but fixing them is definitely outside of the scope of this PR).
3. When the form is resubmitted and there are lunches that already exist, those lunches are no longer deleted. Only lunches that are no longer wanted are deleted, and only new lunches for selected timeslots that don't already have lunches are created.

Fixes #3528.