### PR TITLE
ci: add top-level permissions for least-privilege security

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,10 +9,16 @@ on:
   schedule:
     - cron: '0 17 * * 2'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,9 @@ on:
     # The branches below must be a subset of the branches above
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: ${{ matrix.travis_job }} (Python ${{ matrix.python-version }})


### PR DESCRIPTION
Fixes #4020 

## Description

Add a top-level `permissions: contents: read` to both CI workflows to restrict the default `GITHUB_TOKEN` to read-only for all jobs.

## Changes

### `tests.yml`

- Added top-level `permissions: contents: read`
- The `build` job (lint + test) only uses `actions/checkout`, run scripts, and `codecov-action` — no write access needed

### `codeql-analysis.yml`

- Added top-level `permissions: contents: read`
- Added job-level `permissions` on `analyze` job with `security-events: write` — CodeQL needs this to upload SARIF results

## Why

Without a top-level `permissions` block, all jobs inherit default `GITHUB_TOKEN` permissions, which on `push` events includes write access to contents, packages, deployments, etc. This follows the [GitHub-recommended least-privilege principle](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token) for workflow tokens.