### PR TITLE
Upgrade the catsflagsrecs page

### DIFF
--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -2061,6 +2061,9 @@ class ClassCategories(models.Model):
     symbol = models.CharField(max_length=1, default='?', blank=False, help_text='A single character to represent the category')
     seq = models.IntegerField(default=0, help_text='Categories will be ordered by this.  Smaller is earlier; the default is 0.')
 
+    def used_by_classes(self):
+        return ClassSubject.objects.filter(category=self).exists()
+
     class Meta:
         verbose_name_plural = 'Class categories'
         app_label = 'program'

--- a/esp/esp/program/models/flags.py
+++ b/esp/esp/program/models/flags.py
@@ -83,6 +83,9 @@ class ClassFlagType(models.Model):
     get_flag_types.depend_on_m2m('program.Program', 'flag_types', lambda prog, flag_type: {'program': prog})
     get_flag_types = classmethod(get_flag_types)
 
+    def used_by_flags(self):
+        return ClassFlag.objects.filter(flag_type=self).exists()
+
 class ClassFlag(models.Model):
     subject = AjaxForeignKey('ClassSubject', related_name='flags')
     flag_type = models.ForeignKey(ClassFlagType)

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -2289,6 +2289,9 @@ class RecordType(models.Model):
     def is_custom(self):
         return self.name not in self.BUILTIN_TYPES
 
+    def used_by_records(self):
+        return Record.objects.filter(event=self).exists()
+
     class Meta:
         app_label = 'users'
 

--- a/esp/templates/program/categories_and_flags.html
+++ b/esp/templates/program/categories_and_flags.html
@@ -41,6 +41,9 @@ function deleteRecordType() {
     Class Category, Flag Type, and Record Type Management
 </h2>
 
+<p>This page is for adding, removing, and editing website-wide Class Categories, Flag Types, and Record Types. Note that new categories and flag types will not automatically populate into existing programs.
+You will need to use the main settings page for a specific program to modify which of the categories and flag types below will be available for teachers and admins (respectively) for that program.</p>
+
 <div id="program_form">
 
     {% if open_section == "categories" %}
@@ -56,6 +59,10 @@ function deleteRecordType() {
 
     <div class="dspcont">
     {% endif %}
+
+    <p>Teachers choose categories for their classes when they register them. These categories are then displayed in schedules, catalogs, etc.
+    The following class <b>categories</b> are available to use for your programs. You can add another category or edit an existing one using the form below.
+    Note that you can not delete categories that are already being used for classes.</p>
 
     <form method="post">
     <input type="hidden" name="command" value="{% if cat_form.instance.id %}edit{% else %}add{% endif %}" />
@@ -97,7 +104,7 @@ function deleteRecordType() {
                         <input type="hidden" name="id" value="{{ cat.id }}" />
                         <input type="hidden" name="command" value="delete" />
                         <input type="hidden" name="object" value="category" />
-                        <input type="submit" value="Delete" class="btn btn-danger" />
+                        <input type="submit" value="Delete" class="btn btn-danger" {% if cat.used_by_classes %}disabled title="This category is used for classes and can not be deleted"{% endif %}/>
                     </form>
                 </center>
             </td>
@@ -119,6 +126,10 @@ function deleteRecordType() {
 
     <div class="dspcont">
     {% endif %}
+
+    <p>Flags allow you to annotate classes with particular information (e.g., classroom needs, needs further review).
+    The following flag <b>types</b> are available to use for your programs. You can add another flag type or edit an existing one using the form below.
+    Note that you can not delete flag types that are already being used for class flags.</p>
 
     <form method="post">
     <input type="hidden" name="command" value="{% if flag_form.instance.id %}edit{% else %}add{% endif %}" />
@@ -164,7 +175,7 @@ function deleteRecordType() {
                         <input type="hidden" name="id" value="{{ ft.id }}" />
                         <input type="hidden" name="command" value="delete" />
                         <input type="hidden" name="object" value="flag_type" />
-                        <input type="submit" value="Delete" class="btn btn-danger" />
+                        <input type="submit" value="Delete" class="btn btn-danger" {% if ft.used_by_flags %}disabled title="This flag type is used for flags and can not be deleted"{% endif %}/>
                     </form>
                 </center>
             </td>
@@ -186,6 +197,10 @@ function deleteRecordType() {
 
     <div class="dspcont">
     {% endif %}
+
+    <p>Records allow you to mark that a user has performed some action (e.g., checked into a program or took a survey) at a specific time.
+    The following record <b>types</b> are available to use for your programs (many of which are built-in). You can add another record type or edit an existing one using the form below.
+    Note that you can not edit or delete record types that are built-in. You also can not delete record types that are already being used for user records.</p>
 
     <form method="post">
     <input type="hidden" name="command" value="{% if rec_form.instance.id %}edit{% else %}add{% endif %}" />
@@ -227,7 +242,7 @@ function deleteRecordType() {
                         <input type="hidden" name="id" value="{{ rt.id }}" />
                         <input type="hidden" name="command" value="delete" />
                         <input type="hidden" name="object" value="record_type" />
-                        <input type="submit" value="Delete" class="btn btn-danger" {% if not rt.is_custom %}disabled title="Can not delete built-in record types" {% endif %}/>
+                        <input type="submit" value="Delete" class="btn btn-danger" {% if not rt.is_custom %}disabled title="Can not delete built-in record types" {% endif %}{% if rt.used_by_records %}disabled title="This record type is used for records and can not be deleted"{% endif %}/>
                     </form>
                 </center>
             </td>


### PR DESCRIPTION
The catsflagsrecs page (for editing Categories, Flag Types, and Record Types) was pretty bares when I first made it (#stablereleasecrunch). This fixes that by adding a bunch of textual information to the page to help admins understand what the different object types are. Further, objects that are now in-use (e.g., a category that is assigned to a class subject) can no longer be deleted (but can be edited).

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3558.