### PR TITLE
Only show "Remove Variable" buttons for optional variables

### DIFF
--- a/esp/public/media/theme_editor/theme_editor.js
+++ b/esp/public/media/theme_editor/theme_editor.js
@@ -11,11 +11,11 @@ function showColor() {
             showPaletteOnly: true
         });
         // Create the "Reset Color" button
-        var resetButton = $j('<button class="reset-color" type="button" style="margin-left: 1.5px;">Reset Color</button>').click(function() {
+        var resetButton = $j('<button class="reset-color" type="button" style="margin-left: 1.5px;">Reset Color</button>').on('click', function() {
             $j(this).siblings("input").spectrum("set", default_color); // Reset color to default
         });
         // Create the "Remove" button
-        var removeButton = $j('<button class="remove-color" type="button" style="margin-left: 5px;">Remove Variable</button>').click(function() {
+        var removeButton = $j('<button class="remove-color" type="button" style="margin-left: 5px;">Remove Variable</button>').on('click', function() {
             var input = $j(this).siblings("input");
             input.spectrum("destroy");
             $j(this).parents(".control-group").remove();
@@ -25,7 +25,8 @@ function showColor() {
         if ($j(this).siblings(".reset-color").length == 0) {
             $j(this).parent(".controls").append(resetButton);
         }
-        if ($j(this).filter("[id*=accent]").length == 1 && $j(this).siblings(".remove-color").length == 0) {
+        var reg = new RegExp("optional", "i");
+        if (reg.test($j(this).parents("[id^=adv_category]").children("h3").text()) && $j(this).siblings(".remove-color").length == 0) {
             $j(this).parent(".controls").append(removeButton);
         }
     });
@@ -60,10 +61,10 @@ function showCustomPalette() {
         });
     });
     var $active;
-    $j("#palette_custom_div .sp-replacer").click(function(e) {
+    $j("#palette_custom_div .sp-replacer").on('click', function(e) {
         $active = $j(e.target).closest(".sp-replacer").prev();
     });
-    $j(".sp-container button.sp-cancel").click(function(e) {
+    $j(".sp-container button.sp-cancel").on('click', function(e) {
         $active.spectrum("destroy");
         $active.remove();
     });
@@ -77,12 +78,12 @@ $j(document).ready(function(){
     $j(".length, .text").each(function(){
         var el = $j(this)
         var default_val = el.data("default");
-        var resetButton = $j('<button class="reset-length" type="button" style="margin-left: 1.5px;">Reset</button>').click(function() {
+        var resetButton = $j('<button class="reset-length" type="button" style="margin-left: 1.5px;">Reset</button>').on('click', function() {
             el.val(default_val); // Reset to default value
         });
         el.parent(".controls").append(resetButton);
     });
-    $j('#addToPalette').click(function(){
+    $j('#addToPalette').on('click', function(){
         var newColor = $j('<input>');
         newColor.addClass('palette');
         newColor.attr({
@@ -103,7 +104,7 @@ $j(document).ready(function(){
     $j('select.select_opt_var').val('');
     
     //  Allow form elements to be created for optional variables
-    $j('button.add_opt_var_button').click(function (event) {
+    $j('button.add_opt_var_button').on('click', function (event) {
         event.preventDefault();
         
         // Determine which optional variable we are trying to add.
@@ -130,12 +131,12 @@ $j(document).ready(function(){
                 });
 
             // Create the "Reset Color" button
-            var resetButton = $j('<button class="reset-color" type="button" style="margin-left: 5px;">Reset Color</button>').click(function() {
+            var resetButton = $j('<button class="reset-color" type="button" style="margin-left: 5px;">Reset Color</button>').on('click', function() {
                 $j(this).siblings("input").spectrum("set", option_el.data('default')); // Reset color to default
             });
 
             // Create the "Remove" button
-            var removeButton = $j('<button class="remove-color" type="button" style="margin-left: 5px;">Remove Variable</button>').click(function() {
+            var removeButton = $j('<button class="remove-color" type="button" style="margin-left: 5px;">Remove Variable</button>').on('click', function() {
                 $j(this).siblings("input").spectrum("destroy");
                 $j(this).parents(".control-group").remove();
                 option_el.show();


### PR DESCRIPTION
This fixes the theme customization page so that only optional variables have a "Remove Variable" button. While I was at it, I cleaned up some deprecated jQuery code.

Fixes #3730.