### PR TITLE
Prettify the confirmation email

### DIFF
--- a/esp/esp/program/modules/forms/admincore.py
+++ b/esp/esp/program/modules/forms/admincore.py
@@ -140,13 +140,14 @@ def get_template_source(template_list):
 
 class ReceiptsForm(BetterForm):
     confirm = forms.CharField(widget=forms.Textarea(attrs={'class': 'fullwidth'}),
-                              help_text = "This text is shown on the website when a student clicks the 'confirm registration' button (HTML is supported).\
-                                           If no text is supplied, the default text will be used. The text is then followed by the student's information,\
-                                           the program information, the student's purchased items, and the student's schedule.",
+                              help_text = mark_safe("This text is <b>shown on the website</b> when a student clicks the 'confirm registration' button (HTML is supported).\
+                                                    If no text is supplied, the default text will be used. The text is then followed by the student's information,\
+                                                    the program information, the student's purchased items, and the student's schedule."),
                               required = False)
     confirmemail = forms.CharField(widget=forms.Textarea(attrs={'class': 'fullwidth'}),
-                              help_text = "This receipt is sent via email when a student clicks the 'confirm registration' button.\
-                                           If no text is supplied, the default text will be used.",
+                              help_text = mark_safe("This text is <b>sent via email</b> when a student clicks the 'confirm registration' button.\
+                                                     If no text is supplied, the default text will be used. The text is then followed by the student's information,\
+                                                     the program information, the student's purchased items, and the student's schedule."),
                               required = False)
     cancel = forms.CharField(widget=forms.Textarea(attrs={'class': 'fullwidth'}),
                               help_text = "This receipt is shown on the website when a student clicks the 'cancel registration' button.\
@@ -163,7 +164,7 @@ class ReceiptsForm(BetterForm):
             elif action == "confirm":
                 receipt_text = get_template_source(['program/receipts/%s_custom_pretext.html' %(self.program.id), 'program/receipts/default_pretext.html'])
             elif action == "confirmemail":
-                receipt_text = get_template_source(['program/confemails/%s_confemail.txt' %(self.program.id),'program/confemails/default.txt'])
+                receipt_text = get_template_source(['program/confemails/%s_confemail_pretext.html' %(self.program.id),'program/confemails/default_pretext.html'])
             else:
                 receipt_text = ""
             self.fields[action].initial = receipt_text.encode('UTF-8')
@@ -178,7 +179,7 @@ class ReceiptsForm(BetterForm):
                 if action == "confirm":
                     default_text = get_template_source(['program/receipts/%s_custom_pretext.html' %(self.program.id), 'program/receipts/default_pretext.html'])
                 elif action == "confirmemail":
-                    default_text = get_template_source(['program/confemails/%s_confemail.txt' %(self.program.id),'program/confemails/default.txt'])
+                    default_text = get_template_source(['program/confemails/%s_confemail_pretext.html' %(self.program.id),'program/confemails/default_pretext.html'])
                 elif action == "cancel":
                     default_text = ""
                 if cleaned_text == default_text:

--- a/esp/esp/program/modules/handlers/studentregcore.py
+++ b/esp/esp/program/modules/handlers/studentregcore.py
@@ -205,11 +205,12 @@ class StudentRegCore(ProgramModuleObj, CoreModule):
         else:
             raise ESPError("You must finish all the necessary steps first, then click on the Save button to finish registration.", log=False)
 
-        cfe = ConfirmationEmailController()
-        cfe.send_confirmation_email(user, self.program)
-
         # when does class registration close for this user?
         context['deadline'] = Permission.user_deadline_when(user, "Student/Classes", prog)
+
+        cfe = ConfirmationEmailController()
+        # this email includes the student's schedule (by default), so send a new email each time they confirm their reg
+        cfe.send_confirmation_email(user, self.program, context = context, repeat = True)
 
         context["request"] = request
         context["program"] = prog

--- a/esp/templates/program/confemails/default.html
+++ b/esp/templates/program/confemails/default.html
@@ -1,0 +1,135 @@
+<html>
+
+<head>
+<style type="text/css">
+    .Enrolled
+     {
+        color: red;
+        font-weight: bold;
+     }
+    .NotAccepted
+     {
+       color: red;
+     }
+    .table-bordered
+     {
+       border: 1px solid #dddddd;
+       border-collapse: separate;
+       -webkit-border-radius: 4px;
+       -moz-border-radius: 4px;
+       border-radius: 4px;
+     }
+    .table-bordered th, .table-bordered td
+     {
+       border-left: 1px solid #dddddd;
+     }
+    .table th, .table td
+     {
+       line-height: 20px;
+       text-align: left;
+       border-top: 1px solid #dddddd;
+     }
+</style>
+</head>
+
+{% autoescape off %}
+{{ pretext }}
+{% endautoescape %}
+
+<hr size="1" color="#000000" />
+
+<p>
+User Information: <br />
+<ul>
+<li>Username: {{ user.username }}</li>
+<li>Full Name: {{ user.first_name }} {{ user.last_name }}</li>
+<li>User ID: {{ user.id }}</li>
+</ul>
+</p>
+
+<p>
+Program Information: <br />
+<ul>
+<li>Name: {{ program.niceName }}</li>
+<li>Date Range: {{ program.date_range }}</li>
+{% if deadline %}
+<li>Class Registration Closes: {{ deadline|date:"D d M Y" }} {{ deadline|time:"H:i" }}</li>
+{% endif %}
+</ul>
+</p>
+
+<p>
+Payment Information: <br />
+<ul>
+<li>Amount Owed: ${{ user.itemizedcosttotal|floatformat:"-2" }}</li>
+{% if user.required %}
+<li>Required Choices:</li>
+<ul>
+{% for item in user.required %}
+<li>{{ item.line_item.text }}{% if item.option.description %} -- {{ item.option.description }}{% endif %}</li>
+{% endfor %}
+</ul>
+{% endif %}
+{% if user.meals %}
+<li>Optional Purchases:</li>
+<ul>
+{% for item in user.meals %}
+<li>{{ item.line_item.text }}{% if item.option.description %} -- {{ item.option.description }}{% endif %}</li>
+{% endfor %}
+</ul>
+{% endif %}
+</ul>
+</p>
+
+<br />
+<table cellpadding="3" class="table table-bordered">
+<tr style="background-color: #f9f9f9">
+    <th colspan="2" style="text-align: center;">
+    Classes for {{ user.first_name }} {{ user.last_name }} - ID: {{ user.id }}
+    </th>
+</tr>
+{% for timeslot in timeslots %}
+    {% ifchanged timeslot.0.start.day %}
+        <tr style="background-color: #f9f9f9"><th colspan="3" height="3" style="text-align: center;">Classes beginning on {{ timeslot.0.pretty_date }}</th></tr>
+    {% endifchanged %}
+    {% ifchanged timeslot.2 %}
+        <tr style="background-color: #f9f9f9"><th colspan="3" height="3" style="text-align: center;">Block {{ timeslot.2 }}</th></tr>
+    {% endifchanged %}
+    <tr>
+    {% ifequal timeslot.0.event_type.description "Compulsory" %}
+        <td width="25%" valign="middle" align="center" class="compulsory_event_time">{{ timeslot.0.short_description }}</td>
+        <td valign="middle" align="center" class="compulsory_event_desc">{{ timeslot.0.description }}</td>
+    </tr>
+    {% else %}
+        <td width="25%" valign="middle" align="center">{{ timeslot.0.short_description }}</td>
+        {% if timeslot.1|length_is:0 %}
+            <td style="vertical-align: middle !important;" align="center" class="class_desc">
+                No classes
+            </td>
+        {% elif timeslot.1.0.first_meeting_time %}
+            <td style="vertical-align: middle; border-left: 5px solid {% cycle 'black' 'lightgray' %}" align="center" rowspan="{{ timeslot.1.0.section.get_meeting_times|length }}" class="class_desc">
+            {% for cls in timeslot.1 %}
+                {% comment %}{% if use_priority %}{% endcomment %}
+                    {% if not cls.section.verbs|length_is:0 %}
+                        <i>{% for v in cls.section.verbs %}<span class="{{ v }}">{{ v }}</span>{% if not forloop.last %}, {% endif %}{% endfor %}:</i>
+                    {% endif %}
+                {% comment %}{% endif %}{% endcomment %}
+                {{ cls.section }}{% if not cls.first_meeting_time %} <b>(continued)</b>{% endif %} 
+                
+                {% if request.user.onsite_local %}
+                    ({{ cls.section.prettyrooms|join:", " }})
+                {% endif %}
+                {% if not forloop.last %}<br />{% endif %}
+            {% endfor %}
+            </td>
+        {% endif %}
+    </tr>
+    {% endifequal %}
+{% endfor %}
+</table>
+
+<br />
+
+</div>
+
+</html>

--- a/esp/templates/program/confemails/default.txt
+++ b/esp/templates/program/confemails/default.txt
@@ -1,7 +1,0 @@
-Dear {{ user.first_name }},
-
-Thank you for registering for {{ program.niceName }}!  This is a preliminary confirmation email for your {{ program.program_type }} registration; you can come back and change your classes until registration closes.  We will contact you via email with further information.
-
-{{ program.niceName }} Directors
-
-

--- a/esp/templates/program/confemails/default_pretext.html
+++ b/esp/templates/program/confemails/default_pretext.html
@@ -1,0 +1,5 @@
+<p>Dear {{ user.first_name }},</p>
+
+<p>Thank you for registering for {{ program.niceName }}! This is a preliminary confirmation email for your {{ program.program_type }} registration. Your registration details are included below. You can come back and change your classes until registration closes. We will contact you via email with further information.</p>
+
+<p>{{ program.niceName }} Directors</p>


### PR DESCRIPTION
This makes the student registration confirmation email prettier, copying most of the changes from #3706. The receipt setting now modifies the pretext of the email (which is now an HTML email). The rest of the email includes various bits of information, including the student's schedule. Because the email now includes the schedule, I've changed the behavior of the confirmation button to now always send a new copy of confirmation email.

Fixes #3753.