### PR TITLE
Remove dependence on outdated memcached GitHub action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,10 @@ jobs:
           - 5432:5432
         # needed because the postgres container does not provide a healthcheck
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+      memcached:
+        image: memcached:alpine
+        ports:
+          - 11211:11211
     strategy:
       fail-fast: false
       matrix:
@@ -32,7 +36,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: niden/actions-memcached@v7
     - name: Set up Python ${{ matrix.python-version }}
       uses: deadsnakes/action@v3.2.0
       with:


### PR DESCRIPTION
The memcached GitHub action that we were depending on (https://github.com/niden/actions-memcached) no longer works. This is an attempt to remove that dependency and use built-in GitHub machinery to spin up the service instead.

Let's see if the tests pass...