### PR TITLE
ci: add greeting workflow for first-time contributors

### DIFF
--- a/.github/workflows/greeting.yml
+++ b/.github/workflows/greeting.yml
@@ -31,7 +31,7 @@ jobs:
 
             **Review process:**
             - A maintainer will review your changes as soon as possible
-            - Please ensure your PR follows our [contributing guidelines](https://github.com/learning-unlimited/ESP-Website/blob/main/docs/dev/contributing.rst)
+            - Please ensure your PR follows our [contributing guidelines](https://github.com/learning-unlimited/ESP-Website/wiki#i-want-to-get-involved)
             - Make sure CI checks pass (lint and tests)
 
             We're a volunteer-run project, so reviews may take some time. Thank you for your contribution! 🚀


### PR DESCRIPTION
## Description

Add a GitHub Actions workflow that automatically welcomes first-time contributors when they open their first issue or PR.

**Features:**

- Welcomes first-time issue reporters with helpful links to docs and existing issues
- Welcomes first-time PR authors with contributing guidelines and review process info
- Sets expectations about response times (volunteer-run project)
- Uses `actions/first-interaction@v1` official action

## Related Issue

Closes #4069

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [x] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## Checklist

- [x] Self-reviewed the code
- [x] Updated documentation (if needed)
- [x] No new warnings or errors introduced
