### PR TITLE
Add tag to enable Google Analytics

### DIFF
--- a/esp/esp/tagdict/__init__.py
+++ b/esp/esp/tagdict/__init__.py
@@ -492,6 +492,13 @@ all_global_tags = {
         'category': 'manage',
         'is_setting': True,
     },
+    'google_analytics_id': {
+        'is_boolean': False,
+        'help_text': 'A <a href="https://support.google.com/analytics/answer/12270356?hl=en" target="_blank">measurement ID</a> for a <a href="https://developers.google.com/analytics" target="_blank">Google Analytics</a> property. The format of a measurement ID in Google Analytics 4 is "G-" followed by a combination of numbers and letters, such as "G-PSW1MY7HB4". Setting this value will enable the passing of traffic data to Google Analytics.',
+        'default': '',
+        'category': 'manage',
+        'is_setting': True,
+    },
     'shirt_types': {
         'is_boolean': False,
         'help_text': 'Comma-separated list of shirt type options',

--- a/esp/templates/elements/html
+++ b/esp/templates/elements/html
@@ -126,6 +126,18 @@
 
     {% block xtrajs %}{% endblock xtrajs %}
 
+    {% load getTag %}
+    {% if "google_analytics_id"|getTag %}
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{ 'google_analytics_id'|getTag }}"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+    
+      gtag('config', '{{ "google_analytics_id"|getTag }}');
+    </script>
+    {% endif %}
     {% endblock javascript %}
   </head>
   


### PR DESCRIPTION
This adds a global tag for admins to set a Google Analytics ID. Setting this tag then adds the javascript to nearly all pages (via elements/html) which should then enable traffic data collection via Google Analytics.

Fixes #3811