### PR TITLE
Rename Phase Zero to Program Lottery in user-facing text 

### DIFF
--- a/esp/esp/program/modules/handlers/studentregphasezero.py
+++ b/esp/esp/program/modules/handlers/studentregphasezero.py
@@ -74,8 +74,8 @@ class StudentRegPhaseZero(ProgramModuleObj):
     @classmethod
     def module_properties(cls):
         return {
-            "admin_title": "Student Registration Phase Zero",
-            "link_title": "Student Registration Phase Zero",
+            "admin_title": "Program Lottery Registration",
+            "link_title": "Program Lottery Registration",
             "module_type": "learn",
             "seq": 2,
             "required": True,

--- a/esp/esp/program/modules/handlers/studentregphasezeromanage.py
+++ b/esp/esp/program/modules/handlers/studentregphasezeromanage.py
@@ -56,8 +56,8 @@ class StudentRegPhaseZeroManage(ProgramModuleObj):
         return {
             "module_type": "manage",
             'required': False,
-            'admin_title': 'Manage Student Registration Phase Zero',
-            'link_title': 'Manage Phase Zero',
+            'admin_title': 'Manage Program Lottery',
+            'link_title': 'Manage Program Lottery',
             'choosable': 0,
         }
 

--- a/esp/templates/errors/program/phasezero_closed.html
+++ b/esp/templates/errors/program/phasezero_closed.html
@@ -1,19 +1,19 @@
 {% extends "main.html" %}
 
-{% block title %}Student Lottery Closed{% endblock %}
+{% block title %}Program Lottery Closed{% endblock %}
 
 
 {% block content %}
 
-<h1>{{ program.niceName }} Student Lottery Closed</h1>
+<h1>{{ program.niceName }} Program Lottery Closed</h1>
 
 <strong>
 <p>
-The student lottery for {{ program.niceName }} is now closed and it appears you did not enter. Please look in the <a href="/learn/index.html">students section</a> of our site for information about the schedule for this program.  Alternatively, feel free to go <a href="javascript:history.back();">back</a> to the page that you came from.
+The program lottery for {{ program.niceName }} is now closed and it appears you did not enter. Please look in the <a href="/learn/index.html">students section</a> of our site for information about the schedule for this program.  Alternatively, feel free to go <a href="javascript:history.back();">back</a> to the page that you came from.
 </p>
 
 <p>
-If you think this message was in error, send us an <a href="mailto:{{ DEFAULT_EMAIL_ADDRESSES.support }}">email</a>, telling us what you were trying to do, the URL of the page, and that Phase Zero closed.
+If you think this message was in error, send us an <a href="mailto:{{ DEFAULT_EMAIL_ADDRESSES.support }}">email</a>, telling us what you were trying to do, the URL of the page, and that the program lottery closed.
 </p>
 </strong>
 

--- a/esp/templates/program/modules/studentregphasezero/confirmation.html
+++ b/esp/templates/program/modules/studentregphasezero/confirmation.html
@@ -49,9 +49,9 @@
 {% endblock %}
 
 {% block content %}
-<h1 style="color: black">Phase Zero (Student Lottery) for {{program.niceName}}</h1>
+<h1 style="color: black">Program Lottery for {{program.niceName}}</h1>
 {% inline_program_qsd_block program "learn:studentregphasezero/top" %}
-Welcome to Phase Zero, or the Student Lottery, for {{program.niceName}}. Any student that submits interest to the program before the end of phase zero will receive a lottery ticket. We will then select a random portion of these tickets that will then have guaranteed entry into the program. Only students selected in the student lottery may proceed to register for classes.
+Welcome to the Program Lottery for {{program.niceName}}. Any student that submits interest to the program before the lottery closes will receive a lottery ticket. We will then select a random portion of these tickets that will then have guaranteed entry into the program. Only students selected in the program lottery may proceed to register for classes.
 {% end_inline_program_qsd_block %}
 
 {% if join_error %}

--- a/esp/templates/program/modules/studentregphasezero/status.html
+++ b/esp/templates/program/modules/studentregphasezero/status.html
@@ -2,7 +2,7 @@
 {% load render_qsd %}
 {% load users %}
 
-{% block title %} Manage Phase Zero for {{program.niceName}} {% endblock %}
+{% block title %} Manage Program Lottery for {{program.niceName}} {% endblock %}
 
 {% block stylesheets %}
 {{ block.super }}
@@ -62,7 +62,7 @@ td {
 {% endblock xtrajs %}
 
 {% block content %}
-<h1>Manage Phase Zero (Student Lottery) for {{program.niceName}}</h1>
+<h1>Manage Program Lottery for {{program.niceName}}</h1>
 
 <center>
 {% include "program/modules/bigboardmodule/bigboard_graph.html" %}

--- a/esp/templates/program/modules/studentregphasezero/submit.html
+++ b/esp/templates/program/modules/studentregphasezero/submit.html
@@ -49,9 +49,9 @@ input {
 {% endblock %}
 
 {% block content %}
-<h1>Phase Zero (Student Lottery) for {{program.niceName}}</h1>
+<h1>Program Lottery for {{program.niceName}}</h1>
 {% inline_program_qsd_block program "learn:studentregphasezero/top" %}
-Welcome to Phase Zero, or the Student Lottery, for {{program.niceName}}. Any student that submits interest to the program before the end of phase zero will receive a lottery ticket. We will then select a random portion of these tickets that will then have guaranteed entry into the program. Only students selected in the student lottery may proceed to register for classes.
+Welcome to the Program Lottery for {{program.niceName}}. Any student that submits interest to the program before the lottery closes will receive a lottery ticket. We will then select a random portion of these tickets that will then have guaranteed entry into the program. Only students selected in the program lottery may proceed to register for classes.
 {% end_inline_program_qsd_block %}
 
 <hr>


### PR DESCRIPTION
Resolve #3198 
Replace all user-facing occurrences of "Phase Zero" / "Student Lottery" with "Program Lottery" in templates and module handler titles.

Kindly review this @willgearty 
Issue assigned to me.