### PR TITLE
Fix: allow non-alphanumeric characters in unsubscribe links

### DIFF
--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -1179,10 +1179,12 @@ class BaseESPUser(object):
         user_hash = hash(str(self.id) + str(program.id))
         return '{0:06d}'.format(abs(user_hash))[:6]
 
-    # modified from here: https://www.grokcode.com/819/one-click-unsubscribes-for-django-apps/
+    # modified from here:
+    # https://www.grokcode.com/819/one-click-unsubscribes-for-django-apps/
     def unsubscribe_link(self):
-        username, token = self.make_token().split(":", 1)
-        return reverse('unsubscribe', kwargs={'username': username, 'token': token,})
+        token = self.make_token()[len(self.username) + 1:]
+        return reverse('unsubscribe',
+                       kwargs={'username': self.username, 'token': token})
 
     def unsubscribe_link_full(self):
         unsub_link = self.unsubscribe_link()

--- a/esp/esp/users/urls.py
+++ b/esp/esp/users/urls.py
@@ -24,12 +24,15 @@ urlpatterns = [
     url(r'^signedout/?$', views.signed_out_message),
     url(r'^login/?$', views.CustomLoginView.as_view(), name="login"),
     url(r'^disableaccount/?$', views.disable_account),
-    url(r'^grade_change_request/?$', GradeChangeRequestView.as_view(), name = 'grade_change_request'),
+    url(r'^grade_change_request/?$', GradeChangeRequestView.as_view(),
+        name='grade_change_request'),
     url(r'^makeadmin/?$', views.make_admin),
     url(r'^loginhelp', views.LoginHelpView.as_view(), name='Login Help'),
     url(r'^morph/?$', views.morph_into_user),
-    url(r'^unsubscribe/(?P<username>[\w.@+-]+)/(?P<token>[\w.:\-_=]+)/$', views.unsubscribe, name="unsubscribe"),
-    url(r'^unsubscribe_oneclick/(?P<username>[\w.@+-]+)/(?P<token>[\w.:\-_=]+)/$', views.unsubscribe_oneclick, name="unsubscribe_oneclick"),
+    url(r'^unsubscribe/(?P<username>[^/]+)/(?P<token>[\w.:\-_=]+)/$',
+        views.unsubscribe, name="unsubscribe"),
+    url(r'^unsubscribe_oneclick/(?P<username>[^/]+)/(?P<token>[\w.:\-_=]+)/$',
+        views.unsubscribe_oneclick, name="unsubscribe_oneclick"),
 ]
 
 urlpatterns += [


### PR DESCRIPTION
## Description

Fix an issue where `unsubscribe_link()` failed for users whose usernames contained non-alphanumeric characters (such as spaces, colons, or punctuation). The failure was blocking email processing because the token extraction logic split incorrectly on colons and the URL routing regex was too restrictive.

---

## Changes Made

- **esp/esp/users/models/init.py**  
  Replaced `.split(":", 1)` with string slicing:
  [len(self.username) + 1:]

This correctly isolates the security token regardless of characters in the username.

- **esp/esp/users/urls.py**  
Updated regex for `unsubscribe` and `unsubscribe_oneclick` routes from:
[\w.@+-]+
to:
[^/]+

allowing any character except the URL separator.

- **Linting**  
Resolved multiple PEP-8 / Flake8 violations (E501, E251, E265).

---

## Impact

This is a non-breaking bug fix that restores unsubscribe functionality for affected users. No behavioral changes for existing valid usernames.

---

## Related Issue

Closes #3978 

---

## Type of Change

- [x] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  
- [x] Refactor / cleanup  
- [ ] CI/CD or build change  

---

## Testing

- [x] Existing tests pass  
- [ ] New tests added (if applicable)  
- [x] Manually verified  
- Tested URL generation and reversing for usernames containing:
  - `!`
  - `:`
  - spaces

---
## AI Disclosure
No AI tools were used for this pull request.
---
## Checklist

- [x] Self-reviewed the code  
- [x] Updated documentation (if needed)  
- [x] No new warnings or errors introduced