### PR TITLE
Fix handling of disabled teacher text buttons in teacher checkin

### DIFF
--- a/esp/public/media/scripts/onsite/teacher_checkin.js
+++ b/esp/public/media/scripts/onsite/teacher_checkin.js
@@ -116,7 +116,7 @@ $j(function(){
                 var $me = $j(this);
                 var $td = $j(this.parentNode);
                 var $msg = $td.children('.message');
-                var $txtbtn = $j(this).closest('tr').find('.text');
+                var $txtbtn = $j(this).closest('tr').find('.text:not(.not-configured)');
                 
                 $msg.text(response.message);
                 $td.prev().prop('class', 'checked-in');
@@ -271,7 +271,7 @@ $j(function(){
             }
             for (var $td of $tds) {
                 $td.children('.checkin').show().prop('disabled', false);
-                $td.closest('tr').find('.text').prop('disabled', false).removeAttr("title");
+                $td.closest('tr').find('.text:not(.not-configured)').prop('disabled', false).removeAttr("title");
                 $td.prev().prop('class', 'not-checked-in');
                 $td.children('.message').html("");
             }

--- a/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
+++ b/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
@@ -239,7 +239,7 @@
         <td class="text-teacher">
             <span class="message"></span>
             <input data-username="{{ teacher.username }}" data-section="{{ section.id }}"
-                   class="button text" type="button" value="Text Teacher"
+                   class="button text{% if not text_configured %} not-configured{% endif %}" type="button" value="Text Teacher"
                    {% if teacher.id in arrived %} disabled title="Teacher already checked in"
                    {% elif not text_configured %} disabled title="Twilio texting settings are not configured"
                    {% elif teacher.phone == default_phone %} disabled title="No contact info"{% endif %}/>


### PR DESCRIPTION
This fixes a bug where the teacher text button on the checkin page would always be reenabled after undo a check-in, even when Twilio is not properly set up.

Fixes #3864.