### PR TITLE
Fix "Reset Color" buttons for non-theme-specific variables

### DIFF
--- a/esp/esp/themes/controllers.py
+++ b/esp/esp/themes/controllers.py
@@ -247,6 +247,8 @@ class ThemeController(object):
         return css_data
 
     def get_variable_defaults(self, theme_name=None):
+        # This is particularly important for themes that have variables files with LESS (e.g., darken())
+        # Otherwise it basically does the same thing as find_less_variables()
         if theme_name is None:
             theme_name = self.get_current_theme()
 
@@ -271,7 +273,9 @@ class ThemeController(object):
         css_data = self.compile_less(less_data)
 
         # extract the newly compiled variables
-        defaults = dict(re.findall(r'\s([a-zA-Z0-9_]+):\s*(.*?);', css_data))
+        compiled_defaults = dict(re.findall(r'\s([a-zA-Z0-9_]+):\s*(.*?);', css_data))
+        defaults = self.find_less_variables(flat=True)
+        defaults.update(compiled_defaults)
 
         return defaults
 

--- a/esp/templates/themes/editor.html
+++ b/esp/templates/themes/editor.html
@@ -120,7 +120,7 @@ var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% 
                         <div class="control-group">
                             <label class="control-label" for="bodybg">Background{% if theme_name == "fruitsalad" or theme_name == "floaty" %} (outside the frame){% endif %}:</label>
                             <div class="controls">
-                                <input type="text" id="bodybg" name="bodyBackground" class="color" value="{{bodyBackground}}"/>
+                                <input type="text" id="bodybg" name="bodyBackground" class="color" value="{{bodyBackground}}" data-default="{{ variable_defaults|index:'bodyBackground' }}"/>
                             </div>
                         </div>
 
@@ -128,7 +128,7 @@ var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% 
                         <div class="control-group">
                             <label class="control-label" for="contentbg">Content Background{% if theme_name == "fruitsalad" or theme_name == "floaty" %} (within the frame){% endif %}:</label>
                             <div class="controls">
-                                <input type="text" id="contentbg" name="contentBackground" class="color" value="{{contentBackground}}"/>
+                                <input type="text" id="contentbg" name="contentBackground" class="color" value="{{contentBackground}}" data-default="{{ variable_defaults|index:'contentBackground' }}"/>
                             </div>
                         </div>
                     {% endif %}
@@ -137,7 +137,7 @@ var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% 
                         <div class="control-group">
                             <label class="control-label" for="heroUnitBackground">Hero Unit Background:</label>
                             <div class="controls">
-                                <input type="text" id="heroUnitBackground" name="heroUnitBackground" class="color" value="{{heroUnitBackground}}"/>
+                                <input type="text" id="heroUnitBackground" name="heroUnitBackground" class="color" value="{{heroUnitBackground}}" data-default="{{ variable_defaults|index:'heroUnitBackground' }}"/>
                             </div>
                         </div>
                     {% endif %}
@@ -145,14 +145,14 @@ var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% 
                         <div class="control-group">
                             <label class="control-label" for="textColor">Text:</label>
                             <div class="controls">
-                                <input type="text" class="color" id="textColor" name="textColor" value="{{ textColor }}"/>
+                                <input type="text" class="color" id="textColor" name="textColor" value="{{ textColor }}" data-default="{{ variable_defaults|index:'textColor' }}"/>
                             </div>
                         </div>
                         
                         <div class="control-group">
                             <label class="control-label" for="headingsColor">Headings:</label>
                             <div class="controls">
-                                <input type="text" class="color" id="headingsColor" name="headingsColor" value="{{ headingsColor }}"/>
+                                <input type="text" class="color" id="headingsColor" name="headingsColor" value="{{ headingsColor }}" data-default="{{ variable_defaults|index:'headingsColor' }}"/>
                             </div>
                       </div>
                       
@@ -161,7 +161,7 @@ var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% 
                         <div class="control-group">
                             <label class="control-label" for="titleColor">Content Page Titles:</label>
                             <div class="controls">
-                                <input type="text" class="color" id="titleColor" name="titleColor" value="{{ titleColor }}"/>
+                                <input type="text" class="color" id="titleColor" name="titleColor" value="{{ titleColor }}" data-default="{{ variable_defaults|index:'titleColor' }}"/>
                             </div>
                         </div>
                         {% endif %}
