### PR TITLE
Self checkin fixes

### DIFF
--- a/esp/esp/program/modules/base.py
+++ b/esp/esp/program/modules/base.py
@@ -282,6 +282,9 @@ class ProgramModuleObj(models.Model):
 
         return mark_safe(link)
 
+    def makeSelfCheckinLink(self):
+        return self.makeLink()
+
     def get_setup_title(self):
         if hasattr(self, 'setup_title') and self.setup_title is not None and str(self.setup_title).strip() != '':
             return self.setup_title

--- a/esp/esp/program/modules/handlers/studentclassregmodule.py
+++ b/esp/esp/program/modules/handlers/studentclassregmodule.py
@@ -209,8 +209,12 @@ class StudentClassRegModule(ProgramModuleObj):
         return (len(user.getSectionsFromProgram(self.program)[:1]) > 0)
 
     def makeSelfCheckinLink(self):
+        if self.deadline_met():
+            text = self.module.link_title
+        else:
+            text = "Class changes is currently closed, please contact the admin team to register for classes"
         link = u'<a href="%sstudentonsite" title="%s" class="vModuleLink" >%s</a>' % \
-            (self.program.get_learn_url(), self.module.link_title, self.module.link_title)
+            (self.program.get_learn_url(), text, text)
         return mark_safe(link)
 
     def deadline_met(self, extension=None):

--- a/esp/esp/program/modules/handlers/studentclassregmodule.py
+++ b/esp/esp/program/modules/handlers/studentclassregmodule.py
@@ -48,6 +48,7 @@ from django.http import HttpResponse, Http404
 from django.views.decorators.cache import cache_control
 from django.views.decorators.vary import vary_on_cookie
 from django.core.cache import cache
+from django.utils.safestring import mark_safe
 
 from esp.program.modules.base import ProgramModuleObj, needs_teacher, needs_student, needs_admin, usercheck_usetl, meets_deadline, meets_any_deadline, main_call, aux_call, meets_cap, no_auth
 from esp.program.modules.handlers.onsiteclasslist import OnSiteClassList
@@ -206,6 +207,11 @@ class StudentClassRegModule(ProgramModuleObj):
         else:
             user = get_current_request().user
         return (len(user.getSectionsFromProgram(self.program)[:1]) > 0)
+
+    def makeSelfCheckinLink(self):
+        link = u'<a href="%sstudentreg" title="%s" class="vModuleLink" >%s</a>' % \
+            (self.program.get_learn_url(), self.module.link_title, self.module.link_title)
+        return mark_safe(link)
 
     def deadline_met(self, extension=None):
         #   Allow default extension to be overridden if necessary

--- a/esp/esp/program/modules/handlers/studentclassregmodule.py
+++ b/esp/esp/program/modules/handlers/studentclassregmodule.py
@@ -209,7 +209,7 @@ class StudentClassRegModule(ProgramModuleObj):
         return (len(user.getSectionsFromProgram(self.program)[:1]) > 0)
 
     def makeSelfCheckinLink(self):
-        link = u'<a href="%sstudentreg" title="%s" class="vModuleLink" >%s</a>' % \
+        link = u'<a href="%sstudentonsite" title="%s" class="vModuleLink" >%s</a>' % \
             (self.program.get_learn_url(), self.module.link_title, self.module.link_title)
         return mark_safe(link)
 

--- a/esp/esp/program/modules/handlers/studentonsite.py
+++ b/esp/esp/program/modules/handlers/studentonsite.py
@@ -70,7 +70,9 @@ class StudentOnsite(ProgramModuleObj, CoreModule):
         """ Display the landing page for the student onsite webapp """
         context = self.onsitecontext(request, tl, one, two, prog)
         user = request.user
-        context.update(StudentClassRegModule.prepare_static(user, prog))
+        scrm = prog.getModule("StudentClassRegModule")
+        context.update(StudentClassRegModule.prepare_static(user, prog, scrm = scrm))
+        context['deadline_met'] = scrm.deadline_met()
 
         context['webapp_page'] = 'schedule'
         context['scrmi'] = prog.studentclassregmoduleinfo

--- a/esp/esp/program/modules/handlers/studentonsite.py
+++ b/esp/esp/program/modules/handlers/studentonsite.py
@@ -217,7 +217,7 @@ class StudentOnsite(ProgramModuleObj, CoreModule):
             context['modules'] = filter(lambda x: (x.isRequired() and not x.isCompleted()), modules)
             context['records'] = filter(lambda x: not x['isCompleted'], records)
 
-            if Tag.getProgramTag('student_self_checkin_paid', program = prog):
+            if Tag.getBooleanTag('student_self_checkin_paid', program = prog):
                 iac = IndividualAccountingController(prog, user)
                 context['owes_money'] = iac.amount_due() > 0
                 if context['owes_money']:

