### PR TITLE
Copy over choosable=2 modules from template programs

### DIFF
--- a/esp/esp/program/modules/handlers/financialaidappmodule.py
+++ b/esp/esp/program/modules/handlers/financialaidappmodule.py
@@ -34,6 +34,7 @@ Learning Unlimited, Inc.
 """
 from esp.program.modules.base import ProgramModuleObj, needs_teacher, needs_student, needs_admin, usercheck_usetl, meets_deadline, main_call, aux_call
 from esp.program.modules import module_ext
+from esp.accounting.controllers import ProgramAccountingController
 from esp.utils.web import render_to_response, secure_required
 from esp.middleware      import ESPError
 from esp.users.models    import ESPUser, User
@@ -181,6 +182,10 @@ This request can be (re)viewed at:
                                   request,
                                   {'form': form, 'app': app})
 
+    def isStep(self):
+        # Only show this module if there are things (with costs) for financial aid to cover
+        pac = ProgramAccountingController(self.program)
+        return pac.get_lineitemtypes().filter(for_finaid=True, amount_dec__gt=0).exists()
 
     class Meta:
         proxy = True

--- a/esp/esp/program/views.py
+++ b/esp/esp/program/views.py
@@ -555,8 +555,6 @@ def newprogram(request):
             if 'template_prog' in request.session:
                 # Force all ProgramModuleObjs and their extensions to be created now
                 old_prog = Program.objects.get(id=request.session['template_prog'])
-                # Copy any manually enabled modules
-                new_prog.program_modules.add(*old_prog.program_modules.filter(choosable=2))
                 # If we are using another program as a template, let's copy the seq and required values from that program.
                 new_prog.getModules(old_prog=old_prog)
                 # Copy CRMI settings from old program

--- a/esp/esp/program/views.py
+++ b/esp/esp/program/views.py
@@ -554,8 +554,10 @@ def newprogram(request):
 
             if 'template_prog' in request.session:
                 # Force all ProgramModuleObjs and their extensions to be created now
-                # If we are using another program as a template, let's copy the seq and required values from that program.
                 old_prog = Program.objects.get(id=request.session['template_prog'])
+                # Copy any manually enabled modules
+                new_prog.program_modules.add(*old_prog.program_modules.filter(choosable=2))
+                # If we are using another program as a template, let's copy the seq and required values from that program.
                 new_prog.getModules(old_prog=old_prog)
                 # Copy CRMI settings from old program
                 old_crmi = ClassRegModuleInfo.objects.get(program=old_prog)

--- a/esp/templates/program/newprogram.html
+++ b/esp/templates/program/newprogram.html
@@ -45,8 +45,21 @@ Use a past program as a template:
 {% endfor %}
 </select>
 <br />
-<font color="#4CC417">If you use a program as a template, make sure to carefully look through and update all fields below!</font>
 </p>
+{% if template_prog_id != 0 %}
+<div class="alert alert-info" role="alert">
+<span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+If you use a program as a template, make sure to carefully look through and update all fields below!</br>
+In addition to importing the settings listed in the form below, using this program as a template will also copy the following:
+<ul>
+    <li>Teacher class registration settings</li>
+    <li>Student class registration settings</li>
+    <li>Tag settings</li>
+    <li>Module sequence and required settings</li>
+    <li>Manually enabled modules</li>
+</ul>
+</div>
+{% endif %}
 
 <div id="alumni_form">
   <form action="{{ request.path }}" method="post">


### PR DESCRIPTION
This copies over any modules from a template program that are "choosable=2" (i.e., manually enabled). This makes it so we aren't encouraging the use of these modules, but we are copying them over in case chapters have decided to use them.

While I was at it, I also cleaned up the new program form with a pretty blue box with information about all of these seemingly random things we copy over from template programs.

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3573.