### PR TITLE
Avail groups

### DIFF
--- a/esp/esp/program/modules/handlers/resourcemodule.py
+++ b/esp/esp/program/modules/handlers/resourcemodule.py
@@ -633,7 +633,10 @@ class ResourceModule(ProgramModuleObj):
 
         #   Group contiguous blocks of time for the program
         time_options = self.program.getTimeSlots(types=['Class Time Block','Open Class Time Block'])
-        time_groups = Event.group_contiguous(list(time_options), int(Tag.getProgramTag('availability_group_tolerance', program = prog)))
+        if not Tag.getBooleanTag('availability_group_timeslots'):
+            time_groups = [list(time_options)]
+        else:
+            time_groups = Event.group_contiguous(list(time_options), int(Tag.getProgramTag('availability_group_tolerance', program = prog)))
 
         #   Retrieve remaining context information
         context['timeslots'] = [{'selections': group} for group in time_groups]

--- a/esp/public/media/default_styles/availability.css
+++ b/esp/public/media/default_styles/availability.css
@@ -4,6 +4,10 @@
   align-items: center;
 }
 
+.container1 {
+  flex-grow: 2;
+}
+
 .side {
   width: 280px;
 }
@@ -17,14 +21,14 @@
   font-family: sans-serif;
 }
 
