### PR TITLE
fix: add transaction.atomic to StudentClassApp.admit

### DIFF
--- a/esp/esp/application/models.py
+++ b/esp/esp/application/models.py
@@ -198,6 +198,7 @@ class StudentClassApp(models.Model):
             if model is not None:
                 self.__class__ = model
 
+    @transaction.atomic
     def admit(self):
         # note: this will un-admit the student from all other classes
         for classapp in self.app.studentclassapp_set.all():


### PR DESCRIPTION

**Branch:** `fix/transaction-application`
**Closes:** Part of #4054 

## Summary

Adds `@transaction.atomic` to `StudentClassApp.admit()` in `esp/application/models.py`.

## Context

The `admit()` method un-admits a student from all sibling class apps (looping and calling `.save()` on each), then admits the current one. Without a transaction, a failure mid-loop could leave the student partially un-admitted from other classes while not yet admitted to the target class.

## Changes

```diff
+    @transaction.atomic
     def admit(self):
         # note: this will un-admit the student from all other classes
         for classapp in self.app.studentclassapp_set.all():
```

## Risk Assessment

**Low** — `transaction` was already imported in this file. No external I/O inside the method.
