### PR TITLE
Upgrade fabfile to use fabric 3

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -208,7 +208,7 @@ def _psql(c, cmd=None, *args, **kwargs):
         return c.sudo(
             "psql -AXqt -c " + shlex.quote(formatted),
             user="postgres",
-            **kwargs, hide="stdout", 
+            **kwargs, hide="stdout",
         )
     else:
         interactive_cmd("sudo -i -u postgres psql; exit")


### PR DESCRIPTION
I've tested that `fab runserver` works with python 3.13 and fabric 3.15, but I still need to test all of the other commands.

- [x] `fab runserver`
- [x] `fab refresh`
- [ ] `fab setup`
- [x] ~~`fab manage:shell_plus`~~ `fab manage --cmd shell_plus`
- [x] ~~`fab manage:migrate`~~ `fab manage --cmd migrate`
- [x] ~~`fab dumpdb`~~ `fab dumpdb --filename dumped_db.sql`
- [ ] ~~`fab loaddb`~~ `fab loaddb --filename dumped_db.sql`
- [ ] `fab emptydb`
- [x] `fab pqsl`

Fixes #3966 and Fixes #2578