### PR TITLE
fix(web): route unknown complex paths to fallback page

### DIFF
--- a/esp/esp/urls.py
+++ b/esp/esp/urls.py
@@ -162,3 +162,8 @@ urlpatterns += [
     url(r'^manage/templateoverride/(?P<template_id>[0-9]+)',
         esp.utils.views.diff_templateoverride),
 ]
+
+# Keep unknown program domains functional for deeper paths
+urlpatterns += [
+    url(r'^(?P<path>.+)$', main.unknown_program_fallback),
+]

--- a/esp/esp/web/tests.py
+++ b/esp/esp/web/tests.py
@@ -76,6 +76,12 @@ class PageTest(TestCase):
         self.assertStringContains(six.text_type(response.content, encoding='UTF-8'), "<html")
         self.assertNotStringContains(six.text_type(response.content, encoding='UTF-8'), "You're seeing this error because you have <code>DEBUG = True</code>")
 
+    def testUnknownProgramFallbackPath(self):
+        c = Client()
+        response = c.get("/test")
+        self.assertEqual(response.status_code, 200)
+        self.assertStringContains(six.text_type(response.content, encoding='UTF-8'), "<html")
+
 class NavbarTest(TestCase):
 
     def get_navbar_titles(self, path='/'):

--- a/esp/esp/web/views/main.py
+++ b/esp/esp/web/views/main.py
@@ -66,6 +66,14 @@ def home(request):
     context = {'navbar_list': makeNavBar('', nav_category)}
     return render_to_response('index.html', request, context)
 
+
+@cache_control(max_age=180)
+@disable_csrf_cookie_update
+def unknown_program_fallback(request, path):
+    # For chapter domains without active program routes, keep unknown paths
+    # user-friendly by serving the same landing page as "/".
+    return home(request)
+
 def program(request, tl, one, two, module, extra = None):
     """ Return program-specific pages """
     from esp.program.models import Program


### PR DESCRIPTION
Fixes #3892 

adding a fallback route for unmatched complex URLs (for example `/test`) so unknown program domains render the landing/unknown-program page instead of failing route resolution.

Includes a regression test to verify complex path fallback behavior.
