### PR TITLE
Remove link to admin pages

### DIFF
--- a/esp/esp/themes/theme_data/barebones/templates/sidebar/admin.html
+++ b/esp/esp/themes/theme_data/barebones/templates/sidebar/admin.html
@@ -1,34 +1,6 @@
-<!-- <li class="hidden nav-header admin">Admin</li>
-
-{# TODO(benkraft): Allow configuring these too. #}
-<li class="admin hidden"><a href="/admin/">
-    <i class="glyphicon glyphicon-cog"></i> Administration Pages
-</a></li>
-<li class="admin hidden"><a href="/manage/programs/">
-    <i class="glyphicon glyphicon-time"></i> Programs
-</a></li>
-<li class="admin hidden"><a href="/admin/filebrowser/browse/">
-    <i class="glyphicon glyphicon-film"></i> Media Files
-</a></li>
-<li class="admin hidden"><a href="/themes/">
-    <i class="glyphicon glyphicon-eye-open"></i> Themes
-</a></li>
--->
 <li class="unmorph hidden"><a href="/myesp/switchback/">
     <i class="glyphicon glyphicon-user"></i> Unmorph to <script type="text/javascript">document.write(esp_user.cur_retTitle);</script>
 </a></li>
-<!--
-<li class="onsite hidden"><a href="/myesp/onsite/">
-    <i class="glyphicon glyphicon-pencil"></i> Onsite Registration
-</a></li>
-<li class="admin hidden">
-  <a>
-    <i class="glyphicon glyphicon-user"></i> Find User
-  </a>
-  <form id="user_search_form" name="user_search_form" method="get" action="/manage/usersearch">
-    <input type="text" id="user_search_field" name="userstr">
-  </form>
-</li> -->
 
 {% comment %} === Admin Toolbar (includes user search) === {% endcomment %}
 {% load modules %}

--- a/esp/esp/themes/theme_data/barebones/templates/sidebar/admin.html
+++ b/esp/esp/themes/theme_data/barebones/templates/sidebar/admin.html
@@ -45,6 +45,7 @@ var currentPrograms = [
     },
 {% endfor %}
 ];
+var debug = {{ settings.DEBUG|yesno:"true,false" }};
 </script>
 <script type="text/javascript" src="/media/scripts/admin_bar.js"> </script>
 {% comment %} === End Admin Toolbar === {% endcomment %}

--- a/esp/esp/themes/theme_data/barebones/templates/sidebar/admin.html
+++ b/esp/esp/themes/theme_data/barebones/templates/sidebar/admin.html
@@ -31,6 +31,7 @@
 </li> -->
 
 {% comment %} === Admin Toolbar (includes user search) === {% endcomment %}
+{% load modules %}
 <link rel="stylesheet" type="text/css" href="/media/default_styles/admin_bar.css">
 <div id="adminbar" class="admin hidden" style="position: fixed !important">
   <div class="title" onclick="ESP.toggleDisplay('adminbar_content');">Admin Toolbar</div>
@@ -42,6 +43,7 @@ var currentPrograms = [
     {
         urlBase: "{{ current_program.getUrlBase }}",
         name: "{{ current_program.niceName }}",
+        class_search: {% if current_program|hasModule:"ClassSearchModule" %}true{% else %}false{% endif %}
     },
 {% endfor %}
 ];

