### PR TITLE
Fix unmorph button for droplets theme

### DIFF
--- a/esp/esp/themes/theme_data/droplets/templates/navbar/admin.html
+++ b/esp/esp/themes/theme_data/droplets/templates/navbar/admin.html
@@ -27,7 +27,9 @@
       {% comment %} === End Admin Toolbar === {% endcomment %}
     </ul>
   </li>
-  <li class="unmorph hidden">
+</ul>
+<ul class="nav pull-left unmorph hidden">
+  <li>
     <a href="/myesp/switchback/">
       <i class="glyphicon glyphicon-user"></i> Unmorph to <script type="text/javascript">document.write(esp_user.cur_retTitle);</script>
     </a>

--- a/esp/public/media/scripts/content/user_classes.js
+++ b/esp/public/media/scripts/content/user_classes.js
@@ -1,5 +1,5 @@
 function update_user_classes() {
-    if (esp_user.cur_admin == "1") {
+    if (esp_user.cur_admin == "1" || esp_user.cur_retTitle) {
         $j(".admin").removeClass("hidden");
         $j(".onsite").removeClass("hidden");
         $j(".hide-if-admin").addClass("hidden");

--- a/esp/public/media/theme_editor/less/responsive-utilities.less
+++ b/esp/public/media/theme_editor/less/responsive-utilities.less
@@ -13,8 +13,8 @@
 // Hide from screenreaders and browsers
 // Credit: HTML5 Boilerplate
 .hidden {
-  display: none;
-  visibility: hidden;
+  display: none !important;
+  visibility: hidden !important;
 }
 
 // Visibility utilities


### PR DESCRIPTION
This does the following:

1. Fixes the unmorph button so it no longer disappears a few pages after morphing on the droplets theme
2. Keeps the admin toolbar visible when morphed on any theme (since you still have access to pages that require you to be an admin)

Fixes https://github.com/learning-unlimited/ESP-Website/issues/3848