### PR TITLE
Show any/all tag form errors at the top of the page

### DIFF
--- a/esp/templates/program/modules/admincore/tags.html
+++ b/esp/templates/program/modules/admincore/tags.html
@@ -15,6 +15,7 @@
 
 {% block content %}
 
+{% load main %}
 {% load render_qsd %}
 
 <h1>{% if program %}Tag Settings for {{ program.niceName }} (ID: {{ program.id }}){% else %}Global Tag Settings{% endif %}</h1>
@@ -35,7 +36,17 @@
 
 <form action="/manage/{% if program %}{{ program.getUrlBase }}/{% endif %}tags/" method="post">
 {% autoescape off %}
-{% if form.non_field_errors %}{{ form.non_field_errors }}{% endif %}
+{% if form.errors %}
+<div class="alert alert-danger">
+  <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+  Encountered the following errors while processing the form (fix and resubmit):
+  <ul class="errorlist">
+      {% for tag, error in form.errors.items %}
+        <li>{{ tag|as_form_label }}{{ error }}</li>
+      {% endfor %}
+  </ul>
+</div>
+{% endif %}
 {% endautoescape %}
 {% for fieldset in form.fieldsets %}
 {% if fieldset.name in categories %}


### PR DESCRIPTION
If there are any errors when submitting the tag settings form, they are now collectively shown at the top of the page (because otherwise admins can't tell that there are any errors since all of the categories are collapsed).

![image](https://github.com/learning-unlimited/ESP-Website/assets/7232514/481774ac-b61a-4ce6-8239-9607ec3ddca5)

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3607.