### PR TITLE
Add validation for JSON-formatted tags

### DIFF
--- a/esp/esp/tagdict/__init__.py
+++ b/esp/esp/tagdict/__init__.py
@@ -2,10 +2,22 @@ from collections import OrderedDict
 from django import forms
 from django.forms import widgets
 from django.core.validators import RegexValidator
+from django.core.exceptions import ValidationError
 from decimal import Decimal
 import datetime
 
 from esp.users.forms import _states
+
+import json
+
+def validate_JSON(value):
+    try:
+        json.loads(value)
+    except ValueError:
+        raise ValidationError('Enter a valid JSON value.')
+
+class JSONValidatedCharField(forms.CharField):
+    default_validators = [validate_JSON]
 
 # Lists of all tags used anywhere in the codebase
 # Populated by hand, so don't be too surprised if something is missing
@@ -29,6 +41,7 @@ all_global_tags = {
         'default': None,
         'category': 'teach',
         'is_setting': True,
+        'field': JSONValidatedCharField(),
     },
     'allow_global_restypes': {
         'is_boolean': True,
@@ -65,6 +78,7 @@ all_global_tags = {
         'default': None,
         'category': 'teach',
         'is_setting': True,
+        'field': JSONValidatedCharField(),
     },
     'class_style_choices': {
         'is_boolean': False,
@@ -72,6 +86,7 @@ all_global_tags = {
         'default': None,
         'category': 'teach',
         'is_setting': True,
+        'field': JSONValidatedCharField(),
     },
     'volunteer_tshirt_options': {
         'is_boolean': True,
@@ -350,6 +365,7 @@ all_global_tags = {
         'default': '[7,8,9,10,11,12]',
         'category': 'learn',
         'is_setting': True,
+        'field': JSONValidatedCharField(),
     },
     'user_types': {
         'is_boolean': False,
@@ -357,6 +373,7 @@ all_global_tags = {
         'default': '[["Student", {"label": "Student (up through 12th grade)", "profile_form": "StudentProfileForm"}],["Teacher", {"label": "Volunteer Teacher", "profile_form": "TeacherProfileForm"}],["Guardian", {"label": "Guardian of Student", "profile_form": "GuardianProfileForm"}],["Educator", {"label": "K-12 Educator", "profile_form": "EducatorProfileForm"}],["Volunteer", {"label": "Onsite Volunteer", "profile_form": "VolunteerProfileForm"}]]',
         'category': 'manage',
         'is_setting': True,
+        'field': JSONValidatedCharField(),
     },
     'student_profile_gender_field': {
         'is_boolean': True,
@@ -428,6 +445,7 @@ all_global_tags = {
         'default': '{}',
         'category': 'manage',
         'is_setting': True,
+        'field': JSONValidatedCharField(),
     },
     'admin_home_page': {
         'is_boolean': False,
@@ -456,6 +474,7 @@ all_global_tags = {
         'default': None,
         'category': 'manage',
         'is_setting': True,
+        'field': JSONValidatedCharField(),
     },
     'google_cloud_api_key': {
         'is_boolean': False,
@@ -932,6 +951,7 @@ all_program_tags = {
         'default': '{}',
         'category': 'learn',
         'is_setting': True,
+        'field': JSONValidatedCharField(),
     },
     'learn_extraform_id': {
         'is_boolean': False,
@@ -955,6 +975,7 @@ all_program_tags = {
         'default': '{}',
         'category': 'learn',
         'is_setting': True,
+        'field': JSONValidatedCharField(),
     },
     'no_overlap_classes': {
         'is_boolean': False,
@@ -1005,6 +1026,7 @@ all_program_tags = {
         'default': None,
         'category': 'learn',
         'is_setting': True,
+        'field': JSONValidatedCharField(),
     },
     'program_size_by_grade': {
         'is_boolean': False,
@@ -1012,6 +1034,7 @@ all_program_tags = {
         'default': None,
         'category': 'learn',
         'is_setting': True,
+        'field': JSONValidatedCharField(),
     },
     'grade_ranges': {
         'is_boolean': False,
@@ -1019,6 +1042,7 @@ all_program_tags = {
         'default': None,
         'category': 'class',
         'is_setting': True,
+        'field': JSONValidatedCharField(),
     },
     'studentschedule_show_empty_blocks': {
         'is_boolean': True,
@@ -1290,6 +1314,7 @@ all_program_tags = {
         'default': None,
         'category': 'manage',
         'is_setting': False,
+        'field': JSONValidatedCharField(),
     },
     'student_schedule_pretext': {
         'is_boolean': False,

--- a/esp/templates/program/modules/admincore/tags.html
+++ b/esp/templates/program/modules/admincore/tags.html
@@ -31,7 +31,7 @@
 {% endif %}
 <div class="alert alert-danger">
   <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
-  Please be aware that these settings can be very sensitive and there are currently no warnings or blocks in place to prevent you from providing incorrect values. Please use caution, read the help text, and make sure to test everything whenever you change any of these settings! Feel free to contact <a href="mailto:websupport@learningu.org">websupport</a> with any questions.
+  Please be aware that these settings can be very sensitive and there are currently only a few warnings or blocks in place to prevent you from providing incorrect values. Please use caution, read the help text, and make sure to test everything whenever you change any of these settings! Feel free to contact <a href="mailto:websupport@learningu.org">websupport</a> with any questions.
 </div>
 
 <form action="/manage/{% if program %}{{ program.getUrlBase }}/{% endif %}tags/" method="post">


### PR DESCRIPTION
This adds validation to all existing tags that require a JSON-formatted string (if they are set through the tag settings interface).

Fixes #2084.