### PR TITLE
Replace bare except with NameError in database settings

### DIFF
--- a/esp/esp/settings.py
+++ b/esp/esp/settings.py
@@ -61,17 +61,17 @@ TEMPLATES[0]['OPTIONS']['debug'] = DEBUG
 if len(DATABASES['default']['USER']) == 0:
     try:
         DATABASES['default']['USER'] = DATABASE_USER
-    except:
+    except NameError:
         raise Exception("You need to supply either DATABASES['default']['USER'] or DATABASE_USER in database_settings.py")
 if len(DATABASES['default']['PASSWORD']) == 0:
     try:
         DATABASES['default']['PASSWORD'] = DATABASE_PASSWORD
-    except:
+    except NameError:
         raise Exception("You need to supply either DATABASES['default']['PASSWORD'] or DATABASE_PASSWORD in database_settings.py")
 if len(DATABASES['default']['NAME']) == 0:
     try:
         DATABASES['default']['NAME'] = DATABASE_NAME
-    except:
+    except NameError:
         raise Exception("You need to supply either DATABASES['default']['NAME'] or DATABASE_NAME in local_settings.py")
 
 SERVER_EMAIL = 'server@%s' % EMAIL_HOST_SENDER


### PR DESCRIPTION
Fixes #4191 

Replaces the three bare `except`: blocks in database config fallback (USER, PASSWORD, NAME) with `except NameError`:. Expected behaviour: Missing `DATABASE_USER/DATABASE_PASSWORD/DATABASE_NAME` still raises the same clear message; all other startup errors propagate, so the actual cause is visible.