### PR TITLE
Fix bulk account module issues

### DIFF
--- a/esp/esp/program/modules/handlers/bulkcreateaccountmodule.py
+++ b/esp/esp/program/modules/handlers/bulkcreateaccountmodule.py
@@ -97,7 +97,7 @@ class BulkCreateAccountModule(ProgramModuleObj):
         for prefix, number in prefix_dict.iteritems():
             pw = prefix + str(random.randrange(1000000))
             create_users_for_program(prog, prefix + '{}', pw, groups, number)
-            result[prefix] = pw
+            result[prefix] = {'password': pw, 'number': number}
         context = {'passwords': result}
 
         return render_to_response(self.baseDir() + 'bulk_create_response.html', request, context)
@@ -176,7 +176,7 @@ def get_group(group):
 
 
 def create_user_with_profile(username, password, program, groups):
-    print "creating", username
+    # print "creating", username
     user = ESPUser.objects.create_user(username=username, password=password)
     user.groups.add(*groups)
     return {

--- a/esp/esp/program/modules/handlers/bulkcreateaccountmodule.py
+++ b/esp/esp/program/modules/handlers/bulkcreateaccountmodule.py
@@ -78,7 +78,26 @@ class BulkCreateAccountModule(ProgramModuleObj):
             return self.bulk_account_error(request, 'You must select either the Student or Teacher group, '
                             + 'in addition to any other groups you want.')
 
-        result = create_users_for_schools(prog, groups, prefix_dict)
+        result = {}
+        # check none of the prefixes have been used before
+        used_prefixes = []
+        for prefix in prefix_dict:
+            if ESPUser.objects.filter(username = prefix + "1").exists():
+                used_prefixes.append(prefix)
+        if len(used_prefixes) > 2:
+            return self.bulk_account_error(request, 'The prefixes ' + ', '.join(used_prefixes[:-1]) + ', and ' + used_prefixes[-1]
+                                                    + ' have been used before. Please choose different prefixes.')
+        if len(used_prefixes) == 2:
+            return self.bulk_account_error(request, 'The prefixes ' + ' and '.join(used_prefixes)
+                                                    + ' have been used before. Please choose different prefixes.')
+        elif len(used_prefixes) == 1:
+            return self.bulk_account_error(request, 'The prefix ' + used_prefixes[0]
+                                                    + ' has been used before. Please choose a different prefix.')
+        # create users
+        for prefix, number in prefix_dict.iteritems():
+            pw = prefix + str(random.randrange(1000000))
+            create_users_for_program(prog, prefix + '{}', pw, groups, number)
+            result[prefix] = pw
         context = {'passwords': result}
 
         return render_to_response(self.baseDir() + 'bulk_create_response.html', request, context)
@@ -93,33 +112,6 @@ class BulkCreateAccountModule(ProgramModuleObj):
     class Meta:
         proxy = True
         app_label = 'modules'
-
-
-def create_users_for_schools(program, groups, schools):
-    """
-    Create a sequentially numbered list of users for some schools, with a randomly generated
-    password for each school.
-
-    :param program:
-       The program for which we should create these users.
-    :param groups:
-       The groups that all of these users should be added to.  IN ADDITION TO ANY OTHER DESIRED
-       GROUPS, YOU MUST ADD EITHER THE "Student" or "Teacher" GROUP (probably the former in most
-       use cases of this script); OTHERWISE, THE PROFILE VIEWER MAY FAIL.
-    :param schools:
-       A dictionary where the key is a string indicating the school and is the prefix
-       for all the usernames; the value is the number of accounts desired for that school.  For
-       example, if there is an item 'xyz' : 20, then the usernames will be xyz1, xyz2, ..., xyz20.
-    :return:
-       A dictionary where the key is a school prefix, and the value is the randomly generated
-       password (which will start with the prefix).
-    """
-    ret = {}
-    for school, number in schools.iteritems():
-        pw = school + str(random.randrange(1000000))
-        create_users_for_program(program, school + '{}', pw, groups, number)
-        ret[school] = pw
-    return ret
 
 
 def create_users_for_program(program, username_format, password_format, groups, number=1):

--- a/esp/templates/program/modules/bulkcreateaccountmodule/bulk_create_form.html
+++ b/esp/templates/program/modules/bulkcreateaccountmodule/bulk_create_form.html
@@ -55,7 +55,7 @@
         {% endfor %}
     </select>
     <p>You must select either "Student" or "Teacher", in addition to any other groups you want.</p>
-    <p>If the group you want doesn't exist, you should <a href="/admin/auth/group/add/" target="_blank">create</a> it first, then refresh this page.</p>
+    <p>If the group you want doesn't exist, you should <a href="/manage/{{ program.getUrlBase }}/usergroup" target="_blank">create</a> it first, then refresh this page.</p>
 
     <br/>
 

--- a/esp/templates/program/modules/bulkcreateaccountmodule/bulk_create_response.html
+++ b/esp/templates/program/modules/bulkcreateaccountmodule/bulk_create_response.html
@@ -20,13 +20,16 @@
         <tr>
             <th>Prefix</th>
             <th>Password</th>
+            <th># Accounts</th>
         </tr>
-        {% for prefix, password in passwords.items %}
+        {% for prefix, data in passwords.items %}
             <tr>
                 <td>{{ prefix }}</td>
-                <td>{{ password }}</td>
+                <td>{{ data.password }}</td>
+                <td>{{ data.number }}</td>
             </tr>
         {% endfor %}
     </table>
+    {% include "program/modules/admincore/returnlink.html" %}
 
 {% endblock %}


### PR DESCRIPTION
This makes the following changes to the bulk account creation module:

- Changed the link to the admin pages to the user group module page
- Now return an error if a prefix has been used before (this is checked by just looking for a user with the username {prefix}1)

Fixes #3576