### PR TITLE
Donations and the extra costs form

### DIFF
--- a/esp/esp/accounting/controllers.py
+++ b/esp/esp/accounting/controllers.py
@@ -327,7 +327,7 @@ class IndividualAccountingController(ProgramAccountingController):
         result = []
         program_account = self.default_program_account()
         source_account = self.default_source_account()
-        line_items = self.get_lineitemtypes().exclude(text__in=self.admission_items)
+        line_items = self.get_lineitemtypes(include_donations=False).exclude(text__in=self.admission_items)
 
         #   Clear existing transfers
         Transfer.objects.filter(user=self.user, line_item__in=line_items).delete()

--- a/esp/esp/program/modules/handlers/studentextracosts.py
+++ b/esp/esp/program/modules/handlers/studentextracosts.py
@@ -352,7 +352,8 @@ class StudentExtraCosts(ProgramModuleObj):
         return render_to_response(self.baseDir()+'extracosts.html',
                                   request,
                                   { 'errors': not forms_all_valid, 'error_custom': error_custom, 'forms': forms, 'finaid_grant': iac.latest_finaid_grant(), 'select_qty': len(multicosts_list) > 0,
-                                    'paid_for': iac.has_paid(), 'amount_paid': iac.amount_paid(), 'paid_for_text': Tag.getProgramTag("already_paid_extracosts_text", program = prog) })
+                                    'paid_for': iac.has_paid(), 'amount_paid': iac.amount_paid(), 'amount_donation': iac.amount_donation(),
+                                    'paid_for_text': Tag.getProgramTag("already_paid_extracosts_text", program = prog) })
 
     def isStep(self):
         return self.lineitemtypes().exists()

--- a/esp/public/media/scripts/program/modules/extracosts.js
+++ b/esp/public/media/scripts/program/modules/extracosts.js
@@ -8,6 +8,8 @@ var prog_cost = 0;
 $j(function() {
     // the amount that has already been paid
     amount_paid = parseFloat($j("#amount_paid").data("total")) || 0;
+    // the amount of donations that were promised
+    amount_donation = parseFloat($j("#amount_donation").data("donation")) || 0;
     // the dollar amount of financial aid that is provided
     finaid_max_dec = parseFloat($j("#amount_finaid").data("max_dec")) || 0;
     // the percent of remaining cost that is covered by financial aid
@@ -59,7 +61,7 @@ function updateTotalCost() {
     // update the financial aid total on the page (should always be negative)
     if (amount_finaid > 0) $j("#amount_finaid").html("-$" + Number(amount_finaid).toFixed(2));
     // calculate the amount due after accounting for what has already been paid and what financial aid covers
-    amount_due = total_extras + prog_cost - amount_paid - amount_finaid;
+    amount_due = total_extras + prog_cost + amount_donation - amount_paid - amount_finaid;
     // update the amount due on the page
     if (amount_due < 0) {
         $j("#amount_due").html("-$" + Number(-amount_due).toFixed(2)).css("color", "red");

--- a/esp/templates/program/modules/studentextracosts/extracosts.html
+++ b/esp/templates/program/modules/studentextracosts/extracosts.html
@@ -104,6 +104,9 @@ td>ul { list-style-type: none; padding: 0px }
         {% if not program.sibling_discount %}
         <p>Program admission: <span style="font-weight: bold;" id="amount_cost" data-total="{{ program.base_cost|floatformat:2 }}">${{ program.base_cost|floatformat:2 }}</span></p>
         {% endif %}
+        {% if amount_donation > 0 %}
+        <p>Donation: <span style="font-weight: bold;" id="amount_donation" data-donation="{{ amount_donation|floatformat:2 }}">${{ amount_donation|floatformat:2 }}</span></p>
+        {% endif %}
         {% if paid_for %}
         <p>Total amount previously paid: <span style="font-weight: bold;" id="amount_paid" data-total="{{ amount_paid|floatformat:2 }}">-${{ amount_paid|floatformat:2 }}</span></p>
         {% endif %}


### PR DESCRIPTION
This started out as a simple fix for #3790, making sure we don't accidentally delete donation transfers when someone submits the extra costs form after paying. However, I then also realized that the form didn't even show if someone had paid for a donation, so it would confusingly show a negative balance (#3843). I've addressed that here as well by including the donation in the accounting info beneath the form (if there is a donation).

![image](https://github.com/user-attachments/assets/53c03b83-9b03-4a24-9c42-5e5ea2b5a478)

Fixes #3790. Fixes #3843.