### PR TITLE
Custom form module fixes

### DIFF
--- a/esp/esp/program/modules/handlers/teachercustomformmodule.py
+++ b/esp/esp/program/modules/handlers/teachercustomformmodule.py
@@ -115,7 +115,10 @@ class TeacherCustomFormModule(ProgramModuleObj):
                 plain_form = form_wizard.get_form(step)
                 #   Load previous results, with a hack for multiple choice questions.
                 for field in plain_form.fields:
-                    if isinstance(plain_form.fields[field], forms.MultipleChoiceField):
+                    #   Some fields aren't saved or don't have values (e.g., instruction fields)
+                    if not hasattr(prev_results[0], field):
+                        continue
+                    elif isinstance(plain_form.fields[field], forms.MultipleChoiceField):
                         field_dict[field] = getattr(prev_results[0], field).split(';')
                     else:
                         field_dict[field] = getattr(prev_results[0], field)

--- a/esp/esp/program/modules/handlers/teacherquizmodule.py
+++ b/esp/esp/program/modules/handlers/teacherquizmodule.py
@@ -52,7 +52,7 @@ class TeacherQuizComboForm(ComboForm):
 
     def done(self, form_list, **kwargs):
         # Delete old records, if any exist, and then make a new one
-        rt = RecordType.objects.filter(name=self.event)
+        rt = RecordType.objects.get(name=self.event)
         Record.objects.filter(user=self.curr_request.user, program=self.program, event=rt).delete()
         Record.objects.create(user=self.curr_request.user, program=self.program, event=rt)
         return super(TeacherQuizComboForm, self).done(form_list=form_list, redirect_url = '/teach/'+self.program.getUrlBase()+'/teacherreg', **kwargs)

--- a/esp/esp/tagdict/__init__.py
+++ b/esp/esp/tagdict/__init__.py
@@ -896,7 +896,7 @@ all_program_tags = {
         'help_text': 'Form ID of the custom form used for student registration',
         'default': None,
         'category': 'learn',
-        'is_setting': True,
+        'is_setting': False,
         'field': forms.IntegerField(min_value=1),
     },
     'teach_extraform_id': {
@@ -904,7 +904,7 @@ all_program_tags = {
         'help_text': 'Form ID of the custom form used for teacher registration',
         'default': None,
         'category': 'teach',
-        'is_setting': True,
+        'is_setting': False,
         'field': forms.IntegerField(min_value=1),
     },
     'donation_settings': {
@@ -954,7 +954,7 @@ all_program_tags = {
         'help_text': 'The ID of the customform to associate with the Teacher Quiz Module',
         'default': None,
         'category': 'teach',
-        'is_setting': True,
+        'is_setting': False,
         'field': forms.IntegerField(min_value=1),
     },
     'display_registration_names': {


### PR DESCRIPTION
This makes the following fixes for custom form modules:

1. When loading a user's previous answers, skip questions that don't have answers (e.g., optional questions, instruction fields, etc)
2. Remove the custom form module tags from the tag settings page (custom forms should be linked to programs through the custom form editor)

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3556 and fixes https://github.com/learning-unlimited/ESP-Website/issues/3555.