### PR TITLE
fix: add transaction.atomic to UserForwarder.updateTarget

### DIFF
--- a/esp/esp/users/models/forwarder.py
+++ b/esp/esp/users/models/forwarder.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from django.utils.encoding import python_2_unicode_compatible
-from django.db import models
+from django.db import models, transaction
 
 # esp dependencies
 from esp.db.fields import AjaxForeignKey
@@ -72,15 +72,16 @@ class UserForwarder(models.Model):
         # Update
         self.target = target
         if save:
-            self.save()
-            # Flatten
-            if flatten:
-                for f in rewrites:
-                    f.target = target
-                    if f.source == f.target:
-                        f.delete()
-                    else:
-                        f.save()
+            with transaction.atomic():
+                self.save()
+                # Flatten
+                if flatten:
+                    for f in rewrites:
+                        f.target = target
+                        if f.source == f.target:
+                            f.delete()
+                        else:
+                            f.save()
 
     @staticmethod
     def forward(source, target):


### PR DESCRIPTION
**Branch:** `fix/transaction-user-forwarder`
**Closes:** Part of #4054 
## Summary

Wraps the save+flatten block in `UserForwarder.updateTarget()` in `esp/users/models/forwarder.py` with `transaction.atomic`.

## Context

When `flatten=True`, `updateTarget` saves itself then loops over forwarders, calling `.save()` or `.delete()` on each. A failure mid-loop could leave a broken forwarder chain with some forwarders pointing to an old target and the current forwarder pointing to the new target.

## Changes

```diff
         self.target = target
         if save:
-            self.save()
-            # Flatten
-            if flatten:
-                for f in rewrites:
-                    f.target = target
-                    if f.source == f.target:
-                        f.delete()
-                    else:
-                        f.save()
+            with transaction.atomic():
+                self.save()
+                # Flatten
+                if flatten:
+                    for f in rewrites:
+                        f.target = target
+                        if f.source == f.target:
+                            f.delete()
+                        else:
+                            f.save()
```

## Risk Assessment

**Low** — Pure DB operations, no external I/O.
