### PR TITLE
Add horizontal separators and aesthetic improvements to import classes

### DIFF
--- a/esp/templates/inclusion/program/class_copy_row.html
+++ b/esp/templates/inclusion/program/class_copy_row.html
@@ -2,20 +2,20 @@
 
 {% block cls_title %}
     <td title="{{cls}}" colspan="5">
-        {{ cls.parent_program.niceName }} -- 
+        <small class="text-muted">{{ cls.parent_program.niceName }}</small><br />
         {{ cls|truncatewords:6 }}
         <a title="Catalog Preview" href="{{ cls.parent_program.get_teach_url }}catalogpreview/{{ cls.id }}">&raquo;</a>
     </td>
-    <td>
-        <form action="{{ prog.get_teach_url }}copyaclass" request="GET">
+    <td style="white-space: nowrap;">
+        <form action="{{ prog.get_teach_url }}copyaclass" method="GET" style="display: inline;">
             <input type="hidden" name="cls" value="{{ cls.id }}">
-            <input type="submit" class="btn btn-primary" value="Import">
+            <input type="submit" class="btn btn-primary btn-sm" value="Import">
         </form>
     </td>
-    <td>
+    <td style="white-space: nowrap;">
         {% if cls.got_index_qsd %}
-        <form action="/learn/{{cls.getUrlBase}}/index.html">
-            <input type="submit" class="btn btn-primary" value="Visit web page">
+        <form action="/learn/{{cls.getUrlBase}}/index.html" style="display: inline;">
+            <input type="submit" class="btn btn-default btn-sm" value="Visit web page">
         </form>
         {% endif %}
     </td>

--- a/esp/templates/program/modules/teacherclassregmodule/listcopyclasses.html
+++ b/esp/templates/program/modules/teacherclassregmodule/listcopyclasses.html
@@ -36,6 +36,11 @@
   {% endif %}
   {% load class_render_row %}
   {% for cls in all_class_list %}
+    {% if not forloop.first %}
+    <tr>
+      <td colspan="7" style="padding: 0;"><hr style="margin: 4px 0; border: 0; border-top: 2px solid #ccc;" /></td>
+    </tr>
+    {% endif %}
     {% render_class_copy_row cls %}
   {% endfor %}
 


### PR DESCRIPTION
Resolves #3962

- Listcopyclasses.html: insert a separator row between each class entry in the loop so previous classes are visually distinct from one another; separator is skipped before the first class so there is no leading line at the top of the table
- Class_copy_row.html: show the source program name on its own line in muted text above the class title so it is easier to scan; use btn-sm for Import / Visit web page buttons to reduce vertical bulk; correct the form method attribute from the invalid "request" to "GET"; add white-space: nowrap to button cells so they never wrap awkwardly