### PR TITLE
Reset and remove optional fruitsalad variables

### DIFF
--- a/esp/esp/themes/views.py
+++ b/esp/esp/themes/views.py
@@ -325,6 +325,7 @@ def editor(request):
             else:
                 category_vars.append((key, 'text', initial_val))
         context['adv_vars'][category_name] = category_vars
+    context['variable_defaults'] = tc.get_variable_defaults(current_theme)
 
     return render_to_response('themes/editor.html', request, context)
 

--- a/esp/public/media/theme_editor/theme_editor.js
+++ b/esp/public/media/theme_editor/theme_editor.js
@@ -1,5 +1,6 @@
 function showColor() {
     $j('.color').each(function(i){
+        var default_color = $j(this).data("default");
         $j(this).spectrum({
             type: "color",
             showInput: true,
@@ -11,7 +12,7 @@ function showColor() {
         });
         // Create the "Reset Color" button
         var resetButton = $j('<button class="reset-color" type="button" style="margin-left: 1.5px;">Reset Color</button>').click(function() {
-            $j(this).siblings("input").spectrum("set", "#000000"); // Reset color to default
+            $j(this).siblings("input").spectrum("set", default_color); // Reset color to default
         });
         // Create the "Remove" button
         var removeButton = $j('<button class="remove-color" type="button" style="margin-left: 5px;">Remove Variable</button>').click(function() {
@@ -69,6 +70,14 @@ $j(document).ready(function(){
     showColor();
     showBasePalette();
     showCustomPalette();
+    $j(".length, .text").each(function(){
+        var el = $j(this)
+        var default_val = el.data("default");
+        var resetButton = $j('<button class="reset-length" type="button" style="margin-left: 1.5px;">Reset</button>').click(function() {
+            el.val(default_val); // Reset to default value
+        });
+        el.parent(".controls").append(resetButton);
+    });
     $j('#addToPalette').click(function(){
         var newColor = $j('<input>');
         newColor.addClass('palette');
@@ -98,6 +107,7 @@ $j(document).ready(function(){
         var button_id_prefix = 'add_opt_var_';
         var select_id = 'new_opt_var_' + button_id.substr(button_id_prefix.length);
         var select_val = $j('#' + select_id).val();
+        var option_el = $j("#new_opt_var_2").find(":selected");
         
         // Don't want duplicate variables
         if ($j("#id_" + select_val).length == 0) {
@@ -107,14 +117,14 @@ $j(document).ready(function(){
                     id: 'id_' + select_val,
                     class: 'color',
                     type: 'text',
-                    value: '#000000',
+                    value: option_el.data('default'),
                     name: select_val,
                     style: 'display: none;'
                 });
 
             // Create the "Reset Color" button
             var resetButton = $j('<button class="reset-color" type="button" style="margin-left: 5px;">Reset Color</button>').click(function() {
-                $j(this).siblings("input").spectrum("set", "#000000"); // Reset color to default
+                $j(this).siblings("input").spectrum("set", option_el.data('default')); // Reset color to default
             });
 
             // Create the "Remove" button

--- a/esp/public/media/theme_editor/theme_editor.js
+++ b/esp/public/media/theme_editor/theme_editor.js
@@ -16,7 +16,7 @@ function showColor() {
         // Create the "Remove" button
         var removeButton = $j('<button class="remove-color" type="button" style="margin-left: 5px;">Remove Variable</button>').click(function() {
             $j(this).siblings("input").spectrum("destroy");
-            $j(this).parent(".control-group").remove();
+            $j(this).parents(".control-group").remove();
         });
         if ($j(this).siblings(".reset-color").length == 0) {
             $j(this).parent(".controls").append(resetButton);
@@ -120,15 +120,17 @@ $j(document).ready(function(){
             // Create the "Remove" button
             var removeButton = $j('<button class="remove-color" type="button" style="margin-left: 5px;">Remove Variable</button>').click(function() {
                 $j(this).siblings("input").spectrum("destroy");
-                $j(this).parent(".control-group").remove();
+                $j(this).parents(".control-group").remove();
             });
 
             // Create a control group and append the color input and reset button
-            var controlGroup = $j('<div class="control-group">')
-                .append($j('<label class="control-label" for="' + select_val + '">').html(select_val))
+            var controlsDiv = $j('<div class="controls">')
                 .append(colorInput)
                 .append(resetButton)
                 .append(removeButton);
+            var controlGroup = $j('<div class="control-group">')
+                .append($j('<label class="control-label" for="' + select_val + '">').html(select_val))
+                .append(controlsDiv)
 
             // Append the control group to the parent element
             $j(event.target).parent().parent().parent().append(controlGroup);

--- a/esp/public/media/theme_editor/theme_editor.js
+++ b/esp/public/media/theme_editor/theme_editor.js
@@ -9,6 +9,21 @@ function showColor() {
             palette: [palette_list],
             showPaletteOnly: true
         });
+        // Create the "Reset Color" button
+        var resetButton = $j('<button class="reset-color" type="button" style="margin-left: 1.5px;">Reset Color</button>').click(function() {
+            $j(this).siblings("input").spectrum("set", "#000000"); // Reset color to default
+        });
+        // Create the "Remove" button
+        var removeButton = $j('<button class="remove-color" type="button" style="margin-left: 5px;">Remove Variable</button>').click(function() {
+            $j(this).siblings("input").spectrum("destroy");
+            $j(this).parent(".control-group").remove();
+        });
+        if ($j(this).siblings(".reset-color").length == 0) {
+            $j(this).parent(".controls").append(resetButton);
+        }
+        if ($j(this).filter("[id*=accent]").length == 1 && $j(this).siblings(".remove-color").length == 0) {
+            $j(this).parent(".controls").append(removeButton);
+        }
     });
 }
 
@@ -37,7 +52,7 @@ function showCustomPalette() {
             showInitial: true,
             showButtons: true,
             preferredFormat: "hex",
-            cancelText: "Remove",
+            cancelText: "Remove"
         });
     });
     var $active;
@@ -78,16 +93,47 @@ $j(document).ready(function(){
     $j('button.add_opt_var_button').click(function (event) {
         event.preventDefault();
         
-        //  Determine which optional variable we are trying to add.
+        // Determine which optional variable we are trying to add.
         var button_id = event.target.id;
         var button_id_prefix = 'add_opt_var_';
         var select_id = 'new_opt_var_' + button_id.substr(button_id_prefix.length);
         var select_val = $j('#' + select_id).val();
+        
+        // Don't want duplicate variables
+        if ($j("#id_" + select_val).length == 0) {
+            // Create a new color input field
+            var colorInput = $j('<input>')
+                .attr({
+                    id: 'id_' + select_val,
+                    class: 'color',
+                    type: 'text',
+                    value: '#000000',
+                    name: select_val,
+                    style: 'display: none;'
+                });
 
-        //  Insert a new color selector for the desired variable
-        $j(event.target).parent().parent().parent().append($j('<div class="control-group">')
-            .append($j('<label class="control-label" for="' + select_val + '">').html(select_val))
-            .append($j('<input id="id_' + select_val + '" class="color" type="text" value="#000000" name="' + select_val + '" style="display: none;" />')));
-        showColor();
+            // Create the "Reset Color" button
+            var resetButton = $j('<button class="reset-color" type="button" style="margin-left: 5px;">Reset Color</button>').click(function() {
+                $j(this).siblings("input").spectrum("set", "#000000"); // Reset color to default
+            });
+
+            // Create the "Remove" button
+            var removeButton = $j('<button class="remove-color" type="button" style="margin-left: 5px;">Remove Variable</button>').click(function() {
+                $j(this).siblings("input").spectrum("destroy");
+                $j(this).parent(".control-group").remove();
+            });
+
+            // Create a control group and append the color input and reset button
+            var controlGroup = $j('<div class="control-group">')
+                .append($j('<label class="control-label" for="' + select_val + '">').html(select_val))
+                .append(colorInput)
+                .append(resetButton)
+                .append(removeButton);
+
+            // Append the control group to the parent element
+            $j(event.target).parent().parent().parent().append(controlGroup);
+
+            showColor();
+        }
     });
 });

--- a/esp/public/media/theme_editor/theme_editor.js
+++ b/esp/public/media/theme_editor/theme_editor.js
@@ -16,8 +16,11 @@ function showColor() {
         });
         // Create the "Remove" button
         var removeButton = $j('<button class="remove-color" type="button" style="margin-left: 5px;">Remove Variable</button>').click(function() {
-            $j(this).siblings("input").spectrum("destroy");
+            var input = $j(this).siblings("input");
+            input.spectrum("destroy");
             $j(this).parents(".control-group").remove();
+            console.log(input.attr("name"));
+            $j("option[value=" + input.attr("name") + "]").show();
         });
         if ($j(this).siblings(".reset-color").length == 0) {
             $j(this).parent(".controls").append(resetButton);
@@ -67,6 +70,7 @@ function showCustomPalette() {
 }
 
 $j(document).ready(function(){
+    
     showColor();
     showBasePalette();
     showCustomPalette();
@@ -95,8 +99,8 @@ $j(document).ready(function(){
         $j(this).popover({placement:'left', animation:false});
     });
     
-    //  Show optional variable selector if there are optional variables available
-    $j('div.opt_var_div:has(select.select_opt_var:has(option))').removeClass('hidden');
+    //  Make optional variable dropdown blank
+    $j('select.select_opt_var').val('');
     
     //  Allow form elements to be created for optional variables
     $j('button.add_opt_var_button').click(function (event) {
@@ -106,8 +110,11 @@ $j(document).ready(function(){
         var button_id = event.target.id;
         var button_id_prefix = 'add_opt_var_';
         var select_id = 'new_opt_var_' + button_id.substr(button_id_prefix.length);
-        var select_val = $j('#' + select_id).val();
+        var select_el = $j('#' + select_id);
+        var select_val = select_el.val();
         var option_el = $j("#new_opt_var_2").find(":selected");
+        option_el.hide();
+        select_el.val("");
         
         // Don't want duplicate variables
         if ($j("#id_" + select_val).length == 0) {
@@ -131,6 +138,7 @@ $j(document).ready(function(){
             var removeButton = $j('<button class="remove-color" type="button" style="margin-left: 5px;">Remove Variable</button>').click(function() {
                 $j(this).siblings("input").spectrum("destroy");
                 $j(this).parents(".control-group").remove();
+                option_el.show();
             });
 
             // Create a control group and append the color input and reset button

--- a/esp/templates/themes/editor.html
+++ b/esp/templates/themes/editor.html
@@ -52,7 +52,10 @@ var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% 
 </style>
 {% endblock %}
 {% block title %}Theme Editor{% endblock %}
-{% block content %} 
+{% block content %}
+
+{% load main %}
+
 <div class="row-fluid">
     <div class="span12">
         <h1>Theme Editor</h1>
@@ -420,7 +423,7 @@ var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% 
                                 <div class="controls">
                                     <select id="new_opt_var_{{ forloop.counter0 }}" name="new_opt_var_{{ forloop.counter0 }}" class="select_opt_var">
                                         {% for item in data %}{% if not item.2 %}
-                                        <option value="{{ item.0 }}">{{ item.0 }}</option>
+                                        <option value="{{ item.0 }}" data-default="{{ variable_defaults|index:item.0 }}">{{ item.0 }}</option>
                                         {% endif %}{% endfor %}
                                     </select>
                                     <button class="btn add_opt_var_button" id="add_opt_var_{{ forloop.counter0 }}">Add</button>
@@ -430,7 +433,7 @@ var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% 
                             <div class="control-group" id="ctlgrp_{{ item.0 }}">
                                 <label class="control-label" for="{{ item.0 }}">{{ item.0 }}:</label>
                                 <div class="controls">
-                                    <input type="text" class="{{ item.1 }}" id="id_{{ item.0 }}" name="{{ item.0 }}" value="{{ item.2 }}"/>
+                                    <input type="text" class="{{ item.1 }}" id="id_{{ item.0 }}" name="{{ item.0 }}" value="{{ item.2 }}" data-default="{{ variable_defaults|index:item.0 }}"/>
                                 </div>
                             </div>
                             {% endif %}{% endfor %}

--- a/esp/templates/themes/editor.html
+++ b/esp/templates/themes/editor.html
@@ -410,8 +410,9 @@ var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% 
                         {% for category, data in adv_vars.items %}{% if not data|length_is:0 %}
                         <div id="adv_category_{{ forloop.counter0 }}">
                             <h3>Category: {{ category }}<hr/></h3>
+                            {% if category == "variables_optional" %}
                             <!-- Dropdown box for adding an optional variable override that is not yet defined -->
-                            <div class="control-group opt_var_div hidden">
+                            <div class="control-group opt_var_div">
                                 <div> Accent 1 for each side tab refers to the accent on the left part of the side tab, the background color of the heading bar, and the unselected top tabs when the specified number side tab is selected.
                                 </div>
                                 </br>
@@ -422,13 +423,14 @@ var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% 
                                 <label class="control-label" for="new_opt_var_{{ forloop.counter0 }}">Add a variable:</label>
                                 <div class="controls">
                                     <select id="new_opt_var_{{ forloop.counter0 }}" name="new_opt_var_{{ forloop.counter0 }}" class="select_opt_var">
-                                        {% for item in data %}{% if not item.2 %}
-                                        <option value="{{ item.0 }}" data-default="{{ variable_defaults|index:item.0 }}">{{ item.0 }}</option>
-                                        {% endif %}{% endfor %}
+                                        {% for item in data %}
+                                        <option value="{{ item.0 }}" data-default="{{ variable_defaults|index:item.0 }}"{% if item.2 %} hidden{% endif %}>{{ item.0 }}</option>
+                                        {% endfor %}
                                     </select>
                                     <button class="btn add_opt_var_button" id="add_opt_var_{{ forloop.counter0 }}">Add</button>
                                 </div>
                             </div>
+                            {% endif %}
                             {% for item in data %}{% if item.2 %}
                             <div class="control-group" id="ctlgrp_{{ item.0 }}">
                                 <label class="control-label" for="{{ item.0 }}">{{ item.0 }}:</label>


### PR DESCRIPTION
This adds the following functionality to the theme editor:

- Added a "Reset Color" button next to each color chooser

And when optional variables are included (I believe this is just for the fruitsalad theme atm):

- Added a "Remove Variable" button next to the new "Reset Color" buttons which removes the entire variable from the form
- Made it so you can't add a variable that already exists in the form

I've checked and the addition and removal of variables is saved whenever you press the "Test" submission button.

![image](https://github.com/learning-unlimited/ESP-Website/assets/7232514/a18f6a1c-292c-48a8-8e93-619b71d6f896)

Fixes #3674. Supersedes #3675.