### PR TITLE
Finaid approval page fixes

### DIFF
--- a/esp/templates/program/modules/finaidapprovemodule/finaid.html
+++ b/esp/templates/program/modules/finaidapprovemodule/finaid.html
@@ -18,6 +18,12 @@
     #finaid_table {
       width: 100% !important;
       margin: 0px !important;
+      position: relative;
+    }
+    th {
+      position: sticky;
+      top: 0;
+      z-index: 10000;
     }
     </style>
 {% endblock %}
@@ -87,7 +93,7 @@ function toggle(source) {
     <input name="percent" type="number" min="0" step="1" max="100" value="100" required>
     <br />
     <input type="submit" value="Approve Requests" class="btn btn-primary" >
-    <input type="checkbox" id="approve_blanks_checkbox" name="approve_blanks" checked> Approve blank requests?
+    <input type="checkbox" id="approve_blanks_checkbox" name="approve_blanks"> Approve blank requests?
   </form>
 
   {% if error %}


### PR DESCRIPTION
This makes it so the header of the table doesn't move when you scroll the table and also changes the default setting to _not_ approve blank requests.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3563 and fixes https://github.com/learning-unlimited/ESP-Website/issues/3565.