### PR TITLE
Add ability to enable/disable contact form

### DIFF
--- a/esp/esp/tagdict/__init__.py
+++ b/esp/esp/tagdict/__init__.py
@@ -507,6 +507,13 @@ all_global_tags = {
         'category': 'theme',
         'is_setting': False,
     },
+    'contact_form_enabled': {
+        'is_boolean': True,
+        'help_text': 'Should the contact form at /contact/contact be enabled?',
+        'default': False,
+        'category': 'manage',
+        'is_setting': True,
+    },
 }
 
 # Any tag used with Tag.getProgramTag()

--- a/esp/esp/urls.py
+++ b/esp/esp/urls.py
@@ -120,7 +120,8 @@ urlpatterns += [
 
 # Specific .html pages that have defaults
 urlpatterns += [
-    url(r'^faq', TemplateView.as_view(template_name='faq.html'), name='FAQ'),
+    url(r'^(faq|faq\.html)$', main.FAQView.as_view(), name='FAQ'),
+    url(r'^(contact|contact\.html)$', main.ContactUsView.as_view(), name='Contact Us'),
 ]
 
 urlpatterns += [

--- a/esp/esp/utils/web.py
+++ b/esp/esp/utils/web.py
@@ -43,6 +43,8 @@ from django.http import HttpResponse, HttpResponseRedirect
 from esp.middleware import ESPError
 from esp.themes.controllers import ThemeController
 from esp.program.models import Program
+from esp.web.views.navBar import makeNavBar
+from esp.tagdict.models import Tag
 from django.conf import settings
 import django.shortcuts
 
@@ -59,14 +61,9 @@ def get_from_id(id, module, strtype = 'object', error = True):
         return None
     return foundobj
 
-def render_to_response(template, request, context, content_type=None, use_request_context=True):
-    from esp.web.views.navBar import makeNavBar
-    from esp.tagdict.models import Tag
+def esp_context_stuff():
+    context = {}
 
-    if isinstance(template, (basestring,)):
-        template = [ template ]
-
-    section = request.path.split('/')[1]
     tc = ThemeController()
     context['theme'] = tc.get_template_settings()
     context['current_theme_version'] = Tag.getTag("current_theme_version")
@@ -76,6 +73,15 @@ def render_to_response(template, request, context, content_type=None, use_reques
     context['settings'] = settings
 
     context['current_programs'] = Program.current_programs()
+    return context
+
+def render_to_response(template, request, context, content_type=None, use_request_context=True):
+    if isinstance(template, (basestring,)):
+        template = [ template ]
+
+    section = request.path.split('/')[1]
+    
+    context.update(esp_context_stuff())
 
     # create nav bar list
     if not 'navbar_list' in context:

--- a/esp/esp/utils/web.py
+++ b/esp/esp/utils/web.py
@@ -80,7 +80,7 @@ def render_to_response(template, request, context, content_type=None, use_reques
         template = [ template ]
 
     section = request.path.split('/')[1]
-    
+
     context.update(esp_context_stuff())
 
     # create nav bar list

--- a/esp/esp/web/views/main.py
+++ b/esp/esp/web/views/main.py
@@ -55,6 +55,7 @@ from esp.tagdict.models import Tag
 from esp.utils.no_autocookie import disable_csrf_cookie_update
 
 from django.views.decorators.cache import cache_control
+from django.conf import settings
 
 try:
     from cStringIO import StringIO

--- a/esp/esp/web/views/main.py
+++ b/esp/esp/web/views/main.py
@@ -140,7 +140,7 @@ def contact(request, section='esp'):
     """
     from esp.dbmail.models import send_mail
     # if not set up, immediately redirect
-    if not Tag.getTag('contact_form_enabled'):
+    if not Tag.getBooleanTag('contact_form_enabled'):
         return HttpResponseRedirect("/contact.html")
 
     if 'success' in request.GET:

--- a/esp/templates/contact_qsd.html
+++ b/esp/templates/contact_qsd.html
@@ -6,12 +6,13 @@
 {% block content %}
 
 {% load render_qsd %}
+{% load getTag %}
 
 {% inline_qsd_block "contact" %}
 
 <p>
-For general communication, please email us at <b><a href="mailto:{{ settings.DEFAULT_EMAIL_ADDRESSES.default }}">{{ settings.DEFAULT_EMAIL_ADDRESSES.default }}</a></b>.
 Before contacting us with a question or concern, please check our <b><a href="/faq.html">FAQ page</a></b>.
+If your question is still not answered, please contact us {% if "contact_form_enabled"|getBooleanTag %}via <b><a href="/contact/contact">our contact form</a></b>{% else %} via email at <b><a href="mailto:{{ settings.DEFAULT_EMAIL_ADDRESSES.default }}">{{ settings.DEFAULT_EMAIL_ADDRESSES.default }}</a></b>{% endif %}.
 </p>
 
 {% end_inline_qsd_block %}

--- a/esp/templates/contact_qsd.html
+++ b/esp/templates/contact_qsd.html
@@ -1,0 +1,18 @@
+{% extends "main.html" %}
+
+{% block title %}Contact Us{% endblock %}
+{% block content_title %}Contact Us{% endblock %}
+
+{% block content %}
+
+{% load render_qsd %}
+
+{% inline_qsd_block "contact" %}
+
+<p>
+For general communication, please email us at <b><a href="mailto:{{ settings.DEFAULT_EMAIL_ADDRESSES.default }}">{{ settings.DEFAULT_EMAIL_ADDRESSES.default }}</a></b>.
+Before contacting us with a question or concern, please check our <b><a href="/faq.html">FAQ page</a></b>.
+</p>
+
+{% end_inline_qsd_block %}
+{% endblock %}


### PR DESCRIPTION
This adds a tag that allows admins to enable the contact form (the form is now disabled by default). If the form is disabled, the URL now redirects to /contact.html (before POSTs are processed). Since this page didn't exist before (most chapters make their own QSD page), I've now added a default page for this URL. If chapters already had QSD set for this page, it should be used instead. While I was at it, I cleaned up my previous implementation of the default FAQ page (#3174). Both of these pages now properly show various theme and admin toolbar bits that were previously missing.

Fixes #2303 (finally).