@@ -176,14 +176,14 @@ var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% 
                         <div class="control-group">
                             <label class="control-label" for="linkColor">Links:</label>
                             <div class="controls">
-                                <input type="text" class="color" id="linkColor" name="linkColor" value="{{ linkColor }}"/>
+                                <input type="text" class="color" id="linkColor" name="linkColor" value="{{ linkColor }}" data-default="{{ variable_defaults|index:'linkColor' }}"/>
                             </div>
                         </div>
 
                         <div class="control-group">
                             <label class="control-label" for="linkColorHover">Link Hover Effect:</label>
                             <div class="controls">
-                                <input type="text" class="color" id="linkColorHover" name="linkColorHover" value="{{ linkColorHover }}"/>
+                                <input type="text" class="color" id="linkColorHover" name="linkColorHover" value="{{ linkColorHover }}" data-default="{{ variable_defaults|index:'linkColorHover' }}"/>
                             </div>
                         </div>
                     </div>
@@ -236,7 +236,7 @@ var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% 
                         <div class="control-group">
                             <label class="control-label" for="navbarBackground">Background:</label>
                             <div class="controls">
-                                <input type="text" class="color" id="navbarBackground" name="navbarBackground" value="{{ navbarBackground }}"/>
+                                <input type="text" class="color" id="navbarBackground" name="navbarBackground" value="{{ navbarBackground }}" data-default="{{ variable_defaults|index:'navbarBackground' }}"/>
                             </div>
                         </div>
 
@@ -244,7 +244,7 @@ var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% 
                         <div class="control-group">
                             <label class="control-label" for="navbarBackgroundHighlight">Highlight:</label>
                             <div class="controls">
-                                <input type="text" class="color" id="navbarBackgroundHighlight" name="navbarBackgroundHighlight" value="{{ navbarBackgroundHighlight }}"/>
+                                <input type="text" class="color" id="navbarBackgroundHighlight" name="navbarBackgroundHighlight" value="{{ navbarBackgroundHighlight }}" data-default="{{ variable_defaults|index:'navbarBackgroundHighlight' }}"/>
                             </div>
                         </div>
 
@@ -252,7 +252,7 @@ var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% 
                         <div class="control-group">
                             <label class="control-label" for="navbarText">Text:</label>
                             <div class="controls">
-                                <input type="text" class="color" id="navbarText" name="navbarText" value="{{ navbarText }}"/>
+                                <input type="text" class="color" id="navbarText" name="navbarText" value="{{ navbarText }}" data-default="{{ variable_defaults|index:'navbarText' }}"/>
                             </div>
                         </div>
                     {% endif %}
@@ -260,14 +260,14 @@ var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% 
                         <div class="control-group">
                             <label class="control-label" for="navbarLinkColor">Links:</label>
                             <div class="controls">
-                                <input type="text" class="color" id="navbarLinkColor" name="navbarLinkColor" value="{{ navbarLinkColor }}"/>
+                                <input type="text" class="color" id="navbarLinkColor" name="navbarLinkColor" value="{{ navbarLinkColor }}" data-default="{{ variable_defaults|index:'navbarLinkColor' }}"/>
                             </div>
                         </div>
 
                         <div class="control-group">
                             <label class="control-label" for="navbarLinkColorHover">Link Hover:</label>
                             <div class="controls">
-                                <input type="text" class="color" id="navbarLinkColorHover" name="navbarLinkColorHover" value="{{ navbarLinkColorHover }}"/>
+                                <input type="text" class="color" id="navbarLinkColorHover" name="navbarLinkColorHover" value="{{ navbarLinkColorHover }}" data-default="{{ variable_defaults|index:'navbarLinkColorHover' }}"/>
                             </div>
                         </div>
                 {% endif %}
@@ -285,7 +285,7 @@ var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% 
                         <div class="control-group">
                             <label class="control-label" for="sidebarText">Text:</label>
                             <div class="controls">
-                                <input type="text" class="color" id="sidebarText" name="sidebarText" value="{{ sidebarText }}"/>
+                                <input type="text" class="color" id="sidebarText" name="sidebarText" value="{{ sidebarText }}" data-default="{{ variable_defaults|index:'sidebarText' }}"/>
                             </div>
                         </div>
                     {% endif %}
