### PR TITLE
Fixes the bottom of the catalog

### DIFF
--- a/esp/esp/program/modules/handlers/studentclassregmodule.py
+++ b/esp/esp/program/modules/handlers/studentclassregmodule.py
@@ -543,8 +543,6 @@ class StudentClassRegModule(ProgramModuleObj):
                 class_blobs.append(category_header_str % (class_category_id, class_category_id, cls.category.category))
             class_blobs.append(render_class_direct(cls))
             class_blobs.append('<br />')
-        if categories_sort:
-            class_blobs.append('</div>')
         context['class_descs'] = ''.join(class_blobs)
         #   Include the program explicitly; this is a cached page, without RequestContext
         context['program'] = self.program


### PR DESCRIPTION
Fixes #3787 on fruitsalad, but I haven't tested it on other themes yet.

For the record, I understand why this fixes the problem in #3787 (by removing a stray `</div>`), but I don't understand why it was a stray `</div>` to begin with. As far as I can tell, this code should be there to close the `<div>` that is created above it.