### PR TITLE
Add reCAPTCHA to the contact form

### DIFF
--- a/esp/esp/django_settings.py
+++ b/esp/esp/django_settings.py
@@ -247,6 +247,7 @@ INSTALLED_APPS = (
     'argcache.apps.ArgCacheConfig',
     'django_extensions',
     'reversion',
+    'captcha',
     'form_utils',
     'django.contrib.redirects',
     'debug_toolbar',

--- a/esp/esp/django_settings.py
+++ b/esp/esp/django_settings.py
@@ -411,3 +411,5 @@ ADMIN_TOOLS_INDEX_DASHBOARD = 'admintoolsdash.CustomIndexDashboard'
 ADMIN_TOOLS_APP_INDEX_DASHBOARD = 'admintoolsdash.CustomAppIndexDashboard'
 
 ADMIN_TOOLS_THEMING_CSS = '/media/default_styles/admin_theme.css'
+
+SILENCED_SYSTEM_CHECKS = ['captcha.recaptcha_test_key_error']

--- a/esp/esp/web/forms/contact_form.py
+++ b/esp/esp/web/forms/contact_form.py
@@ -38,6 +38,8 @@ from django.utils.translation import gettext_lazy as _
 
 from django.conf import settings
 
+from captcha.fields import ReCaptchaField
+
 person_type = (
     ('Student', 'K-12 Student'),
     ('Parent',  'Parent/Guardian'),
@@ -84,4 +86,4 @@ class ContactForm(forms.Form):
     # checking whether they want to recover login information.
     decline_password_recovery = forms.BooleanField(required=False, widget=forms.HiddenInput)
 
-
+    captcha = ReCaptchaField()

--- a/esp/requirements.txt
+++ b/esp/requirements.txt
@@ -9,6 +9,7 @@ django-filebrowser-no-grappelli==3.8.0 # Provides admin panel interface for file
 django-form-utils==1.0.3 # Provides BetterForm (used in customforms) and BetterModelForm (used in program creation)
 django-formtools==2.1 # Used once in customforms
 django-localflavor==1.1 # Provides address and phone number fields
+django-recaptcha==2.0.6 # Provides support for Google reCAPTCHA
 django-reversion==1.10.0 # Handles versioning, currently for QSD and TemplateOverrides
 django-selenium==0.9.8 # Runs selenium tests which probably don't work anymore
 django-sendgrid-v5==0.9.0 # Provides support for using SendGrid as the EmailBackend


### PR DESCRIPTION
This adds google's [reCAPTCHA](https://www.google.com/recaptcha/about/) to the contact form using the [django-captcha package](https://github.com/torchbox/django-recaptcha/tree/2.0.6). This should cut down on the spam to this form.

![image](https://user-images.githubusercontent.com/7232514/198428734-24b6d839-63c6-4fdd-aaa5-d0633e47f0b0.png)

Fixes #2303.