### PR TITLE
ci: add automatic PR labeler based on changed files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,73 @@
+# Configuration for actions/labeler
+# Maps file paths to labels that will be automatically applied to PRs
+
+# Documentation changes
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/**'
+          - '**/*.md'
+          - '**/*.rst'
+
+# CI/CD changes
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**'
+          - 'deploy/**'
+          - 'codecov.yml'
+          - 'Vagrantfile'
+
+# Backend/Django changes
+backend:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'esp/**/*.py'
+          - 'esp/requirements.txt'
+
+# Frontend/templates changes
+frontend:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'esp/templates/**'
+          - 'esp/public/media/**'
+          - '**/*.js'
+          - '**/*.css'
+          - '**/*.html'
+
+# Database/migrations
+database:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/migrations/**'
+          - 'esp/esp/db/**'
+
+# Program module changes
+programs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'esp/esp/program/**'
+
+# User management
+users:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'esp/esp/users/**'
+
+# Testing
+tests:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/tests/**'
+          - '**/seltests/**'
+          - '**/*_test.py'
+          - '**/test_*.py'
+
+# Configuration/settings
+config:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'esp/esp/settings.py'
+          - 'esp/esp/django_settings.py'
+          - 'esp/esp/local_settings.py.*'
+          - 'deploy/config_templates/**'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,19 @@
+name: PR Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    if: github.repository == 'learning-unlimited/ESP-Website'
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          sync-labels: true  # Remove labels when files no longer match


### PR DESCRIPTION
## Description

Add automatic PR labeling based on changed files to help maintainers quickly identify what areas of the codebase each PR affects.

**Labels configured:**

- `documentation` - docs, markdown, rst files
- `ci` - GitHub workflows, deploy scripts
- `backend` - Python code in esp/
- `frontend` - templates, JS, CSS
- `database` - migrations
- `programs` - program module
- `users` - user management
- `tests` - test files
- `config` - settings and configuration

**Features:**

- Uses `actions/labeler@v5`
- `sync-labels: true` removes labels when files no longer match
- Only runs on main repository (not forks)

## Related Issue

Closes #4071

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [x] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## AI Disclosure

This PR was created with AI assistance (GitHub Copilot).

## Checklist

- [x] Self-reviewed the code
- [x] Updated documentation (if needed)
- [x] No new warnings or errors introduced

---

**Note:** The labels referenced in `.github/labeler.yml` should be created in repository settings if they don't already exist.
