### PR TITLE
Fixed Header Height Miscalculation

### DIFF
--- a/esp/public/media/theme_editor/less/variables.less
+++ b/esp/public/media/theme_editor/less/variables.less
@@ -209,7 +209,7 @@
 // Navbar
 // -------------------------
 //@navbarCollapseWidth:             979px;
-@navbarCollapseDesktopWidth:      @navbarCollapseWidth + 1;
+@navbarCollapseDesktopWidth:      ~"calc( @{navbarCollapseWidth} + 1px)";
 
 @navbarHeight:                    40px;
 //@navbarBackgroundHighlight:       #ffffff;


### PR DESCRIPTION
Fixed .less calculation error leading to a header miscalculation. Error was introduced when adding navbar width as an editable variable.