### PR TITLE
Render emails within `iframe`s

### DIFF
--- a/esp/templates/admin/emails.html
+++ b/esp/templates/admin/emails.html
@@ -96,7 +96,10 @@ tr.email-details {
 $j(function() {
     $j("tr.email-header").click(function(event) {
         var $target = $j(event.target).parent("tr.email-header");
-        $target.next("tr").toggle();
+        var $row = $target.next("tr");
+        $row.toggle();
+        var iframe = $row.find("iframe")[0];
+        iframe.style.height = iframe.contentWindow.document.body.scrollHeight + 16 + 'px';
         if ($target.find("td:first").html() == "+") {
             $target.find("td:first").html("-");
         } else {

--- a/esp/templates/admin/emails.html
+++ b/esp/templates/admin/emails.html
@@ -75,9 +75,9 @@ tr.email-details {
             <td style="text-align:center;">{{ req.num_sent }}</td>
         </tr>
         <tr class="email-details">
-            {% autoescape off %}
-            <td colspan="3" style="vertical-align:top;">{{ req.msgtext }}</td>
-            {% endautoescape %}
+            <td colspan="3" style="vertical-align:top;">
+                <iframe srcdoc="{{ req.msgtext|join:""|escape }}" style="width: 100%; max-height: 600px;"></iframe>
+            </td>
             <td colspan="2" style="vertical-align:top;padding:0;"><table>
                 <tr><td><i>Sent by:</i><br /><a href="/manage/userview?username={{ req.creator|urlencode }}">{{ req.creator }}</a></td></tr>
                 <tr><td><i>Sending address:</i><br />{{ req.sender }}</td></tr>

--- a/esp/templates/program/modules/commmodule/preview.html
+++ b/esp/templates/program/modules/commmodule/preview.html
@@ -60,9 +60,7 @@ users to whom you are sending this email.
 <p>
 <strong>Email body:</strong>
 <br />
-{% autoescape off %}
-    {{ rendered_text }}
-{% endautoescape %}
+<iframe srcdoc="{{ rendered_text|join:""|escape }}" style="width: 100%; max-height: 800px;"></iframe>
 <br />
 </p>
 

--- a/esp/templates/program/modules/commmodule/preview.html
+++ b/esp/templates/program/modules/commmodule/preview.html
@@ -95,4 +95,14 @@ users to whom you are sending this email.
 <input type="submit" value="Send Message!" id="submitform" class="btn btn-primary" />
 </form>
 
+<script>
+$j(function() {
+    $j("iframe").each(function(index, element) {
+        element.onload = function() {
+            element.style.height = element.contentWindow.document.body.scrollHeight + 16 + 'px';
+        }
+    });
+});
+</script>
+
 {% endblock %}

--- a/esp/templates/public_email.html
+++ b/esp/templates/public_email.html
@@ -30,4 +30,14 @@
 <iframe srcdoc="{{ email_req.msgtext|join:""|escape }}" style="width: 100%; max-height: 800px;"></iframe>
 </div>
 
+<script>
+$j(function() {
+    $j("iframe").each(function(index, element) {
+        element.onload = function() {
+            element.style.height = element.contentWindow.document.body.scrollHeight + 16 + 'px';
+        }
+    });
+});
+</script>
+
 {% endblock %}

--- a/esp/templates/public_email.html
+++ b/esp/templates/public_email.html
@@ -25,12 +25,9 @@
 
 <h2 id="subject">Subject: <u>{{ email_req.subject }}</u></h2>
 <h2>Send Date: {{ email_req.created_at|date:"DATE_FORMAT" }}</h2>
-<h2>Message Text:</h2>
-{% autoescape off %}
+<h2>Message Body:</h2>
 <div id="msgtext">
-<p>{{ email_req.msgtext }}</p>
+<iframe srcdoc="{{ email_req.msgtext|join:""|escape }}" style="width: 100%; max-height: 800px;"></iframe>
 </div>
-{% endautoescape %}
-  
 
 {% endblock %}


### PR DESCRIPTION
This renders the richtext of emails within `iframe`s to isolate their stylings and prevent them from altering the main page while viewing the emails. This has been done on the communications panel preview page, the email status page, and the public email view page.

Fixes #3896 