### PR TITLE
Restore statistics button

### DIFF
--- a/esp/templates/program/manage_programs.html
+++ b/esp/templates/program/manage_programs.html
@@ -69,6 +69,13 @@
                 </button>
             </a>
         </div>
+		<div class="module_button">
+            <a href="/manage/statistics/" title="Statistics">
+                <button type="button" class="module_link_large">
+                    <div class="module_link_main"><i class="glyphicon glyphicon-stats"></i> View Statistics</div>
+                </button>
+            </a>
+        </div>
         <div class="module_button">
             <a href="/manage/tags/" title="Manage class categories, flag types, and record types">
                 <button type="button" class="module_link_large">


### PR DESCRIPTION
Restored the statistics button to the program management page. Fixes #3861 