### PR TITLE
Consider index.html Redirects for Navbar

### DIFF
--- a/esp/public/media/scripts/nav.js
+++ b/esp/public/media/scripts/nav.js
@@ -13,8 +13,26 @@ $j('#side-dashboard a').prop('href', function() {
 
 //Select the appropriate nav-list <li> that contains an <a> which points to the current 
 //page, and make it active.
-$j('ul.nav li a[href="'+window.location.pathname+'"]').parent().addClass('active');
-$j('ul.nav li a[href="'+window.location.pathname+'/"]').parent().addClass('active');
+function highlightNavLink() {
+  const path = window.location.pathname
+  let candidateUrls = [
+    path, // standard path
+    path + "/" // adds trailing slash
+  ]
+  if (path.endsWith("index.html")) {
+    candidateUrls.push(
+      path.slice(0, -10), // remove "index.html"
+      path.slice(0, -11) // remove "/index.html"
+    )
+  }
+  
+  candidateUrls.forEach((url)=>{
+    let elem = document.querySelector(`ul.nav li a[href="${url}"]`)
+    if (elem) elem.parentElement.classList.add("active")
+  })
+}
+
+highlightNavLink()
 
 $j('.navbar-manage-contractible').hide();
 $j('.navbar-manage-expander').on("click", function () {


### PR DESCRIPTION
This PR refactors existing nav-highlighting logic and considers the case where a link is the same as the page minus "index.html".

For example if the user is on `/learn/Splash/index.html` and there's a navbar entry with a href of `/learn/Splash/` or `/learn/Splash`, these will now be considered matches for highlighting purposes.

Resolves #3596 