### PR TITLE
Allow for overflow in battlescreen tables

### DIFF
--- a/esp/public/media/default_styles/battlescreen.css
+++ b/esp/public/media/default_styles/battlescreen.css
@@ -58,7 +58,6 @@ color: #006600;
    border-radius: 5px;
    outline: 2px solid #99F;
    outline-offset: -1px;
-   overflow: hidden;
 }
 
 #battlescreen > table > thead th {


### PR DESCRIPTION
This reenables overflow in battlescreen tables, which includes the dashboard table and the table on /teacherreg. I'm not really sure why I initially added this CSS rule, and I can't find anything that breaks, but it's possible I'm missing something.

Fixes #3869.