### PR TITLE
Ignore duplicate room resources when scheduling classes

### DIFF
--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -702,7 +702,8 @@ class ClassSection(models.Model):
 
     def assign_room(self, base_room, clear_others=False, allow_partial=False, lock=0):
         """ Assign the classroom given, at the times needed by this class. """
-        rooms_to_assign = base_room.identical_resources().filter(event__in=list(self.meeting_times.all()))
+        # Ignore duplicates (ordered by "id" to be deterministic)
+        rooms_to_assign = base_room.identical_resources().filter(event__in=list(self.meeting_times.all())).order_by("name", "event", "id").distinct("name", "event")
 
         status = True
         errors = []


### PR DESCRIPTION
While it is not currently possible to create duplicate classrooms (see https://github.com/learning-unlimited/ESP-Website/issues/303#issuecomment-1791752073), this makes it so any stray duplicate room resources (either those created before such duplicates were made impossible or those created manually in the admin panel) do not cause issues when scheduling classes with the ajax scheduler. We now ignore any of these duplicates, and the order_by() call should make it so we always ignore the same duplicate resource(s).

Fixes https://github.com/learning-unlimited/ESP-Website/issues/1188.