### PR TITLE
Fix case where regProf wasn't set

### DIFF
--- a/esp/esp/web/views/myesp.py
+++ b/esp/esp/web/views/myesp.py
@@ -207,13 +207,13 @@ def profile_editor(request, prog_input=None, responseuponCompletion = True, role
             except:
                 pass
             form = FormClass(curUser, replacement_data)
+            if prog_input is None:
+                regProf = RegistrationProfile.getLastProfile(curUser)
+            else:
+                regProf = RegistrationProfile.getLastForProgram(curUser, prog)
+            if regProf.id is None:
+                regProf = RegistrationProfile.getLastProfile(curUser)
             if not Tag.getBooleanTag('allow_change_grade_level'):
-                if prog_input is None:
-                    regProf = RegistrationProfile.getLastProfile(curUser)
-                else:
-                    regProf = RegistrationProfile.getLastForProgram(curUser, prog)
-                if regProf.id is None:
-                    regProf = RegistrationProfile.getLastProfile(curUser)
                 if regProf.student_info:
                     if regProf.student_info.dob and 'dob' in form.fields:
                         form.data['dob'] = regProf.student_info.dob


### PR DESCRIPTION
This fixes a very specific use case (the form has an error and the "allow_change_grade_level" tag is set to True) for the profile form that forgot to set a variable that was then used later.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3626.