--- a/esp/esp/tagdict/__init__.py
+++ b/esp/esp/tagdict/__init__.py
@@ -1238,6 +1238,13 @@ all_program_tags = {
                                             ('open', 'Students only need to access the self checkin page'),
                                             ('code', 'Students must enter their unique code to check themselves in')]),
     },
+    'student_self_checkin_paid': {
+        'is_boolean': True,
+        'help_text': 'Whether students must have already paid their entire balance before they can check themselves in.',
+        'default': True,
+        'category': 'onsite',
+        'is_setting': True,
+    },
     'already_paid_extracosts_allowed': {
         'is_boolean': True,
         'help_text': 'Whether students should be able to return to the extracosts page to add items or change options after they have already paid once via credit card.',

--- a/esp/esp/tagdict/__init__.py
+++ b/esp/esp/tagdict/__init__.py
@@ -1168,7 +1168,7 @@ all_program_tags = {
     'student_onsite_checkin_note': {
         'is_boolean': False,
         'help_text': 'The message that is shown at the top of the student webapp schedule when a student is NOT checked in.',
-        'default': 'Note: You will not be able to change any classes or see your classrooms until after your check-in has been processed by the admin team.',
+        'default': 'Note: You will not be able to see your classrooms until after your check-in has been processed by the admin team.',
         'category': 'onsite',
         'is_setting': True,
     },

--- a/esp/templates/program/modules/studentonsite/schedule.html
+++ b/esp/templates/program/modules/studentonsite/schedule.html
@@ -85,7 +85,7 @@ function togglePopup() {
   </div>
 
   <div class="popup" onclick="togglePopup()">
-      <span class="popuptext" id="myPopup">Not checked in yet!</span>
+      <span class="popuptext" id="myPopup">You must be checked in to make class changes right now!</span>
   </div>
 
 </center>

--- a/esp/templates/program/modules/studentonsite/schedule.html
+++ b/esp/templates/program/modules/studentonsite/schedule.html
@@ -60,7 +60,7 @@ function togglePopup() {
                     </td>
                 {% endif %}
                 <td class="edit">
-                    {% if checked_in %}
+                    {% if deadline_met or checked_in %}
                         <!--link to filtered course catalog like the fillslot page-->
                         <a class="no-dec" href="/learn/{{one}}/{{two}}/onsitecatalog/{{timeslot.0.id}}" title="{% if cls %}View other classes{% else %}Add a class{% endif %}"><i class="material-icons md-4">{% if cls %}create{% else %}add{% endif %}</i></a>
                         {% if cls and cls.first_meeting_time %}

--- a/esp/templates/program/modules/studentonsite/selfcheckin.html
+++ b/esp/templates/program/modules/studentonsite/selfcheckin.html
@@ -2,6 +2,8 @@
 
 {% block body %}
 
+{% load modules %}
+
 <center>
     <div class="main">
         <table>
@@ -19,7 +21,7 @@
                 </td>
             </tr>
         </table>
-        {% elif modules or records %}
+        {% elif modules or records or owes_money %}
         <table>
             <tr>
                 <td>
@@ -39,6 +41,11 @@
                 <td>{{ record.full_event }}</td>
             </tr>
             {% endfor %}
+            {% if owes_money %}
+            <tr>
+                <td>{% if payment_url %}<a title="Pay your balance" class="vModuleLink" href="/learn/{{one}}/{{two}}/{{ payment_url }}">Pay your balance</a>{% else %}See an admin team member to pay your balance{% endif %}</td>
+            </tr>
+            {% endif %}
         </table>
         {% else %}
         <form method="POST">

--- a/esp/templates/program/modules/studentonsite/selfcheckin.html
+++ b/esp/templates/program/modules/studentonsite/selfcheckin.html
@@ -27,14 +27,12 @@
                 </td>
             </tr>
             {% for module in modules %}
-            {% if module.isStep and module.isRequired and not module.isRequired %}
             <tr>
                 <td>
-                {% autoescape off %}{{ module.makeLink }}{% endautoescape %}
+                {% autoescape off %}{{ module.makeSelfCheckinLink }}{% endautoescape %}
                 {% if module.required_label %}<i>{{ module.required_label }}</i>{% endif %}
                 </td>
             </tr>
-            {% endif %}
             {% endfor %}
             {% for record in records %}
             <tr>


### PR DESCRIPTION
This makes it so that the "Sign up for classes" link shows up (and links to the main studentreg page) on the student selfcheckin page if the class registration module is required and the student hasn't registered for any classes yet:
![image](https://user-images.githubusercontent.com/7232514/217981766-70c50e5b-ff5a-44d1-b4e7-d0cde8d9cfa1.png)

This also adds to option (on by default) to require payment before self checkin (as requested by Stanford). If neither of the credit card modules are enabled, the student is instructed to see an admin team member.

Fixes #3587.