### PR TITLE
fix: add transaction.atomic to onsite checkin operations

### DIFF
--- a/esp/esp/program/modules/handlers/onsitecheckinmodule.py
+++ b/esp/esp/program/modules/handlers/onsitecheckinmodule.py
@@ -41,6 +41,7 @@ from esp.utils.web import render_to_response
 from esp.users.forms.generic_search_form import StudentSearchForm
 from esp.users.models    import ESPUser, Record, RecordType
 from django.http import HttpResponse
+from django.db import transaction
 from django.template.loader import render_to_string
 from esp.users.views    import search_for_user
 
@@ -233,20 +234,21 @@ class OnSiteCheckinModule(ProgramModuleObj):
 
                     if student.isStudent():
                         self.student = student
-                        for key in ['attended', 'paid', 'liab', 'med']:
-                            if form.cleaned_data[key]:
-                                if key == "attended":
-                                    if prog.isCheckedIn(student):
-                                        results['existing'].append(code)
+                        with transaction.atomic():
+                            for key in ['attended', 'paid', 'liab', 'med']:
+                                if form.cleaned_data[key]:
+                                    if key == "attended":
+                                        if prog.isCheckedIn(student):
+                                            results['existing'].append(code)
+                                        else:
+                                            self.create_record(key)
+                                            results['new'].append(code)
                                     else:
-                                        self.create_record(key)
-                                        results['new'].append(code)
-                                else:
-                                    created = self.create_record(key)
-                                    if created:
-                                        results[key]['new'].append(code)
-                                    else:
-                                        results[key]['existing'].append(code)
+                                        created = self.create_record(key)
+                                        if created:
+                                            results[key]['new'].append(code)
+                                        else:
+                                            results[key]['existing'].append(code)
                     else:
                         results['not_student'].append(code)
         else:
@@ -306,15 +308,16 @@ class OnSiteCheckinModule(ProgramModuleObj):
             user = ESPUser.objects.filter(id = request.POST['userid']).first()
             if user:
                 self.student = user
-                for key in ['attended', 'paid', 'liab', 'med']:
-                    if key in request.POST:
-                        self.create_record(key)
-                    else:
-                        self.delete_record(key)
-                if "undocheckin" in request.POST:
-                    Record.objects.filter(event__name="attended", program=self.program, user=self.student).order_by("-time")[0].delete()
-                if "undocheckout" in request.POST:
-                    Record.objects.filter(event__name="checked_out", program=self.program, user=self.student).order_by("-time")[0].delete()
+                with transaction.atomic():
+                    for key in ['attended', 'paid', 'liab', 'med']:
+                        if key in request.POST:
+                            self.create_record(key)
+                        else:
+                            self.delete_record(key)
+                    if "undocheckin" in request.POST:
+                        Record.objects.filter(event__name="attended", program=self.program, user=self.student).order_by("-time")[0].delete()
+                    if "undocheckout" in request.POST:
+                        Record.objects.filter(event__name="checked_out", program=self.program, user=self.student).order_by("-time")[0].delete()
                 message = "Check-in updated for " + user.username
             else:
                 error = True


### PR DESCRIPTION
**Branch:** `fix/transaction-onsite-checkin`
**Closes:** Part of #4054

## Summary

Wraps per-user mutation blocks in `checkin()` and `barcodecheckin()` in `esp/program/modules/handlers/onsitecheckinmodule.py` with `transaction.atomic`.

## Changes

### `checkin()`

The block that iterates over `['attended', 'paid', 'liab', 'med']` calling `create_record`/`delete_record`, plus undo operations, is now wrapped in `with transaction.atomic()`.

### `barcodecheckin()`

The per-student block that creates multiple records is now wrapped in `with transaction.atomic()`.

## Risk Assessment

**Low** — Pure DB operations per user, no external I/O inside the transaction blocks.