@@ -293,7 +293,7 @@ var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% 
                         <div class="control-group">
                             <label class="control-label" for="sidebarLink">Links:</label>
                             <div class="controls">
-                                <input type="text" class="color" id="sidebarLink" name="sidebarLink" value="{{ sidebarLink }}"/>
+                                <input type="text" class="color" id="sidebarLink" name="sidebarLink" value="{{ sidebarLink }}" data-default="{{ variable_defaults|index:'sidebarLink' }}"/>
                             </div>
                         </div>
 
@@ -301,7 +301,7 @@ var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% 
                         <div class="control-group">
                             <label class="control-label" for="sidebarHeader">Headers:</label>
                             <div class="controls">
-                                <input type="text" class="color" id="sidebarHeader" name="sidebarHeader" value="{{ sidebarHeader }}"/>
+                                <input type="text" class="color" id="sidebarHeader" name="sidebarHeader" value="{{ sidebarHeader }}" data-default="{{ variable_defaults|index:'sidebarHeader' }}"/>
                             </div>
                         </div>
                     {% endif %}
@@ -309,7 +309,7 @@ var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% 
                         <div class="control-group">
                             <label class="control-label" for="sidebarBackground">Background:</label>
                             <div class="controls">
-                                <input type="text" class="color" id="sidebarBackground" name="sidebarBackground" value="{{ sidebarBackground }}"/>
+                                <input type="text" class="color" id="sidebarBackground" name="sidebarBackground" value="{{ sidebarBackground }}" data-default="{{ variable_defaults|index:'sidebarBackground' }}"/>
                             </div>
                         </div>
 
@@ -317,7 +317,7 @@ var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% 
                         <div class="control-group">
                             <label class="control-label" for="sidebarLinkHover">Links:</label>
                             <div class="controls">
-                                <input type="text" class="color" id="sidebarLinkHover" name="sidebarLinkHover" value="{{ sidebarLinkHover }}"/>
+                                <input type="text" class="color" id="sidebarLinkHover" name="sidebarLinkHover" value="{{ sidebarLinkHover }}" data-default="{{ variable_defaults|index:'sidebarLinkHover' }}"/>
                             </div>
                         </div>
 
@@ -325,7 +325,7 @@ var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% 
                         <div class="control-group">
                             <label class="control-label" for="sidebarHover">Link Background:</label>
                             <div class="controls">
-                                <input type="text" class="color" id="sidebarHover" name="sidebarHover" value="{{ sidebarHover }}"/>
+                                <input type="text" class="color" id="sidebarHover" name="sidebarHover" value="{{ sidebarHover }}" data-default="{{ variable_defaults|index:'sidebarHover' }}"/>
                             </div>
                         </div>
                     {% endif %}
@@ -335,14 +335,14 @@ var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% 
                         <div class="control-group">
                             <label class="control-label" for="sidebarActive">Links:</label>
                             <div class="controls">
-                                <input type="text" class="color" id="sidebarActive" name="sidebarActive" value="{{ sidebarActive }}"/>
+                                <input type="text" class="color" id="sidebarActive" name="sidebarActive" value="{{ sidebarActive }}" data-default="{{ variable_defaults|index:'sidebarActive' }}"/>
                             </div>
                         </div>
 
                         <div class="control-group">
                             <label class="control-label" for="sidebarActiveBackground">Background:</label>
                             <div class="controls">
-                                <input type="text" class="color" id="sidebarActiveBackground" name="sidebarActiveBackground" value="{{ sidebarActiveBackground }}"/>
+                                <input type="text" class="color" id="sidebarActiveBackground" name="sidebarActiveBackground" value="{{ sidebarActiveBackground }}" data-default="{{ variable_defaults|index:'sidebarActiveBackground' }}"/>
                             </div>
                         </div>
                     {% endif %}
@@ -351,14 +351,14 @@ var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% 
                         <div class="control-group">
                             <label class="control-label" for="navbarLinkColor">Links:</label>
                             <div class="controls">
