### PR TITLE
Add Bootstrap 5 / SCSS compilation support to ThemeController

### DIFF
--- a/esp/esp/themes/settings.py
+++ b/esp/esp/themes/settings.py
@@ -5,11 +5,14 @@ from os import path
 from collections import OrderedDict
 
 # can we avoid hardcoding this?
-less_dir = path.join(settings.PROJECT_ROOT, 'public', 'media', 'theme_editor', 'less') #directory containing less files used by theme editor
-themes_dir = path.join(settings.PROJECT_ROOT, 'public', 'media', 'theme_editor', 'themes') #directory containing the themes
+theme_editor_dir = path.join(settings.PROJECT_ROOT, 'public', 'media', 'theme_editor')
+less_dir = path.join(theme_editor_dir, 'less') #directory containing less files used by theme editor
+themes_dir = path.join(theme_editor_dir, 'themes') #directory containing the themes
 variables_less = path.join(less_dir, 'variables.less')
 # directory containing the javascript that shows the palette
-palette_dir = path.join(settings.PROJECT_ROOT, 'public', 'media', 'theme_editor')
+palette_dir = theme_editor_dir
+# Bootstrap 5 SCSS source; installed via: cd esp/public/media/theme_editor && npm install
+bootstrap5_scss_dir = path.join(theme_editor_dir, 'node_modules', 'bootstrap', 'scss')
 
 # and this...
 sans_serif_fonts = OrderedDict([("Arial", "Arial, sans-serif"),

--- a/esp/public/media/theme_editor/package.json
+++ b/esp/public/media/theme_editor/package.json
@@ -23,4 +23,9 @@
     , "connect": "2.1.3"
     , "hogan.js": "2.0.0"
   }
+  , "dependencies": {
+      "bootstrap": "^5.3.3"
+    , "bootswatch": "^5.3.3"
+    , "sass": "^1.70.0"
+  }
 }


### PR DESCRIPTION


Adds infrastructure for themes to use Bootstrap 5 (SCSS) alongside
existing Bootstrap 2 (LESS) themes without breaking anything:

- ThemeController.has_scss(): detects themes with scss/ directory
- ThemeController.compile_scss(): compiles SCSS via dart-sass
- ThemeController.get_scss_load_paths(): resolves Bootstrap 5 and
  Bootswatch load paths from npm-installed node_modules
- ThemeController.find_scss_variables(): reads $var SCSS declarations
- ThemeController.compile_css() now routes to _compile_css_less() or
  _compile_css_scss() based on theme type
- ThemeController.get_variable_defaults() handles SCSS themes
- themes/settings.py: adds theme_editor_dir and bootstrap5_scss_dir
- theme_editor/package.json: adds bootstrap ^5.3.3, bootswatch ^5.3.3,
  and sass ^1.70.0 as dependencies

To install Bootstrap 5 SCSS for use in new themes:
  cd esp/public/media/theme_editor && npm install