### PR TITLE
ci: upgrade CodeQL workflow to v3 actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,28 +16,18 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
-
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      # Override language selection by uncommenting this and choosing your languages
-      # with:
-      #   languages: go, javascript, csharp, python, cpp, java
+      uses: github/codeql-action/init@v3
+      with:
+        languages: python, javascript
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -51,4 +41,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary

Fixes #3983

Upgrades the CodeQL analysis workflow from deprecated v2 actions to the latest stable versions and fixes deprecated patterns.

## Changes

- **`actions/checkout`**: `v2` → `v4`
- **`github/codeql-action/init`**: `v2` → `v3`
- **`github/codeql-action/autobuild`**: `v2` → `v3`
- **`github/codeql-action/analyze`**: `v2` → `v3`
- **Removed** deprecated `git checkout HEAD^2` PR workaround (no longer needed with modern checkout action)
- **Added** explicit `languages: python, javascript` to CodeQL init step (previously relied on autodetection)

## Why

- GitHub has deprecated Node 16 runners; v2 actions will stop working
- The `git checkout HEAD^2` pattern was a workaround for old checkout behavior and is now unnecessary
- Explicit language specification improves scan reliability and speed

## Testing

- Workflow syntax validated
- No functional changes to the codebase — only CI config updates