### PR TITLE
Theme icon fixes

### DIFF
--- a/esp/esp/utils/widgets.py
+++ b/esp/esp/utils/widgets.py
@@ -786,7 +786,7 @@ class NavStructureWidgetWithIcons(NavStructureWidget):
     add_link_body = """
         entry.append($j("<span>Icon: </span>"));
         var select = $j("<select class='data_icon nav_secondary_field input-medium glyphicon' />");
-        select.append($j("<option value=''" +
+        select.append($j("<option style='font-family: Glyphicons Halflings' value=''" +
                          (data.icon ? "" : " selected") +
                          ">(none)</option>"));
         %(entries)s
@@ -795,7 +795,7 @@ class NavStructureWidgetWithIcons(NavStructureWidget):
     """ % {
         'super_add_link_body': NavStructureWidget.add_link_body,
         'entries': '\n'.join('''
-            select.append($j("<option value='%(icon)s'" +
+            select.append($j("<option style='font-family: Glyphicons Halflings' value='%(icon)s'" +
                              (data.icon === "%(icon)s" ? " selected" : "") +
                              ">%(unicode)s (%(icon)s)</option>"));'''
             % {'icon': icon, 'unicode': text_unicode}

--- a/esp/esp/utils/widgets.py
+++ b/esp/esp/utils/widgets.py
@@ -324,7 +324,7 @@ function {{ name }}_add_link(obj, data)
     var delete_button = $j("<button class='btn btn-mini btn-danger'>Delete link</button>");
     delete_button.on("click", {{ name }}_delete_link);
     entry.append(delete_button);
-    $j("#{{ name }}_entries input").on("change", {{ name }}_save);
+    $j("#{{ name }}_entries input, #{{ name }}_entries select").on("change", {{ name }}_save);
 }
 
 function {{ name }}_add_tab(obj, data)

--- a/esp/esp/utils/widgets.py
+++ b/esp/esp/utils/widgets.py
@@ -785,7 +785,8 @@ _ICONS = OrderedDict([
 class NavStructureWidgetWithIcons(NavStructureWidget):
     add_link_body = """
         entry.append($j("<span>Icon: </span>"));
-        var select = $j("<select class='data_icon nav_secondary_field input-medium glyphicon' />");
+        var select = $j("<select style='font-family: Glyphicons Halflings'" +
+                        "class='data_icon nav_secondary_field input-medium glyphicon' />");
         select.append($j("<option style='font-family: Glyphicons Halflings' value=''" +
                          (data.icon ? "" : " selected") +
                          ">(none)</option>"));


### PR DESCRIPTION
This fixes two issues for theme navigation icons (used by bigpicture and droplets):

1. Most of the icons in the dropdown weren't rendering properly
2. Changing the icon wasn't being saved in the theme settings (Fixes #3812)