### PR TITLE
Fix UnboundLocalError in LoginView.form_valid()

### DIFF
--- a/esp/esp/users/views/__init__.py
+++ b/esp/esp/users/views/__init__.py
@@ -143,7 +143,9 @@ class CustomLoginView(LoginView):
             reply = HttpMetaRedirect('/myesp/profile')
         elif next_url in mask_locations:
             reply = mask_redirect(user, next_url)
-        elif reply.status_code == 302:
+        else:
+            # form_valid() is only called on successful authentication, so we
+            # are always on the success path here — no need to check status_code.
             reply = HttpMetaRedirect(next_url)
 
         reply._new_user = user


### PR DESCRIPTION
Description
Fixes an UnboundLocalError where the reply variable was referenced before assignment in form_valid().

As discussed in the issue, this logic was a remnant of the legacy function-based login view. In the current class-based LoginView, form_valid() is only invoked upon successful authentication. Therefore, we are guaranteed to be in the "success" path, and checking for [status_code == 302] is redundant.

Changes:
Changed the redundant elif reply.status_code == 302: to a standard else: block.
Added a code comment to explain the logic for future maintainability and clarity.
Fixes #3979