### PR TITLE
Added confirmation page for clearing ajax scheduling cache

### DIFF
--- a/esp/esp/program/modules/handlers/ajaxschedulingmodule.py
+++ b/esp/esp/program/modules/handlers/ajaxschedulingmodule.py
@@ -201,7 +201,9 @@ class AJAXSchedulingModule(ProgramModuleObj):
         Clears the change log for this program. """
 
         self.get_change_log(prog).entries.all().delete()
-        return HttpResponse('')
+        #TODO: change to a page saying cache has been cleared
+        context = {}
+        return render_to_response(self.baseDir()+'clear_cache_confirmation.html', request, context)
 
     def get_change_log(self, prog):
         change_log = module_ext.AJAXChangeLog.objects.filter(program=prog)


### PR DESCRIPTION
Added a page to confirm manually clearing the ajax scheduler cache. Fixes #3822 