### PR TITLE
ci: Add pip-audit security scan for dependency vulnerabilities

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,3 +82,17 @@ jobs:
         verbose: true
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  security:
+    name: Security Scan
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+    - name: Install pip-audit
+      run: pip install pip-audit
+    - name: Run pip-audit
+      run: pip-audit -r esp/requirements.txt


### PR DESCRIPTION
Fixes #4047 

## Summary

Adds automated security scanning for Python dependencies using `pip-audit`, the official PyPA tool for detecting known vulnerabilities.

## Changes

- Added new `security` job to `.github/workflows/tests.yml`
- Uses `pip-audit` to scan `esp/requirements.txt` for known CVEs
- Configured as warn-only to avoid blocking PRs

## Implementation Details

```yaml
security:
  name: Security Scan
  runs-on: ubuntu-latest
  continue-on-error: true
  steps:
    - uses: actions/checkout@v4
    - uses: actions/setup-python@v5
      with:
        python-version: "3.10"
    - name: Install pip-audit
      run: pip install pip-audit
    - name: Run pip-audit
      run: pip-audit -r esp/requirements.txt
```

## Key Decisions

| Decision                  | Rationale                                                                    |
| ------------------------- | ---------------------------------------------------------------------------- |
| `continue-on-error: true` | Warn-only mode; won't block PRs while existing vulnerabilities are addressed |
| Python 3.10               | pip-audit doesn't require matching project Python version                    |
| Separate job              | Runs in parallel, no DB/cache services needed                                |
| `pip-audit` over `safety` | Official PyPA tool, actively maintained                                      |

## Benefits

- **Visibility** — Immediate feedback on dependency vulnerabilities
- **Automation** — No manual security audits needed
- **Non-blocking** — Won't disrupt existing workflow while issues are fixed
- **Fast** — Lightweight job, adds ~30 seconds to CI

## Testing

1. Push to branch triggers workflow
2. Security job appears in Actions tab
3. Scan output shows vulnerabilities (expected for current dependencies)
4. Job shows yellow warning status, doesn't block merge

## Future Improvements

- Add `--ignore-vuln` for known unfixable issues
- Change to `continue-on-error: false` once vulnerabilities addressed
- Pair with Dependabot for automated update PRs