### PR TITLE
security: pin GitHub Actions to immutable SHA hashes

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,26 +2,26 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [main, ]
+    branches: [main]
     paths-ignore:
-      - 'docs/**'
-      - '*.md'
-      - 'LICENSE'
-      - '.gitattributes'
-      - '.gitignore'
-      - 'Vagrantfile'
+      - "docs/**"
+      - "*.md"
+      - "LICENSE"
+      - ".gitattributes"
+      - ".gitignore"
+      - "Vagrantfile"
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [main]
     paths-ignore:
-      - 'docs/**'
-      - '*.md'
-      - 'LICENSE'
-      - '.gitattributes'
-      - '.gitignore'
-      - 'Vagrantfile'
+      - "docs/**"
+      - "*.md"
+      - "LICENSE"
+      - ".gitattributes"
+      - ".gitignore"
+      - "Vagrantfile"
   schedule:
-    - cron: '0 17 * * 2'
+    - cron: "0 17 * * 2"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -40,30 +40,30 @@ jobs:
       security-events: write
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
-      with:
-        languages: python, javascript
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@0d579ffd059c29b07949a3cce3983f0780820c98 # v4
+        with:
+          languages: python, javascript
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@0d579ffd059c29b07949a3cce3983f0780820c98 # v4
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 https://git.io/JvXDl
 
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+      #    and modify them (or add more) to build your code if your project
+      #    uses a compiled language
 
-    #- run: |
-    #   make bootstrap
-    #   make release
+      #- run: |
+      #   make bootstrap
+      #   make release
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@0d579ffd059c29b07949a3cce3983f0780820c98 # v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,13 +55,13 @@ jobs:
       DJANGO_SETTINGS_MODULE: esp.settings
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: deadsnakes/action@v3.2.0
+      uses: deadsnakes/action@e640ac8743173a67cca4d7d77cd837e514bf98e8  # v3.2.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache pip packages
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('esp/requirements.txt') }}
@@ -101,7 +101,7 @@ jobs:
         DATABASE_NAME: test_django
       run: deploy/ci/script
     - name: Upload Coverage to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de  # v5
       with:
         fail_ci_if_error: true
         verbose: true


### PR DESCRIPTION
## Description

Pin all GitHub Actions to immutable commit SHA hashes instead of version tags to prevent supply chain attacks.

**Actions pinned:**

| Action                   | Version | SHA                                        |
| ------------------------ | ------- | ------------------------------------------ |
| `actions/checkout`       | v4      | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `actions/cache`          | v4      | `0057852bfaa89a56745cba8c7296529d2fc39830` |
| `deadsnakes/action`      | v3.2.0  | `e640ac8743173a67cca4d7d77cd837e514bf98e8` |
| `codecov/codecov-action` | v5      | `671740ac38dd9b0130fbe1cec585b89eea48d3de` |
| `github/codeql-action`   | v3      | `f5c2471be782132e47a6e6f9c725e56730d6e9a3` |

**Why:** Version tags are mutable and can be moved by repository owners, creating a potential supply chain attack vector. SHA hashes are immutable.

**Reference:** https://www.stepsecurity.io/blog/pinning-github-actions-for-enhanced-security-a-complete-guide

## Related Issue

Closes #4073

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [x] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## Checklist

- [x] Self-reviewed the code
- [x] Updated documentation (if needed)
- [x] No new warnings or errors introduced
