### PR TITLE
Link to LU feature request page on /manage/programs

### DIFF
--- a/esp/esp/program/modules/handlers/admincore.py
+++ b/esp/esp/program/modules/handlers/admincore.py
@@ -39,6 +39,7 @@ from django.db.models.query import Q
 from django.forms.formsets import formset_factory
 from django.forms.models import model_to_dict
 from django.http import HttpResponseRedirect
+from django.utils import timezone  # add timezone from local_settings.py in labels
 
 from esp.accounting.controllers import ProgramAccountingController
 from esp.cal.models import Event
@@ -54,6 +55,11 @@ from datetime import datetime
 from copy import copy
 from collections import OrderedDict
 
+
+TZINFO = timezone.get_current_timezone()  # get timezone set in local_settings.py
+FTIMEZONE = " (" + datetime.now(tz=TZINFO).strftime("%Z") + ")"  # formatted timezone
+
+
 class EditPermissionForm(forms.Form):
     start_date = forms.DateTimeField(widget=DateTimeWidget(), required=False)
     end_date = forms.DateTimeField(widget=DateTimeWidget(), required=False)
@@ -63,8 +69,8 @@ class EditPermissionForm(forms.Form):
 class NewDeadlineForm(forms.Form):
     deadline_type = forms.ChoiceField(choices=filter(lambda x: "Administer" not in x[0], Permission.PERMISSION_CHOICES))
     role = forms.ChoiceField(choices = [("Student","Students"),("Teacher","Teachers"),("Volunteer","Volunteers")])
-    start_date = forms.DateTimeField(label='Opening date/time', initial=datetime.now, widget=DateTimeWidget(), required=False)
-    end_date = forms.DateTimeField(label='Closing date/time', initial=None, widget=DateTimeWidget(), required=False)
+    start_date = forms.DateTimeField(label='Opening date/time' + FTIMEZONE, initial=datetime.now, widget=DateTimeWidget(), required=False)
+    end_date = forms.DateTimeField(label='Closing date/time' + FTIMEZONE, initial=None, widget=DateTimeWidget(), required=False)
 
     def __init__(self, *args, **kwargs):
         super(NewDeadlineForm, self).__init__(*args, **kwargs)
@@ -75,8 +81,8 @@ class NewPermissionForm(forms.Form):
     permission_type = forms.ChoiceField(choices=filter(lambda x: "Administer" not in x[0], Permission.PERMISSION_CHOICES))
     user = AjaxForeignKeyNewformField(key_type=ESPUser, field_name='user', label='User',
         help_text='Start typing a username or "Last Name, First Name", then select the user from the dropdown.')
-    perm_start_date = forms.DateTimeField(label='Opening date/time', initial=datetime.now, widget=DateTimeWidget(), required=False)
-    perm_end_date = forms.DateTimeField(label='Closing date/time', initial=None, widget=DateTimeWidget(), required=False)
+    perm_start_date = forms.DateTimeField(label='Opening date/time' + FTIMEZONE, initial=datetime.now, widget=DateTimeWidget(), required=False)
+    perm_end_date = forms.DateTimeField(label='Closing date/time' + FTIMEZONE, initial=None, widget=DateTimeWidget(), required=False)
 
 class AdminCore(ProgramModuleObj, CoreModule):
     doc = """Includes the core views for managing a program (e.g. settings, dashboard)."""

--- a/esp/templates/django/forms/widgets/datetimepicker.html
+++ b/esp/templates/django/forms/widgets/datetimepicker.html
@@ -1,5 +1,5 @@
 {% include "django/forms/widgets/datetime.html" %}
 <span id="{{ id }}-info"><span id="{{ id }}-gi"></span><span id="{{ id }}-duration"></span></span>
 <script type="text/javascript">
-    setupDatepickerDurationLabel('{{ jquerywidget }}', '{{ id }}', '{{ media_url }}', '{{ date_format }}', '{{ time_format }}');
+    setupDatepickerDurationLabel('{{ jquerywidget }}', '{{ id }}', '{{ media_url }}', '{{ date_format }}', '{{ time_format}}');
 </script>

--- a/esp/templates/program/manage_programs.html
+++ b/esp/templates/program/manage_programs.html
@@ -47,6 +47,7 @@
           <li><a href="https://docs.google.com/document/d/10WZVUf3y_ajc3f7Ur-QSd0B9i_7derNczcTh24Oa3LM/view">LU website guide (in progress)</a></li>
 
           <li>If you're not sure how to do something contact your mentor(s). If you are an associate or full Chapter, contact <a href="mailto:websupport@learningu.org">websupport</a> (or Chapter Services, as appropriate) with questions, problems, or requests.</li>
+          <li>Want to request a new website feature? See the LU wiki <a href="https://wiki.learningu.org/How_to_use_the_website#Feature_Requests">Feature Requests page.</a></li>
         </ul>
         </p>
     </td>

--- a/esp/templates/program/modules/admincore/deadlines.html
+++ b/esp/templates/program/modules/admincore/deadlines.html
@@ -71,8 +71,8 @@
             {% if forloop.counter0|divisibleby:"5" %}
             <tr>
                 <th>Deadline</th>
-                <th>Start</th>
-                <th>End</th>
+                <th>Start {% now "(T)" %}</th>
+                <th>End {% now "(T)" %} </th>
                 <th></th>
             </tr>
             {% endif %}
@@ -164,7 +164,7 @@
     <tr>
         <th>User</th>
         <th>Permission</th>
-        <th>Timing</th>
+        <th>Timing {% now "(T)" %}</th>
         <th></th>
     </tr>
     {% endif %}


### PR DESCRIPTION
# On the manage deadline page:
Added a link to the LU wiki [feature requests page](https://wiki.learningu.org/How_to_use_the_website#Feature_Requests) in the `Here are some tips:` section of the `/manage/programs` page.

# Example screenshots:
## Old Page
![1149-old-crop](https://user-images.githubusercontent.com/124770788/218906650-81e1e653-9568-4b10-8843-51e31b4ef59a.png)

## New Page
![1149-crop](https://user-images.githubusercontent.com/124770788/218906505-ca558b06-8c41-4221-8ea7-49bffb2325c6.png)


Fixes #1149
