### PR TITLE
Hide empty categories in the catalog

### DIFF
--- a/esp/esp/program/modules/handlers/studentclassregmodule.py
+++ b/esp/esp/program/modules/handlers/studentclassregmodule.py
@@ -521,23 +521,29 @@ class StudentClassRegModule(ProgramModuleObj):
         collapse_full_classes = Tag.getBooleanTag('collapse_full_classes', prog)
         class_blobs = []
 
-        category_header_str = """<hr size="1"/>
-    <a name="cat%d"></a>
-      <p style="font-size: 1.2em;" class="category">
-         %s
-      </p>
-      <p class="linktop">
-         <a href="#top">[ Return to Category List ]</a>
-      </p>
+        category_header_str = """
+    <div class="cat_wrapper" data-category="%d">
+      <hr size="1"/>
+      <a name="cat%d"></a>
+        <p style="font-size: 1.2em;" class="category">
+           %s
+        </p>
+        <p class="linktop">
+           <a href="#top">[ Return to Category List ]</a>
+        </p>
 """
 
         class_category_id = None
         for cls in classes:
             if cls.category.id != class_category_id and categories_sort:
                 class_category_id = cls.category.id
-                class_blobs.append(category_header_str % (class_category_id, cls.category.category))
+                if (class_category_id != None):
+                    class_blobs.append('</div>')
+                class_blobs.append(category_header_str % (class_category_id, class_category_id, cls.category.category))
             class_blobs.append(render_class_direct(cls))
             class_blobs.append('<br />')
+        if categories_sort:
+            class_blobs.append('</div>')
         context['class_descs'] = ''.join(class_blobs)
         #   Include the program explicitly; this is a cached page, without RequestContext
         context['program'] = self.program

--- a/esp/esp/tagdict/__init__.py
+++ b/esp/esp/tagdict/__init__.py
@@ -507,6 +507,13 @@ all_global_tags = {
         'category': 'theme',
         'is_setting': False,
     },
+    'hide_empty_categories': {
+        'is_boolean': True,
+        'help_text': 'Should categories with no classes be hidden in the catalog? (this includes when filtering)',
+        'default': True,
+        'category': 'learn',
+        'is_setting': True,
+    },
 }
 
 # Any tag used with Tag.getProgramTag()

--- a/esp/public/media/scripts/program/modules/catalog.js
+++ b/esp/public/media/scripts/program/modules/catalog.js
@@ -1,0 +1,169 @@
+// Inject difficulty data from the tag to support custom difficulties
+const DIFFICULTIES = INJECTED_DIFFICULTIES !== "None" 
+    ? JSON.parse(INJECTED_DIFFICULTIES)
+    : [
+        ["*", "This Shouldn't Appear!"],
+        ["**", "This Shouldn't Appear!"],
+        ["***", "This Shouldn't Appear!"],
+        ["****", "This Shouldn't Appear!"]
+    ];
+
+const MODIFIED_COLOR = "#0066ff22";
+
+const FILTER_IDS = ["grade_filter", "difficulty_filter", "status_filter", "duration_filter"];
+
+/**
+    Converts from hours to a formatted duration (eg. "0.05" -> "5 mins", "1.5" -> "1 hour 30 mins")
+    @param {string} numString - a duration as a float in a string (eg. "0.05")
+    @returns {string} the formatted time (eg. "1 hour 30 mins")
+*/
+function floatToFormattedTime(numString) {
+    let float = Number(numString);
+    let result = "";
+    if (Math.floor(float) >= 1) {
+        result += `${Math.floor(float)} hrs`;
+    }
+    if (float - Math.floor(float) > 0.01) {
+        result += ` ${Math.round((float - Math.floor(float))*60)} mins`;
+    }
+    return result;
+}
+
+function hideClass(cls) {
+    $j(cls).hide();
+}
+
+function showClass(cls) {
+    $j(cls).show();
+}
+
+// Filters for the different pieces of class information. Each of these returns a predicate
+// which returns true if the class matches the filter passed to the parent function.
+
+function gradeFilter(grade) {
+    return cls => grade === "all" || cls.classList.contains(`grade_${grade}`);
+}
+
+function difficultyFilter(difficulty) {
+    return cls => difficulty === "all" || cls.getAttribute("data-difficulty") === difficulty;
+}
+
+function durationFilter(duration) {
+    return cls => duration === "all" || cls.getAttribute("data-duration") === duration;
+}
+
+function openFilter(status) {
+    return cls => {
+        return status === "all" ||
+        (status === "closed" && cls.getAttribute("data-is-closed") === "True") || 
+        (status === "open" && cls.getAttribute("data-is-closed") === "False");
+    }
+}
+
+function applyCurrentFilters() {
+    applyFilters(getOptions())
+    updateEmptyCategories();
+}
+
+function applyFilters({grade, difficulty, status, duration}) {
+    let classes = Array.from(document.getElementsByClassName("show_class"));
+    let shownClasses = classes
+        .filter(gradeFilter(grade))
+        .filter(difficultyFilter(difficulty))
+        .filter(openFilter(status))
+        .filter(durationFilter(duration));
+
+    classes.forEach(hideClass);
+    shownClasses.forEach(showClass);
+}
+
+function getOptions() {
+    return {
+        grade: document.getElementById("grade_filter").value,
+        difficulty: document.getElementById("difficulty_filter").value,
+        status: document.getElementById("status_filter").value,
+        duration: document.getElementById("duration_filter").value,
+    }
+}
+
+function updateEmptyCategories() {
+    $j(".cat_wrapper").each(function() {
+       if ($j(this).children("div").filter(function() { return $j(this).css("display") != "none" }).length == 0) {
+           if (hide_empty_cats) {
+               $j(this).hide();
+               $j("a[data-category=" + $j(this).data("category") + "]").attr('disabled', true).addClass('disabled');
+           }
+       } else {
+           $j(this).show();
+           $j("a[data-category=" + $j(this).data("category") + "]").attr('disabled', false).removeClass('disabled');
+       }
+    });
+}
+
+var student_grade = esp_user.cur_grade;
+if (student_grade != "" && student_grade != null) {
+    student_grade = parseInt(student_grade);
+    const gradeFilterElem = document.getElementById("grade_filter")
+    if (gradeFilterElem.querySelector(`option[value="${student_grade}"]`)) {
+        gradeFilterElem.value = student_grade
+    }
+}
+
+applyCurrentFilters()
+
+// Set up duration options by finding all unique durations from the classes in the catalog
+const durationFilterElem = document.getElementById("duration_filter");
+let uniqueLengths = [
+        // Convert to and back from a Set to keep only unique values
+        ...new Set(
+            Array.from(document.getElementsByClassName("show_class"))
+                .map(cls=>cls.getAttribute("data-duration"))
+        )
+    ]
+    .sort((a,b)=>a-b) // least to greatest
+    .map((val)=>[val, floatToFormattedTime(val)])
+    .forEach(([raw, formatted])=>{
+        let option = document.createElement("option")
+        option.setAttribute("value", raw)
+        option.textContent = formatted
+        durationFilterElem.append(option)
+    });
+
+// Set up difficulties by getting them from tag data (injected further up)
+const difficultyFilterElem = document.getElementById("difficulty_filter");
+
+DIFFICULTIES.forEach(([difficulty])=>{
+    let option = document.createElement("option")
+    option.setAttribute("value", difficulty)
+    option.textContent = difficulty
+    difficultyFilterElem.append(option)
+});
+
+function setModifiedColor(selectElem) {
+    if (selectElem.value !== "all") {
+        selectElem.style.background = MODIFIED_COLOR;
+    } else {
+        selectElem.style.background = "";
+    }
+}
+
+FILTER_IDS.forEach((id)=>{
+    const filterElem = document.getElementById(id)
+    // Covers the case when a page refresh has preserved form values
+    // or the grade is automatically set.
+    setModifiedColor(filterElem);
+
+    filterElem.addEventListener("change", ()=>{
+        setModifiedColor(filterElem)
+        applyCurrentFilters()
+    });
+})
+
+function configure_addbuttons()
+{
+    if (register_from_catalog) {
+        //  Registration from the catalog is allowed
+        $j("input.addbutton").show();
+    }
+}
+$j(document).ready(configure_addbuttons);

--- a/esp/public/media/scripts/program/modules/catalog.js
+++ b/esp/public/media/scripts/program/modules/catalog.js
@@ -13,7 +13,7 @@ const MODIFIED_COLOR = "#0066ff22";
 const FILTER_IDS = ["grade_filter", "difficulty_filter", "status_filter", "duration_filter"];
 
 /**
-    Converts from hours to a formatted duration (eg. "0.05" -> "5 mins", "1.5" -> "1 hour 30 mins")
+    Converts from hours to a formatted duration (eg. "0.05" -> "3 mins", "1.5" -> "1 hour 30 mins")
     @param {string} numString - a duration as a float in a string (eg. "0.05")
     @returns {string} the formatted time (eg. "1 hour 30 mins")
 */

--- a/esp/templates/program/modules/studentclassregmodule/catalog.html
+++ b/esp/templates/program/modules/studentclassregmodule/catalog.html
@@ -7,6 +7,13 @@
 {% block stylesheets %}
 {{ block.super }}
 <link rel="stylesheet" type="text/css" href="/media/styles/catalog.css" />
+<style>
+a.disabled {
+    opacity: 0.5;
+    pointer-events: none;
+    cursor: default;
+}
+</style>
 {% endblock %}
 
 {% block xtrajs %}
@@ -17,6 +24,10 @@
 
 <script type="text/javascript">
 {% include "program/modules/studentclassregmodule/common-js.html.js" %}
+// set some variables for catalog.js
+const INJECTED_DIFFICULTIES = "{{ "teacherreg_difficulty_choices"|getTag|escapejs }}";
+const register_from_catalog = {{ register_from_catalog|yesno:"true,false" }};
+const hide_empty_cats = {{ "hide_empty_categories"|getBooleanTag|yesno:"true,false" }};
 </script>
 {% endblock %}
 
@@ -80,10 +91,7 @@ Viewing classes for: {{ timeslot.friendly_name }}
 {% if forloop.counter0|divisibleby:2 %}
 <tr>{% endif %}
   <td style="width: 50%; vertical-align: top;" valign="top" align="center">
-
-    <a href="#cat{{ category.id }}" title="Click to skip down to `{{ category.category }}'">
-              {{category.category}}
-    </a>
+    <a href="#cat{{ category.id }}" data-category="{{ category.id }}" title="Click to skip down to `{{ category.category }}'">{{category.category}}</a>
   </td>
  {% if forloop.counter|divisibleby:2 %}
 </tr>{% endif %} 
@@ -108,166 +116,6 @@ if (document.getElementById("student_schedule")) {
 {% autoescape off %}{{ class_descs }}{% endautoescape %}
 </div>
 
-<script type="text/javascript">
-
-// Inject difficulty data from the tag to support custom difficulties
-const INJECTED_DIFFICULTIES = "{{ "teacherreg_difficulty_choices" | getTag | escapejs }}"
-const DIFFICULTIES = INJECTED_DIFFICULTIES !== "None" 
-    ? JSON.parse(INJECTED_DIFFICULTIES)
-    : [
-        ["*", "This Shouldn't Appear!"],
-        ["**", "This Shouldn't Appear!"],
-        ["***", "This Shouldn't Appear!"],
-        ["****", "This Shouldn't Appear!"]
-    ]
-
-const MODIFIED_COLOR = "#0066ff22"
-
-const FILTER_IDS = ["grade_filter", "difficulty_filter", "status_filter", "duration_filter"]
-
-/**
-    Converts from hours to a formatted duration (eg. "0.05" -> "5 mins", "1.5" -> "1 hour 30 mins")
-    @param {string} numString - a duration as a float in a string (eg. "0.05")
-    @returns {string} the formatted time (eg. "1 hour 30 mins")
-*/
-function floatToFormattedTime(numString) {
-    let float = Number(numString)
-    let result = ""
-    if (Math.floor(float) >= 1) {
-        result += `${Math.floor(float)} hrs`
-    }
-    if (float - Math.floor(float) > 0.01) {
-        result += ` ${Math.round((float - Math.floor(float))*60)} mins`
-    }
-    return result
-}
-
-function hideClass(cls) {
-    cls.style.display = "none"
-}
-
-function showClass(cls) {
-    cls.style.display = ""
-}
-
-// Filters for the different pieces of class information. Each of these returns a predicate
-// which returns true if the class matches the filter passed to the parent function.
-
-function gradeFilter(grade) {
-    return cls => grade === "all" || cls.classList.contains(`grade_${grade}`)
-}
-
-function difficultyFilter(difficulty) {
-    return cls => difficulty === "all" || cls.getAttribute("data-difficulty") === difficulty
-}
-
-function durationFilter(duration) {
-    return cls => duration === "all" || cls.getAttribute("data-duration") === duration
-}
-
-function openFilter(status) {
-    return cls => {
-        return status === "all" ||
-        (status === "closed" && cls.getAttribute("data-is-closed") === "True") || 
-        (status === "open" && cls.getAttribute("data-is-closed") === "False")
-    }
-}
-
-function applyCurrentFilters() {
-    applyFilters(getOptions())
-}
-
-function applyFilters({grade, difficulty, status, duration}) {
-    let classes = Array.from(document.getElementsByClassName("show_class"))
-    let shownClasses = classes
-        .filter(gradeFilter(grade))
-        .filter(difficultyFilter(difficulty))
-        .filter(openFilter(status))
-        .filter(durationFilter(duration))
-
-    classes.forEach(hideClass)
-    shownClasses.forEach(showClass)
-}
-
-function getOptions() {
-    return {
-        grade: document.getElementById("grade_filter").value,
-        difficulty: document.getElementById("difficulty_filter").value,
-        status: document.getElementById("status_filter").value,
-        duration: document.getElementById("duration_filter").value,
-    }
-}
-
-var student_grade = esp_user.cur_grade;
-if (student_grade != "" && student_grade != null) {
-    student_grade = parseInt(student_grade);
-    const gradeFilterElem = document.getElementById("grade_filter")
-    if (gradeFilterElem.querySelector(`option[value="${student_grade}"]`)) {
-        gradeFilterElem.value = student_grade
-    }
-}
-
-applyCurrentFilters()
-
-// Set up duration options by finding all unique durations from the classes in the catalog
-const durationFilterElem = document.getElementById("duration_filter")
-let uniqueLengths = [
-        // Convert to and back from a Set to keep only unique values
-        ...new Set(
-            Array.from(document.getElementsByClassName("show_class"))
-                .map(cls=>cls.getAttribute("data-duration"))
-        )
-    ]
-    .sort((a,b)=>a-b) // least to greatest
-    .map((val)=>[val, floatToFormattedTime(val)])
-    .forEach(([raw, formatted])=>{
-        let option = document.createElement("option")
-        option.setAttribute("value", raw)
-        option.textContent = formatted
-        durationFilterElem.append(option)
-    })
-
-// Set up difficulties by getting them from tag data (injected further up)
-const difficultyFilterElem = document.getElementById("difficulty_filter")
-
-DIFFICULTIES.forEach(([difficulty])=>{
-    let option = document.createElement("option")
-    option.setAttribute("value", difficulty)
-    option.textContent = difficulty
-    difficultyFilterElem.append(option)
-})
-
-function setModifiedColor(selectElem) {
-    if (selectElem.value !== "all") {
-        selectElem.style.background = MODIFIED_COLOR
-    } else {
-        selectElem.style.background = ""
-    }
-}
-
-FILTER_IDS.forEach((id)=>{
-    const filterElem = document.getElementById(id)
-    // Covers the case when a page refresh has preserved form values
-    // or the grade is automatically set.
-    setModifiedColor(filterElem)
-
-    filterElem.addEventListener("change", ()=>{
-        setModifiedColor(filterElem)
-        applyCurrentFilters()
-    })
-})
-</script>
-
-
-<script type="text/javascript">
-function configure_addbuttons()
-{
-    {% if register_from_catalog %}
-    //  Registration from the catalog is allowed
-    $j("input.addbutton").show();
-    {% endif %}
-}
-$j(document).ready(configure_addbuttons);
-</script>
+<script type="text/javascript" src="/media/scripts/program/modules/catalog.js"></script>
 
 {% endblock %}


### PR DESCRIPTION
This hides any empty categories in the catalog (more relevant now thanks to the filtering implemented in https://github.com/learning-unlimited/ESP-Website/pull/3632) provided the new tag is set to True (the default). If a category is hidden, the corresponding category link at the top is disabled and faded.

I didn't check it, but I believe this should also work for the `/fillslot` student registration pages.

Fixes #3661.