### PR TITLE
Fix the highlighting of the moderator directory cell

### DIFF
--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Moderators.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Moderators.js
@@ -171,6 +171,15 @@ function ModeratorDirectory(el, moderators) {
     };
 
     /**
+     * Get the directory cell for a moderator
+     *
+     * @param moderator: A moderator object
+     */
+    this.getModeratorCell = function(moderator) {
+        return $j("[id='moderator_" + moderator.id + "']").data("moderatorCell");
+    };
+
+    /**
      * Calculate a moderator's number of available slots (based on the moderator form and their existing assignments)
      * @param moderator: A moderator object
      */
@@ -244,7 +253,8 @@ function ModeratorDirectory(el, moderators) {
         }
 
         this.selectedModerator = moderator;
-        if(this.selectedModeratorCell) this.selectedModeratorCell.el.addClass("selected-moderator");
+        this.selectedModeratorCell = this.getModeratorCell(moderator);
+        this.selectedModeratorCell.el.addClass("selected-moderator");
         this.matrix.sectionInfoPanel.displayModerator(moderator);
         this.availableTimeslots = this.getAvailableTimeslots(moderator);
         this.matrix.highlightTimeslots(this.availableTimeslots, null, moderator);
@@ -396,7 +406,8 @@ function ModeratorCell(el, moderator, matrix) {
 
         this.el.addClass("moderator-cell");
         var baseURL = this.matrix.sections.getBaseUrlString();
-        this.el[0].innerHTML = this.el[0].innerHTML = "<td>" + this.moderator.first_name + " " + this.moderator.last_name + 
+        this.el.attr('id', "moderator_" + this.moderator.id);
+        this.el[0].innerHTML = "<td>" + this.moderator.first_name + " " + this.moderator.last_name + 
             "</br><a target='_blank' href='" + baseURL +
             "edit_availability?user=" + this.moderator.username +
             "'>Edit Availability</a>" + " <a target='_blank' href='/manage/userview?username=" +

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Scheduler.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Scheduler.js
@@ -150,7 +150,6 @@ function Scheduler(
         // set up handler for selecting moderators
         $j("body").on("click", "td.moderator-cell", function(evt, ui) {
             var moderatorCell = $j(evt.currentTarget).data("moderatorCell");
-            this.moderatorDirectory.selectedModeratorCell = moderatorCell;
             this.moderatorDirectory.selectModerator(moderatorCell.moderator);
         }.bind(this));
 


### PR DESCRIPTION
This fixes the way we highlight the directory cell when a moderator is selected (or unselected). This also now highlights the moderator when they are selected via the info panel for a section.

Fixes #3712.