### PR TITLE
Force browsers to update cached css when theme is changed

### DIFF
--- a/esp/esp/tagdict/__init__.py
+++ b/esp/esp/tagdict/__init__.py
@@ -465,6 +465,13 @@ all_global_tags = {
         'is_setting': True,
         'field': forms.DateField(widget=forms.SelectDateWidget(years=[datetime.date.today().year]))
     },
+    'current_theme_version': {
+        'is_boolean': False,
+        'help_text': 'A random hexidecimal string to force browser refreshing of theme files',
+        'default': "8daf9a",
+        'category': 'manage',
+        'is_setting': False,
+    },
 }
 
 # Any tag used with Tag.getProgramTag()

--- a/esp/esp/themes/controllers.py
+++ b/esp/esp/themes/controllers.py
@@ -39,6 +39,7 @@ logger = logging.getLogger(__name__)
 import os
 import os.path
 import shutil
+import random
 import re
 import subprocess
 import tempfile
@@ -274,6 +275,7 @@ class ThemeController(object):
         with open(output_filename, 'w') as output_file:
             output_file.write(THEME_COMPILED_WARNING + css_data)
         logger.debug('Wrote %.1f KB CSS output to %s', len(css_data) / 1000., output_filename)
+        Tag.setTag("current_theme_version", value = hex(random.getrandbits(16)))
 
     def recompile_theme(self, theme_name=None, customization_name=None, keep_files=None):
         """
@@ -357,6 +359,7 @@ class ThemeController(object):
         Tag.unSetTag('current_theme_name')
         Tag.unSetTag('current_theme_params')
         Tag.unSetTag('current_theme_palette')
+        Tag.unSetTag('current_theme_version')
         self.unset_current_customization()
 
         #   Clear the Varnish cache

--- a/esp/esp/utils/web.py
+++ b/esp/esp/utils/web.py
@@ -61,6 +61,7 @@ def get_from_id(id, module, strtype = 'object', error = True):
 
 def render_to_response(template, request, context, content_type=None, use_request_context=True):
     from esp.web.views.navBar import makeNavBar
+    from esp.tagdict.models import Tag
 
     if isinstance(template, (basestring,)):
         template = [ template ]
@@ -68,6 +69,7 @@ def render_to_response(template, request, context, content_type=None, use_reques
     section = request.path.split('/')[1]
     tc = ThemeController()
     context['theme'] = tc.get_template_settings()
+    context['current_theme_version'] = Tag.getTag("current_theme_version")
     context['settings'] = settings
 
     context['current_programs'] = Program.current_programs()

--- a/esp/templates/elements/html
+++ b/esp/templates/elements/html
@@ -15,7 +15,7 @@
     <link rel="stylesheet" type="text/css" href="/media/styles/qsd.css" />
 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/2.3.2/css/bootstrap-responsive.css" rel="stylesheet"/>
-    <link rel="stylesheet" type="text/css" href="/media/styles/theme_compiled.css"/>
+    <link rel="stylesheet" type="text/css" href="/media/styles/theme_compiled.css?v={{ current_theme_version }}"/>
     <link href="{{ settings.CDN_ADDRESS }}/bootstrap/docs/assets/js/google-code-prettify/prettify.css" rel="stylesheet"/>
 
     <link rel="stylesheet" type="text/css" href="/media/styles/user_visibility.css" media="all" />


### PR DESCRIPTION
There's always been this really annoying bug/feature when you change themes that forces you to hard-refresh the page to force your browser to get the new version of the compiled theme css file.

Now, whenever you change the theme, it effectively changes the URL of the css file, so it will immediately be refreshed by your browser. I imagine this should also result in faster theme changes on the normal user side as well.