### PR TITLE
Change extracost selections after paying

### DIFF
--- a/esp/esp/program/modules/forms/lineitems.py
+++ b/esp/esp/program/modules/forms/lineitems.py
@@ -16,6 +16,9 @@ class LineItemForm(forms.ModelForm):
         }
         help_texts = {
             'required': 'Should this line item be automatically added for every student?',
+            'for_finaid': 'Should financial aid cover this line item? Note that if this is checked, all quantities will be covered up to the max quantity. \
+                           If you would like only one instance of this line item to be covered by financial aid, you should set the max quantity to 1 and make \
+                           a duplicate line item with a different name and higher max quantity that is not covered by financial aid.'
         }
         widgets = {
             'amount_dec': forms.NumberInput(attrs={'placeholder': '(cost)'}),

--- a/esp/esp/program/modules/forms/splashinfo.py
+++ b/esp/esp/program/modules/forms/splashinfo.py
@@ -34,9 +34,10 @@ Learning Unlimited, Inc.
 
 from django import forms
 from esp.program.models import Program
+from esp.utils.widgets import RadioSelectWithData
 
 class SiblingDiscountForm(forms.Form):
-    siblingdiscount = forms.TypedChoiceField(choices=[], coerce=lambda x: x == 'True', widget=forms.RadioSelect)
+    siblingdiscount = forms.TypedChoiceField(choices=[], coerce=lambda x: x == 'True')
     siblingname = forms.CharField(max_length=128, required=False)
 
     def __init__(self, *args, **kwargs):
@@ -44,10 +45,14 @@ class SiblingDiscountForm(forms.Form):
             program = kwargs.pop('program')
         else:
             raise KeyError('Need to supply program as named argument to SiblingDiscountForm')
-        self.base_fields['siblingdiscount'].choices = [(False, 'I am the first in my household enrolling in Splash (+ $' + str(program.base_cost) + ').'),
-                                                       (True, 'I have a sibling already enrolled in Splash (+ $' + str(program.base_cost - program.sibling_discount) + ').')]
-        self.base_fields['siblingdiscount'].initial = True
         super(SiblingDiscountForm, self).__init__(*args, **kwargs)
+        choices = [(False, 'I am the first in my household enrolling in Splash (+ $' + str(program.base_cost) + ').'),
+                   (True, 'I have a sibling already enrolled in Splash (+ $' + str(program.base_cost - program.sibling_discount) + ').')]
+        option_data = {False: {'cost': program.base_cost},
+                       True: {'cost': program.base_cost - program.sibling_discount}}
+        self.fields['siblingdiscount'].widget = RadioSelectWithData(option_data=option_data)
+        self.fields['siblingdiscount'].choices = choices
+        self.fields['siblingdiscount'].initial = True
 
     def clean(self):
         cleaned_data = super(SiblingDiscountForm, self).clean()

--- a/esp/esp/program/modules/forms/splashinfo.py
+++ b/esp/esp/program/modules/forms/splashinfo.py
@@ -48,8 +48,8 @@ class SiblingDiscountForm(forms.Form):
         super(SiblingDiscountForm, self).__init__(*args, **kwargs)
         choices = [(False, 'I am the first in my household enrolling in Splash (+ $' + str(program.base_cost) + ').'),
                    (True, 'I have a sibling already enrolled in Splash (+ $' + str(program.base_cost - program.sibling_discount) + ').')]
-        option_data = {False: {'cost': program.base_cost},
-                       True: {'cost': program.base_cost - program.sibling_discount}}
+        option_data = {False: {'cost': program.base_cost, 'for_finaid': 'true'},
+                       True: {'cost': program.base_cost - program.sibling_discount, 'for_finaid': 'true'}}
         self.fields['siblingdiscount'].widget = RadioSelectWithData(option_data=option_data)
         self.fields['siblingdiscount'].choices = choices
         self.fields['siblingdiscount'].initial = True

--- a/esp/esp/program/modules/handlers/studentextracosts.py
+++ b/esp/esp/program/modules/handlers/studentextracosts.py
@@ -166,14 +166,6 @@ class StudentExtraCosts(ProgramModuleObj):
         if iac.has_paid():
             if not Tag.getBooleanTag('already_paid_extracosts_allowed', program = prog):
                 raise ESPError("You've already paid for this program.  Please make any further changes onsite so that we can charge or refund you properly.", log=False)
-        selected_types = [t.line_item for t in iac.get_transfers().select_related('line_item')]
-        paid_types = []
-        for t in iac.get_transfers().select_related('line_item'):
-            if t.paid_in is not None:
-                paid_types.append(t.line_item)
-        # TODO: add disabled attribute to paid_types
-
-
 
         #   Determine which line item types we will be asking about
         costs_list = self.lineitemtypes().filter(max_quantity__lte=1, lineitemoptions__isnull=True)

--- a/esp/esp/tagdict/__init__.py
+++ b/esp/esp/tagdict/__init__.py
@@ -131,20 +131,6 @@ all_global_tags = {
         'category': 'learn',
         'is_setting': True,
     },
-    'already_paid_extracosts_allowed': {
-        'is_boolean': True,
-        'help_text': 'Whether students should be able to return to the extracosts page to add items or change options after they have already paid once via credit card.',
-        'default': True ,
-        'category': 'learn',
-        'is_setting': True,
-    },
-    'already_paid_extracosts_text': {
-        'is_boolean': False,
-        'help_text': 'The message that will be shown to users who have already paid by credit card and have returned to the extra costs page, if allowed.',
-        'default': 'You have already paid for some selected items via credit card and cannot remove these items using this form. If an item has multiple options, you may switch your selected option to an option of equal or greater cost; you cannot select a less expensive option using this form. You may still add items and will need to pay the extra balance.' ,
-        'category': 'learn',
-        'is_setting': True,
-    },
     'onsite_classlist_min_refresh': {
         'is_boolean': False,
         'help_text': 'Maximum refresh speed for the onsite classlist to avoid server overload (in seconds).',
@@ -1237,6 +1223,19 @@ all_program_tags = {
         'field': forms.ChoiceField(choices=[('none', 'None (disable student self checkin)'),
                                             ('open', 'Students only need to access the self checkin page'),
                                             ('code', 'Students must enter their unique code to check themselves in')]),
+    'already_paid_extracosts_allowed': {
+        'is_boolean': True,
+        'help_text': 'Whether students should be able to return to the extracosts page to add items or change options after they have already paid once via credit card.',
+        'default': True ,
+        'category': 'learn',
+        'is_setting': True,
+    },
+    'already_paid_extracosts_text': {
+        'is_boolean': False,
+        'help_text': 'The message that will be shown to users who have already paid by credit card and have returned to the extra costs page, if allowed.',
+        'default': 'You have already paid for some selected items via credit card and cannot remove these items using this form. If an item has multiple options, you may switch your selected option to an option of equal or greater cost; you cannot select a less expensive option using this form. You may still add items and will need to pay the extra balance.' ,
+        'category': 'learn',
+        'is_setting': True,
     },
 }
 

--- a/esp/esp/tagdict/__init__.py
+++ b/esp/esp/tagdict/__init__.py
@@ -131,6 +131,20 @@ all_global_tags = {
         'category': 'learn',
         'is_setting': True,
     },
+    'already_paid_extracosts_allowed': {
+        'is_boolean': True,
+        'help_text': 'Whether students should be able to return to the extracosts page to add items or change options after they have already paid once via credit card.',
+        'default': True ,
+        'category': 'learn',
+        'is_setting': True,
+    },
+    'already_paid_extracosts_text': {
+        'is_boolean': False,
+        'help_text': 'The message that will be shown to users who have already paid by credit card and have returned to the extra costs page, if allowed.',
+        'default': 'You have already paid for some selected items via credit card and cannot remove these items using this form. If an item has multiple options, you may switch your selected option to an option of equal or greater cost; you cannot select a less expensive option using this form. You may still add items and will need to pay the extra balance.' ,
+        'category': 'learn',
+        'is_setting': True,
+    },
     'onsite_classlist_min_refresh': {
         'is_boolean': False,
         'help_text': 'Maximum refresh speed for the onsite classlist to avoid server overload (in seconds).',

--- a/esp/esp/tagdict/__init__.py
+++ b/esp/esp/tagdict/__init__.py
@@ -1223,6 +1223,7 @@ all_program_tags = {
         'field': forms.ChoiceField(choices=[('none', 'None (disable student self checkin)'),
                                             ('open', 'Students only need to access the self checkin page'),
                                             ('code', 'Students must enter their unique code to check themselves in')]),
+    },
     'already_paid_extracosts_allowed': {
         'is_boolean': True,
         'help_text': 'Whether students should be able to return to the extracosts page to add items or change options after they have already paid once via credit card.',
@@ -1233,7 +1234,11 @@ all_program_tags = {
     'already_paid_extracosts_text': {
         'is_boolean': False,
         'help_text': 'The message that will be shown to users who have already paid by credit card and have returned to the extra costs page, if allowed.',
-        'default': 'You have already paid for some selected items via credit card and cannot remove these items using this form. If an item has multiple options, you may switch your selected option to an option of equal or greater cost; you cannot select a less expensive option using this form. You may still add items and will need to pay the extra balance.' ,
+        'default': 'You have already paid for this program via credit card. You are welcome to change your \
+                    selections below. If your new balance is larger than what you have already paid, \
+                    you can pay the remaining balance via credit card. If your new balance is smaller \
+                    than what you have already paid, we will treat the negative balance as a donation \
+                    to our program (thanks!).' ,
         'category': 'learn',
         'is_setting': True,
     },

--- a/esp/public/media/scripts/program/modules/extracosts.js
+++ b/esp/public/media/scripts/program/modules/extracosts.js
@@ -6,7 +6,7 @@ var amount_due = 0;
 var prog_cost = 0;
 
 $j(function() { 
-    amount_paid = parseFloat($j("#amount_paid").data("total"));
+    amount_paid = parseFloat($j("#amount_paid").data("total")) || 0;
     finaid_percent = (parseFloat($j("#amount_finaid").data("percent")) || 0) * 0.01;
     finaid_max_dec = parseFloat($j("#amount_finaid").data("max_dec")) || 0;
     prog_cost = parseFloat($j("#amount_cost").data("total")) || 0;
@@ -47,7 +47,7 @@ function updateTotalCost() {
     $j("#total_cost").html("$" + Number(total_cost).toFixed(2));
     amount_finaid = Math.min(finaid_covered, finaid_max_dec);
     if (amount_finaid < finaid_covered) amount_finaid += (finaid_covered - amount_finaid) * finaid_percent;
-    $j("#amount_finaid").html("-$" + Number(amount_finaid).toFixed(2));
+    if (amount_finaid > 0) $j("#amount_finaid").html("-$" + Number(amount_finaid).toFixed(2));
     amount_due = total_cost - amount_paid - amount_finaid;
     if (amount_due < 0) {
         $j("#amount_due").html("-$" + Number(-amount_due).toFixed(2)).css("color", "red");

--- a/esp/public/media/scripts/program/modules/extracosts.js
+++ b/esp/public/media/scripts/program/modules/extracosts.js
@@ -1,0 +1,44 @@
+var amount_paid = 0;
+var amount_finaid = 0;
+var amount_due = 0;
+
+$j(function() { 
+    amount_paid = parseFloat($j("#amount_paid").data("total"));
+    amount_finaid = parseFloat($j("#amount_finaid").data("total"));
+    updateTotalCost();
+    $j("input[name*='-cost']").on('change', updateTotalCost);
+    $j("input[name*='-count']").on('change', updateTotalCost);
+    $j("input[name*='-option']").on('change', updateTotalCost);
+    $j("input[name*='-siblingdiscount']").on('change', updateTotalCost);
+});
+
+function updateTotalCost() {
+    console.log("hello");
+    var total_cost = 0;
+    $j("input.cost:checked").each(function() {
+        total_cost += parseFloat($j(this).data('cost'));
+    });
+    $j("input.multicost").each(function() {
+        total_cost += parseInt($j(this).val()) * parseFloat($j(this).data('cost'));
+    });
+    $j("input[name*='-option']:checked, input[name*='-siblingdiscount']:checked").each(function() {
+        if ($j(this).data('is_custom')) {
+            var cost = parseFloat($j(this).parent().next().val());
+            if (!isNaN(cost)) total_cost += parseFloat($j(this).parent().next().val());
+        } else {
+            total_cost += parseFloat($j(this).data('cost'));
+        }
+    });
+    $j("#total_cost").html(Number(total_cost).toFixed(2));
+    amount_due = total_cost - amount_paid - amount_finaid;
+    $j("#amount_due").html(Number(amount_due).toFixed(2));
+}
+
+/*
+ * A click handler that unchecks all inputs with the same name as the
+ * button.
+ **/
+function remove_item(button) {
+    $j("input[name="+button.name+"]").prop("checked", false);
+    updateTotalCost();
+}

--- a/esp/public/media/scripts/program/modules/extracosts.js
+++ b/esp/public/media/scripts/program/modules/extracosts.js
@@ -1,11 +1,14 @@
 var amount_paid = 0;
+var finaid_percent = 0;
+var finaid_max_dec = 0;
 var amount_finaid = 0;
 var amount_due = 0;
 var prog_cost = 0;
 
 $j(function() { 
     amount_paid = parseFloat($j("#amount_paid").data("total"));
-    amount_finaid = parseFloat($j("#amount_finaid").data("total"));
+    finaid_percent = (parseFloat($j("#amount_finaid").data("percent")) || 0) * 0.01;
+    finaid_max_dec = parseFloat($j("#amount_finaid").data("max_dec")) || 0;
     prog_cost = parseFloat($j("#amount_cost").data("total")) || 0;
     updateTotalCost();
     $j("input[name*='-cost']").on('change', updateTotalCost);
@@ -15,22 +18,36 @@ $j(function() {
 });
 
 function updateTotalCost() {
+    var cost = 0;
     var total_cost = 0;
+    var finaid_covered = 0;
     $j("input.cost:checked").each(function() {
-        total_cost += parseFloat($j(this).data('cost'));
+        cost = parseFloat($j(this).data('cost'));
+        total_cost += cost;
+        if ($j(this).data('for_finaid')) finaid_covered += cost;
     });
     $j("input.multicost").each(function() {
-        total_cost += parseInt($j(this).val()) * parseFloat($j(this).data('cost'));
+        cost = parseInt($j(this).val()) * parseFloat($j(this).data('cost'))
+        total_cost += cost;
+        if ($j(this).data('for_finaid')) finaid_covered += cost;
     });
     $j("input[name*='-option']:checked, input[name*='-siblingdiscount']:checked").each(function() {
         if ($j(this).data('is_custom')) {
-            total_cost += parseFloat($j(this).parent().next().val()) || 0;
+            cost = parseFloat($j(this).parent().next().val()) || 0;
+            total_cost += cost;
+            if ($j(this).data('for_finaid')) finaid_covered += cost;
         } else {
-            total_cost += parseFloat($j(this).data('cost'));
+            cost = parseFloat($j(this).data('cost'));
+            total_cost += cost;
+            if ($j(this).data('for_finaid')) finaid_covered += cost;
         }
     });
     total_cost += prog_cost;
+    finaid_covered += prog_cost;
     $j("#total_cost").html("$" + Number(total_cost).toFixed(2));
+    amount_finaid = Math.min(finaid_covered, finaid_max_dec);
+    if (amount_finaid < finaid_covered) amount_finaid += (finaid_covered - amount_finaid) * finaid_percent;
+    $j("#amount_finaid").html("-$" + Number(amount_finaid).toFixed(2));
     amount_due = total_cost - amount_paid - amount_finaid;
     if (amount_due < 0) {
         $j("#amount_due").html("-$" + Number(-amount_due).toFixed(2)).css("color", "red");

--- a/esp/public/media/scripts/program/modules/extracosts.js
+++ b/esp/public/media/scripts/program/modules/extracosts.js
@@ -1,10 +1,12 @@
 var amount_paid = 0;
 var amount_finaid = 0;
 var amount_due = 0;
+var prog_cost = 0;
 
 $j(function() { 
     amount_paid = parseFloat($j("#amount_paid").data("total"));
     amount_finaid = parseFloat($j("#amount_finaid").data("total"));
+    prog_cost = parseFloat($j("#amount_cost").data("total")) || 0;
     updateTotalCost();
     $j("input[name*='-cost']").on('change', updateTotalCost);
     $j("input[name*='-count']").on('change', updateTotalCost);
@@ -13,7 +15,6 @@ $j(function() {
 });
 
 function updateTotalCost() {
-    console.log("hello");
     var total_cost = 0;
     $j("input.cost:checked").each(function() {
         total_cost += parseFloat($j(this).data('cost'));
@@ -23,15 +24,24 @@ function updateTotalCost() {
     });
     $j("input[name*='-option']:checked, input[name*='-siblingdiscount']:checked").each(function() {
         if ($j(this).data('is_custom')) {
-            var cost = parseFloat($j(this).parent().next().val());
-            if (!isNaN(cost)) total_cost += parseFloat($j(this).parent().next().val());
+            total_cost += parseFloat($j(this).parent().next().val()) || 0;
         } else {
             total_cost += parseFloat($j(this).data('cost'));
         }
     });
-    $j("#total_cost").html(Number(total_cost).toFixed(2));
+    total_cost += prog_cost;
+    $j("#total_cost").html("$" + Number(total_cost).toFixed(2));
     amount_due = total_cost - amount_paid - amount_finaid;
-    $j("#amount_due").html(Number(amount_due).toFixed(2));
+    if (amount_due < 0) {
+        $j("#amount_due").html("-$" + Number(-amount_due).toFixed(2)).css("color", "red");
+        $j("#donation_warning").html("(Thank you for your donation!)").show();
+    } else if (amount_due == 0) {
+        $j("#amount_due").html("$" + Number(amount_due).toFixed(2)).css("color", "black");
+        $j("#donation_warning").hide();
+    } else {
+        $j("#amount_due").html("$" + Number(amount_due).toFixed(2)).css("color", "black");
+        $j("#donation_warning").html("(Don't forget to pay for your remaining balance!)").show();
+    }
 }
 
 /*

--- a/esp/templates/django/forms/widgets/choicewithother.html
+++ b/esp/templates/django/forms/widgets/choicewithother.html
@@ -8,7 +8,10 @@
           {% endif %}
           {% for option in options %}
             {% if not forloop.parentloop.last and forloop.last %}
-            <li>{% include option.template_name with widget=option %}{{ option.label }}</li>
+            <li>
+              <label{% if option.attrs.id %} for="{{ option.attrs.id }}"{% endif %}>
+                {% include option.template_name with widget=option %}{{ option.label }}
+            </li>
             {% else %}
             <li>
               <label{% if option.attrs.id %} for="{{ option.attrs.id }}_{{ option.name }}"{% endif %}>

--- a/esp/templates/django/forms/widgets/choicewithother.html
+++ b/esp/templates/django/forms/widgets/choicewithother.html
@@ -12,7 +12,7 @@
             {% else %}
             <li>
               <label{% if option.attrs.id %} for="{{ option.attrs.id }}_{{ option.name }}"{% endif %}>
-                <input type="radio"{% if option.attrs.id %} id="{{ option.attrs.id }}_{{ option.name }}"{% endif %} value="{{ option.value }}" name="{{ radiowidget.name }}"{% if radiowidget.other.0 == radiowidget.value %} checked="true"{% endif %}/>
+                <input type="radio" {% if option.attrs.id %} id="{{ option.attrs.id }}_{{ option.name }}"{% endif %} value="{{ option.value }}" name="{{ radiowidget.name }}"{% if radiowidget.other.0 == radiowidget.value %} checked="true"{% endif %} {% for name, value in option.attrs.items %}{% if name != "id" and name != "checked" %}{% if value is not False %} {{ name }}{% if value is not True %}="{{ value|stringformat:'s' }}"{% endif %}{% endif %}{% endif %}{% endfor %}/>
                 {{ option.label }}
               </label>
               {% include textwidget.template_name with widget=textwidget %}

--- a/esp/templates/program/modules/studentextracosts/extracosts.html
+++ b/esp/templates/program/modules/studentextracosts/extracosts.html
@@ -8,6 +8,11 @@
 <link rel="stylesheet" href="//code.jquery.com/ui/1.13.0/themes/smoothness/jquery-ui.css">
 {% endblock %}
 
+{% block xtrajs %}
+    {{ block.super }}
+    <script type="text/javascript" src="/media/scripts/program/modules/extracosts.js"></script>
+{% endblock %}
+
 {% block content %}
 <style type="text/css">
 .nocheckmark { border: 1px solid black; }
@@ -45,21 +50,18 @@ td>ul { list-style-type: none; padding: 0px }
 <tr>
     <td><b>{{ f.LineItem.text }}</b> {% if f.LineItem.required or f.type == "sibling" %}(required; please make a selection below){% else %}(optional){% endif %}</td>
 </tr>
-<tr style="border-bottom: 1px dashed grey;">
+<tr {% if f.type != "sibling" %}style="border-bottom: 1px dashed grey;"{% endif %}>
     <td>
         {% if f.type == "single" %}
             {% if f.form.cost.errors %}<div style="color: red;">{{ f.form.cost.errors|join:", " }}</div>{% endif %}
             {{ f.form.cost }} ${{ f.LineItem.amount_dec|floatformat:2 }}
-        {% endif %}
-        {% if f.type == "multiple" %}
+        {% elif f.type == "multiple" %}
             {% if f.form.count.errors %}<div style="color: red;">{{ f.form.count.errors|join:", " }}</div>{% endif %}
             {{ f.form.count }} ${{ f.LineItem.amount_dec|floatformat:2 }} each
-        {% endif %}
-        {% if f.type == "select" %}
+        {% elif f.type == "select" %}
             {% if f.form.option.errors %}<div style="color: red;">{{ f.form.option.errors|join:", " }}</div>{% endif %}
             {{ f.form.option }}
-        {% endif %}
-        {% if f.type == "sibling" %}
+        {% elif f.type == "sibling" %}
             {% if f.form.siblingdiscount.errors %}<div style="color: red;">{{ f.form.siblingdiscount.errors|join:", " }}</div>{% endif %}
             {{ f.form.siblingdiscount }}
     </td>
@@ -74,7 +76,7 @@ td>ul { list-style-type: none; padding: 0px }
                 </td>
             </tr>
             {% endif %}
-            <tr>
+            <tr style="border-bottom: 1px dashed grey;">
                 <td>{{ f.form.siblingname }}</td>
             </tr>
         {% endif %}
@@ -94,6 +96,19 @@ td>ul { list-style-type: none; padding: 0px }
     </td>
 </tr>
 {% endfor %}
+{% if paid_for %}
+<tr>
+    <td align="right">
+        <p>Total amount previously paid: $<span style="font-weight: bold;" id="amount_paid" data-total="{{ amount_paid|floatformat:2 }}">{{ amount_paid|floatformat:2 }}</span></p>
+        {% if program.sibling_discount %}
+        <p>Total amount of financial aid: $<span style="font-weight: bold;" id="amount_finaid" data-total="{{ amount_finaid|floatformat:2 }}">{{ amount_finaid|floatformat:2 }}</span></p>
+        {% endif %}
+        <p>Total cost of selected items: $<span style="font-weight: bold;" id="total_cost"></span></p>
+        <p>Total amount due: $<span style="font-weight: bold;" id="amount_due"></span></p>
+        <p id="donation_warning" hidden></p>
+    </td>
+</tr>
+{% endif %}
 <tr>
     <td align="center">
         <input type="submit" class="btn btn-primary" value="Save"/>
@@ -103,15 +118,5 @@ td>ul { list-style-type: none; padding: 0px }
 </center>
 </form>
 </div>
-
-<script type="text/javascript">
-    /*
-     * A click handler that unchecks all inputs with the same name as the
-     * button.
-     **/
-    function remove_item(button) {
-        $j("input[name="+button.name+"]").prop("checked", false);
-    }
-</script>
 
 {% endblock %}

--- a/esp/templates/program/modules/studentextracosts/extracosts.html
+++ b/esp/templates/program/modules/studentextracosts/extracosts.html
@@ -26,6 +26,9 @@ td>ul { list-style-type: none; padding: 0px }
 <p>Food and other additional items can only be changed up until <b>1 week before the program.</b></p>
 {% end_inline_program_qsd_block %}
 
+<br /> 
+{% if paid_for %}<div class="formerror">{{ paid_for_text }}</div>{% endif %} 
+
 <br />
 
 {% if error_custom %}<div class="formerror">You selected a choice with a custom amount but did not specify an amount; please do so below. </div>

--- a/esp/templates/program/modules/studentextracosts/extracosts.html
+++ b/esp/templates/program/modules/studentextracosts/extracosts.html
@@ -98,20 +98,20 @@ td>ul { list-style-type: none; padding: 0px }
 {% endfor %}
 <tr>
     <td align="right">
-        {% if paid_for %}
-        <p>Total amount previously paid: <span style="font-weight: bold;" id="amount_paid" data-total="{{ amount_paid|floatformat:2 }}">${{ amount_paid|floatformat:2 }}</span></p>
-        {% else %}
-        <span style="font-weight: bold;" id="amount_paid" data-total="0"></span>
-        {% endif %}
+        <p>Total cost of selected items: <span style="font-weight: bold;" id="total_cost"></span></p>
         {% if not program.sibling_discount %}
         <p>Program admission: <span style="font-weight: bold;" id="amount_cost" data-total="{{ program.base_cost|floatformat:2 }}">${{ program.base_cost|floatformat:2 }}</span></p>
         {% endif %}
-        {% if amount_finaid > 0 %}
-        <p>Total amount of financial aid: <span style="font-weight: bold;" id="amount_finaid" data-total="{{ amount_finaid|floatformat:2 }}">${{ amount_finaid|floatformat:2 }}</span></p>
+        {% if paid_for %}
+        <p>Total amount previously paid: <span style="font-weight: bold;" id="amount_paid" data-total="{{ amount_paid|floatformat:2 }}">-${{ amount_paid|floatformat:2 }}</span></p>
+        {% else %}
+        <span style="font-weight: bold;" id="amount_paid" data-total="0"></span>
+        {% endif %}
+        {% if finaid_grant %}
+        <p>Total amount of financial aid: <span style="font-weight: bold;" id="amount_finaid" data-percent="{{ finaid_grant.percent|floatformat:2 }}" data-max_dec="{{ finaid_grant.amount_max_dec|floatformat:2 }}"></span></p>
         {% else %}
         <span style="font-weight: bold;" id="amount_finaid" data-total="0"></span>
         {% endif %}
-        <p>Total cost of selected items: <span style="font-weight: bold;" id="total_cost"></span></p>
         <p id="due_warning">Total amount due: <span style="font-weight: bold;" id="amount_due"></span></p>
         {% if paid_for %}
         <p id="donation_warning" style="color: blue;" hidden></p>

--- a/esp/templates/program/modules/studentextracosts/extracosts.html
+++ b/esp/templates/program/modules/studentextracosts/extracosts.html
@@ -104,13 +104,9 @@ td>ul { list-style-type: none; padding: 0px }
         {% endif %}
         {% if paid_for %}
         <p>Total amount previously paid: <span style="font-weight: bold;" id="amount_paid" data-total="{{ amount_paid|floatformat:2 }}">-${{ amount_paid|floatformat:2 }}</span></p>
-        {% else %}
-        <span style="font-weight: bold;" id="amount_paid" data-total="0"></span>
         {% endif %}
         {% if finaid_grant %}
         <p>Total amount of financial aid: <span style="font-weight: bold;" id="amount_finaid" data-percent="{{ finaid_grant.percent|floatformat:2 }}" data-max_dec="{{ finaid_grant.amount_max_dec|floatformat:2 }}"></span></p>
-        {% else %}
-        <span style="font-weight: bold;" id="amount_finaid" data-total="0"></span>
         {% endif %}
         <p id="due_warning">Total amount due: <span style="font-weight: bold;" id="amount_due"></span></p>
         {% if paid_for %}

--- a/esp/templates/program/modules/studentextracosts/extracosts.html
+++ b/esp/templates/program/modules/studentextracosts/extracosts.html
@@ -83,7 +83,7 @@ td>ul { list-style-type: none; padding: 0px }
         
         {# If num_options, radio buttons will be used for the field. In order to  #}
         {# be able to remove a selected item, we need a button. The Javascript    #}
-        {# code for the button is at the bottom.                                  #}
+        {# code for the button is in extracosts.js.                               #}
 
         {% if f.LineItem.num_options and not f.LineItem.required %}
             <button type="button"
@@ -96,19 +96,28 @@ td>ul { list-style-type: none; padding: 0px }
     </td>
 </tr>
 {% endfor %}
-{% if paid_for %}
 <tr>
     <td align="right">
-        <p>Total amount previously paid: $<span style="font-weight: bold;" id="amount_paid" data-total="{{ amount_paid|floatformat:2 }}">{{ amount_paid|floatformat:2 }}</span></p>
-        {% if program.sibling_discount %}
-        <p>Total amount of financial aid: $<span style="font-weight: bold;" id="amount_finaid" data-total="{{ amount_finaid|floatformat:2 }}">{{ amount_finaid|floatformat:2 }}</span></p>
+        {% if paid_for %}
+        <p>Total amount previously paid: <span style="font-weight: bold;" id="amount_paid" data-total="{{ amount_paid|floatformat:2 }}">${{ amount_paid|floatformat:2 }}</span></p>
+        {% else %}
+        <span style="font-weight: bold;" id="amount_paid" data-total="0"></span>
         {% endif %}
-        <p>Total cost of selected items: $<span style="font-weight: bold;" id="total_cost"></span></p>
-        <p>Total amount due: $<span style="font-weight: bold;" id="amount_due"></span></p>
-        <p id="donation_warning" hidden></p>
+        {% if not program.sibling_discount %}
+        <p>Program admission: <span style="font-weight: bold;" id="amount_cost" data-total="{{ program.base_cost|floatformat:2 }}">${{ program.base_cost|floatformat:2 }}</span></p>
+        {% endif %}
+        {% if amount_finaid > 0 %}
+        <p>Total amount of financial aid: <span style="font-weight: bold;" id="amount_finaid" data-total="{{ amount_finaid|floatformat:2 }}">${{ amount_finaid|floatformat:2 }}</span></p>
+        {% else %}
+        <span style="font-weight: bold;" id="amount_finaid" data-total="0"></span>
+        {% endif %}
+        <p>Total cost of selected items: <span style="font-weight: bold;" id="total_cost"></span></p>
+        <p id="due_warning">Total amount due: <span style="font-weight: bold;" id="amount_due"></span></p>
+        {% if paid_for %}
+        <p id="donation_warning" style="color: blue;" hidden></p>
+        {% endif %}
     </td>
 </tr>
-{% endif %}
 <tr>
     <td align="center">
         <input type="submit" class="btn btn-primary" value="Save"/>


### PR DESCRIPTION
This adds the ability (enabled by default) for students to return to the extracosts page after they have paid via credit card and choose different extracost options. This could be a 1 for 1 change (where there is no balance change), a positive change in balance (where the student would then need to pay via credit card again), or a negative change in balance (which we treat as a temporary/permanent donation).

The students can return to this page as many times as they would like between and after paying (provided the tag is enabled, which is the default). As changes are made, the (new!) subtotal (and balance if the student has paid already) at the bottom of the form updates automatically.

![image](https://user-images.githubusercontent.com/7232514/212219252-cf451125-fa0c-42cb-9c4d-e6810b34d8d0.png)

Fixes #3570.