### PR TITLE
Mod UI fixes

### DIFF
--- a/esp/esp/program/modules/base.py
+++ b/esp/esp/program/modules/base.py
@@ -398,6 +398,9 @@ class ProgramModuleObj(models.Model):
     def isStep(self):
         return True
 
+    def inModulesList(self):
+        return self.isStep()
+
     @classmethod
     def module_properties(cls):
         """

--- a/esp/esp/program/modules/handlers/admincore.py
+++ b/esp/esp/program/modules/handlers/admincore.py
@@ -552,8 +552,40 @@ class AdminCore(ProgramModuleObj, CoreModule):
                 pmo.required = False
                 pmo.required_label = request.POST.get("%s_label" % mod_id, "")
                 pmo.save()
+            # Override some settings that shouldn't be changed
+            # Profile modules should always be required and always first
+            pmos = ProgramModuleObj.objects.filter(program = prog, module__handler = "RegProfileModule")
+            for pmo in pmos:
+                pmo.seq = 0
+                pmo.required = True
+                pmo.save()
+            # Credit card modules should never be required and always last
+            pmos = ProgramModuleObj.objects.filter(program = prog, module__handler__contains = "CreditCardModule_")
+            for pmo in pmos:
+                pmo.seq = 10000
+                pmo.required = False
+                pmo.save()
+            # The confirm reg module should never be required
+            pmos = ProgramModuleObj.objects.filter(program = prog, module__handler = "StudentRegConfirm")
+            for pmo in pmos:
+                pmo.required = False
+                pmo.save()
+            # The availability module should always be required
+            pmos = ProgramModuleObj.objects.filter(program = prog, module__handler = "AvailabilityModule")
+            for pmo in pmos:
+                pmo.required = True
+                pmo.save()
+            # The acknowledgment modules should always be required
+            pmos = ProgramModuleObj.objects.filter(program = prog, module__handler__contains = "AcknowledgementModule")
+            for pmo in pmos:
+                pmo.required = True
+                pmo.save()
+            # The two phase lottery module should always be required
+            pmos = ProgramModuleObj.objects.filter(program = prog, module__handler = "StudentRegTwoPhase")
+            for pmo in pmos:
+                pmo.required = True
+                pmo.save()
 
-        # Are there any modules that we should manually exclude here? Credit card module?
         learn_modules = [mod for mod in prog.getModules(tl = 'learn') if mod.inModulesList()]
         context['learn_modules'] = {'required': filter(lambda mod: mod.required, learn_modules),
                                     'not_required': filter(lambda mod: not mod.required, learn_modules)}

--- a/esp/esp/program/modules/handlers/admincore.py
+++ b/esp/esp/program/modules/handlers/admincore.py
@@ -495,8 +495,7 @@ class AdminCore(ProgramModuleObj, CoreModule):
         if request.method == 'POST':
             if "default_seq" in request.POST or "default_req" in request.POST or "default_lab" in request.POST:
                 # Reset some or all values for learn and teach modules
-                print("hello")
-                for pmo in [mod for mod in prog.getModules(tl = 'learn') if mod.isStep()]:
+                for pmo in [mod for mod in prog.getModules(tl = 'learn') if mod.inModulesList()]:
                     pmo = ProgramModuleObj.objects.get(id=pmo.id) # Get the uncached object to make sure we trigger the cache
                     if "default_seq" in request.POST: # Reset module seq values
                         pmo.seq = pmo.module.seq
@@ -505,7 +504,7 @@ class AdminCore(ProgramModuleObj, CoreModule):
                     if "default_lab" in request.POST: # Reset module required label values
                         pmo.required_label = ""
                     pmo.save()
-                for pmo in [mod for mod in prog.getModules(tl = 'teach') if mod.isStep()]:
+                for pmo in [mod for mod in prog.getModules(tl = 'teach') if mod.inModulesList()]:
                     pmo = ProgramModuleObj.objects.get(id=pmo.id) # Get the uncached object to make sure we trigger the cache
                     if "default_seq" in request.POST: # Reset module seq values
                         pmo.seq = pmo.module.seq
@@ -555,10 +554,10 @@ class AdminCore(ProgramModuleObj, CoreModule):
                 pmo.save()
 
         # Are there any modules that we should manually exclude here? Credit card module?
-        learn_modules = [mod for mod in prog.getModules(tl = 'learn') if mod.isStep()]
+        learn_modules = [mod for mod in prog.getModules(tl = 'learn') if mod.inModulesList()]
         context['learn_modules'] = {'required': filter(lambda mod: mod.required, learn_modules),
                                     'not_required': filter(lambda mod: not mod.required, learn_modules)}
-        teach_modules = [mod for mod in prog.getModules(tl = 'teach') if mod.isStep()]
+        teach_modules = [mod for mod in prog.getModules(tl = 'teach') if mod.inModulesList()]
         context['teach_modules'] = {'required': filter(lambda mod: mod.required, teach_modules),
                                     'not_required': filter(lambda mod: not mod.required, teach_modules)}
         context['one'] = one

--- a/esp/esp/program/modules/handlers/admincore.py
+++ b/esp/esp/program/modules/handlers/admincore.py
@@ -555,8 +555,12 @@ class AdminCore(ProgramModuleObj, CoreModule):
                 pmo.save()
 
         # Are there any modules that we should manually exclude here? Credit card module?
-        context['learn_modules'] = [mod for mod in prog.getModules(tl = 'learn') if mod.isStep()]
-        context['teach_modules'] = [mod for mod in prog.getModules(tl = 'teach') if mod.isStep()]
+        learn_modules = [mod for mod in prog.getModules(tl = 'learn') if mod.isStep()]
+        context['learn_modules'] = {'required': filter(lambda mod: mod.required, learn_modules),
+                                    'not_required': filter(lambda mod: not mod.required, learn_modules)}
+        teach_modules = [mod for mod in prog.getModules(tl = 'teach') if mod.isStep()]
+        context['teach_modules'] = {'required': filter(lambda mod: mod.required, teach_modules),
+                                    'not_required': filter(lambda mod: not mod.required, teach_modules)}
         context['one'] = one
         context['two'] = two
         context['program'] = prog

--- a/esp/esp/program/modules/handlers/studentregphasezero.py
+++ b/esp/esp/program/modules/handlers/studentregphasezero.py
@@ -253,6 +253,9 @@ class StudentRegPhaseZero(ProgramModuleObj):
     def isStep(self):
         return False
 
+    def inModulesList(self):
+        return True
+
     class Meta:
         proxy = True
         app_label = 'modules'

--- a/esp/templates/program/modules/admincore/modules.html
+++ b/esp/templates/program/modules/admincore/modules.html
@@ -36,66 +36,66 @@
     <input type='hidden' name='learn_not_req' id='learn_not_req'>
     <input type='hidden' name='teach_req' id='teach_req'>
     <input type='hidden' name='teach_not_req' id='teach_not_req'>
-    
-    <div class="wrapper">
-        <h2>
-          Student Registration
-        </h2>
-        <div id="learn_mods" class="column">
-            <h3>
-                Required
-            </h3>
-            <ol id="sortable1" class="connectedSortable">
-            {% for mod in learn_modules.required %}
-                <li id='{{ mod.id }}' class="ui-state-default{% if mod.required_label %} has_label{% endif %}">
-                    {{ mod.module.admin_title }}<br/>
-                    <input type="text" name="{{ mod.id }}_label" value="{{ mod.required_label }}" placeholder="(requirement label)"{% if not mod.required_label %} style="display: none;"{% endif %}>
-                </li>
-            {% endfor %}
-            </ol>
-            <h3>
-                Not Required
-            </h3>
-            <ol id="sortable2" class="connectedSortable">
-            {% for mod in learn_modules.not_required %}
-                <li id='{{ mod.id }}' class="ui-state-default{% if mod.required_label %} has_label{% endif %}">
-                    {{ mod.module.admin_title }}<br/>
-                    <input type="text" name="{{ mod.id }}_label" value="{{ mod.required_label }}" placeholder="(requirement label)"{% if not mod.required_label %} style="display: none;"{% endif %}>
-                </li>
-            {% endfor %}
-            </ol>
+    <div style="float: left; width: 100%;">
+        <div class="wrapper">
+            <h2>
+              Student Registration
+            </h2>
+            <div id="learn_mods" class="column">
+                <h3>
+                    Required
+                </h3>
+                <ol id="sortable1" class="connectedSortable">
+                {% for mod in learn_modules.required %}
+                    <li id='{{ mod.id }}' class="ui-state-default{% if mod.required_label %} has_label{% endif %}">
+                        {{ mod.module.admin_title }}<br/>
+                        <input type="text" name="{{ mod.id }}_label" value="{{ mod.required_label }}" placeholder="(requirement label)"{% if not mod.required_label %} style="display: none;"{% endif %}>
+                    </li>
+                {% endfor %}
+                </ol>
+                <h3>
+                    Not Required
+                </h3>
+                <ol id="sortable2" class="connectedSortable">
+                {% for mod in learn_modules.not_required %}
+                    <li id='{{ mod.id }}' class="ui-state-default{% if mod.required_label %} has_label{% endif %}">
+                        {{ mod.module.admin_title }}<br/>
+                        <input type="text" name="{{ mod.id }}_label" value="{{ mod.required_label }}" placeholder="(requirement label)"{% if not mod.required_label %} style="display: none;"{% endif %}>
+                    </li>
+                {% endfor %}
+                </ol>
+            </div>
+        </div>
+        <div class="wrapper">
+            <h2>
+              Teacher Registration
+            </h2>
+            <div id="teach_mods" class="column">
+                <h3>
+                    Required
+                </h3>
+                <ol id="sortable3" class="connectedSortable">
+                {% for mod in teach_modules.required %}
+                    <li id='{{ mod.id }}' class="ui-state-default{% if mod.required_label %} has_label{% endif %}">
+                        {{ mod.module.admin_title }}<br/>
+                        <input type="text" name="{{ mod.id }}_label" value="{{ mod.required_label }}" placeholder="(requirement label)"{% if not mod.required_label %} style="display: none;"{% endif %}>
+                    </li>
+                {% endfor %}
+                </ol>
+                <h3>
+                    Not Required
+                </h3>
+                <ol id="sortable4" class="connectedSortable">
+                {% for mod in teach_modules.not_required %}
+                    <li id='{{ mod.id }}' class="ui-state-default{% if mod.required_label %} has_label{% endif %}">
+                        {{ mod.module.admin_title }}<br/>
+                        <input type="text" name="{{ mod.id }}_label" value="{{ mod.required_label }}" placeholder="(requirement label)"{% if not mod.required_label %} style="display: none;"{% endif %}>
+                    </li>
+                {% endfor %}
+                </ol>
+            </div>
         </div>
     </div>
-    <div class="wrapper">
-        <h2>
-          Teacher Registration
-        </h2>
-        <div id="teach_mods" class="column">
-            <h3>
-                Required
-            </h3>
-            <ol id="sortable3" class="connectedSortable">
-            {% for mod in teach_modules.required %}
-                <li id='{{ mod.id }}' class="ui-state-default{% if mod.required_label %} has_label{% endif %}">
-                    {{ mod.module.admin_title }}<br/>
-                    <input type="text" name="{{ mod.id }}_label" value="{{ mod.required_label }}" placeholder="(requirement label)"{% if not mod.required_label %} style="display: none;"{% endif %}>
-                </li>
-            {% endfor %}
-            </ol>
-            <h3>
-                Not Required
-            </h3>
-            <ol id="sortable4" class="connectedSortable">
-            {% for mod in teach_modules.not_required %}
-                <li id='{{ mod.id }}' class="ui-state-default{% if mod.required_label %} has_label{% endif %}">
-                    {{ mod.module.admin_title }}<br/>
-                    <input type="text" name="{{ mod.id }}_label" value="{{ mod.required_label }}" placeholder="(requirement label)"{% if not mod.required_label %} style="display: none;"{% endif %}>
-                </li>
-            {% endfor %}
-            </ol>
-        </div>
-    </div>
-    
     <center><input class="fancybutton" type="submit" value="Save Modules"/></center>
 </form>
 

--- a/esp/templates/program/modules/admincore/modules.html
+++ b/esp/templates/program/modules/admincore/modules.html
@@ -28,7 +28,15 @@
 
 <div class="alert alert-danger">
   <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
-  Please be aware that some modules require other modules (e.g., teacher class registration usually requires a teacher to have already set their availability), some modules should always be required (e.g., the two-phase student registration module), and some modules should always be last (e.g., the credit card payment module). Please use common sense and make sure to test everything whenever you change any of these settings! Feel free to contact <a href="mailto:websupport@learningu.org">websupport</a> with any questions.
+  Please be aware that some modules require other modules to have been completed already (e.g., teacher class registration usually requires a teacher to have already set their availability). Please use common sense and make sure to test everything whenever you change any of these settings! Feel free to contact <a href="mailto:websupport@learningu.org">websupport</a> with any questions. Furthermore, the following settings will always be enforced regardless of how you move the modules below:
+  <ul>
+    <li>Profile Editor Modules must always be first <i>and</i> required</li>
+    <li>The Availability Module must always be required</li>
+    <li>Acknowledgment Modules must always be required</li>
+    <li>The Two Phase Lottery Module must always be required</li>
+    <li>The Credit Card Module must always be last <i>and</i> can not be required</li>
+    <li>The Confirm Registration Module can not be required</li>
+  </ul>
 </div>
 
 <form action="/manage/{{ program.getUrlBase }}/modules/" method="post">

--- a/esp/templates/program/modules/admincore/modules.html
+++ b/esp/templates/program/modules/admincore/modules.html
@@ -46,16 +46,18 @@
                 Required
             </h3>
             <ol id="sortable1" class="connectedSortable">
-            {% for mod in learn_modules %}
-                {% ifchanged mod.required %}
-                    {% if not mod.required %}
-                        </ol>
-                        <h3>
-                            Not Required
-                        </h3>
-                        <ol id="sortable2" class="connectedSortable">
-                    {% endif %}
-                {% endifchanged %}
+            {% for mod in learn_modules.required %}
+                <li id='{{ mod.id }}' class="ui-state-default{% if mod.required_label %} has_label{% endif %}">
+                    {{ mod.module.admin_title }}<br/>
+                    <input type="text" name="{{ mod.id }}_label" value="{{ mod.required_label }}" placeholder="(requirement label)"{% if not mod.required_label %} style="display: none;"{% endif %}>
+                </li>
+            {% endfor %}
+            </ol>
+            <h3>
+                Not Required
+            </h3>
+            <ol id="sortable2" class="connectedSortable">
+            {% for mod in learn_modules.not_required %}
                 <li id='{{ mod.id }}' class="ui-state-default{% if mod.required_label %} has_label{% endif %}">
                     {{ mod.module.admin_title }}<br/>
                     <input type="text" name="{{ mod.id }}_label" value="{{ mod.required_label }}" placeholder="(requirement label)"{% if not mod.required_label %} style="display: none;"{% endif %}>
@@ -73,16 +75,18 @@
                 Required
             </h3>
             <ol id="sortable3" class="connectedSortable">
-            {% for mod in teach_modules %}
-                {% ifchanged mod.required %}
-                    {% if not mod.required %}
-                        </ol>
-                        <h3>
-                            Not Required
-                        </h3>
-                        <ol id="sortable4" class="connectedSortable">
-                    {% endif %}
-                {% endifchanged %}
+            {% for mod in teach_modules.required %}
+                <li id='{{ mod.id }}' class="ui-state-default{% if mod.required_label %} has_label{% endif %}">
+                    {{ mod.module.admin_title }}<br/>
+                    <input type="text" name="{{ mod.id }}_label" value="{{ mod.required_label }}" placeholder="(requirement label)"{% if not mod.required_label %} style="display: none;"{% endif %}>
+                </li>
+            {% endfor %}
+            </ol>
+            <h3>
+                Not Required
+            </h3>
+            <ol id="sortable4" class="connectedSortable">
+            {% for mod in teach_modules.not_required %}
                 <li id='{{ mod.id }}' class="ui-state-default{% if mod.required_label %} has_label{% endif %}">
                     {{ mod.module.admin_title }}<br/>
                     <input type="text" name="{{ mod.id }}_label" value="{{ mod.required_label }}" placeholder="(requirement label)"{% if not mod.required_label %} style="display: none;"{% endif %}>


### PR DESCRIPTION
This fixes the following issues with the modules UI:

1. The phase zero module is now shown on the page and there is now a way to manually include other non-isStep modules (Fixes https://github.com/learning-unlimited/ESP-Website/issues/3634).
2. There are always Required and Not Required sections, even when there are no modules in those sections (Fixes https://github.com/learning-unlimited/ESP-Website/issues/3635).
3. We now enforce various module setting restrictions (e.g., Credit Card Module can never be required) and list these restrictions in the Big Red Box (TM) (Fixes https://github.com/learning-unlimited/ESP-Website/issues/3636).
 
![image](https://user-images.githubusercontent.com/7232514/228998489-9e7427be-6985-4184-84f2-aec7e5f759ef.png)