### PR TITLE
fix: enable transaction.atomic on lsr_submit and lsr_submit_HSSP

### DIFF
--- a/esp/esp/program/views.py
+++ b/esp/esp/program/views.py
@@ -136,7 +136,7 @@ def lottery_student_reg_simple(request, program = None):
     return render_to_response('program/modules/lotterystudentregmodule/student_reg_simple.html', request, {})
 
 
-#@transaction.atomic
+@transaction.atomic
 @login_required
 def lsr_submit(request, program=None):
 
@@ -221,7 +221,7 @@ def lsr_submit(request, program=None):
     return HttpResponse(json.dumps(errors), content_type='application/json')
 
 
-#@transaction.atomic
+@transaction.atomic
 @login_required
 def lsr_submit_HSSP(request, program, priority_limit, data):  # temporary function. will merge the two later -jmoldow 05/31
 


### PR DESCRIPTION
**Branch:** `fix/transaction-lsr-submit`
**Closes:** Part of #4054 

## Summary

Uncomments the `@transaction.atomic` decorators on `lsr_submit()` and `lsr_submit_HSSP()` in `esp/program/views.py`.

## Context

These decorators were commented out since the original code in 2011 (as `@transaction.commit_manually`) and mechanically updated to `@transaction.atomic` in a 2015 refactor but never actually enabled. Both functions perform multiple `unpreregister_student()` / `preregister_student()` / `.expire()` calls that should be atomic to prevent partial schedule updates on failure.

## Changes

```diff
-#@transaction.atomic
+@transaction.atomic
 @login_required
 def lsr_submit(request, program=None):
```

```diff
-#@transaction.atomic
+@transaction.atomic
 @login_required
 def lsr_submit_HSSP(request, program, priority_limit, data):
```

## Risk Assessment

**Low** — These functions don't contain email sends or external API calls inside the critical path. They only do DB writes and return JSON.
