### PR TITLE
Fix how we check for potential redirect programs

### DIFF
--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -730,6 +730,10 @@ class BaseESPUser(object):
     def getEnrolledSectionsAll(self):
         return self.getSections(None, verbs=['Enrolled'])
 
+    def getLearntPrograms(self):
+        learnt_programs = Program.objects.filter(id__in = list(self.getSections().values_list('parent_class__parent_program', flat = True)))
+        return learnt_programs
+
     @cache_function
     def getFirstClassTime(self, program):
         sections = self.getSections(program, verbs=['Enrolled']).order_by('meeting_times')


### PR DESCRIPTION
Upon submitting the profile form at /myesp/profile, we check to see if we can easily redirect the user to registration for an individual program, or, if there are multiple programs of interest, we present a list. This modifies that process to include programs that users (teachers/students) have registered for already but have not concluded yet.

Fixes #3729.