### PR TITLE
Added docker-based dev setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.github
+.vagrant
+env
+venv
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+*.swp
+*.tmp
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+FROM python:3.7-bullseye
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH="/opt/venv/bin:${PATH}"
+
+WORKDIR /workspace
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    curl \
+    dvipng \
+    git \
+    imagemagick \
+    libcurl4-openssl-dev \
+    libevent-dev \
+    libfreetype6-dev \
+    libjpeg-dev \
+    libmemcached-dev \
+    libpq-dev \
+    libssl-dev \
+    nodejs \
+    npm \
+    texlive \
+    texlive-latex-extra \
+    zlib1g-dev \
+    && npm install -g less@1.7.5 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY esp/requirements.txt /tmp/requirements.txt
+RUN python -m venv "${VIRTUAL_ENV}" && \
+    python -m pip install --upgrade pip setuptools==57.5.0 wheel==0.38.4 && \
+    python -m pip install --no-cache-dir -r /tmp/requirements.txt
+
+COPY docker/entrypoint.sh /usr/local/bin/esp-entrypoint
+RUN chmod +x /usr/local/bin/esp-entrypoint
+
+ENTRYPOINT ["esp-entrypoint"]
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Lint and Unit Tests](https://github.com/learning-unlimited/ESP-Website/actions/workflows/tests.yml/badge.svg)](https://github.com/learning-unlimited/ESP-Website/actions/workflows/tests.yml)
 [![codecov](https://codecov.io/gh/learning-unlimited/ESP-Website/branch/main/graph/badge.svg?token=eY0C5a1Lju)](https://codecov.io/gh/learning-unlimited/ESP-Website)
 # ESP Website
-This repository contains a website to help manage the logistics of preparing for and running large, short-term educational programs. It is written and maintained by members and alums of the interscholastic Splash community and [Learning Unlimited](https://learningu.org). Documentation for [program administrators](/docs/admin) and [developers](/docs/dev) is in the [`docs`](/docs) directory, including [dev setup documentation](/docs/dev/vagrant.rst) and [instructions for contributors](/docs/dev/contributing.rst).  Additional documentation for chapters of Learning Unlimited is on the [LU Wiki](https://wiki.learningu.org).
+This repository contains a website to help manage the logistics of preparing for and running large, short-term educational programs. It is written and maintained by members and alums of the interscholastic Splash community and [Learning Unlimited](https://learningu.org). Documentation for [program administrators](/docs/admin) and [developers](/docs/dev) is in the [`docs`](/docs) directory, including dev setup documentation for [Vagrant](/docs/dev/vagrant.rst) and [Docker](/docs/dev/docker.rst), plus [instructions for contributors](/docs/dev/contributing.rst). Additional documentation for chapters of Learning Unlimited is on the [LU Wiki](https://wiki.learningu.org).
 
 ## Looking to contribute?
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+services:
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    working_dir: /workspace/esp
+    command: python manage.py runserver 0.0.0.0:8000
+    volumes:
+      - .:/workspace
+    ports:
+      - "8000:8000"
+    environment:
+      - PYTHONUNBUFFERED=1
+    depends_on:
+      db:
+        condition: service_healthy
+      memcached:
+        condition: service_started
+
+  db:
+    image: postgres:14
+    environment:
+      - POSTGRES_DB=devsite_django
+      - POSTGRES_USER=esp
+      - POSTGRES_PASSWORD=esp
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U esp -d devsite_django"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  memcached:
+    image: memcached:1.6-alpine
+    command: memcached -m 256 -I 2m
+
+volumes:
+  postgres_data:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -eu
+
+APP_ROOT="/workspace/esp"
+LOCAL_SETTINGS="${APP_ROOT}/esp/local_settings.py"
+DOCKER_LOCAL_SETTINGS="/workspace/docker/local_settings.py"
+
+if [ ! -f "${LOCAL_SETTINGS}" ]; then
+  cp "${DOCKER_LOCAL_SETTINGS}" "${LOCAL_SETTINGS}"
+fi
+
+if [ ! -e "${APP_ROOT}/public/media/images" ]; then
+  ln -s "${APP_ROOT}/public/media/default_images" "${APP_ROOT}/public/media/images"
+fi
+
+if [ ! -e "${APP_ROOT}/public/media/styles" ]; then
+  ln -s "${APP_ROOT}/public/media/default_styles" "${APP_ROOT}/public/media/styles"
+fi
+
+exec "$@"

--- a/docker/local_settings.py
+++ b/docker/local_settings.py
@@ -1,0 +1,43 @@
+"""Local settings for Docker-based development."""
+
+from __future__ import absolute_import
+import os
+
+SITE_INFO = (1, "devsite.learningu.org", "LU Dev Site")
+CACHE_PREFIX = "ludev"
+PROJECT_ROOT = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..")
+USE_MAILMAN = False
+DEBUG = True
+SHOW_TEMPLATE_ERRORS = DEBUG
+CACHE_DEBUG = False
+
+DATABASES = {
+    "default": {
+        "NAME": "devsite_django",
+        "HOST": "db",
+        "PORT": "5432",
+        "ENGINE": "django.db.backends.postgresql_psycopg2",
+        "USER": "esp",
+        "PASSWORD": "esp",
+    }
+}
+
+CACHES = {
+    "default": {
+        "BACKEND": "esp.utils.memcached_multikey.CacheClass",
+        "LOCATION": "memcached:11211",
+        "TIMEOUT": 86400,
+    }
+}
+
+MIDDLEWARE_LOCAL = []
+
+EMAIL_HOST_SENDER = "devsite.learningu.org"
+VARNISH_HOST = None
+DEBUG_TOOLBAR = True
+EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+CLOSURE_COMPILER_PATH = "/usr/lib/closure/bin"
+
+SECRET_KEY = "docker-dev-only-secret-key"
+
+ALLOWED_HOSTS = ["localhost", "127.0.0.1"]

--- a/docs/dev/README.rst
+++ b/docs/dev/README.rst
@@ -1,2 +1,8 @@
 This directory contains developer documentation for the ESP Website.
 
+Useful starting points:
+
+* `<contributing.rst>`_ for the project workflow and pull request process.
+* `<vagrant.rst>`_ for Vagrant-based local development.
+* `<docker.rst>`_ for Docker-based local development.
+

--- a/docs/dev/contributing.rst
+++ b/docs/dev/contributing.rst
@@ -1,7 +1,7 @@
 Workflow
 ========
 
-To set up your dev server, see `<vagrant.rst>`_.  The remainder of this document assumes you've set up a dev server, and are ready to contribute a change.
+To set up your dev server, see `<vagrant.rst>`_ or `<docker.rst>`_. The remainder of this document assumes you've set up a dev server, and are ready to contribute a change.
 
 Recommended one-time setup
 --------------------------
@@ -27,13 +27,29 @@ For normal, non-urgent features and bug fixes
 
 The following workflow applies if you've already been added as a collaborator to the repository.  If not, you should fork it using the button on Github, add it as a remote, and replace all of the ``git push``/``git push origin`` steps with ``git push remote-name``.
 
-From the directory ``/esp``: ::
+From the repository root: ::
 
   git checkout main  # for historical reasons we use 'main' instead of 'master'
   git pull
-  ./update_deps.sh # on vagrant: see vagrant docs; no need to bother if deps haven’t changed
-  ./manage.py update # on vagrant: fab refresh
   git checkout -b new-branch-name
+
+Then update your dev environment (choose one): ::
+
+  # Vagrant workflow
+  ./update_deps.sh  # no need to run if deps have not changed
+  ./manage.py update  # or use `fab refresh`
+
+  # Docker workflow
+  docker compose up -d db memcached
+  docker compose run --rm web python manage.py migrate
+
+To run the site locally while developing (choose one): ::
+
+  # Vagrant
+  fab runserver
+
+  # Docker
+  docker compose up web
 
 Write some code!
 Test your code!

--- a/docs/dev/docker.rst
+++ b/docs/dev/docker.rst
@@ -1,0 +1,87 @@
+Docker based dev setup
+======================
+
+.. contents:: :local:
+
+Introduction
+------------
+
+This setup provides a Docker-based alternative to the Vagrant workflow for local
+development. It is especially useful on macOS Apple Silicon systems where
+``vagrant_utm`` has known reliability issues with Vagrant 2.4.x.
+
+Prerequisites
+-------------
+
+Install:
+
+* Docker Desktop (or Docker Engine + Compose plugin)
+* Git
+
+Quick start
+-----------
+
+From the repository root, build and start all services: ::
+
+    docker compose up --build -d
+
+Run database migrations: ::
+
+    docker compose run --rm web python manage.py migrate
+
+Create a superuser (optional): ::
+
+    docker compose run --rm web python manage.py createsuperuser
+
+Run the development server (foreground): ::
+
+    docker compose up web
+
+Then open http://localhost:8000.
+
+Contributor command reference
+-----------------------------
+
+Most day-to-day commands can be run as follows: ::
+
+    # Apply migrations after pulling changes
+    docker compose run --rm web python manage.py migrate
+
+    # Start the dev server
+    docker compose up web
+
+    # Run an arbitrary Django management command
+    docker compose run --rm web python manage.py <command>
+
+    # Run the test suite
+    docker compose run --rm web python manage.py test
+
+What the compose stack includes
+-------------------------------
+
+* ``web``: Django app container
+* ``db``: PostgreSQL database
+* ``memcached``: Cache backend
+
+The repository is bind-mounted into ``/workspace`` inside the ``web`` container,
+so code edits on your host are reflected immediately.
+
+Notes
+-----
+
+* On first boot, ``docker/entrypoint.sh`` creates ``esp/esp/local_settings.py``
+  from ``docker/local_settings.py`` if it is missing.
+* Existing Vagrant/Fabric commands remain supported; this is an additional
+  development path, not a replacement.
+* To run management commands, use ``docker compose run --rm web ...``.
+
+Stopping and cleanup
+--------------------
+
+Stop services: ::
+
+    docker compose down
+
+Remove containers and the database volume: ::
+
+    docker compose down -v

--- a/esp/esp/settings.py
+++ b/esp/esp/settings.py
@@ -227,13 +227,14 @@ for (key, value) in CONTACTFORM_EMAIL_CHOICES:
         CONTACTFORM_EMAIL_ADDRESSES[key] = DEFAULT_EMAIL_ADDRESSES[{'esp':'default','general':'default','esp-web':'support','relations':'default'}[key]]
 
 
-CACHES = {
-    'default': {
-        'BACKEND': 'esp.utils.memcached_multikey.CacheClass',
-        'LOCATION': '127.0.0.1:11211',
-        'TIMEOUT': DEFAULT_CACHE_TIMEOUT,
+if 'CACHES' not in globals():
+    CACHES = {
+        'default': {
+            'BACKEND': 'esp.utils.memcached_multikey.CacheClass',
+            'LOCATION': '127.0.0.1:11211',
+            'TIMEOUT': DEFAULT_CACHE_TIMEOUT,
+        }
     }
-}
 
 MIDDLEWARE = tuple([pair[1] for pair in sorted(MIDDLEWARE_GLOBAL + MIDDLEWARE_LOCAL)])
 


### PR DESCRIPTION
Fixes #4087 

Added a Docker-based dev setup (Dockerfile + docker-compose) as an alternative to Vagrant, mainly for Apple Silicon compatibility.

Documented the full Docker workflow for contributors and linked it from existing dev docs.

Also fixed cache settings precedence so local_settings.py overrides are respected (required for Docker memcached host config).