### PR TITLE
ci: add path filters to skip CI on unrelated changes

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,9 +3,23 @@ name: "CodeQL"
 on:
   push:
     branches: [main, ]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - 'LICENSE'
+      - '.gitattributes'
+      - '.gitignore'
+      - 'Vagrantfile'
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - 'LICENSE'
+      - '.gitattributes'
+      - '.gitignore'
+      - 'Vagrantfile'
   schedule:
     - cron: '0 17 * * 2'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,8 +3,22 @@ name: "Lint and Unit Tests"
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - 'LICENSE'
+      - '.gitattributes'
+      - '.gitignore'
+      - 'Vagrantfile'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - 'LICENSE'
+      - '.gitattributes'
+      - '.gitignore'
+      - 'Vagrantfile'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Fixes #4026 

## Description

Use `paths-ignore` to skip CI when only non-code files are changed. This avoids the deadlock issue with required status checks that occurs when using `paths` filters (required checks never report status on ignored paths, blocking PRs forever).

## Changes

### `tests.yml` & `codeql-analysis.yml`

Added `paths-ignore` to both `push` and `pull_request` triggers:

```yaml
paths-ignore:
  - "docs/**"
  - "*.md"
  - "LICENSE"
  - ".gitattributes"
  - ".gitignore"
  - "Vagrantfile"
```

## Why `paths-ignore` instead of `paths`?

Using `paths` would prevent required status checks (lint, test) from reporting **any** status on doc-only PRs, causing them to be stuck in "pending" forever. `paths-ignore` is fail-safe — CI runs by default and is only skipped for known non-code paths.

## Benefits

- **Saves CI minutes** — no wasted runs on doc-only changes
- **Faster feedback** — CI queue isn't clogged with unnecessary runs
- **Safe** — new/unknown file types trigger CI by default
