### PR TITLE
Add tests for makeaclass/editclass views & fix status on teacher edit

### DIFF
--- a/esp/esp/program/controllers/classreg.py
+++ b/esp/esp/program/controllers/classreg.py
@@ -79,7 +79,7 @@ class ClassCreationController(object):
         for teacher in cls.get_teachers():
             self.require_teacher_has_time(teacher, current_user, extra_time)
 
-        self.make_class_happen(cls, None, reg_form, resource_formset, editing=True)
+        self.make_class_happen(cls, current_user, reg_form, resource_formset, editing=True)
 
         self.send_class_mail_to_directors(cls, False)
 


### PR DESCRIPTION
Resolves : #794 
Related to : #3780 
Adds MakeEditClassTest covering the class create/edit form behavior:
- Teacher can create a class (POST to makeaclass) and it is created with UNREVIEWED status with the teacher properly associated
- Teacher availability is auto-assigned if none set on class creation
- Invalid form data re-renders the form rather than redirecting
- GET editclass pre-populates the form with existing class data
- Teacher can update class title via editclass POST
- Teacher editing an accepted class marks it UNREVIEWED
- Admin editing an accepted class preserves ACCEPTED status
- Another teacher cannot access the class edit form

Also fixes ClassCreationController.editclass() to pass current_user to make_class_happen() instead of None, so that propose() is called for teachers (marking class as unreviewed) but not for admins.