### PR TITLE
Fix extra b's in LaTeX output by decoding bytes to str

### DIFF
--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -1512,7 +1512,7 @@ class ClassSubject(models.Model, CustomFormsLinkModel):
             return rooms
 
     def ascii_info(self):
-        return self.class_info.encode('ascii', 'ignore')
+        return self.class_info.encode('ascii', 'ignore').decode('ascii')
 
     def _get_meeting_times(self):
         timeslot_id_list = []

--- a/esp/esp/utils/templatetags/latex.py
+++ b/esp/esp/utils/templatetags/latex.py
@@ -96,7 +96,7 @@ def texescape(value):
     value = value.replace('\r',   '\n')
     value = value.replace('\n',   '~\\\\\n')
 
-    value = value.encode('ascii', 'ignore')
+    value = value.encode('ascii', 'ignore').decode('ascii')
 
     return value
 


### PR DESCRIPTION
Resolve #3963 
Fixed the extra `b'...'` characters appearing throughout the catalog, student schedules, and LaTeX output.

__Root cause:__ In Python 3, `str.encode('ascii', 'ignore')` returns a `bytes` object instead of a `str`. When rendered in a template or LaTeX context, it displays as `b'some text'` instead of just `some text`.

Kindly Review @willgearty 
Thanks
