### PR TITLE
Fix form submission handling

### DIFF
--- a/esp/templates/elements/html
+++ b/esp/templates/elements/html
@@ -79,7 +79,12 @@
     <!-- prevent forms from being submitted twice -->
     <script text="text/javascript">
       $j(function() {
-        $j('[type=submit]:not(.stripe-button-el)').click(function(){
+        $j('[type=submit]:not(.stripe-button-el)').on('click', function(event){
+          <!-- prevent any other behaviors -->
+          event.preventDefault();
+          event.stopPropagation();
+          
+          <!-- disable the submit button -->
           $j(this).prop('disabled', true);
           var form = $j(this).parents('form');
           <!-- this adds a hidden field in case we care what the button name/value are -->
@@ -88,9 +93,24 @@
               name: $j(this).prop('name'),
               value: $j(this).prop('value')
           }).appendTo(form);
+          <!-- check csrf cookie in form (we prevented this above) -->
+          check_csrf_cookie(form[0]);
+          var submitted = false;
+          <!-- check form validity -->
           if(form[0].reportValidity()) {
-            form.submit();
-          } else {
+            <!-- run form's onsubmit if it has one -->
+            if(form[0].hasAttribute("onsubmit")) {
+              if(form[0].onsubmit()) {
+                form[0].submit();
+                submitted = true;
+              }
+            } else {
+              form[0].submit();
+              submitted = true;
+            }
+          }
+          <!-- if we didn't end up submitting the form, reenable the submit button -->
+          if(!submitted) {
             $j(this).prop('disabled', false);
           }
         });

--- a/esp/templates/program/modules/teacherclassregmodule/classedit.html
+++ b/esp/templates/program/modules/teacherclassregmodule/classedit.html
@@ -53,7 +53,7 @@
 {% endif %}
 
 <div id="program_form">
-<form action="{{request.path}}" id="clsform" name="clsform" method="post" class="form-inline"{% if grade_range_popup %} onSubmit="check_grade_range(this)"{% endif %}">
+<form action="{{request.path}}" id="clsform" name="clsform" method="post" class="form-inline"{% if grade_range_popup %} onsubmit="return check_grade_range(this);"{% endif %}">
 
 {% if form.errors %}
 <p align="center">

--- a/esp/templates/program/modules/volunteersignup/signup.html
+++ b/esp/templates/program/modules/volunteersignup/signup.html
@@ -21,7 +21,7 @@ label.required:after {
 function confirm_cancellation() {
     $j("input[name=clear_requests]").val("True");
     $j("#confirm_cancellation_dialog").dialog("close");
-    $j("#volunteer_shift_form").submit();
+    $j("#volunteer_shift_form").trigger("submit");
 }
 
 function decline_cancellation() {
@@ -39,7 +39,7 @@ $j(document).ready(function () {
         //  Check if the user has previous requests and is asking to clear all of them
         var checkboxes_checked = $j("input[name=requests]:checked");
         if (($j("input[name=has_previous_requests]").val() == "True") &&
-            (checkboxes_checked.size() == 0)) {
+            (checkboxes_checked.length == 0)) {
             //  If so, prevent the form from being submitted - we want a confirmation
             event.preventDefault();
             
@@ -145,7 +145,7 @@ The directors have been notified that you are no longer able to volunteer at {{ 
         </div>
         {{ form.non_field_errors }}
         <br><br>
-        <input style="display: block" id="volunteer_form_submit" type="submit" value="Submit" class="btn btn-primary" />
+        <input style="display: block" id="volunteer_form_submit" type="button" value="Submit" class="btn btn-primary" />
       </div>
     </center>
   </form>


### PR DESCRIPTION
This fixes the way that we handle form submissions (with respect to the previous fix to prevent double button presses). I have only tested this behavior on the class registration form, but it seems to work well there (including with the popup when the grade range is too wide). During review it would probably be good to check a few other forms to make sure they all still work, too.

Fixes #3668. Fixes #3664.