### PR TITLE
Student self checkin

### DIFF
--- a/esp/esp/program/modules/forms/admincore.py
+++ b/esp/esp/program/modules/forms/admincore.py
@@ -1,6 +1,7 @@
 from decimal import Decimal
 from django import forms
 from django.contrib import admin
+from django.template import Template, Context
 from django.template.loader import select_template
 from django.utils.safestring import mark_safe
 from form_utils.forms import BetterForm, BetterModelForm
@@ -207,7 +208,12 @@ class ProgramTagSettingsForm(BetterForm):
                     self.fields[key] = forms.BooleanField()
                 else:
                     self.fields[key] = forms.CharField()
-                self.fields[key].help_text = tag_info.get('help_text', '')
+                # some help texts need to be rendered
+                if key in ['student_self_checkin']:
+                    template = Template(tag_info.get('help_text', ''))
+                    self.fields[key].help_text = template.render(Context({'program': self.program}))
+                else:
+                    self.fields[key].help_text = tag_info.get('help_text', '')
                 self.fields[key].initial = self.fields[key].default = tag_info.get('default')
                 self.fields[key].required = False
                 set_val = Tag.getBooleanTag(key, program = self.program) if tag_info.get('is_boolean', False) else Tag.getProgramTag(key, program = self.program)

--- a/esp/esp/program/modules/handlers/nametagmodule.py
+++ b/esp/esp/program/modules/handlers/nametagmodule.py
@@ -69,10 +69,11 @@ class NameTagModule(ProgramModuleObj):
         context.update(usc.prepare_context(prog, target_path='/manage/%s/generatetags' % prog.url))
         context['combo_form'] = False
         context['include_continue'] = False
+        context['self_checkin'] = Tag.getProgramTag('student_self_checkin', program = prog) == 'code'
 
         return render_to_response(self.baseDir()+'selectoptions.html', request, context)
 
-    def nametag_data(self, users_list1, user_title1, users_list2 = ESPUser.objects.none(), user_title2 = None):
+    def nametag_data(self, users_list1, user_title1, users_list2 = ESPUser.objects.none(), user_title2 = None, program = None):
         users = []
         users_list = [ user for user in users_list1 | users_list2]
         users_list = filter(lambda x: len(x.first_name+x.last_name), users_list)
@@ -83,10 +84,13 @@ class NameTagModule(ProgramModuleObj):
                 title = user_title1
             else:
                 title = user_title2
-            users.append({'title': title,
-                          'name' : '%s %s' % (user.first_name, user.last_name),
-                          'id'   : user.id,
-                          'username': user.username})
+            user_dict = {'title': title,
+                         'name' : '%s %s' % (user.first_name, user.last_name),
+                         'id'   : user.id,
+                         'username': user.username}
+            if program and Tag.getProgramTag('student_self_checkin', program = program) == 'code':
+                user_dict['hash'] = user.userHash(program)
+            users.append(user_dict)
         return users
 
     @aux_call
@@ -108,7 +112,7 @@ class NameTagModule(ProgramModuleObj):
             data = ListGenModule.processPost(request)
             usc = UserSearchController()
             filterObj = usc.filter_from_postdata(prog, data)
-            users = self.nametag_data(ESPUser.objects.filter(filterObj.get_Q()).distinct(), user_title)
+            users = self.nametag_data(ESPUser.objects.filter(filterObj.get_Q()).distinct(), user_title, program = prog)
 
         elif idtype == 'students':
             user_title = "Student"
@@ -118,7 +122,7 @@ class NameTagModule(ProgramModuleObj):
             else:
                 students = ESPUser.objects.filter(student_dict['confirmed']).distinct()
 
-            users = self.nametag_data(students, user_title)
+            users = self.nametag_data(students, user_title, program = prog)
 
         elif idtype == 'teacher':
             user_title = "Teacher"

--- a/esp/esp/program/modules/handlers/studentonsite.py
+++ b/esp/esp/program/modules/handlers/studentonsite.py
@@ -258,9 +258,7 @@ class SelfCheckinForm(forms.Form):
             raise KeyError('Need to supply program and user as named arguments to SelfCheckinForm')
         super(SelfCheckinForm, self).__init__(*args, **kwargs)
         mode = Tag.getProgramTag('student_self_checkin', program = program)
