### PR TITLE
ci: add workflow to label stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,31 @@
+name: 'Close stale issues'
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Runs daily at midnight UTC
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # Issues
+          days-before-stale: 30
+          days-before-close: -1  # Never auto-close
+          stale-issue-label: 'stale'
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had
+            any activity in the last 30 days. If this issue is still relevant, please
+            leave a comment or remove the stale label.
+
+          # Pull Requests — do not mark stale
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+
+          # Exempt labels — issues with these labels won't be marked stale
+          exempt-issue-labels: 'pinned,security,bug,enhancement'


### PR DESCRIPTION
Closes #4006 

## Summary

Adds a GitHub Actions workflow ([.github/workflows/stale.yml](cci:7://file:///home/arnav/Desktop/ESP-Website/.github/workflows/stale.yml:0:0-0:0)) using
`actions/stale@v9` that automatically labels issues as `stale` after
30 days of inactivity.

## Details

- Labels issues with `stale` after 30 days of no activity
- Posts an automated comment notifying the author
- **No auto-closing** — only labeling
- **PRs are excluded** — only issues are affected
- Exempt issue labels: `pinned`, `security`, `bug`, `enhancement`
- Runs daily at midnight UTC