### PR TITLE
Fix accounting search form

### DIFF
--- a/esp/templates/program/modules/accountingmodule/accounting.html
+++ b/esp/templates/program/modules/accountingmodule/accounting.html
@@ -20,7 +20,7 @@ table {
 {% block content %}
 <h2>Accounting{% if target_user %} for {{ target_user.name }} ({{ target_user.username }} / {{ target_user.id }}){% endif %}{% if prog_results|length_is:"1" %} for {{ prog_results.0.program.niceName }}{% endif %}</h2>
 <div id="program_form">
-<form id="accountingsearchform" name="accountingsearchform" method="POST">
+<form action="{% if program %}/manage/{{ program.getUrlBase }}/accounting{% else %}/accounting/user{% endif %}" id="accountingsearchform" name="accountingsearchform" method="POST">
 <table>
     <col width="85%">
     <col width="15%">


### PR DESCRIPTION
This fixes the accounting search form such that it always loads the selected user (from my testing, I think the only formerly broken edge case was when you had a user specified by a GET parameter then tried to select a new user with the search form). Note that this template is used for both the /accounting/user page and the /manage/x/y/accounting page.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3564.