### PR TITLE
ci: add isort for automated import sorting enforcement

### DIFF
--- a/deploy/lint
+++ b/deploy/lint
@@ -7,6 +7,10 @@ popd > /dev/null
 
 BASEDIR="$(dirname "$SCRIPTDIR")"
 
+echo "Running import sort check..."
+isort --check-only --diff "$BASEDIR/esp" --skip-glob "**/migrations/*" --skip env
+echo -e "\033[1A\033[27C success!"
+
 echo "Running lint checks..."
 
 # For now, ignore everything except:

--- a/esp/requirements.txt
+++ b/esp/requirements.txt
@@ -22,6 +22,7 @@ bleach==6.0.0 # For sanitizing QSD content
 dill # For migrating Python 2 pickles in the database
 docutils==0.12 # Needed for django.contrib.admindocs
 flake8==3.9.2 # Required for linter
+isort==5.13.2 # Import sorting for consistent organization
 ipython==7.34.0 # Used for shell_plus
 Markdown==2.3.1 # Used in QSD
 numpy==1.16.6 # Used mainly in the lottery and class change controller

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[tool.isort]
+profile = "django"
+line_length = 120
+skip = [".git", "env", "migrations", "__pycache__"]
+skip_glob = ["**/migrations/*"]
+known_django = ["django"]
+known_first_party = ["esp"]
+sections = ["FUTURE", "STDLIB", "DJANGO", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER"]
+default_section = "THIRDPARTY"


### PR DESCRIPTION
## Description

Add automated import sorting enforcement using **isort** to ensure consistent import organization across the Python codebase.

**Changes:**

- Add `isort==5.13.2` to requirements.txt
- Add `pyproject.toml` with Django-compatible isort configuration
- Update `deploy/lint` script to check import order before flake8

**Configuration highlights:**

- Uses Django profile for familiar import grouping
- Groups: stdlib → django → third-party → first-party (esp)
- Skips migrations and virtualenv directories
- Line length: 120 (consistent with project)

**Usage:**

```bash
# Check only (CI)
isort --check-only --diff esp/

# Auto-fix all imports
isort esp/
```

## Related Issue

Closes #4079

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [x] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## Checklist

- [x] Self-reviewed the code
- [x] Updated documentation (if needed)
- [x] No new warnings or errors introduced

---

**Note:** After merging, a follow-up PR may be needed to run `isort esp/` to fix existing import order violations.