--- a/esp/esp/themes/theme_data/bigpicture/templates/sidebar/admin.html
+++ b/esp/esp/themes/theme_data/bigpicture/templates/sidebar/admin.html
@@ -1,34 +1,6 @@
-<!-- <li class="hidden nav-header admin">Admin</li>
-
-{# TODO(benkraft): Allow configuring these too. #}
-<li class="admin hidden"><a href="/admin/">
-    <i class="glyphicon glyphicon-cog"></i> Administration Pages
-</a></li>
-<li class="admin hidden"><a href="/manage/programs/">
-    <i class="glyphicon glyphicon-time"></i> Programs
-</a></li>
-<li class="admin hidden"><a href="/admin/filebrowser/browse/">
-    <i class="glyphicon glyphicon-film"></i> Media Files
-</a></li>
-<li class="admin hidden"><a href="/themes/">
-    <i class="glyphicon glyphicon-eye-open"></i> Themes
-</a></li>
--->
 <li class="unmorph hidden"><a href="/myesp/switchback/">
     <i class="glyphicon glyphicon-user"></i> Unmorph to <script type="text/javascript">document.write(esp_user.cur_retTitle);</script>
 </a></li>
-<!--
-<li class="onsite hidden"><a href="/myesp/onsite/">
-    <i class="glyphicon glyphicon-pencil"></i> Onsite Registration
-</a></li>
-<li class="admin hidden">
-  <a>
-    <i class="glyphicon glyphicon-user"></i> Find User
-  </a>
-  <form id="user_search_form" name="user_search_form" method="get" action="/manage/usersearch">
-    <input type="text" id="user_search_field" name="userstr">
-  </form>
-</li> -->
 
 {% comment %} === Admin Toolbar (includes user search) === {% endcomment %}
 {% load modules %}

--- a/esp/esp/themes/theme_data/bigpicture/templates/sidebar/admin.html
+++ b/esp/esp/themes/theme_data/bigpicture/templates/sidebar/admin.html
@@ -45,6 +45,7 @@ var currentPrograms = [
     },
 {% endfor %}
 ];
+var debug = {{ settings.DEBUG|yesno:"true,false" }};
 </script>
 <script type="text/javascript" src="/media/scripts/admin_bar.js"> </script>
 {% comment %} === End Admin Toolbar === {% endcomment %}

--- a/esp/esp/themes/theme_data/bigpicture/templates/sidebar/admin.html
+++ b/esp/esp/themes/theme_data/bigpicture/templates/sidebar/admin.html
@@ -31,6 +31,7 @@
 </li> -->
 
 {% comment %} === Admin Toolbar (includes user search) === {% endcomment %}
+{% load modules %}
 <link rel="stylesheet" type="text/css" href="/media/default_styles/admin_bar.css">
 <div id="adminbar" class="admin hidden" style="position: fixed !important">
   <div class="title" onclick="ESP.toggleDisplay('adminbar_content');">Admin Toolbar</div>
@@ -42,6 +43,7 @@ var currentPrograms = [
     {
         urlBase: "{{ current_program.getUrlBase }}",
         name: "{{ current_program.niceName }}",
+        class_search: {% if current_program|hasModule:"ClassSearchModule" %}true{% else %}false{% endif %}
     },
 {% endfor %}
 ];

--- a/esp/esp/themes/theme_data/circles/templates/users/loginbox_content.html
+++ b/esp/esp/themes/theme_data/circles/templates/users/loginbox_content.html
@@ -61,6 +61,7 @@
 </div>
 
 {% comment %} === Admin Toolbar (includes user search) === {% endcomment %}
+{% load modules %}
 <link rel="stylesheet" type="text/css" href="/media/default_styles/admin_bar.css">
 <div id="adminbar" class="admin hidden" style="position: fixed !important">
   <div class="title" onclick="ESP.toggleDisplay('adminbar_content');">Admin Toolbar</div>
@@ -72,6 +73,7 @@ var currentPrograms = [
     {
         urlBase: "{{ current_program.getUrlBase }}",
         name: "{{ current_program.niceName }}",
+        class_search: {% if current_program|hasModule:"ClassSearchModule" %}true{% else %}false{% endif %}
     },
 {% endfor %}
 ];

--- a/esp/esp/themes/theme_data/circles/templates/users/loginbox_content.html
+++ b/esp/esp/themes/theme_data/circles/templates/users/loginbox_content.html
@@ -75,6 +75,7 @@ var currentPrograms = [
     },
 {% endfor %}
 ];
+var debug = {{ settings.DEBUG|yesno:"true,false" }};
 </script>
 <script type="text/javascript" src="/media/scripts/admin_bar.js"> </script>
 {% comment %} === End Admin Toolbar === {% endcomment %}

--- a/esp/esp/themes/theme_data/floaty/templates/main.html
+++ b/esp/esp/themes/theme_data/floaty/templates/main.html
@@ -22,6 +22,7 @@
 
 <div id="nav_area">
     {% comment %} === Admin Toolbar (includes user search) === {% endcomment %}
