### PR TITLE
Fix missing sibling discount bug

### DIFF
--- a/esp/esp/accounting/controllers.py
+++ b/esp/esp/accounting/controllers.py
@@ -156,19 +156,34 @@ class ProgramAccountingController(BaseAccountingController):
         return result
 
     def default_program_account(self):
-        return Account.objects.filter(program=self.program).order_by('id')[0]
+        accounts = Account.objects.filter(program=self.program).order_by('id')
+        if accounts.exists():
+            return accounts[0]
+        return None
 
     def default_payments_lineitemtype(self):
-        return LineItemType.objects.filter(program=self.program, for_payments=True).order_by('-id')[0]
+        lineitems = LineItemType.objects.filter(program=self.program, for_payments=True).order_by('-id')
+        if lineitems.exists():
+            return lineitems[0]
+        return None
 
     def default_finaid_lineitemtype(self):
-        return LineItemType.objects.filter(program=self.program, text='Financial aid grant').order_by('-id')[0]
+        lineitems =  LineItemType.objects.filter(program=self.program, text='Financial aid grant').order_by('-id')
+        if lineitems.exists():
+            return lineitems[0]
+        return None
 
     def default_siblingdiscount_lineitemtype(self):
-        return LineItemType.objects.filter(program=self.program, text='Sibling discount').order_by('-id')[0]
+        lineitems =  LineItemType.objects.filter(program=self.program, text='Sibling discount').order_by('-id')
+        if lineitems.exists():
+            return lineitems[0]
+        return None
 
     def default_admission_lineitemtype(self):
-        return LineItemType.objects.filter(program=self.program, text='Program admission').order_by('-id')[0]
+        lineitems =  LineItemType.objects.filter(program=self.program, text='Program admission').order_by('-id')
+        if lineitems.exists():
+            return lineitems[0]
+        return None
 
     def get_lineitemtypes_Q(self, include_donations=True, required_only=False, optional_only=False, payment_only=False, lineitemtype_id=None):
         if lineitemtype_id:

--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -1283,12 +1283,10 @@ class Program(models.Model, CustomFormsLinkModel):
         from esp.accounting.models import LineItemType
         if value is not None:
             self._sibling_discount = Decimal(value)
-            Tag.setTag('sibling_discount', target=self, value=self._sibling_discount)
-            LineItemType.objects.get_or_create(text='Sibling discount', program=self, amount_dec = self._sibling_discount)
         else:
             self._sibling_discount = Decimal('0.00')
-            Tag.objects.filter(key='sibling_discount', object_id=self.id).delete()
-            LineItemType.objects.filter(text='Sibling discount', program=self).delete()
+        Tag.setTag('sibling_discount', target=self, value=self._sibling_discount)
+        LineItemType.objects.get_or_create(text='Sibling discount', program=self, amount_dec = self._sibling_discount)
 
     sibling_discount = property(_sibling_discount_get, _sibling_discount_set)
 


### PR DESCRIPTION
This makes the following changes:

1. When program settings are saved, the sibling discount tag and line item will always be set (before, they were not set if the setting was left blank)
2. To double ensure that this bug is no longer an issue, if the line item still doesn't exist, we then return None instead of erroring. This case is already handled within the credit card module by the filter in this line:
https://github.com/learning-unlimited/ESP-Website/blob/5e7715948d4cf3bc7f91e8562f3aae93ecca13fb/esp/esp/program/modules/handlers/creditcardmodule_stripe.py#L173

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3628.