-.left span {
+.details {
   background-color: #dbe3e7;
   border-radius: 4px;
   -moz-border-radius: 4px;
   -webkit-border-radius: 4px;
   padding: 5px 5px;
   font-size: small;
-  width: 160px;
+  width: 100%;
   display: none;
 }
 
@@ -43,6 +47,8 @@ td.group, table.group {
   vertical-align: top !important;
   border-spacing: 0px 2px !important;
   padding: 0 !important;
+  margin-left: 20px;
+  margin-right: 20px;
 }
 
 .wrap table {
@@ -56,8 +62,8 @@ td.group, table.group {
   font-weight: bold !important;
   background: #CCCCCC !important;
   padding: 3px !important;
-  height: 80px !important;
-  width: 75px !important;
+  height: 25px !important;
+  width: 90px !important;
 }
 
 .label {
@@ -68,6 +74,7 @@ td.group, table.group {
 }
 
 .proposed, .canDo, .teaching {
+  padding: 6px !important;
   font-size: 16px !important;
   text-align: center !important;
 }
@@ -90,6 +97,10 @@ td.group, table.group {
 
 .headerText {
   font-size: 18px;
+}
+
+.subheaderText {
+  font-size: 16px;
 }
 
 form {

--- a/esp/public/media/scripts/program/modules/availability.js
+++ b/esp/public/media/scripts/program/modules/availability.js
@@ -22,6 +22,10 @@ var Availability = (function () {
         return $j(td).hasClass("canDo");
     }
     
+    function isTD(td) {
+        return $j(td).is("td");
+    }
+    
     //Activate checkbox
     function checkbox_on(td) {
         var checkbox = $j('input[value='+td.getAttribute("name")+']')[0]
@@ -72,14 +76,16 @@ var Availability = (function () {
         var block = document.getElementById("block_" + col);
         for (var i = 1; i < block.rows.length; i++) {
             var td = block.rows[i].cells[0];
-            if (!isSet(td)) somethingToSet = true;
+            if (!isSet(td) && isTD(td)) somethingToSet = true;
         }
         for (var i = 1; i < block.rows.length; i++) {
             var td = block.rows[i].cells[0];
-            if (somethingToSet) {
-                checkbox_on(td);
-            } else {
-                checkbox_off(td);
+            if (isTD(td)) {
+                if (somethingToSet) {
+                    checkbox_on(td);
+                } else {
+                    checkbox_off(td);
+                }
             }
         }
     }
@@ -121,21 +127,21 @@ var Availability = (function () {
             }
         });
 
-        //Populate the right sidebar
+        //Populate the legend in the right sidebar
         $j(document).ready(function () {
-            $j(".wrap").append($j(".right"));
-            $j(".right").show();
+            $j(".side.left").append($j(".summary_div"));
+            $j(".summary_div").show();
         });
 
         //If there is hover text, show it when hovering over the timeslot
         $j(".group td").mouseover(function() {
             var hover_text = $j('input[value='+parseInt($j(this).attr('name'))+']').data('hover')
             if (hover_text) {
-                $j(".left .summary").html(hover_text);
-                $j(".left .summary").css("display", "block");
+                $j(".right .details").html(hover_text);
+                $j(".right .details").css("display", "block");
             }
         }).mouseout(function() {
-            $j(".left .summary").css("display", "none");
+            $j(".right .details").css("display", "none");
         });
     }
 

--- a/esp/templates/program/modules/availability.html
+++ b/esp/templates/program/modules/availability.html
@@ -6,9 +6,7 @@
 
 <center>
   <div class="wrap">
-    <div class="side left">
-      <span class="summary"></span>
-    </div>
+    <div class="side left"></div>
     <div class="container1">
       <table class="noselect" id="grid" onmouseup="Availability.mouseup_event();" style="cursor: default;">
         <tbody>
@@ -19,14 +17,19 @@
                 <tbody>
                   <tr><th class="dateHeader weekday" onclick="Availability.header_switch(event,{{ forloop.counter }});">
                     <div class="headerText">
-                      {{ group.0.slot.start|date:"D" }}<br>
-                      {{ group.0.slot.start|date:"d" }}<br>
-                      {{ group.0.slot.start|date:"M" }}
+                      Block {{ forloop.counter}}
                     </div>
                   </th></tr>
                   {% for time in group %}
+                    {% ifchanged time.slot.start|date %}
+                    <tr><th class="dateHeader weekday" nowrap="">
+                      <div class="subheaderText">
+                        {{ time.slot.start|date:"D d M" }}
+                      </div>
+                    </th></tr>
+                    {% endifchanged %}
                     <tr><td nowrap="" class="proposed" onmousedown="Availability.mousedown_event(this);" onmouseover="Availability.mouseover_event(this);" name="{{ time.id }}">
-                      {{ time.slot.start|date:"g:i A"}}
+                      {{ time.slot.start|date:"g:i A" }}
                     </td></tr>
                   {% endfor %}
                 </tbody>
@@ -37,6 +40,9 @@
           </tr>
         </tbody>
       </table>
+    </div>
+    <div class="side right">
+      <span class="details"></span>
     </div>
   </div>
 </center>

--- a/esp/templates/program/modules/availabilitymodule/availability_form.html
+++ b/esp/templates/program/modules/availabilitymodule/availability_form.html
@@ -98,7 +98,7 @@ You can click on individual timeblocks, highlight multiple timeblocks, and even 
 
 </div>
 
-<div class="side right" hidden>
+<div class="summary_div" hidden>
   <span class="summary" style="background-color: #EFEFEF;">Not Available</span>
   <span class="summary" style="background-color: #00FF00;">Available</span>
   <span class="summary" style="background-color: #42b3f4;">Scheduled</span>

--- a/esp/templates/program/modules/resourcemodule/timeslots.html
+++ b/esp/templates/program/modules/resourcemodule/timeslots.html
@@ -43,13 +43,15 @@
         <td><b>Options</b></td>
     </tr>
     {% for h in timeslots %}
-    {% ifchanged h.selections.0.start.date %}
-    <th colspan="5" align="center">{{ h.selections.0.pretty_date }}</th>
-    {% endifchanged %}
     <tr>
-        <th class="small" colspan="5" align="center"><b>Block {{ forloop.counter }}</b></th>
+        <th colspan="5" align="center"><b>Block {{ forloop.counter }}</b></th>
     </tr>
         {% for t in h.selections %}
+        {% ifchanged t.start.date %}
+        <tr>
+            <th colspan="5" align="center">{{ t.pretty_date }}</th>
+        </tr>
+        {% endifchanged %}
         <tr>
             <td>{{ t.short_description }}</td>
             <td>{{ t.event_type }}</td>


### PR DESCRIPTION
This fixes the availability form interface for various timeslot grouping edge cases, such as:

1. The "Availability group timeslots" global tag is set to False (so all timeslots are in a single group)
2. A group of timeslots spans multiple days

While I was at it, I also made some minor visual changes to give the availability form a bit more breathing room:
![image](https://user-images.githubusercontent.com/7232514/220678291-84e99f4b-e42c-40cf-a2d7-a35d4d8c1935.png)

I also updated the resources page to have the same formatting (so now admins will know roughly what the groupings will look like to teachers):
![image](https://user-images.githubusercontent.com/7232514/220676107-ce513762-9b71-476b-8f34-05ff92b5d993.png)

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3617.