### PR TITLE
Fix get_full_path() cache dependencies

### DIFF
--- a/esp/esp/program/modules/base.py
+++ b/esp/esp/program/modules/base.py
@@ -271,6 +271,7 @@ class ProgramModuleObj(models.Model):
         return '/%s/%s/%s' % (
             self.module.module_type, self.program.url, self.main_view)
     get_full_path.depend_on_row('modules.ProgramModuleObj', 'self')
+    get_full_path.depend_on_model('program.Program')
 
     def makeLink(self):
         if not self.module.module_type == 'manage':


### PR DESCRIPTION
This fixes the last (I hope) of the URLs that weren't updating when a program name/URL is changed. This includes links that are made via `makeLink` (e.g., checkbox interfaces, list of programs at the bottom of the main program management page, maybe the onsite boxes?) and the goToCore link (e.g., the redirect when a student adds or removes a class at /studentreg). I couldn't find a way to depend on only a single Program, so we depend on the entire model, but that isn't changed too often, so I think that's fine.

Fixes #3598.