+    {% load modules %}
     <style>
         #content_area h2, h3, p, form {
 	        padding-left: 0px;
@@ -39,6 +40,7 @@
         {
             urlBase: "{{ current_program.getUrlBase }}",
             name: "{{ current_program.niceName }}",
+            class_search: {% if current_program|hasModule:"ClassSearchModule" %}true{% else %}false{% endif %}
         },
     {% endfor %}
     ];

--- a/esp/esp/themes/theme_data/floaty/templates/main.html
+++ b/esp/esp/themes/theme_data/floaty/templates/main.html
@@ -42,6 +42,7 @@
         },
     {% endfor %}
     ];
+    var debug = {{ settings.DEBUG|yesno:"true,false" }};
     </script>
     <script type="text/javascript" src="/media/scripts/admin_bar.js"> </script>
     {% comment %} === Ends Admin Toolbar (includes user search) === {% endcomment %}

--- a/esp/esp/themes/theme_data/floaty/templates/main.html
+++ b/esp/esp/themes/theme_data/floaty/templates/main.html
@@ -108,23 +108,6 @@
     </div>
     {% endif %}
     {% endif %}
-    
-    <!-- Old Admin
-    <div class="box admin hidden">
-    <div class="box_header"> Admin</div>	
-    <ul>
-    <li class="admin hidden"><a href="/admin/"><i class="glyphicon glyphicon-tasks" aria-hidden="true"></i> Administration pages</a>
-        <ul>
-            <li class="admin hidden"><a href="/admin/miniblog/entry/">Sidebar messages</a></li>
-            <li class="admin hidden"><a href="/admin/miniblog/announcementlink/">Sidebar links</a></li>
-        </ul>
-    </li>
-	<li class="admin hidden"><a href="/manage/programs/"><i class="glyphicon glyphicon-th-large" aria-hidden="true"></i> Manage programs</a></li>
-    <li class="admin hidden"><a href="/admin/filebrowser/browse/"><i class="glyphicon glyphicon-tasks" aria-hidden="true"></i> Manage media files</a>
-	<li class="admin hidden"><a href="/themes/"><i class="glyphicon glyphicon-pencil" aria-hidden="true"></i> Theme settings</a></li>
-    <li class="unmorph hidden"><a href="/myesp/switchback/">Unmorph to <script type="text/javascript">document.write(esp_user.cur_retTitle);</script></a></li>
-    </ul>
-    </div --->
 
     <!-- Onsite -->
     <div class="box onsite hidden">

--- a/esp/esp/themes/theme_data/fruitsalad/templates/main.html
+++ b/esp/esp/themes/theme_data/fruitsalad/templates/main.html
@@ -83,7 +83,8 @@ var currentPrograms = [
         class_search: {% if current_program|hasModule:"ClassSearchModule" %}true{% else %}false{% endif %}
     },
 {% endfor %}
-]; 
+];
+var debug = {{ settings.DEBUG|yesno:"true,false" }};
 </script>
 <script type="text/javascript" src="/media/scripts/admin_bar.js"> </script>
     <div id="page" class="{{ request.path|extract_theme }}">

