### PR TITLE
Set static redirects when conducting admin class functions

### DIFF
--- a/esp/esp/program/modules/handlers/adminclass.py
+++ b/esp/esp/program/modules/handlers/adminclass.py
@@ -277,7 +277,7 @@ class AdminClass(ProgramModuleObj):
         cls.accept()
         if 'redirect' in request.GET:
             return HttpResponseRedirect(request.GET['redirect'])
-        return self.goToCore(tl)
+        return HttpResponseRedirect(prog.get_manage_url() + 'manageclass/' + str(cls.id))
 
     @aux_call
     @needs_admin
@@ -286,7 +286,7 @@ class AdminClass(ProgramModuleObj):
         cls.reject()
         if 'redirect' in request.GET:
             return HttpResponseRedirect(request.GET['redirect'])
-        return self.goToCore(tl)
+        return HttpResponseRedirect(prog.get_manage_url() + 'manageclass/' + str(cls.id))
 
     @aux_call
     @needs_admin
@@ -295,7 +295,7 @@ class AdminClass(ProgramModuleObj):
         cls.propose()
         if 'redirect' in request.GET:
             return HttpResponseRedirect(request.GET['redirect'])
-        return self.goToCore(tl)
+        return HttpResponseRedirect(prog.get_manage_url() + 'manageclass/' + str(cls.id))
 
     @aux_call
     @needs_admin
@@ -306,7 +306,7 @@ class AdminClass(ProgramModuleObj):
         cls = classes[0]
 
         cls.delete(True)
-        return self.goToCore(tl)
+        return HttpResponseRedirect(prog.get_manage_url() + 'dashboard')
 
     @aux_call
     @needs_admin


### PR DESCRIPTION
This makes it so that when you approve/reject/delete/etc a class as an admin that you always go to the manageclass page (unless otherwise specified) afterwards (or the dashboard when deleting since the class is now gone).

Fixes #3659.