### PR TITLE
Reduce width of number column on class_students page

### DIFF
--- a/esp/public/media/default_styles/forms.css
+++ b/esp/public/media/default_styles/forms.css
@@ -185,6 +185,9 @@ input.fancybutton:active
    th:has(+ td) {
       width: 200px;
    }
+   th.program_form_narrow:has(+ td) {
+      width: 20px;
+   }
 }
 
 #program_form td {

--- a/esp/templates/program/modules/teacherclassregmodule/class_students.html
+++ b/esp/templates/program/modules/teacherclassregmodule/class_students.html
@@ -31,7 +31,7 @@ Here are your class' students.  Only those who have enrolled will show up on you
 <table align="center" width="400px">
 <thead>
 <tr>
- <th>
+ <th class="program_form_narrow">
    #
  </th>
  <th>
@@ -60,7 +60,7 @@ Here are your class' students.  Only those who have enrolled will show up on you
     </tr>
     {% for student in students %}
     <tr>
-        <th class="small">{{ forloop.counter }}</th>
+        <th class="program_form_narrow">{{ forloop.counter }}</th>
         <td>{{ student.name }}</td>
         {% if "student_profile_pronoun_field"|getBooleanTag %}
             <td>{{ student.getLastProfile.student_info.pronoun }}</td>


### PR DESCRIPTION
Fixes #3871 by making a new narrow css class for the column with the header "#" on the class_students page