### PR TITLE
Improve custom form module errors

### DIFF
--- a/esp/esp/program/modules/handlers/studentcustomformmodule.py
+++ b/esp/esp/program/modules/handlers/studentcustomformmodule.py
@@ -109,7 +109,11 @@ class StudentCustomFormModule(ProgramModuleObj):
         if custom_form_id:
             cf = Form.objects.get(id=int(custom_form_id))
         else:
-            raise ESPError('Cannot find an appropriate form for this module. Please ask your administrator to create a form and set the learn_extraform_id Tag.', log=False)
+            if request.user.isAdmin():
+                error = 'Cannot find an appropriate form for this module. You should <a href="/customforms" target="_blank">create one</a> and link it to the "Student Custom Form" module of the %s program.' % (self.program)
+            else:
+                error = 'Cannot find an appropriate form for this module. Please ask your administrator to create a form and link it to the "Student Custom Form" module.'
+            raise ESPError(error, log=False)
 
         #   If the user already filled out the form, use their earlier response for the initial values
         if self.isCompleted():

--- a/esp/esp/program/modules/handlers/teachercustomformmodule.py
+++ b/esp/esp/program/modules/handlers/teachercustomformmodule.py
@@ -134,7 +134,11 @@ class TeacherCustomFormModule(ProgramModuleObj):
         if custom_form_id:
             cf = Form.objects.get(id=int(custom_form_id))
         else:
-            raise ESPError('Cannot find an appropriate form for this module.  Please ask your administrator to create a form and set the teach_extraform_id Tag.', log=False)
+            if request.user.isAdmin():
+                error = 'Cannot find an appropriate form for this module. You should <a href="/customforms" target="_blank">create one</a> and link it to the "Teacher Custom Form" module of the %s program.' % (self.program)
+            else:
+                error = 'Cannot find an appropriate form for this module. Please ask your administrator to create a form and link it to the "Teacher Custom Form" module.'
+            raise ESPError(error, log=False)
 
         #   If the user already filled out the form, use their earlier response for the initial values
         if self.isCompleted():

--- a/esp/esp/program/modules/handlers/teacherquizmodule.py
+++ b/esp/esp/program/modules/handlers/teacherquizmodule.py
@@ -115,7 +115,11 @@ class TeacherQuizModule(ProgramModuleObj):
         if custom_form_id:
             cf = Form.objects.get(id=int(custom_form_id))
         else:
-            raise ESPError('Cannot find an appropriate form for the quiz.  Please ask your administrator to create a form and set the quiz_form_id Tag.')
+            if request.user.isAdmin():
+                error = 'Cannot find an appropriate form for this module. You should <a href="/customforms" target="_blank">create one</a> and link it to the "Teacher Logistics Quiz" module of the %s program.' % (self.program)
+            else:
+                error = 'Cannot find an appropriate form for this module. Please ask your administrator to create a form and link it to the "Teacher Logistics Quiz" module.'
+            raise ESPError(error, log=False)
 
         #   If the user already filled out the form, use their earlier response for the initial values
         if self.isCompleted():

--- a/esp/templates/customforms/index.html
+++ b/esp/templates/customforms/index.html
@@ -144,7 +144,7 @@
             </div>
         </div>
         
-        <h3><a href='#'>Links</a></h3>
+        <h3><a href='#'>Link to a Program or Course</a></h3>
         <div>
             <p>Link to -
             <select id="links_id_main">	


### PR DESCRIPTION
This improves the error messages that appear when trying to access a custom form module (student, teacher, or logistics quiz) that doesn't have a linked custom form. If the user is an admin, the message links to /customforms and instructs the admin to make a form and link it to the module. I also updated the header in the custom form creator from "Links" to "Link to a Program or Course" to better align with these instructions.

Fixes #3715
Fixes #3807