### PR TITLE
fixes: Redirect tables cut off when text is too long

### DIFF
--- a/esp/public/media/default_styles/forms.css
+++ b/esp/public/media/default_styles/forms.css
@@ -176,6 +176,8 @@ input.fancybutton:active
    border: 1px solid #CCC;
    border-width: 1px;
    border-collapse: collapse;
+   table-layout: fixed;
+   overflow-wrap: break-word;
 }
 
 #program_form td {


### PR DESCRIPTION
fixes: #3728 