### PR TITLE
Fix unenroll module

### DIFF
--- a/esp/esp/program/modules/handlers/unenrollmodule.py
+++ b/esp/esp/program/modules/handlers/unenrollmodule.py
@@ -36,6 +36,7 @@ Learning Unlimited, Inc.
 import datetime
 import logging
 from django.db.models import signals
+from esp.users.models import Record
 from esp.program.modules.base import ProgramModuleObj, needs_admin, main_call, aux_call
 from esp.program.models import StudentRegistration, RegistrationType
 from esp.users.models import ESPUser
@@ -132,8 +133,8 @@ class UnenrollModule(ProgramModuleObj):
         # students not checked in
         students = ESPUser.objects.filter(
             id__in=enrollments.values('user'))
-        students = students.exclude(
-            record__program=prog, record__event__name='attended')
+        records = Record.objects.filter(program=prog, event__name='attended')
+        students = students.exclude(id__in=records.values('user'))
 
         # enrollments for those students
         relevant = enrollments.filter(user__in=students).values_list(

--- a/esp/esp/program/modules/tests/unenrollmodule.py
+++ b/esp/esp/program/modules/tests/unenrollmodule.py
@@ -81,7 +81,7 @@ class UnenrollModuleTest(ProgramFrameworkTest):
 
         r = self.client.post('/onsite/' + self.program.url + '/unenroll_students', {'selected_enrollments': ','.join(enrollment_ids)})
         self.assertContains(r, 'Expired %d student registrations' % len(enrollment_ids))
-        self.assertContains(r, ', '.join(enrollment_ids))
+        self.assertContains(r, ','.join(enrollment_ids))
 
         enrollments = StudentRegistration.objects.filter(id__in=enrollment_ids)
         self.assertFalse(enrollments.filter(StudentRegistration.is_valid_qobject()).exists())

--- a/esp/public/media/scripts/program/modules/unenroll.js
+++ b/esp/public/media/scripts/program/modules/unenroll.js
@@ -51,7 +51,7 @@ function handle_update(event) {
     $j('#program_form [type=submit]').prop('disabled', _.isEmpty(enrollments));
 
     // display a message
-    $j('#message').html("You have selected <b>" + _.size(students) + " students</b> to be dropped from <b>" + _.size(sections) + " sections</b> (" + _.size(enrollments) + " enrollments total)");
+    $j('#message').html("You have selected <b>" + _.size(students) + " students</b> to be dropped from <b>" + _.size(sections) + " classes</b> (" + _.size(enrollments) + " enrollments total)");
 
     // show "refresh data" link if data is non-stale
     $j('#refresh').toggle(this.stale);

--- a/esp/public/media/scripts/program/modules/unenroll.js
+++ b/esp/public/media/scripts/program/modules/unenroll.js
@@ -51,7 +51,7 @@ function handle_update(event) {
     $j('#program_form [type=submit]').prop('disabled', _.isEmpty(enrollments));
 
     // display a message
-    $j('#message').text("You have selected " + _.size(students) + " students to be dropped from " + _.size(sections) + " sections (" + _.size(enrollments) + " enrollments total)");
+    $j('#message').html("You have selected <b>" + _.size(students) + " students</b> to be dropped from <b>" + _.size(sections) + " sections</b> (" + _.size(enrollments) + " enrollments total)");
 
     // show "refresh data" link if data is non-stale
     $j('#refresh').toggle(this.stale);

--- a/esp/templates/program/modules/unenrollmodule/result.html
+++ b/esp/templates/program/modules/unenrollmodule/result.html
@@ -4,12 +4,25 @@
 
 {% block content %}
 
-<p>Expired {{ ids|length }} student registrations. If this was a mistake, you can ask a webmin to undo it by running:</p>
+<div class="alert alert-info">
+  <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+  {% if undo %}
+  <b>Unexpired {{ ids|length }} student registrations.</b>
+  {% else %}
+  <b>Expired {{ ids|length }} student registrations. If this was a mistake, click the button below:</b>
 
-<pre><code>ids = {{ ids }}
-StudentRegistration.objects.filter(id__in=ids).update(end_date=None)
-</code></pre>
+  <form id="program_form" method="post" action="{{ request.path }}">
+  <input type="hidden" name="selected_enrollments" value="{{ ids|join:"," }}" />
+  <input type="hidden" name="undo" value="" />
 
-<p><a href="/onsite/{{ program.getUrlBase }}/unenroll_students">Back</a></p>
+  <input class="fancybutton" value="Undo Unenroll" type="submit">
+  </form>
+  {% endif %}
+</div>
 
+<br />
+<br />
+<p>
+<a class="btn btn-primary" href="/onsite/{{ program.getUrlBase }}/unenroll_students">Back to Unenroll Module</a>
+</p>
 {% endblock %}

--- a/esp/templates/program/modules/unenrollmodule/select.html
+++ b/esp/templates/program/modules/unenrollmodule/select.html
@@ -13,7 +13,10 @@
 
 <h1>Select Students to Unenroll</h1>
 
-<p>Use the form below to unenroll students who have not checked into the program. Before using this, make sure that the latest check-ins have been recorded in the website.</p>
+<div class="alert alert-info">
+  <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+  Use the form below to unenroll students who have not checked into the program. Before using this, make sure that the latest check-ins have been recorded in the website.
+</div>
 
 <p>
   <span id="message">Loading enrollment numbers...</span>
@@ -24,8 +27,8 @@
   <input type="hidden" name="selected_enrollments" value="" />
   <table cellpadding="4" cellspacing="0" align="center" width="300">
     <tr>
-      <th>Kick students whose first class starts at...</th>
-      <th>from sections starting at...</th>
+      <th width="50%">Kick students whose first class starts at...</th>
+      <th width="50%">from sections starting at...</th>
     </tr>
     {% for t in selections %}
     <tr>

--- a/esp/templates/program/modules/unenrollmodule/select.html
+++ b/esp/templates/program/modules/unenrollmodule/select.html
@@ -28,7 +28,7 @@
   <table cellpadding="4" cellspacing="0" align="center" width="300">
     <tr>
       <th width="50%">Kick students whose first class starts at...</th>
-      <th width="50%">from sections starting at...</th>
+      <th width="50%">from classes starting at...</th>
     </tr>
     {% for t in selections %}
     <tr>


### PR DESCRIPTION
This fixes the onsite unenroll module. Based on some testing, I think there was some database funkiness that was resulting in the wrong list of student registrations being selected. When the module then "unenrolled" the students, it was expiring the wrong registrations, so it didn't end up looking like anything changed.

I should also note that this module hasn't been touched in 9 years and it could use a bit of love. For example, the individual timeslots don't specify how many students/sections they have, and the results page gives some raw python code to run to undo things. I haven't decided yet if I'm going to work on improving that here or in a separate PR.

EDIT: I've made the following UI changes:

- Added a button that will undo the unenrolling (in place of the janky raw code)
- Made the numbers of students/sections more obvious
- Put some text in bootstrap alert banners
- Made the two columns the same width

Fixes #3834.