### PR TITLE
Fix AttributeError in get_email_data when no TextOfEmail records exist

### DIFF
--- a/esp/esp/program/views.py
+++ b/esp/esp/program/views.py
@@ -775,7 +775,11 @@ def get_email_data(start_date):
             req.num_rec = CommModule.approx_num_of_recipients(req.recipients, req.get_sendto_fn())
         req.num_sent = toes.filter(sent__isnull=False).count()
         if req.num_rec == req.num_sent:
-            req.finished_at = toes.order_by('-sent').first().sent
+            last_email = toes.order_by('-sent').first()
+            if last_email is not None:
+                req.finished_at = last_email.sent
+            else:
+                req.finished_at = "(Not finished)"
         else:
             req.finished_at = "(Not finished)"
         requests_list.append(req)


### PR DESCRIPTION
## Description

Added a `None` guard before accessing `.sent` on the queryset result. When no 
**TextOfEmail**
 records exist, `finished_at is set to "(Not finished)"` instead of crashing.
## Related Issue

Closes #4147

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## AI Disclosure

<!-- If you used AI tools for any part of this pull request, please disclose this here -->

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced
