### PR TITLE
Fix profile form when numbers are used for school names

### DIFF
--- a/esp/esp/db/forms.py
+++ b/esp/esp/db/forms.py
@@ -260,9 +260,17 @@ class AjaxForeignKeyNewformField(forms.IntegerField):
                     id = objs[0]['id']
             # Finally, grab the object.
             if id:
-                return self.field.rel.to.objects.get(id=id)
+                objs = self.field.rel.to.objects.filter(id=id)
+                if objs.exists():
+                    return objs[0]
+                else:
+                    return None
 
         elif hasattr(self, 'key_type') and id is not None:
-            return self.key_type.objects.get(id=id)
+            objs = self.key_type.objects.filter(id=id)
+            if objs.exists():
+                return objs[0]
+            else:
+                return None
 
         return id

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -2031,7 +2031,7 @@ class K12School(models.Model):
         return values
 
     def __unicode__(self):
-        if self.contact_id:
+        if self.contact_id and self.contact.address_city and self.contact.address_state:
             return u'%s in %s, %s' % (self.name, self.contact.address_city,
                                        self.contact.address_state)
         else:


### PR DESCRIPTION
This should also fix other uses of `AjaxForeignKeyNewformField` which could presumably break if someone just entered a number in the field. While I was at it, I fixed the string representation of K12School objects. If we don't have a city/state for the contact, then we just use the school name.

Fixes #3746.