### PR TITLE
Support any record type name

### DIFF
--- a/esp/esp/program/modules/handlers/studentregcore.py
+++ b/esp/esp/program/modules/handlers/studentregcore.py
@@ -268,9 +268,8 @@ class StudentRegCore(ProgramModuleObj, CoreModule):
         else:
             tag_data = Tag.getProgramTag('teacher_reg_records', prog)
         if tag_data:
-            event_dict = dict(RecordType.desc())
-            for event in [x.strip().lower() for x in tag_data.split(',') if RecordType.objects.filter(name = x.strip().lower()).exists()]:
-                records.append({'event': event, 'full_event': event_dict[event], 'isCompleted': Record.user_completed(event = event, user = user, program = prog)})
+            for rt in RecordType.objects.filter(name__in=tag_data.split(',')):
+                records.append({'event': rt.name, 'full_event': rt.description, 'isCompleted': Record.user_completed(event = rt, user = user, program = prog)})
             records.sort(key=lambda rec: not rec['isCompleted'])
         return records
 

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -2275,7 +2275,7 @@ class DBList(object):
         return self.key
 
 class RecordType(models.Model):
-    name = models.CharField(max_length=80, help_text = "A unique short snake_case name for the record type", unique=True)
+    name = models.CharField(max_length=80, help_text = "A unique short name for the record type", unique=True)
     description = models.CharField(max_length=255, help_text = "A unique sentence case description for the record type", unique=True)
 
     BUILTIN_TYPES = [

--- a/esp/templates/program/modules/userrecordsmodule/options.html
+++ b/esp/templates/program/modules/userrecordsmodule/options.html
@@ -12,6 +12,7 @@
 <form action="/manage/{{ program.getUrlBase }}/userrecordsfinal?filterid={{ filterid }}" method="post" name="usergroup">
 <input type="hidden" name="selected" value="{{selected}}" />
 <h3>Choose which record(s) to set for these users:</h3>
+<h4>(new record types can be created on <a href="/manage/catsflagsrecs/" target="_blank">this page</a>)</h4>
 {% for rec in records %}
 <input type="checkbox" name="records" value="{{ rec.0 }}" id="records_{{ forloop.counter }}"/> <label for="records_{{ forloop.counter }}">{{ rec.1 }}</label><br>
 {% endfor %}


### PR DESCRIPTION
I fixed the handling of record types in student/teacher registration to now allow any string to be used as a name for a record type (before, only snake_case was really supported).

Fixes #3586