### PR TITLE
Improve credit card module admin error

### DIFF
--- a/esp/esp/program/modules/handlers/creditcardmodule_stripe.py
+++ b/esp/esp/program/modules/handlers/creditcardmodule_stripe.py
@@ -154,7 +154,7 @@ class CreditCardModule_Stripe(ProgramModuleObj):
 
         #   Check for setup of module.  This is also required to initialize settings.
         if not self.check_setup():
-            raise ESPError('The site has not yet been properly set up for credit card payments. Administrators should contact the <a href="mailto:{{settings.SUPPORT}}">websupport team to get it set up.', True)
+            raise ESPError('The site has not yet been properly set up for credit card payments. Administrators should contact the <a href="mailto:{{settings.SUPPORT}}">websupport team</a> to get it set up.', True)
 
         user = request.user
 

--- a/esp/esp/program/modules/handlers/creditcardviewer.py
+++ b/esp/esp/program/modules/handlers/creditcardviewer.py
@@ -89,7 +89,7 @@ class CreditCardViewer(ProgramModuleObj):
     def isStep(self):
         return self.program.hasModule('CreditCardModule_Stripe')
 
-    setup_title = "Set up the 'stripe settings' tag for credit card payments"
+    setup_title = "Set up the website for credit card payments (including the 'stripe settings' tag) (you may need to reach out to the websupport team)"
     setup_path = "tags/learn"
 
     def isCompleted(self):


### PR DESCRIPTION
This improves the message that is shown in the admin checklist when the credit card module is not set up properly. I also fixed the link in the error message in the credit card module itself.

Fixes #3851