### PR TITLE
Fixes for new program and program settings forms

### DIFF
--- a/esp/esp/program/forms.py
+++ b/esp/esp/program/forms.py
@@ -114,28 +114,8 @@ class ProgramCreationForm(BetterModelForm):
 
 
     def save(self, commit=True):
-        '''
-        Takes the program creation form's program_type, term, and term_friendly
-        fields, and constructs the url and name fields on the Program instance;
-        then calls the superclass's save() method.
-        '''
-        #   Filter out unwanted characters from program type to form URL
-        ptype_slug = re.sub('[-\s]+', '_', re.sub('[^\w\s-]', '', unicodedata.normalize('NFKD', self.cleaned_data['program_type'])).strip())
-        new_url = six.u('%(type)s/%(term)s') \
-            % {'type': ptype_slug
-              ,'term': self.cleaned_data['term']
-              }
-        new_name = six.u('%(type)s %(term)s') \
-            % {'type': self.cleaned_data['program_type']
-              ,'term': self.cleaned_data['term_friendly']
-              }
-        # Check that there isn't another program with this URL or name
-        if Program.objects.filter(url=new_url).exclude(id=self.instance.id).exists():
-            raise ESPError("A %s program already exists with this URL. Please choose a new URL or change the URL of the old program." % self.cleaned_data['program_type'], log=False)
-        if Program.objects.filter(name=new_name).exclude(id=self.instance.id).exists():
-            raise ESPError("A %s program already exists with this name. Please choose a new name or change the name of the old program." % self.cleaned_data['program_type'], log=False)
-        self.instance.url = new_url
-        self.instance.name = new_name
+        self.instance.url = self.cleaned_data['new_url']
+        self.instance.name = self.cleaned_data['new_name']
         return super(ProgramCreationForm, self).save(commit=commit)
 
 
@@ -149,6 +129,30 @@ class ProgramCreationForm(BetterModelForm):
         mods.extend(ProgramModule.objects.filter(choosable=1))
         return list(set(mods)) # Database wants a unique collection, so take set
 
+    def clean(self):
+        '''
+        Takes the program creation form's program_type, term, and term_friendly
+        fields, and constructs the url and name fields on the Program instance.
+        '''
+        super(ProgramCreationForm, self).clean()
+        if 'term' in self.cleaned_data and 'term_friendly' in self.cleaned_data:
+            #   Filter out unwanted characters from program type to form URL
+            ptype_slug = re.sub('[-\s]+', '_', re.sub('[^\w\s-]', '', unicodedata.normalize('NFKD', self.cleaned_data['program_type'])).strip())
+            new_url = six.u('%(type)s/%(term)s') \
+                % {'type': ptype_slug
+                  ,'term': self.cleaned_data['term']
+                  }
+            new_name = six.u('%(type)s %(term)s') \
+                % {'type': self.cleaned_data['program_type']
+                  ,'term': self.cleaned_data['term_friendly']
+                  }
+            self.cleaned_data['new_url'] = new_url
+            self.cleaned_data['new_name'] = new_name
+            # Check that there isn't another program with this URL or name
+            if Program.objects.filter(url=new_url).exclude(id=self.instance.id).exists():
+                self.add_error('term', "A %s program already exists with this URL. Please choose a new URL or change the URL of the old program." % self.cleaned_data['program_type'])
+            if Program.objects.filter(name=new_name).exclude(id=self.instance.id).exists():
+                self.add_error('term_friendly', "A %s program already exists with this name. Please choose a new name or change the name of the old program." % self.cleaned_data['program_type'])
 
     class Meta:
         fieldsets = [

--- a/esp/esp/program/modules/forms/admincore.py
+++ b/esp/esp/program/modules/forms/admincore.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from decimal import Decimal
 from django import forms
 from django.conf import settings
 from django.contrib import admin
@@ -8,7 +7,6 @@ from django.template.loader import select_template
 from django.utils.safestring import mark_safe
 from form_utils.forms import BetterForm, BetterModelForm
 
-from esp.accounting.controllers import ProgramAccountingController
 from esp.cal.models import Event
 from esp.program.controllers.lunch_constraints import LunchConstraintGenerator
 from esp.program.forms import ProgramCreationForm
@@ -79,13 +77,6 @@ class ProgramSettingsForm(ProgramCreationForm):
         super(ProgramSettingsForm, self).__init__(*args, **kwargs)
 
     def save(self):
-        prog = self.instance
-        pac = ProgramAccountingController(prog)
-        line_item = pac.default_admission_lineitemtype()
-        line_item.amount_dec=Decimal('%.2f' % self.cleaned_data['base_cost'])
-        line_item.save()
-        line_item.transfer_set.all().update(amount_dec=Decimal('%.2f' % self.cleaned_data['base_cost']))
-        prog.sibling_discount = self.cleaned_data['sibling_discount']
         return super(ProgramSettingsForm, self).save()
 
     class Meta:

--- a/esp/esp/program/views.py
+++ b/esp/esp/program/views.py
@@ -545,8 +545,6 @@ def newprogram(request):
         form = ProgramCreationForm(request.POST)
         if form.is_valid():
             temp_prog = form.save(commit=False)
-            if Program.objects.filter(url=temp_prog.url).exists():
-                raise ESPError("A %s program already exists with this name. Please choose a new name or change the name of the old program." % temp_prog.program_type, log=False)
             perms, modules = prepare_program(temp_prog, form.cleaned_data)
             new_prog = form.save(commit = True)
             commit_program(new_prog, perms, form.cleaned_data['base_cost'], form.cleaned_data['sibling_discount'])

--- a/esp/esp/program/views.py
+++ b/esp/esp/program/views.py
@@ -543,7 +543,9 @@ def newprogram(request):
     # If the form has been submitted, process it.
     if request.method == 'POST':
         form = ProgramCreationForm(request.POST)
-        if form.is_valid():
+        if form.is_valid(): # this should check for duplicate URLs and names using custom cleaning
+                            # https://docs.djangoproject.com/en/1.11/ref/forms/validation/#cleaning-a-specific-field-attribute
+                            # then if not valid, render the filled in form with the errors
             temp_prog = form.save(commit=False)
             perms, modules = prepare_program(temp_prog, form.cleaned_data)
             new_prog = form.save(commit = True)
@@ -609,8 +611,6 @@ def newprogram(request):
                     add_list_members(teachers_list_name, [new_prog.director_email, settings.DEFAULT_EMAIL_ADDRESSES['archive']])
             # Submit and create the program
             return HttpResponseRedirect(manage_url)
-        else:
-            raise ESPError("Improper form data submitted.", log=False)
     # If the form has not been submitted, the default view is a blank form (or the pre-populated form with the template data).
     else:
         if template_prog:


### PR DESCRIPTION
- Prevent program with duplicate name/URL (Fixes #3776)
- Update account name when program name is changed (Fixes #3775)
- Show form errors in form instead of as a Whoops page