### PR TITLE
Fix selectmenus on logo picker page

### DIFF
--- a/esp/esp/django_settings.py
+++ b/esp/esp/django_settings.py
@@ -313,7 +313,7 @@ CDN_ADDRESS = 'https://dfwb7shzx5j05.cloudfront.net'
 JQUERY_VERSION = '3.6.0'
 JQUERY_HASH = 'sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ=='
 
-JQUERY_UI_VERSION = '1.13.0'
+JQUERY_UI_VERSION = '1.13.2'
 
 # allow configuration of additional Javascript to be placed on website
 # configuration should include <script></script> tags

--- a/esp/templates/themes/logos.html
+++ b/esp/templates/themes/logos.html
@@ -40,6 +40,7 @@
       .iconselectmenu()
       .iconselectmenu( "menuWidget")
         .addClass( "ui-menu-icons avatar" );
+    $j("option:hidden:disabled:selected").remove();
   } );
 </script>
 {% endblock %}


### PR DESCRIPTION
This fixes a bug with the dropdown menus on the theme logo picker page. This bug has actually been fixed in the source code of jquery-ui (https://github.com/jquery/jquery-ui/pull/2144), but until it's live, this hack will have to do.

While I was at it, I updated our jquery-ui version from 1.13.0 to 1.13.2, which just included a bunch of random fixes ([1.13.1 changelog](https://jqueryui.com/changelog/1.13.1/), [1.13.2 changelog](https://jqueryui.com/changelog/1.13.2/)).

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3679.