-        user_hash = hash(str(user.id) + str(program.id))
-        self.hash = '{0:06d}'.format(abs(user_hash))[:6]
-        print(self.hash)
+        self.hash = user.userHash(program)
         if mode != 'code':
             self.fields['code'].initial = self.hash
             self.fields['code'].widget = forms.HiddenInput()

--- a/esp/esp/program/modules/handlers/studentonsite.py
+++ b/esp/esp/program/modules/handlers/studentonsite.py
@@ -75,6 +75,7 @@ class StudentOnsite(ProgramModuleObj, CoreModule):
         context['webapp_page'] = 'schedule'
         context['scrmi'] = prog.studentclassregmoduleinfo
         context['checked_in'] = prog.isCheckedIn(user)
+        context['checkin_note'] = Tag.getProgramTag('student_onsite_checkin_note', program = prog)
 
         return render_to_response(self.baseDir()+'schedule.html', request, context)
 

--- a/esp/esp/tagdict/__init__.py
+++ b/esp/esp/tagdict/__init__.py
@@ -1214,12 +1214,13 @@ all_program_tags = {
                       students must have completed all required steps of student registration before \
                       they can check themselves in. The self checkin page is intentionally not linked \
                       to from anywhere in student registration. If this is enabled, you will need to \
-                      provide the URL to students somehow (e.g., via a printed QR code). If unique codes \
-                      are required, these can be printed on nametags via the nametag module.',
+                      provide the <a href="{{ program.get_learn_url }}selfcheckin">URL</a> to students somehow \
+                      (e.g., via a printed QR code). If unique codes are required, these can be printed \
+                      on nametags via the <a href="{{ program.get_manage_url }}selectidoptions">nametag module</a>.',
         'default': 'none',
         'category': 'onsite',
         'is_setting': True,
-        'field': forms.ChoiceField(choices=[('none', 'None (disable student self checkin'),
+        'field': forms.ChoiceField(choices=[('none', 'None (disable student self checkin)'),
                                             ('open', 'Students only need to access the self checkin page'),
                                             ('code', 'Students must enter their unique code to check themselves in')]),
     },

--- a/esp/esp/tagdict/__init__.py
+++ b/esp/esp/tagdict/__init__.py
@@ -1151,6 +1151,13 @@ all_program_tags = {
         'category': 'onsite',
         'is_setting': True,
     },
+    'student_onsite_checkin_note': {
+        'is_boolean': False,
+        'help_text': 'The message that is shown at the top of the student webapp schedule when a student is NOT checked in.',
+        'default': 'Note: You will not be able to change any classes or see your classrooms until after your check-in has been processed by the admin team.',
+        'category': 'onsite',
+        'is_setting': True,
+    },
     'availability_group_tolerance': {
         'is_boolean': False,
         'help_text': 'Time blocks must be less than this many minutes apart to be shown as contiguous for the availability module(s). This will not impact the calculation of possible class durations (see the "Timeblock contiguous tolerance" tag below).',

--- a/esp/esp/tagdict/__init__.py
+++ b/esp/esp/tagdict/__init__.py
@@ -1111,14 +1111,14 @@ all_program_tags = {
         'is_boolean': False,
         'help_text': 'At what time should the student onsite webapp use program attendance if available (instead of enrollment) to determine if a class is full? If blank, program attendance numbers will not be used. Format: HH:MM where HH is in 24 hour time.',
         'default': None,
-        'category': 'learn',
+        'category': 'onsite',
         'is_setting': True,
     },
     'switch_lag_class_attendance': {
         'is_boolean': False,
         'help_text': 'How many minutes into a class should the student onsite webapp use class attendance numbers if available (instead of enrollment or program attendance) to determine if a class is full? If blank, class attendance numbers will not be used.',
         'default': None,
-        'category': 'learn',
+        'category': 'onsite',
         'is_setting': True,
         'field': forms.IntegerField(min_value=0),
     },
@@ -1148,7 +1148,7 @@ all_program_tags = {
         'is_boolean': False,
         'help_text': 'The message that is shown at the top of the teacher webapp schedule when a teacher is NOT checked in.',
         'default': 'Note: Please make sure to check in before your first class today.',
-        'category': 'teach',
+        'category': 'onsite',
         'is_setting': True,
     },
     'availability_group_tolerance': {
@@ -1200,6 +1200,21 @@ all_program_tags = {
         'field': forms.ChoiceField(choices=[('all', 'All students'),
                                             ('program_attendance', 'Only students who attended the program'),
                                             ('class_attendance', 'Only students who attended at least one class')]),
+    },
+    'student_self_checkin': {
+        'is_boolean': False,
+        'help_text': 'Which student self checkin mode would you like to use? Note that, when enabled, \
+                      students must have completed all required steps of student registration before \
+                      they can check themselves in. The self checkin page is intentionally not linked \
+                      to from anywhere in student registration. If this is enabled, you will need to \
+                      provide the URL to students somehow (e.g., via a printed QR code). If unique codes \
+                      are required, these can be printed on nametags via the nametag module.',
+        'default': 'none',
+        'category': 'onsite',
+        'is_setting': True,
+        'field': forms.ChoiceField(choices=[('none', 'None (disable student self checkin'),
+                                            ('open', 'Students only need to access the self checkin page'),
+                                            ('code', 'Students must enter their unique code to check themselves in')]),
     },
 }
 

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -1136,6 +1136,10 @@ class BaseESPUser(object):
             rank = default
         return rank
 
+    def userHash(self, program):
+        user_hash = hash(str(self.id) + str(program.id))
+        return '{0:06d}'.format(abs(user_hash))[:6]
+
 class ESPUser(User, BaseESPUser):
     """ Create a user of the ESP Website
     This user extends the auth.User of django"""

--- a/esp/public/media/default_styles/webapp.css
+++ b/esp/public/media/default_styles/webapp.css
@@ -387,3 +387,13 @@ table.sortable tbody tr:nth-child(2n) td {
 table.sortable tbody tr:nth-child(2n+1) td {
   background: #fff;
 }
+
+#id_code {
+  font-size: xx-large;
+}
+
+#checkin_form .errorlist {
+  list-style-type: none;
+  padding-left: 0;
+  color: #c50000;
+}

--- a/esp/templates/program/modules/nametagmodule/ids.html
+++ b/esp/templates/program/modules/nametagmodule/ids.html
@@ -15,7 +15,8 @@ body { font-family: georgia;
 .idback .help { font-size: 16px; font-weight: bolder; text-align:
                 center; }
 .idback .mapimg { width: 3.95in; height:2.18in; border: 1px solid black; }
-.idback .barcode { width: 3.4in; position: relative; top: 1in; left: .2in; }
+.idback .barcode { width: 3.4in; position: relative; left: .2in; }
+.idback .marginator { margin-top: .6in; }
 
 .singleid,.idback,.numlabel { width:3.9in; height: 3in; overflow: hidden;
             text-align: center; margin: 0px; padding: 0px;}

--- a/esp/templates/program/modules/nametagmodule/selectoptions.html
+++ b/esp/templates/program/modules/nametagmodule/selectoptions.html
@@ -130,7 +130,7 @@ To have good quality IDs:<br />
 <br />
 <br />
 <input type="checkbox" name="barcodes" id="barcodes" />
-<label for="barcodes"> Display barcodes for user ID numbers on back of nametags</label>
+<label for="barcodes"> Display barcodes for user ID numbers{% if self_checkin %} and self checkin codes{% endif %} on back of nametags</label>
 <br />
 <br />
 </div>

--- a/esp/templates/program/modules/nametagmodule/singleidback.html
+++ b/esp/templates/program/modules/nametagmodule/singleidback.html
@@ -1,31 +1,37 @@
 <script type="text/javascript" src="/media/scripts/nametag_barcodes.js"></script>
 
 <div class="idback">
-<div class="marginator">
-    {% if user.id %}
-        <div class="barcode">
-        <div id="inputdata{{ user.id }}">{{ user.id }}</div>
-        </div>
+    <div class="marginator">
+        {% if user.hash %}
+            <div>
+                <h3>Self checkin code: {{ user.hash }}</h3>
+            </div>
+        {% endif %}
+        
+        {% if user.id %}
+            <div class="barcode">
+                <div id="inputdata{{ user.id }}">{{ user.id }}</div>
+            </div>
 
-        <br />
+            <br />
 
-        <script type="text/javascript">
-        /* <![CDATA[ */
-          function get_object(id) {
-           var object = null;
-           if (document.layers) {
-            object = document.layers[id];
-           } else if (document.all) {
-            object = document.all[id];
-           } else if (document.getElementById) {
-            object = document.getElementById(id);
-           }
-           return object;
-          }
-        get_object("inputdata{{ user.id }}").innerHTML=DrawCode39Barcode(get_object("inputdata{{ user.id }}").innerHTML,0);
-        /* ]]> */
-        </script>
-    {% endif %}
-</div>
+            <script type="text/javascript">
+            /* <![CDATA[ */
+              function get_object(id) {
+               var object = null;
+               if (document.layers) {
+                object = document.layers[id];
+               } else if (document.all) {
+                object = document.all[id];
+               } else if (document.getElementById) {
+                object = document.getElementById(id);
+               }
+               return object;
+              }
+            get_object("inputdata{{ user.id }}").innerHTML=DrawCode39Barcode(get_object("inputdata{{ user.id }}").innerHTML,0);
+            /* ]]> */
+            </script>
+        {% endif %}
+    </div>
 </div>
 <!-- End ID //-->

--- a/esp/templates/program/modules/studentonsite/schedule.html
+++ b/esp/templates/program/modules/studentonsite/schedule.html
@@ -26,7 +26,7 @@ function togglePopup() {
         <th colspan="3" class="user_info">
             <i>Classes for {{user.first_name}} {{user.last_name}} - ID: {{user.id}}</i>
             {% if not checked_in %}
-                <p class="checkinnote">Note: You will not be able to change any classes or see your classrooms until after your check-in has been processed by the admin team.</p>
+                <p class="checkinnote">{{ checkin_note }}</p>
             {% endif %}
         </th>
         {% for timeslot in timeslots %}

--- a/esp/templates/program/modules/studentonsite/selfcheckin.html
+++ b/esp/templates/program/modules/studentonsite/selfcheckin.html
@@ -1,0 +1,70 @@
+{% extends "program/modules/studentonsite/webapp.html" %}
+
+{% block body %}
+
+<center>
+    <div class="main">
+        <table>
+            <tr>
+                <th class="user_info">
+                    <i>Self Checkin for {{user.first_name}} {{user.last_name}} - ID: {{user.id}}</i>
+                </th>
+            </tr>
+        </table>
+        {% if checked_in %}
+        <table>
+            <tr>
+                <td>
+                    You are already checked in. <a href="/learn/{{one}}/{{two}}/studentonsite">Click here</a> to go to your class schedule.
+                </td>
+            </tr>
+        </table>
+        {% elif modules or records %}
+        <table>
+            <tr>
+                <td>
+                    <b>You must complete the following registration requirements before you can check yourself in:</b>
+                </td>
+            </tr>
+            {% for module in modules %}
+            {% if module.isStep and module.isRequired and not module.isRequired %}
+            <tr>
+                <td>
+                {% autoescape off %}{{ module.makeLink }}{% endautoescape %}
+                {% if module.required_label %}<i>{{ module.required_label }}</i>{% endif %}
+                </td>
+            </tr>
+            {% endif %}
+            {% endfor %}
+            {% for record in records %}
+            <tr>
+                <td>{{ record.full_event }}</td>
+            </tr>
+            {% endfor %}
+        </table>
+        {% else %}
+        <form method="POST">
+            {% csrf_token %}
+            <table id="checkin_form">
+                <tr>
+                    <td colspan="2">
+                        {% if mode == "code" %}
+                        Enter your self checkin code below, then hit Submit to check yourself in
+                        {% else %}
+                        Click the Submit button to check yourself in
+                        {% endif %}
+                    </td>
+                </tr>
+                {{ form.as_table }}
+                <tr>
+                    <td colspan="2">
+                        <input type="submit" value="Submit" style="font-size: xx-large;">
+                    </td>
+                </tr>
+            </table>
+        </form>
+        {% endif %}
+    </div>
+</center>
+
+{% endblock %}


### PR DESCRIPTION
This adds the infrastructure for students to check themselves in if they have already completed all required registration actions. This includes (partially copied from #2892):

- A tag that specifies whether self checkin requires a unique code or not (or whether it is disabled, the default)
- If a unique code is NOT required, then students just need to go to a page with a checklist of required uncompleted tasks. If the whole checklist is done (in which case there is no checklist), they can click a button and they are checked-in and are taken to the webapp
- If a unique code is REQUIRED, then students will need a code for the same page. This code is a short hash code is unique to a student and the particular program. They need to enter this code into the form to check themselves in.
- These hash codes can be included on the backs of student nametags along with the existing barcodes.

Requested by Stanford.

Fixes #2892.