-                                <input type="text" class="color" id="navbarLinkColor" name="navbarLinkColor" value="{{ navbarLinkColor }}"/>
+                                <input type="text" class="color" id="navbarLinkColor" name="navbarLinkColor" value="{{ navbarLinkColor }}" data-default="{{ variable_defaults|index:'navbarLinkColor' }}"/>
                             </div>
                         </div>
 
                         <div class="control-group">
                             <label class="control-label" for="navbarLinkColorHover">Link Hover:</label>
                             <div class="controls">
-                                <input type="text" class="color" id="navbarLinkColorHover" name="navbarLinkColorHover" value="{{ navbarLinkColorHover }}"/>
+                                <input type="text" class="color" id="navbarLinkColorHover" name="navbarLinkColorHover" value="{{ navbarLinkColorHover }}" data-default="{{ variable_defaults|index:'navbarLinkColorHover' }}"/>
                             </div>
                         </div>
                         {% endcomment %}
@@ -374,39 +374,39 @@ var palette_list = [{% for color in palette.base %} "{{color}}", {% endfor %}{% 
                         <div class="control-group">
                             <label class="control-label" for="btnBackground">Buttons:</label>
                             <div class="controls">
-                                <input type="text" class="color" id="btnBackground" name="btnBackground" value="{{ btnBackground }}"/>
+                                <input type="text" class="color" id="btnBackground" name="btnBackground" value="{{ btnBackground }}" data-default="{{ variable_defaults|index:'btnBackground' }}"/>
                             </div>
                         </div>
                         <div class="control-group">
                             <label class="control-label" for="btnLinkColor">Button Text:</label>
                             <div class="controls">
-                                <input type="text" class="color" id="btnLinkColor" name="btnLinkColor" value="{{ btnLinkColor }}"/>
+                                <input type="text" class="color" id="btnLinkColor" name="btnLinkColor" value="{{ btnLinkColor }}" data-default="{{ variable_defaults|index:'btnLinkColor' }}"/>
                             </div>
                         </div>
 
                         <div class="control-group">
                             <label class="control-label" for="btnPrimaryBackground">Primary Buttons:</label>
                             <div class="controls">
-                                <input type="text" class="color" id="btnPrimaryBackground" name="btnPrimaryBackground" value="{{ btnPrimaryBackground }}"/>
+                                <input type="text" class="color" id="btnPrimaryBackground" name="btnPrimaryBackground" value="{{ btnPrimaryBackground }}" data-default="{{ variable_defaults|index:'btnPrimaryBackground' }}"/>
                             </div>
                         </div>
                         <div class="control-group">
                             <label class="control-label" for="btnPrimaryLinkColor">Primary Button Text:</label>
                             <div class="controls">
-                                <input type="text" class="color" id="btnPrimaryLinkColor" name="btnPrimaryLinkColor" value="{{ btnPrimaryLinkColor }}"/>
+                                <input type="text" class="color" id="btnPrimaryLinkColor" name="btnPrimaryLinkColor" value="{{ btnPrimaryLinkColor }}" data-default="{{ variable_defaults|index:'btnPrimaryLinkColor' }}"/>
                             </div>
                         </div>
 
                         <div class="control-group">
                             <label class="control-label" for="btnInverseBackground">Inverse Buttons:</label>
                             <div class="controls">
-                                <input type="text" class="color" id="btnInverseBackground" name="btnInverseBackground" value="{{ btnInverseBackground }}"/>
+                                <input type="text" class="color" id="btnInverseBackground" name="btnInverseBackground" value="{{ btnInverseBackground }}" data-default="{{ variable_defaults|index:'btnInverseBackground' }}"/>
                             </div>
                         </div>
                         <div class="control-group">
                             <label class="control-label" for="btnInverseLinkColor">Inverse Button Text:</label>
                             <div class="controls">
-                                <input type="text" class="color" id="btnInverseLinkColor" name="btnInverseLinkColor" value="{{ btnInverseLinkColor }}"/>
+                                <input type="text" class="color" id="btnInverseLinkColor" name="btnInverseLinkColor" value="{{ btnInverseLinkColor }}" data-default="{{ variable_defaults|index:'btnInverseLinkColor' }}"/>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
This fixes the remaining "Reset Color" buttons on the theme customization page that I previously forgot to set defaults for.

Fixes #3723.