--- a/esp/public/media/scripts/admin_bar.js
+++ b/esp/public/media/scripts/admin_bar.js
@@ -64,14 +64,16 @@ if (currentPrograms && currentPrograms.forEach) {
     currentPrograms.forEach(function (currentProgram) {
         ESP.registerAdminModule({
             content_html:
-                '<form id="class_search_form" name="class_search_form" method="get" action="/manage/' + currentProgram.urlBase + '/classsearch">' +
+                (currentProgram.class_search ? '<form id="class_search_form" name="class_search_form" method="get" action="/manage/' + currentProgram.urlBase + '/classsearch">' +
                 '<div class="input-append">' +
                 '<input type="text" id="class_search_field" name="namequery" placeholder="Find Class by Title" />' +
                 '<button type="submit" id="class_search_submit" name="class_search_submit" aria-label="Search" class="btn btn-default"><span class="glyphicon glyphicon-search glyphicon-btn-height" aria-hidden="true"></span></button>' +
                 '</div>' +
-                '</form>' +
+                '</form>' : '') +
                 '<div id="adminbar_Manage_content" class="content">' +
-                '    <a href="/manage/' + currentProgram.urlBase +'/main">Main Management Page</a><br /><a href="/manage/' + currentProgram.urlBase +'/dashboard">Program Dashboard</a><br /><a href="/onsite/' + currentProgram.urlBase +'/main">Main Onsite Page</a>' +
+                '<a href="/manage/' + currentProgram.urlBase +'/main">Main Management Page</a><br />' +
+                '<a href="/manage/' + currentProgram.urlBase +'/dashboard">Program Dashboard</a><br />' +
+                '<a href="/onsite/' + currentProgram.urlBase +'/main">Main Onsite Page</a>' +
                 '</div>',
             name: 'class_search',
             displayName: 'Manage ' + currentProgram.name

--- a/esp/public/media/scripts/admin_bar.js
+++ b/esp/public/media/scripts/admin_bar.js
@@ -80,7 +80,11 @@ if (currentPrograms && currentPrograms.forEach) {
 }
 
 ESP.registerAdminModule({
-    content_html: '<a href="/manage/programs/">Manage all programs</a><br/><a href="/manage/pages">Manage static pages</a><br /><a href="/admin/">Administration pages</a><br /><a href="/admin/filebrowser/browse/">Manage media files</a><br /><a href="/themes/">Manage theme settings</a>',
+    content_html: '<a href="/manage/programs/">Manage all programs</a><br/>' +
+                  '<a href="/manage/pages">Manage static pages</a><br />' +
+                  (debug ? '<a href="/admin/">Administration pages</a><br />' : '') +
+                  '<a href="/admin/filebrowser/browse/">Manage media files</a><br />' +
+                  '<a href="/themes/">Manage theme settings</a>',
     name: 'Other',
     displayName: 'Other Important Links'
 });

--- a/esp/templates/admin/base_site.html
+++ b/esp/templates/admin/base_site.html
@@ -23,6 +23,17 @@ ul.ui-autocomplete li
 {
     list-style-type: none;
 }
+.alert-danger {
+    color: #a94442;
+    background-color: #f2dede;
+    border-color: #ebccd1;
+}
+.alert {
+    padding: 15px;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    text-align: center;
+}
 </style>
 {% endblock %}
 
@@ -30,6 +41,9 @@ ul.ui-autocomplete li
 
 {% block nav-global %}{% endblock %}
 
-{% block userlinks %}
+{% block messages %}
+<div class="alert alert-danger">
+    You probably shouldn't be here! You should check out the <a href="/manage/programs">general management page</a> or the main management pages for individual programs before resorting to using these admin pages.
+</div>
 {{ block.super }}
-{% endblock userlinks %}
+{% endblock %}

--- a/esp/templates/sidebar/admin.html
+++ b/esp/templates/sidebar/admin.html
@@ -1,5 +1,5 @@
 <li class="hidden nav-header admin"> Admin</li>	
-	<li class="admin hidden"><a href="/admin/"><i class="icon-tasks"></i>Administration pages</a></li>
+	{% if settings.DEBUG %}<li class="admin hidden"><a href="/admin/"><i class="icon-tasks"></i>Administration pages</a></li>{% endif %}
 	<li class="admin hidden"><a href="/manage/programs/"><i class="icon-th-large"></i>Manage programs</a></li>
     <li class="admin hidden"><a href="/admin/filebrowser/browse/"><i class="icon-tasks"></i>Manage media files</a></li>
 	<li class="admin hidden"><a href="/themes/"><i class="icon-pencil"></i>Theme settings</a></li>


### PR DESCRIPTION
This removes the link to the admin pages for all themes (unless you are on a dev server). I also cleaned up some old code, made it so the class search field only shows if the class search module is enabled, and added a scary banner to the top of the admin pages.

Note, I'm not sure you can actually test the link removal functionality on a dev server, because I tried setting `DEBUG = False` in my settings, and it caused all sorts of issues.

Fixes #3497.