### PR TITLE
Docs for SR14-fixes patch

### DIFF
--- a/docs/admin/releases/14/README.rst
+++ b/docs/admin/releases/14/README.rst
@@ -176,3 +176,12 @@ Dependency changes
 ~~~~~~~~~~~~~~~~~~
 - Upgraded jQuery (1.12.4 -> 3.6.0)
 - Upgraded jQuery UI (1.12.1 -> 1.13.0)
+
+November 2022 Patch
+===================
+
+Minor new features
+~~~~~~~~~~~~~~~~~~
+
+Minor bug fixes
+~~~~~~~~~~~~~~~


### PR DESCRIPTION
This is a PR for all of the documentation for the SR14 fixes release planned for November 2022.