### PR TITLE
Fix handling of teacher interview creation

### DIFF
--- a/esp/esp/program/modules/forms/teacherevents.py
+++ b/esp/esp/program/modules/forms/teacherevents.py
@@ -24,15 +24,15 @@ class TimeslotForm(forms.Form):
         self.fields['minutes'].initial = int(length // 60 - 60 * self.fields['hours'].initial)
         self.fields['description'].initial = slot.description
 
-    def save_timeslot(self, program, slot, type):
+    def save_timeslot(self, program, slot, event_type):
         slot.start = self.cleaned_data['start']
         slot.end = slot.start + timedelta(hours=self.cleaned_data['hours'], minutes=self.cleaned_data['minutes'])
 
-        if isinstance(type, EventType):
-            slot.event_type = type
-        elif type == "training":
+        if isinstance(event_type, EventType):
+            slot.event_type = event_type
+        elif event_type == "training":
             slot.event_type = EventType.get_from_desc('Teacher Training')
-        elif type == "interview":
+        elif event_type == "interview":
             slot.event_type = EventType.get_from_desc('Teacher Interview')
         else:
             slot.event_type = EventType.get_from_desc("Class Time Block") # default event type

--- a/esp/esp/program/modules/handlers/teachereventsmanagemodule.py
+++ b/esp/esp/program/modules/handlers/teachereventsmanagemodule.py
@@ -99,12 +99,12 @@ class TeacherEventsManageModule(ProgramModuleObj):
                     new_timeslot = Event()
 
                     # decide type
-                    type = "training"
+                    event_type = "training"
 
-                    if data.get('submit') == "Add Interview":
-                        type = "interview"
+                    if data.get('submit_btn') == "Add Interview":
+                        event_type = "interview"
 
-                    form.save_timeslot(self.program, new_timeslot, type)
+                    form.save_timeslot(self.program, new_timeslot, event_type)
                 else:
                     context['timeslot_form'] = form
 


### PR DESCRIPTION
This fixes the creation of teacher interview events. While I was in there, I also renamed a variable that was previously named `type` so we don't have any conflicts with the built-in `type()` function.

Fixes #3870.