### PR TITLE
Add clone button in Django admin to duplicate objects (Fixes #596)

### DIFF
--- a/esp/esp/accounting/admin.py
+++ b/esp/esp/accounting/admin.py
@@ -38,18 +38,19 @@ from esp.admin import admin_site
 from esp.accounting.models import Transfer, Account, FinancialAidGrant, \
     LineItemType, LineItemOptions, CybersourcePostback
 from esp.utils.admin_user_search import default_user_search
+from esp.utils.admin import CopyAdminMixin
 
 class LIOInline(admin.TabularInline):
     model = LineItemOptions
 
-class LITAdmin(admin.ModelAdmin):
+class LITAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ['text', 'amount_dec', 'program', 'required', 'for_finaid', 'num_options', 'max_quantity']
     search_fields = ['text', 'amount_dec', 'program__url', 'program__name']
     list_filter = ['program']
     inlines = [LIOInline,]
 admin_site.register(LineItemType, LITAdmin)
 
-class TransferAdmin(admin.ModelAdmin):
+class TransferAdmin(CopyAdminMixin, admin.ModelAdmin):
     def option_description(self, obj):
         if obj.option:
             return obj.option.description
@@ -68,14 +69,14 @@ class TransferAdmin(admin.ModelAdmin):
     raw_id_fields = ['paid_in']  # it's too expensive to iterate over all Transfers to create the dropdown menu
 admin_site.register(Transfer, TransferAdmin)
 
-class AccountAdmin(admin.ModelAdmin):
+class AccountAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ['name', 'program', 'balance']
 admin_site.register(Account, AccountAdmin)
 
 def finalize_finaid_grants(modeladmin, request, queryset):
     for grant in queryset:
         grant.finalize()
-class FinancialAidGrantAdmin(admin.ModelAdmin):
+class FinancialAidGrantAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ['id', 'request', 'user', 'program', 'finalized', 'amount_max_dec', 'percent']
     readonly_fields=('finalized',)
     list_filter = ['request__program']
@@ -83,7 +84,7 @@ class FinancialAidGrantAdmin(admin.ModelAdmin):
     actions = [ finalize_finaid_grants, ]
 admin_site.register(FinancialAidGrant, FinancialAidGrantAdmin)
 
-class CybersourcePostbackAdmin(admin.ModelAdmin):
+class CybersourcePostbackAdmin(CopyAdminMixin, admin.ModelAdmin):
     readonly_fields = ['timestamp']
     list_display = ['timestamp', 'transfer']
     search_fields = ['post_data', '=transfer__id', '=transfer__user__id',

--- a/esp/esp/cal/admin.py
+++ b/esp/esp/cal/admin.py
@@ -36,10 +36,11 @@ Learning Unlimited, Inc.
 from django.contrib import admin
 from esp.admin import admin_site
 from esp.cal.models import EventType, Event
+from esp.utils.admin import CopyAdminMixin
 
 admin_site.register(EventType)
 
-class EventAdmin(admin.ModelAdmin):
+class EventAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ('id', 'program', 'name', 'short_time', 'pretty_date', 'event_type', 'short_description')
     list_filter = ('program', 'start', 'end', 'event_type')
     date_hierarchy = 'start'

--- a/esp/esp/customforms/admin.py
+++ b/esp/esp/customforms/admin.py
@@ -4,6 +4,7 @@ from esp.admin import admin_site
 
 from esp.customforms.models import Form, Page, Section, Field, Attribute
 from esp.utils.admin_user_search import default_user_search
+from esp.utils.admin import CopyAdminMixin
 
 """ Functions to fetch data for columns """
 
@@ -25,31 +26,31 @@ field_form.short_description = 'Form'
 
 """ Classes to control display of instances on admin site """
 
-class FormAdmin(admin.ModelAdmin):
+class FormAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ['title', 'date_created', 'created_by', num_fields]
     search_fields = default_user_search('created_by') + ['title', 'description']
     date_hierarchy = 'date_created'
 admin_site.register(Form, FormAdmin)
 
-class PageAdmin(admin.ModelAdmin):
+class PageAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ['__str__', 'form', 'seq', num_sections]
     list_filter = ('form',)
 admin_site.register(Page, PageAdmin)
 
-class SectionAdmin(admin.ModelAdmin):
+class SectionAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ['title', page_form, 'page', 'seq', num_fields]
     search_fields = ('title', 'description')
     list_filter = ('page', 'page__form')
 admin_site.register(Section, SectionAdmin)
 
-class FieldAdmin(admin.ModelAdmin):
+class FieldAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_filter = ('form',)
     search_fields = ('label',)
     list_display = ['__str__', 'form', 'label', 'field_type', 'section', 'seq', 'required']
     list_editable = list_display[2:]
 admin_site.register(Field, FieldAdmin)
 
-class AttributeAdmin(admin.ModelAdmin):
+class AttributeAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ['attr_type', 'field', 'value', field_form]
     list_filter = ('attr_type', 'field__form')
     list_editable = ['value']

--- a/esp/esp/dbmail/admin.py
+++ b/esp/esp/dbmail/admin.py
@@ -38,30 +38,31 @@ from esp.admin import admin_site
 
 from esp.dbmail.models import MessageVars, EmailList, PlainRedirect, MessageRequest, TextOfEmail
 from esp.utils.admin_user_search import default_user_search
+from esp.utils.admin import CopyAdminMixin
 
-class MessageVarsAdmin(admin.ModelAdmin):
+class MessageVarsAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ('id', 'messagerequest', 'provider_name')
     list_filter = ('provider_name',)
     search_fields = ('messagerequest__subject',)
 admin_site.register(MessageVars, MessageVarsAdmin)
 
-class EmailListAdmin(admin.ModelAdmin):
+class EmailListAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ('description', 'regex')
 admin_site.register(EmailList, EmailListAdmin)
 
-class PlainRedirectAdmin(admin.ModelAdmin):
+class PlainRedirectAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ('original', 'destination')
     search_fields = ('original', 'destination')
 admin_site.register(PlainRedirect, PlainRedirectAdmin)
 
-class MessageRequestAdmin(admin.ModelAdmin):
+class MessageRequestAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ('subject', 'creator', 'sender', 'recipients', 'created_at', 'processed_by', 'processed', 'public')
     list_filter = ('processed', 'processed_by', 'public')
     search_fields = default_user_search('creator') + ['subject', 'sender']
     date_hierarchy = 'processed_by'
 admin_site.register(MessageRequest, MessageRequestAdmin)
 
-class TextOfEmailAdmin(admin.ModelAdmin):
+class TextOfEmailAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ('id', 'send_from', 'send_to', 'subject', 'sent', 'user')
     search_fields = ('=id', 'send_from', 'send_to', 'subject', 'user')
     date_hierarchy = 'sent'

--- a/esp/esp/miniblog/admin.py
+++ b/esp/esp/miniblog/admin.py
@@ -37,15 +37,16 @@ Learning Unlimited, Inc.
 from django.contrib import admin
 from esp.admin import admin_site
 from esp.miniblog.models import AnnouncementLink, Entry, Comment
+from esp.utils.admin import CopyAdminMixin
 
 
-class AnnouncementLinkAdmin(admin.ModelAdmin):
+class AnnouncementLinkAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display= ('category', 'title', 'section', 'highlight_begin', 'highlight_expire')
     list_filter = ('section', 'highlight_begin', 'highlight_expire')
     search_fields=('category', 'title', 'href')
 admin_site.register(AnnouncementLink, AnnouncementLinkAdmin)
 
-class EntryAdmin(admin.ModelAdmin):
+class EntryAdmin(CopyAdminMixin, admin.ModelAdmin):
     search_fields = ['slug', 'content', 'title']
     list_display = ('section', 'slug', 'title', 'highlight_begin', 'highlight_expire')
     list_filter = ('highlight_begin', 'highlight_expire')
@@ -55,7 +56,7 @@ class EntryAdmin(admin.ModelAdmin):
             )
 admin_site.register(Entry, EntryAdmin)
 
-class CommentAdmin(admin.ModelAdmin):
+class CommentAdmin(CopyAdminMixin, admin.ModelAdmin):
     search_fields = ['author__first_name', 'author__last_name',
                      'subject', 'entry__title']
 admin_site.register(Comment, CommentAdmin)

--- a/esp/esp/program/admin.py
+++ b/esp/esp/program/admin.py
@@ -57,18 +57,20 @@ from esp.utils.admin_user_search import default_user_search
 
 from esp.users.admin import ExpiredListFilter
 
-class ProgramModuleAdmin(admin.ModelAdmin):
+from esp.utils.admin import CopyAdminMixin
+
+class ProgramModuleAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ('link_title', 'admin_title', 'handler')
     search_fields = ['link_title', 'admin_title', 'handler']
 admin_site.register(ProgramModule, ProgramModuleAdmin)
 
-class ArchiveClassAdmin(admin.ModelAdmin):
+class ArchiveClassAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ('id', 'title', 'year', 'date', 'category', 'program', 'teacher')
     search_fields = ['id', 'description', 'title', 'program', 'teacher', 'category']
     pass
 admin_site.register(ArchiveClass, ArchiveClassAdmin)
 
-class ProgramAdmin(admin.ModelAdmin):
+class ProgramAdmin(CopyAdminMixin, admin.ModelAdmin):
     class Media:
         css = { 'all': ( 'styles/admin.css', ) }
     list_display = ('id', 'name', 'url', 'director_email', 'grade_min', 'grade_max',)
@@ -76,7 +78,7 @@ class ProgramAdmin(admin.ModelAdmin):
     search_fields = ('name', )
 admin_site.register(Program, ProgramAdmin)
 
-class RegistrationProfileAdmin(admin.ModelAdmin):
+class RegistrationProfileAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ('id', 'user', 'contact_user', 'contact_guardian', 'contact_emergency', 'program', 'last_ts')
     search_fields = default_user_search() + ['contact_user__first_name', 'contact_user__last_name',
                                             'contact_guardian__first_name', 'contact_guardian__last_name',
@@ -89,7 +91,7 @@ class RegistrationProfileAdmin(admin.ModelAdmin):
 
 admin_site.register(RegistrationProfile, RegistrationProfileAdmin)
 
-class TeacherBioAdmin(admin.ModelAdmin):
+class TeacherBioAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ('user', 'program', 'slugbio')
     search_fields = default_user_search() + ['slugbio', 'bio']
 
@@ -101,7 +103,7 @@ class FinancialAidGrantInline(admin.TabularInline):
     max_num = 1
     verbose_name_plural = 'Financial aid grant - enter 100 in "Percent" field to waive entire cost'
 
-class FinancialAidRequestAdmin(admin.ModelAdmin):
+class FinancialAidRequestAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ('user', 'approved', 'reduced_lunch', 'program', 'household_income', 'extra_explaination')
     search_fields = default_user_search() + ['id', 'program__url']
     list_filter = ['program']
@@ -131,7 +133,7 @@ class FinancialAidRequestAdmin(admin.ModelAdmin):
     approve.short_description = "Approve selected financial aid requests for 100%%"
 admin_site.register(FinancialAidRequest, FinancialAidRequestAdmin)
 
-class Admin_SplashInfo(admin.ModelAdmin):
+class Admin_SplashInfo(CopyAdminMixin, admin.ModelAdmin):
     list_display = (
         'student',
         'program',
@@ -149,18 +151,18 @@ def subclass_instance_type(obj):
     return type(obj.subclass_instance())._meta.object_name
 subclass_instance_type.short_description = 'Instance type'
 
-class BooleanTokenAdmin(admin.ModelAdmin):
+class BooleanTokenAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ('expr', 'seq', subclass_instance_type, 'text')
     search_fields = ['text']
 admin_site.register(BooleanToken, BooleanTokenAdmin)
 
-class BooleanExpressionAdmin(admin.ModelAdmin):
+class BooleanExpressionAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ('label', subclass_instance_type, 'num_tokens')
     def num_tokens(self, obj):
         return len(obj.get_stack())
 admin_site.register(BooleanExpression, BooleanExpressionAdmin)
 
-class Admin_ScheduleConstraint(admin.ModelAdmin):
+class Admin_ScheduleConstraint(CopyAdminMixin, admin.ModelAdmin):
     list_display = (
         'program',
         'condition',
@@ -169,21 +171,21 @@ class Admin_ScheduleConstraint(admin.ModelAdmin):
     list_filter = ('program',)
 admin_site.register(ScheduleConstraint, Admin_ScheduleConstraint)
 
-class ScheduleTestOccupiedAdmin(admin.ModelAdmin):
+class ScheduleTestOccupiedAdmin(CopyAdminMixin, admin.ModelAdmin):
     def program(obj):
         return obj.timeblock.program
     list_display = ('timeblock', program, 'expr', 'seq', subclass_instance_type, 'text')
     list_filter = ('timeblock__program',)
 admin_site.register(ScheduleTestOccupied, ScheduleTestOccupiedAdmin)
 
-class ScheduleTestCategoryAdmin(admin.ModelAdmin):
+class ScheduleTestCategoryAdmin(CopyAdminMixin, admin.ModelAdmin):
     def program(obj):
         return obj.timeblock.program
     list_display = ('timeblock', program, 'category', 'expr', 'seq', subclass_instance_type, 'text')
     list_filter = ('timeblock__program',)
 admin_site.register(ScheduleTestCategory, ScheduleTestCategoryAdmin)
 
-class ScheduleTestSectionListAdmin(admin.ModelAdmin):
+class ScheduleTestSectionListAdmin(CopyAdminMixin, admin.ModelAdmin):
     def program(obj):
         return obj.timeblock.program
     list_display = ('timeblock', program, 'section_ids', 'expr', 'seq', subclass_instance_type, 'text')
@@ -192,7 +194,7 @@ admin_site.register(ScheduleTestSectionList, ScheduleTestSectionListAdmin)
 
 class VolunteerOfferInline(admin.StackedInline):
     model = VolunteerOffer
-class VolunteerRequestAdmin(admin.ModelAdmin):
+class VolunteerRequestAdmin(CopyAdminMixin, admin.ModelAdmin):
     def description(obj):
         return obj.timeslot.description
     def time(obj):
@@ -204,7 +206,7 @@ class VolunteerRequestAdmin(admin.ModelAdmin):
     inlines = [VolunteerOfferInline,]
 admin_site.register(VolunteerRequest, VolunteerRequestAdmin)
 
-class VolunteerOfferAdmin(admin.ModelAdmin):
+class VolunteerOfferAdmin(CopyAdminMixin, admin.ModelAdmin):
     def program(obj):
         return obj.request.program
     def description(obj):
@@ -220,7 +222,7 @@ admin_site.register(VolunteerOffer, VolunteerOfferAdmin)
 
 ## class_.py
 
-class Admin_RegistrationType(admin.ModelAdmin):
+class Admin_RegistrationType(CopyAdminMixin, admin.ModelAdmin):
     list_display = ('name', 'category', 'displayName', 'description', )
 admin_site.register(RegistrationType, Admin_RegistrationType)
 
@@ -234,7 +236,7 @@ def renew_student_registrations(modeladmin, request, queryset):
         reg.unexpire()
     modeladmin.message_user(request, "%s registration(s) successfully renewed" % len(queryset))
 
-class StudentRegistrationAdmin(admin.ModelAdmin):
+class StudentRegistrationAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ('id', 'section', 'user', 'relationship', 'start_date', 'end_date',)
     actions = [ expire_student_registrations, renew_student_registrations ]
     search_fields = default_user_search() + ['id', 'section__id', 'section__parent_class__title', 'section__parent_class__id']
@@ -242,7 +244,7 @@ class StudentRegistrationAdmin(admin.ModelAdmin):
     date_hierarchy = 'start_date'
 admin_site.register(StudentRegistration, StudentRegistrationAdmin)
 
-class StudentSubjectInterestAdmin(admin.ModelAdmin):
+class StudentSubjectInterestAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ('id', 'subject', 'user', 'start_date', 'end_date', )
     actions = [ expire_student_registrations, ]
     search_fields = default_user_search() + ['id', 'subject__id', 'subject__title']
@@ -254,7 +256,7 @@ def sec_classrooms(obj):
     return "; ".join(list({x.name +': ' +  str(x.num_students) + " students" for x in obj.classrooms()}))
 def sec_teacher_optimal_capacity(obj):
     return (obj.parent_class.class_size_max if obj.parent_class.class_size_max else obj.parent_class.class_size_optimal)
-class SectionAdmin(admin.ModelAdmin):
+class SectionAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ('emailcode', 'title', 'friendly_times', 'status', 'duration', 'max_class_capacity', sec_teacher_optimal_capacity, sec_classrooms)
     list_display_links = ('title',)
     list_filter = ['status', 'parent_class__parent_program']
@@ -267,7 +269,7 @@ class SectionInline(admin.TabularInline):
     readonly_fields = ('meeting_times', 'prettyrooms')
     can_delete = False
 
-class SubjectAdmin(admin.ModelAdmin):
+class SubjectAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ('category', 'id', 'title', 'parent_program',
                     'pretty_teachers')
     list_display_links = ('title',)
@@ -299,24 +301,24 @@ class SubjectAdmin(admin.ModelAdmin):
     )
 admin_site.register(ClassSubject, SubjectAdmin)
 
-class Admin_ClassCategories(admin.ModelAdmin):
+class Admin_ClassCategories(CopyAdminMixin, admin.ModelAdmin):
      list_display = ('category', 'symbol', 'seq', )
 admin_site.register(ClassCategories, Admin_ClassCategories)
 
-class Admin_ClassSizeRange(admin.ModelAdmin):
+class Admin_ClassSizeRange(CopyAdminMixin, admin.ModelAdmin):
      list_display = ('program', 'range_min', 'range_max', )
      list_filter = ('program',)
 admin_site.register(ClassSizeRange, Admin_ClassSizeRange)
 
 ## app_.py
 
-class StudentAppAdmin(admin.ModelAdmin):
+class StudentAppAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ('user', 'program', 'done')
     search_fields = default_user_search()
     list_filter = ('program',)
 admin_site.register(StudentApplication, StudentAppAdmin)
 
-class Admin_StudentAppQuestion(admin.ModelAdmin):
+class Admin_StudentAppQuestion(CopyAdminMixin, admin.ModelAdmin):
     list_display = (
         'program',
         'subject',
@@ -327,7 +329,7 @@ class Admin_StudentAppQuestion(admin.ModelAdmin):
     list_filter = ('subject__parent_program', 'program', )
 admin_site.register(StudentAppQuestion, Admin_StudentAppQuestion)
 
-class Admin_StudentAppResponse(admin.ModelAdmin):
+class Admin_StudentAppResponse(CopyAdminMixin, admin.ModelAdmin):
     list_display = (
         'question',
         'response',
@@ -339,7 +341,7 @@ class Admin_StudentAppResponse(admin.ModelAdmin):
     list_filter = ('question__subject__parent_program', 'question__program', )
 admin_site.register(StudentAppResponse, Admin_StudentAppResponse)
 
-class Admin_StudentAppReview(admin.ModelAdmin):
+class Admin_StudentAppReview(CopyAdminMixin, admin.ModelAdmin):
     list_display = (
         'reviewer',
         'date',
@@ -350,26 +352,26 @@ class Admin_StudentAppReview(admin.ModelAdmin):
     list_filter = ('date',)
 admin_site.register(StudentAppReview, Admin_StudentAppReview)
 
-class ClassFlagTypeAdmin(admin.ModelAdmin):
+class ClassFlagTypeAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ('name', 'show_in_scheduler', 'show_in_dashboard')
     search_fields = ['name']
     list_filter = ['program']
 admin_site.register(ClassFlagType, ClassFlagTypeAdmin)
 
-class ClassFlagAdmin(admin.ModelAdmin):
+class ClassFlagAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ('flag_type', 'subject', 'comment', 'created_by', 'modified_by')
     readonly_fields = ['modified_by', 'modified_time', 'created_by', 'created_time']
     search_fields = default_user_search('modified_by') + default_user_search('created_by') + ['flag_type__name', 'flag_type__id', 'subject__id', 'subject__title', 'subject__parent_program__url', 'comment']
     list_filter = ['subject__parent_program', 'flag_type']
 admin_site.register(ClassFlag, ClassFlagAdmin)
 
-class PhaseZeroRecordAdmin(admin.ModelAdmin):
+class PhaseZeroRecordAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ('id', 'display_user', 'program')
     search_fields = ['user__username']
     list_filter = ['program']
 admin_site.register(PhaseZeroRecord, PhaseZeroRecordAdmin)
 
-class ModeratorRecordAdmin(admin.ModelAdmin):
+class ModeratorRecordAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ('id', 'user', 'program', 'will_moderate', 'num_slots')
     search_fields = ['user__username']
     list_filter = ['program', 'will_moderate']

--- a/esp/esp/qsd/admin.py
+++ b/esp/esp/qsd/admin.py
@@ -39,8 +39,9 @@ from esp.admin import admin_site
 from esp.qsd.models import QuasiStaticData
 from reversion.admin import VersionAdmin
 from esp.utils.admin_user_search import default_user_search
+from esp.utils.admin import CopyAdminMixin
 
-class QuasiStaticDataAdmin(VersionAdmin):
+class QuasiStaticDataAdmin(CopyAdminMixin, VersionAdmin):
     search_fields = default_user_search('author') + ['title', 'name', 'keywords', 'description', 'url']
     list_display = ['nav_category', 'title', 'url', 'disabled', 'create_date', 'author']
     list_filter = ['nav_category',]

--- a/esp/esp/qsdmedia/admin.py
+++ b/esp/esp/qsdmedia/admin.py
@@ -37,8 +37,9 @@ Learning Unlimited, Inc.
 from django.contrib import admin
 from esp.admin import admin_site
 from esp.qsdmedia.models import Media
+from esp.utils.admin import CopyAdminMixin
 
-class MediaAdmin(admin.ModelAdmin):
+class MediaAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ['owner_type', 'owner_id', 'friendly_name', 'target_file', ]
     list_display_links = ['friendly_name']
     search_fields = ['friendly_name', 'owner_id', ]

--- a/esp/esp/resources/admin.py
+++ b/esp/esp/resources/admin.py
@@ -37,8 +37,9 @@ from django.contrib import admin
 from esp.admin import admin_site
 
 from esp.resources.models import ResourceType, ResourceRequest, Resource, ResourceAssignment
+from esp.utils.admin import CopyAdminMixin
 
-class ResourceTypeAdmin(admin.ModelAdmin):
+class ResourceTypeAdmin(CopyAdminMixin, admin.ModelAdmin):
     def rt_choices(self, obj):
         return "%s" % str(obj.choices)
     rt_choices.short_description = 'Choices'
@@ -47,14 +48,14 @@ class ResourceTypeAdmin(admin.ModelAdmin):
     search_fields = ['name', 'description', 'consumable', 'priority_default',
             'attributes_dumped', 'program__name']
 
-class ResourceRequestAdmin(admin.ModelAdmin):
+class ResourceRequestAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ('target', 'res_type', 'desired_value')
     list_filter = ('res_type__program',)
     search_fields = ['target__parent_class__title', '=target__parent_class__id', 'res_type__name',
             'res_type__description', 'res_type__program__name',
             'desired_value']
 
-class ResourceAdmin(admin.ModelAdmin):
+class ResourceAdmin(CopyAdminMixin, admin.ModelAdmin):
     def program(obj):
         return obj.event.program.name
     list_display = ('name', 'res_type', 'num_students', 'event', 'res_group', program)
@@ -64,7 +65,7 @@ class ResourceAdmin(admin.ModelAdmin):
             'num_students', 'event__name', 'event__short_description',
             '=res_group__id')
 
-class ResourceAssignmentAdmin(admin.ModelAdmin):
+class ResourceAssignmentAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ('id', 'resource', 'target', 'assignment_group', 'returned')
     search_fields = ('=id', 'resource__name', 'target__parent_class__title')
 

--- a/esp/esp/settings.py
+++ b/esp/esp/settings.py
@@ -235,8 +235,11 @@ CACHES = {
     }
 }
 
-MIDDLEWARE = tuple([pair[1] for pair in sorted(MIDDLEWARE_GLOBAL + MIDDLEWARE_LOCAL)])
-
+MIDDLEWARE = tuple([
+    pair[1] for pair in sorted(
+        MIDDLEWARE_GLOBAL + globals().get("MIDDLEWARE_LOCAL", [])
+    )
+])
 # set tempdir so that we don't have to worry about collision
 if not getattr(tempfile, 'alreadytwiddled', False): # Python appears to run this multiple times
     tempdir = os.path.join(tempfile.gettempdir(), "esptmp__" + CACHE_PREFIX)

--- a/esp/esp/survey/admin.py
+++ b/esp/esp/survey/admin.py
@@ -40,22 +40,23 @@ from django.contrib import admin
 from django.conf import settings
 from esp.admin import admin_site
 from esp.survey.models import Survey, SurveyResponse, QuestionType, Question, Answer
+from esp.utils.admin import CopyAdminMixin
 
-class SurveyAdmin(admin.ModelAdmin):
+class SurveyAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_filter = ('category',)
 admin_site.register(Survey, SurveyAdmin)
 
-class SurveyResponseAdmin(admin.ModelAdmin):
+class SurveyResponseAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ('survey', 'time_filled')
     date_hierarchy = 'time_filled'
     list_filter = ('survey', 'time_filled')
 admin_site.register(SurveyResponse, SurveyResponseAdmin)
 
-class QuestionTypeAdmin(admin.ModelAdmin):
+class QuestionTypeAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ('name', '_param_names', 'is_numeric', 'is_countable')
 admin_site.register(QuestionType, QuestionTypeAdmin)
 
-class QuestionAdmin(admin.ModelAdmin):
+class QuestionAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ['seq', 'name', 'question_type', 'survey', 'per_class']
     list_display_links = ['name']
     list_filter = ['survey']

--- a/esp/esp/tagdict/admin.py
+++ b/esp/esp/tagdict/admin.py
@@ -2,8 +2,9 @@ from __future__ import absolute_import
 from esp.tagdict.models import Tag
 from django.contrib import admin
 from esp.admin import admin_site
+from esp.utils.admin import CopyAdminMixin
 
-class TagAdmin(admin.ModelAdmin):
+class TagAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ('key', 'value', 'target', )
     list_filter = ('key', 'object_id', 'content_type__model', )
 admin_site.register(Tag, TagAdmin)

--- a/esp/esp/users/admin.py
+++ b/esp/esp/users/admin.py
@@ -9,19 +9,20 @@ from esp.users.models import UserAvailability, ContactInfo, StudentInfo, Teacher
 from django.contrib.auth.models import Group
 from django.contrib.auth.admin import UserAdmin, GroupAdmin
 from esp.utils.admin_user_search import default_user_search
+from esp.utils.admin import CopyAdminMixin
 import datetime
 
-class UserForwarderAdmin(admin.ModelAdmin):
+class UserForwarderAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ('source', 'target')
     search_fields = default_user_search('source') + default_user_search('target')
 admin_site.register(UserForwarder, UserForwarderAdmin)
 
-class ZipCodeAdmin(admin.ModelAdmin):
+class ZipCodeAdmin(CopyAdminMixin, admin.ModelAdmin):
     search_fields = ('=zip_code',)
     list_display = ('zip_code', 'latitude', 'longitude')
 admin_site.register(ZipCode, ZipCodeAdmin)
 
-class ZipCodeSearchesAdmin(admin.ModelAdmin):
+class ZipCodeSearchesAdmin(CopyAdminMixin, admin.ModelAdmin):
     def count(obj):
         return len(obj.zipcodes.split(','))
     count.short_description = "Number of zip codes"
@@ -29,7 +30,7 @@ class ZipCodeSearchesAdmin(admin.ModelAdmin):
     search_fields = ('=zip_code__zip_code',)
 admin_site.register(ZipCodeSearches, ZipCodeSearchesAdmin)
 
-class UserAvailabilityAdmin(admin.ModelAdmin):
+class UserAvailabilityAdmin(CopyAdminMixin, admin.ModelAdmin):
     def parent_program(obj): #because 'event__program' for some reason doesn't want to work...
         return obj.event.program
     list_display = ['id', 'user', 'event', parent_program]
@@ -38,7 +39,7 @@ class UserAvailabilityAdmin(admin.ModelAdmin):
     ordering = ['-event__program', 'user__username', 'event__start']
 admin_site.register(UserAvailability, UserAvailabilityAdmin)
 
-class ESPUserAdmin(UserAdmin):
+class ESPUserAdmin(CopyAdminMixin, UserAdmin):
     #remove the user_permissions from adminpage
     #(since we don't use it)
     #See https://github.com/django/django/blob/stable/1.3.x/django/contrib/auth/admin.py
@@ -53,12 +54,12 @@ class ESPUserAdmin(UserAdmin):
         )
 admin_site.register(ESPUser, ESPUserAdmin)
 
-class RecordTypeAdmin(admin.ModelAdmin):
+class RecordTypeAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ['id', 'name', 'description']
     search_fields = ['name', 'description']
 admin_site.register(RecordType, RecordTypeAdmin)
 
-class RecordAdmin(admin.ModelAdmin):
+class RecordAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ['id', 'user', 'event', 'program', 'time',]
     list_filter = ['event', 'program', 'time']
     search_fields = default_user_search()
@@ -81,7 +82,7 @@ class ExpiredListFilter(admin.SimpleListFilter):
         elif self.value() == 'expired':
             return queryset.filter(end_date__lte=datetime.datetime.now())
 
-class PermissionAdmin(admin.ModelAdmin):
+class PermissionAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ['id', 'user', 'role', 'permission_type', 'program', 'start_date', 'end_date']
     search_fields = default_user_search() + ['permission_type', 'program__url']
     list_filter = ['permission_type', 'program', 'role', ExpiredListFilter]
@@ -108,12 +109,12 @@ class PermissionAdmin(admin.ModelAdmin):
 
 admin_site.register(Permission, PermissionAdmin)
 
-class ContactInfoAdmin(admin.ModelAdmin):
+class ContactInfoAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ['id', 'user', 'e_mail', 'phone_day']
     search_fields = default_user_search() + ['e_mail']
 admin_site.register(ContactInfo, ContactInfoAdmin)
 
-class UserInfoAdmin(admin.ModelAdmin):
+class UserInfoAdmin(CopyAdminMixin, admin.ModelAdmin):
     search_fields = default_user_search()
 
 class StudentInfoAdmin(UserInfoAdmin):
@@ -138,7 +139,7 @@ class EducatorInfoAdmin(UserInfoAdmin):
     list_display = ['id', 'user', 'position', 'getSchool']
 admin_site.register(EducatorInfo, EducatorInfoAdmin)
 
-class K12SchoolAdmin(admin.ModelAdmin):
+class K12SchoolAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ['name', 'grades', 'contact_title', 'contact_name', 'school_type']
     formfield_overrides = {
         models.TextField: {'widget': forms.TextInput(attrs={'size': '50',}),},
@@ -153,7 +154,7 @@ class K12SchoolAdmin(admin.ModelAdmin):
 
 admin_site.register(K12School, K12SchoolAdmin)
 
-class GradeChangeRequestAdmin(admin.ModelAdmin):
+class GradeChangeRequestAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ['requesting_student', 'claimed_grade', 'approved', 'acknowledged_by', 'acknowledged_time', 'created']
     readonly_fields = ['grade_before_request', 'requesting_student', 'acknowledged_by', 'acknowledged_time', 'claimed_grade']
     search_fields = default_user_search('requesting_student')

--- a/esp/esp/utils/admin.py
+++ b/esp/esp/utils/admin.py
@@ -10,16 +10,30 @@ from esp.admin import admin_site
 from reversion.admin import VersionAdmin
 
 
-class TemplateOverrideAdmin(VersionAdmin):
+class CopyAdminMixin:
+    """Mixin that enables the 'Save as new' button on all admin change views.
+
+    When editing an existing object, this adds a 'Save as new' button that
+    creates a brand-new object pre-populated with the current form's visible
+    field values, making it easy to create several similar objects quickly.
+
+    Usage:
+        class MyModelAdmin(CopyAdminMixin, admin.ModelAdmin):
+            ...
+    """
+    save_as = True
+
+
+class TemplateOverrideAdmin(CopyAdminMixin, VersionAdmin):
     exclude = ['version']
     search_fields = ['name']
     list_display = ['id', 'name', 'version', ]
     list_display_links = ['id', 'name', ]
 
-class PrinterAdmin(admin.ModelAdmin):
+class PrinterAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ['name', 'printer_type']
 
-class PrintRequestAdmin(admin.ModelAdmin):
+class PrintRequestAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ['user', 'printer', 'time_requested', 'time_executed']
     list_filter = ['printer', 'time_requested', 'time_executed']
     date_hierarchy = 'time_requested'

--- a/esp/esp/utils/tests.py
+++ b/esp/esp/utils/tests.py
@@ -445,6 +445,7 @@ class QueryBuilderTest(DjangoTestCase):
                          str(Q(a_db_field="foo bar baz")))
 
 
+
 def suite():
     """Choose tests to expose to the Django tester."""
     s = unittest.TestSuite()
@@ -455,4 +456,86 @@ def suite():
     return s
 
 
+class CopyAdminMixinTest(DjangoTestCase):
+    """Tests for CopyAdminMixin - verifies the 'Save as new' copy button is
+    enabled on all relevant admin classes throughout the project."""
 
+    def test_mixin_sets_save_as(self):
+        """CopyAdminMixin should have save_as = True."""
+        from esp.utils.admin import CopyAdminMixin
+        self.assertTrue(CopyAdminMixin.save_as)
+
+    def test_utils_admin_classes_have_save_as(self):
+        """Admin classes in esp.utils should inherit save_as = True."""
+        from esp.utils.admin import TemplateOverrideAdmin, PrinterAdmin, PrintRequestAdmin
+        for cls in (TemplateOverrideAdmin, PrinterAdmin, PrintRequestAdmin):
+            self.assertTrue(
+                cls.save_as,
+                msg="%s should have save_as = True" % cls.__name__
+            )
+
+    def test_users_admin_classes_have_save_as(self):
+        """Admin classes in esp.users should inherit save_as = True."""
+        from esp.users.admin import (
+            UserForwarderAdmin, ZipCodeAdmin, ZipCodeSearchesAdmin,
+            UserAvailabilityAdmin, ESPUserAdmin, RecordTypeAdmin, RecordAdmin,
+            PermissionAdmin, ContactInfoAdmin, UserInfoAdmin, K12SchoolAdmin,
+            GradeChangeRequestAdmin,
+        )
+        for cls in (
+            UserForwarderAdmin, ZipCodeAdmin, ZipCodeSearchesAdmin,
+            UserAvailabilityAdmin, ESPUserAdmin, RecordTypeAdmin, RecordAdmin,
+            PermissionAdmin, ContactInfoAdmin, UserInfoAdmin, K12SchoolAdmin,
+            GradeChangeRequestAdmin,
+        ):
+            self.assertTrue(
+                cls.save_as,
+                msg="%s should have save_as = True" % cls.__name__
+            )
+
+    def test_program_admin_classes_have_save_as(self):
+        """Admin classes in esp.program should inherit save_as = True."""
+        from esp.program.admin import (
+            ProgramModuleAdmin, ArchiveClassAdmin, ProgramAdmin,
+            RegistrationProfileAdmin, TeacherBioAdmin, StudentRegistrationAdmin,
+            StudentSubjectInterestAdmin, SectionAdmin, SubjectAdmin,
+        )
+        for cls in (
+            ProgramModuleAdmin, ArchiveClassAdmin, ProgramAdmin,
+            RegistrationProfileAdmin, TeacherBioAdmin, StudentRegistrationAdmin,
+            StudentSubjectInterestAdmin, SectionAdmin, SubjectAdmin,
+        ):
+            self.assertTrue(
+                cls.save_as,
+                msg="%s should have save_as = True" % cls.__name__
+            )
+
+    def test_other_admin_classes_have_save_as(self):
+        """Admin classes in other esp apps should inherit save_as = True."""
+        from esp.accounting.admin import LITAdmin, TransferAdmin, AccountAdmin
+        from esp.cal.admin import EventAdmin
+        from esp.dbmail.admin import MessageVarsAdmin, EmailListAdmin
+        from esp.miniblog.admin import AnnouncementLinkAdmin, EntryAdmin
+        from esp.resources.admin import ResourceTypeAdmin, ResourceAdmin
+        from esp.survey.admin import SurveyAdmin, QuestionAdmin
+        from esp.tagdict.admin import TagAdmin
+        from esp.web.admin import NavBarEntryAdmin
+        from esp.qsd.admin import QuasiStaticDataAdmin
+        from esp.qsdmedia.admin import MediaAdmin
+
+        for cls in (
+            LITAdmin, TransferAdmin, AccountAdmin,
+            EventAdmin,
+            MessageVarsAdmin, EmailListAdmin,
+            AnnouncementLinkAdmin, EntryAdmin,
+            ResourceTypeAdmin, ResourceAdmin,
+            SurveyAdmin, QuestionAdmin,
+            TagAdmin,
+            NavBarEntryAdmin,
+            QuasiStaticDataAdmin,
+            MediaAdmin,
+        ):
+            self.assertTrue(
+                cls.save_as,
+                msg="%s should have save_as = True" % cls.__name__
+            )

--- a/esp/esp/web/admin.py
+++ b/esp/esp/web/admin.py
@@ -36,8 +36,9 @@ Learning Unlimited, Inc.
 from django.contrib import admin
 from esp.admin import admin_site
 from esp.web.models import NavBarEntry, NavBarCategory
+from esp.utils.admin import CopyAdminMixin
 
-class NavBarEntryAdmin(admin.ModelAdmin):
+class NavBarEntryAdmin(CopyAdminMixin, admin.ModelAdmin):
     list_display = ('category', 'sort_rank', 'text', 'link')
     list_filter = ('category',)
 


### PR DESCRIPTION
## Description

<!-- Brief summary of the changes and their purpose. -->

## Related Issue

<!-- Link the relevant issue. Use "Closes #123" to auto-close on merge. -->

Closes #596

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor/cleanup
- [ ] CI/CD or build change

## Testing

- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manually verified

## AI Disclosure

<!-- If you used AI tools for any part of this pull request, please disclose this here -->

## Checklist

- [x] Self-reviewed the code
- [x] Updated documentation (if needed)
- [x] No new warnings or errors introduced

Summary

Implements a "Save as new" button across all Django admin change forms
by enabling Django's built-in `ModelAdmin.save_as = True`.

This allows admins to duplicate existing objects easily when creating
similar records (e.g., UserBits, StudentRegistrations, etc.), addressing
Issue #596.

Approach

A reusable `CopyAdminMixin` was introduced in `esp/utils/admin.py.`
to enable `save_as = True`, and applied across all ModelAdmin classes
project-wide.

Tests were added to verify that the mixin is correctly applied.

Fixes #596.