### PR TITLE
Add ability to unassign moderators from unscheduled sections

### DIFF
--- a/esp/public/media/default_styles/scheduling.css
+++ b/esp/public/media/default_styles/scheduling.css
@@ -21,6 +21,12 @@ table.sortable thead th:not(.sorttable_sorted):not(.sorttable_sorted_reverse):no
     cursor: pointer;
 }
 
+td.selected-moderator {
+    outline: 4px solid yellow;
+    position: relative;
+    z-index: 1000;
+}
+
 .matrix-cell{
     height: 40px;
     min-width: 80px;

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Moderators.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Moderators.js
@@ -9,6 +9,7 @@ function ModeratorDirectory(el, moderators) {
     this.el = el;
     this.moderators = moderators;
     this.selectedModerator = null;
+    this.selectedModeratorCell = null;
 
     // Set up filtering
     this.filter = {
@@ -176,7 +177,7 @@ function ModeratorDirectory(el, moderators) {
     this.numAvailableSlots = function(moderator) {
         var avail_slots = moderator.num_slots;
         for(var section of moderator.sections) {
-            var assignment = this.matrix.sections.scheduleAssignments[section]
+            var assignment = this.matrix.sections.scheduleAssignments[section];
             if(assignment){
                 avail_slots -= assignment.timeslots.length;
             }
@@ -243,6 +244,7 @@ function ModeratorDirectory(el, moderators) {
         }
 
         this.selectedModerator = moderator;
+        if(this.selectedModeratorCell) this.selectedModeratorCell.el.addClass("selected-moderator");
         this.matrix.sectionInfoPanel.displayModerator(moderator);
         this.availableTimeslots = this.getAvailableTimeslots(moderator);
         this.matrix.highlightTimeslots(this.availableTimeslots, null, moderator);
@@ -256,6 +258,10 @@ function ModeratorDirectory(el, moderators) {
         this.matrix.sectionInfoPanel.hide();
         this.matrix.sectionInfoPanel.override = override;
         this.matrix.unhighlightTimeslots(this.availableTimeslots, this.selectedModerator);
+        if(this.selectedModeratorCell) {
+            this.selectedModeratorCell.el.removeClass("selected-moderator");
+            this.selectedModeratorCell = null;
+        }
         this.selectedModerator = null;
     };
 

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Scheduler.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Scheduler.js
@@ -150,6 +150,7 @@ function Scheduler(
         // set up handler for selecting moderators
         $j("body").on("click", "td.moderator-cell", function(evt, ui) {
             var moderatorCell = $j(evt.currentTarget).data("moderatorCell");
+            this.moderatorDirectory.selectedModeratorCell = moderatorCell;
             this.moderatorDirectory.selectModerator(moderatorCell.moderator);
         }.bind(this));
 

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/SectionInfoPanel.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/SectionInfoPanel.js
@@ -116,7 +116,8 @@ function SectionInfoPanel(el, sections, togglePanel, sectionCommentDialog) {
     var getModeratorLinks = function(section) {
         var moderator_links_list = []
             $j.each(section.moderator_data, function(index, moderator) {
-                moderator_links_list.push("<a href='#' class='moderator-link' data-moderator='" + moderator.id + "'>" + moderator.first_name + " " + moderator.last_name + "</a>");
+                moderator_links_list.push("<a href='#' class='moderator-link' data-moderator='" + moderator.id + "'>" + moderator.first_name + " " + moderator.last_name +
+                                          "</a> <button class='moderator-remove' data-moderator='" + moderator.id + "' data-section='" + section.id + "'>Remove</button>");
             });
         var moderator_links = moderator_links_list.join(", ");
         return $j(moderator_links);
@@ -184,6 +185,14 @@ function SectionInfoPanel(el, sections, togglePanel, sectionCommentDialog) {
         this.el.append(getHeader(section));
         this.el.append(getToolbar(section));
         this.el.append(getContent(section));
+        if(has_moderator_module === "True") {
+            $j(".moderator-remove").on("click", function(evt) {
+                var mod = this.sections.matrix.moderatorDirectory.getById($j(evt.target).data("moderator"));
+                var sec = this.sections.getById($j(evt.target).data("section"));
+                this.sections.matrix.moderatorDirectory.selectedModerator = mod;
+                this.sections.matrix.moderatorDirectory.unassignModerator(sec);
+            }.bind(this));
+        }
     };
 
     var getModeratorHeader = function(moderator) {

--- a/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
+++ b/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
@@ -313,14 +313,14 @@
       <td class="matrix-cell disabled-cell"></td><td>Classroom is not available</td>
     </tr>
     <tr>
+      <td class="selected-section"></td><td>Selected section{% if has_moderator_module %}/{{ program.getModeratorTitle|lower }}{% endif %}</td>
+    </tr>
+    <tr>
       <td class="locked-cell"></td><td>Locked section</td>
     </tr>
   </table>
   <h3>When scheduling sections:</h3>
   <table width="100%">
-    <tr>
-      <td class="selected-section"></td><td>Selected section</td>
-    </tr>
     <tr>
       <td class="matrix-cell teacher-available-cell"></td><td>All teachers{% if has_moderator_module %}/{{ program.getModeratorTitle|lower }}s{% endif %} available</td>
     </tr>


### PR DESCRIPTION
This adds a "Remove" button for each moderator so that you can unassign them from a section easily, even if the section is unscheduled. I left the "Remaining Slots" calculation alone because it reflects the current scheduled sections (which are the only ones that will be on a moderator's schedule).

![image](https://github.com/learning-unlimited/ESP-Website/assets/7232514/da62aacf-9693-4366-a341-169a1170be63)

While I was at it, I also made it so the selected moderator is highlighted.

Fixes #3653.