### PR TITLE
Fix bug adding extraneous b characters to volunteer csv download

### DIFF
--- a/esp/esp/program/modules/handlers/volunteermanage.py
+++ b/esp/esp/program/modules/handlers/volunteermanage.py
@@ -82,7 +82,7 @@ class VolunteerManage(ProgramModuleObj):
             write_csv.writerow(("Activity", "Time", "Name", "Phone Number", "Email Address", "Comments"))
             for request in requests:
                 for offer in request.get_offers():
-                    write_csv.writerow([codecs.encode(entry, 'utf-8') if entry is not None else '' for entry in
+                    write_csv.writerow([entry if entry is not None else '' for entry in
                         (request.timeslot.description, request.timeslot.pretty_time(), offer.name, offer.phone, offer.email, offer.comments)])
             response['Content-Disposition'] = 'attachment; filename=volunteers.csv'
             return response


### PR DESCRIPTION
Fixed #3872 csv formatting error by removing explicit definition of UTF-8 encoding from the csv.writer writerow command on row 85 of volunteermanage.py used to generate this csv file. 

It now appears to gracefully handle newly added Unicode characters put in the comment field (by inserting unknown character boxes in both notepad and LibreOffice Calc), so it's unclear why this was explicitly specified in the python code to begin with. It is either a Python 2 to Python 3 issue, or further testing is required.