### PR TITLE
fix: add transaction.atomic to ResourceController.delete_classroom

### DIFF
--- a/esp/esp/program/controllers/resources.py
+++ b/esp/esp/program/controllers/resources.py
@@ -33,6 +33,7 @@ Learning Unlimited, Inc.
   Email: web-team@learningu.org
 """
 
+from django.db import transaction
 from django.db.models import ProtectedError
 
 from esp.cal.models import Event
@@ -86,6 +87,7 @@ class ResourceController(object):
         form.save_restype(self.program, new_restype, choices)
         return new_restype
 
+    @transaction.atomic
     def delete_classroom(self, id):
         target_resource = Resource.objects.get(id=id)
         rooms = self.program.getClassrooms().filter(name=target_resource.name)


### PR DESCRIPTION
**Branch:** `fix/transaction-resources`
**Closes:** Part of #4054
## Summary

Adds `@transaction.atomic` to `delete_classroom()` in `esp/program/controllers/resources.py`.

## Context

`delete_classroom` performs a multi-step deletion: unschedules sections (clearing rooms, floating resources, meeting times), deletes associated resources, then deletes the rooms. Without a transaction, a failure mid-way could leave orphan resources or partially unscheduled sections.

## Changes

```diff
+from django.db import transaction
 from django.db.models import ProtectedError
```

```diff
+    @transaction.atomic
     def delete_classroom(self, id):
```

## Risk Assessment

**Low** — Pure DB operations, no external I/O.