### PR TITLE
Theme template loader

### DIFF
--- a/esp/esp/django_settings.py
+++ b/esp/esp/django_settings.py
@@ -330,7 +330,7 @@ DEBUG_TOOLBAR_PANELS = (
     'debug_toolbar.panels.signals.SignalsPanel',
     'debug_toolbar.panels.sql.SQLPanel',
     'debug_toolbar.panels.staticfiles.StaticFilesPanel',
-    'debug_toolbar.panels.templates.TemplatesPanel',
+    'esp.utils.debug_panels.TemplatesPanel',
     'debug_toolbar.panels.timer.TimerPanel',
     'debug_toolbar.panels.versions.VersionsPanel',
     'debug_toolbar.panels.redirects.RedirectsPanel',

--- a/esp/esp/django_settings.py
+++ b/esp/esp/django_settings.py
@@ -185,7 +185,8 @@ TEMPLATES = [
             ],
             'loaders': [
                 'admin_tools.template_loaders.Loader',
-                'esp.utils.template.Loader',
+                'esp.utils.template.Loader', # for template overrides
+                'esp.utils.template.ThemeLoader', # theme templates
                 ('django.template.loaders.cached.Loader',
                     (
                      'django.template.loaders.filesystem.Loader',

--- a/esp/esp/themes/controllers.py
+++ b/esp/esp/themes/controllers.py
@@ -443,22 +443,6 @@ class ThemeController(object):
 
         #   Create template overrides using data provided (our models handle versioning)
         logger.debug('Loading theme: %s', theme_name)
-        for template_name in self.get_template_names(theme_name):
-            #   Read default template override contents provided by theme
-            to = TemplateOverride(name=template_name)
-            template_filename = os.path.join(self.base_dir(theme_name), 'templates', template_name)
-            template_file = open(template_filename, 'r')
-            to.content = template_file.read()
-
-            #   Add a Django template comment tag indicating theme type to the main.html override (for tests)
-            if to.name == 'main.html':
-                to.content += ('\n{%% comment %%} Theme: %s {%% endcomment %%}\n' % theme_name)
-
-            to.save()
-            logger.debug('-- Created template override: %s', template_name)
-
-        #   Clear template override cache
-        TemplateOverrideLoader.get_template_hash.delete_all()
 
         #   Collect LESS files from appropriate sources and compile CSS
         self.compile_css(theme_name, {}, self.css_filename)

--- a/esp/esp/themes/controllers.py
+++ b/esp/esp/themes/controllers.py
@@ -333,15 +333,6 @@ class ThemeController(object):
         if theme_name is None:
             theme_name = self.get_current_theme()
 
-        #   Remove template overrides matching the theme name
-        logger.debug('Clearing theme: %s', theme_name)
-        for template_name in self.get_template_names(theme_name):
-            TemplateOverride.objects.filter(name=template_name).delete()
-            logger.debug('-- Removed template override: %s', template_name)
-
-        #   Clear template override cache
-        TemplateOverrideLoader.get_template_hash.delete_all()
-
         #   If files are to be preserved, copy them to temporary locations
         #   and return a record of those locations (backup_info).
         #   This is much easier than writing new functions for removing and

--- a/esp/esp/utils/debug_panels.py
+++ b/esp/esp/utils/debug_panels.py
@@ -34,6 +34,7 @@ Learning Unlimited, Inc.
 """
 
 from debug_toolbar.panels.templates import TemplatesPanel as BaseTemplatesPanel
+from django.utils.translation import ugettext_lazy as _
 from django.core import signing
 from os.path import normpath
 

--- a/esp/esp/utils/debug_panels.py
+++ b/esp/esp/utils/debug_panels.py
@@ -1,0 +1,84 @@
+
+__author__    = "Individual contributors (see AUTHORS file)"
+__date__      = "$DATE$"
+__rev__       = "$REV$"
+__license__   = "AGPL v.3"
+__copyright__ = """
+This file is part of the ESP Web Site
+Copyright (c) 2012 by the individual contributors
+  (see AUTHORS file)
+
+The ESP Web Site is free software; you can redistribute it and/or
+modify it under the terms of the GNU Affero General Public License
+as published by the Free Software Foundation; either version 3
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public
+License along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+Contact information:
+MIT Educational Studies Program
+  84 Massachusetts Ave W20-467, Cambridge, MA 02139
+  Phone: 617-253-4882
+  Email: esp-webmasters@mit.edu
+Learning Unlimited, Inc.
+  527 Franklin St, Cambridge, MA 02139
+  Phone: 617-379-0178
+  Email: web-team@learningu.org
+"""
+
+from debug_toolbar.panels.templates import TemplatesPanel as BaseTemplatesPanel
+from django.core import signing
+from os.path import normpath
+
+# Override the debug toolbar's TemplatesPanel to fix how it behaves with template overrides
+class TemplatesPanel(BaseTemplatesPanel):
+    def generate_stats(self, request, response):
+        template_context = []
+        for template_data in self.templates:
+            info = {}
+            # Clean up some info about templates
+            template = template_data.get("template", None)
+            if hasattr(template, "origin") and template.origin and template.origin.name:
+                template.origin_name = template.origin.name
+                if template.origin.name == "(template override)":
+                    template.origin_hash = signing.dumps(template.origin.template_name)
+                else:
+                    template.origin_hash = signing.dumps(template.origin.name)
+            else:
+                template.origin_name = _("No origin")
+                template.origin_hash = ""
+            info["template"] = template
+            # Clean up context for better readability
+            if self.toolbar.config["SHOW_TEMPLATE_CONTEXT"]:
+                context_list = template_data.get("context", [])
+                info["context"] = "\n".join(context_list)
+            template_context.append(info)
+
+        # Fetch context_processors/template_dirs from any template
+        if self.templates:
+            context_processors = self.templates[0]["context_processors"]
+            template = self.templates[0]["template"]
+            # django templates have the 'engine' attribute, while jinja
+            # templates use 'backend'
+            engine_backend = getattr(template, "engine", None) or getattr(
+                template, "backend"
+            )
+            template_dirs = engine_backend.dirs
+        else:
+            context_processors = None
+            template_dirs = []
+
+        self.record_stats(
+            {
+                "templates": template_context,
+                "template_dirs": [normpath(x) for x in template_dirs],
+                "context_processors": context_processors,
+            }
+        )

--- a/esp/esp/utils/template.py
+++ b/esp/esp/utils/template.py
@@ -115,7 +115,7 @@ class ThemeLoader(base.Loader):
         except (ImportError, TypeError):
             origin = join(template_dir, template_name)
         return [origin]
-    
+
     # copied from https://github.com/django/django/blob/stable/1.11.x/django/template/loaders/filesystem.py
     def get_contents(self, origin):
         try:


### PR DESCRIPTION
This PR does the following:

1. Adds a new theme template loader. This loads theme templates (if they exist) _after_ the template override loader and _before_ the normal django template loader. This means that template overrides can still override the theme, but the theme templates will always override the default templates.
2. Upgrades the template override loader to Django 1.11+. I have a strong feeling this would have broken when we upgrade to django 2+, so it's probably good to update it now.
3. Modifies the debug toolbar template panel to work with template overrides (before, you couldn't see the content of a template override, nor would you know that it was a template override).
4. Update the clear_theme() and load_theme() methods to not add/remove template overrides, because template overrides of the theme are now intended as overrides. Unfortunately, we'll need to manually delete the template overrides that were made by the theme (but not actual overrides) during the next stable release.

Here is an image of the updated debug toolbar template panel showing templates that were loaded by the 3 different loaders:
![image](https://user-images.githubusercontent.com/7232514/219877238-65355a3f-7fc5-49a4-86af-d7d551338adc.png)


Fixes https://github.com/learning-unlimited/ESP-Website/issues/2046 (also see https://github.com/learning-unlimited/ESP-Website/issues/2098)