### PR TITLE
fix: Add `transaction.atomic` to `ClassSection.cancel` and `preregister_student`

### DIFF
--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -50,7 +50,7 @@ import re
 
 # django Util
 from django.conf import settings
-from django.db import models
+from django.db import models, transaction
 from django.db.models.query import Q
 from django.db.models import signals, Sum
 from django.db.models.manager import Manager
@@ -1100,17 +1100,18 @@ class ClassSection(models.Model):
                 to_email = [t.get_email_sendto_address()]
                 send_mail(email_title, email_content, from_email, to_email)
 
-        self.clearStudents()
+        with transaction.atomic():
+            self.clearStudents()
 
-        #   If specified, remove the class's time and room assignment.
-        if unschedule:
-            self.clearRooms()
-            self.meeting_times.clear()
-            # add a scheduler log entry to make the change occur if anyone currently has the scheduler open
-            prog = self.parent_program
-            prog.getModule("AJAXSchedulingModule").get_change_log(prog).appendScheduling([], "", int(self.id), None)
-        self.status = ClassStatus.CANCELLED
-        self.save()
+            #   If specified, remove the class's time and room assignment.
+            if unschedule:
+                self.clearRooms()
+                self.meeting_times.clear()
+                # add a scheduler log entry to make the change occur if anyone currently has the scheduler open
+                prog = self.parent_program
+                prog.getModule("AJAXSchedulingModule").get_change_log(prog).appendScheduling([], "", int(self.id), None)
+            self.status = ClassStatus.CANCELLED
+            self.save()
 
     def clearStudents(self):
         now = datetime.datetime.now()
@@ -1332,6 +1333,7 @@ class ClassSection(models.Model):
         for list_name in list_names:
             remove_list_member(list_name, user.email)
 
+    @transaction.atomic
     def preregister_student(self, user, overridefull=False, priority=1, prereg_verb = None, fast_force_create=False, webapp=False):
         if prereg_verb is None:
             scrmi = self.parent_program.studentclassregmoduleinfo


### PR DESCRIPTION
**Branch:** `fix/transaction-class-section`
**Closes:** Part of #4054

## Summary

Adds transaction management to two critical `ClassSection` methods in `esp/program/models/class_.py`.

## Changes

### `cancel()`

Wraps only the **DB-mutating tail** (`clearStudents()`, `clearRooms()`, `meeting_times.clear()`, status update, `save()`) in `with transaction.atomic()`. The email-sending portion at the top of the method intentionally stays **outside** the transaction to avoid holding DB locks during I/O.

### `preregister_student()`

Adds `@transaction.atomic` decorator. This method creates `StudentRegistration` objects and potentially annotation registrations — all should succeed or fail together.

## Risk Assessment

**Low** — Email sends are excluded from the transaction block. Added `transaction` to the existing `from django.db import models` line.
