### PR TITLE
Add extended dashboard JSON stats tests (issue #599)

### DIFF
--- a/esp/esp/program/modules/tests/jsondatamodule.py
+++ b/esp/esp/program/modules/tests/jsondatamodule.py
@@ -33,12 +33,14 @@ Learning Unlimited, Inc.
 """
 
 import json
+from collections import Counter
 
 from django.utils.html import escape
 
 from esp.program.tests import ProgramFrameworkTest
 from esp.program.modules.base import ProgramModule, ProgramModuleObj
 from esp.program.models import ClassSubject
+from esp.resources.models import ResourceType
 
 class JSONDataModuleTest(ProgramFrameworkTest):
     ## This test is very incomplete.
@@ -69,10 +71,21 @@ class JSONDataModuleTest(ProgramFrameworkTest):
         ProgramFrameworkTest.classreg_students(cls)
 
     def setUp(self):
-        # Note: do NOT call super().setUp() here; ProgramFrameworkTest.setUp
-        # was already executed once at the class level in setUpTestData above.
-        # Only do lightweight, per-test work: authenticate the client and
-        # (re-)fetch the JSON responses that the test methods assert against.
+        # We deliberately do NOT call super().setUp() here.  ProgramFrameworkTest
+        # mixes two concerns in its setUp: (a) expensive one-time DB scaffolding
+        # (program creation, user creation, etc.) which was already done once at
+        # the class level in setUpTestData, and (b) lightweight per-test state
+        # resets.  Calling super().setUp() per-test would re-run the full program
+        # creation form, which fails because the program already exists.
+        #
+        # We therefore replicate only the per-test isolation steps from
+        # ProgramFrameworkTest.setUp explicitly:
+        #   1. Reset the in-memory ResourceType cache so stale entries from one
+        #      test can't pollute the next (ProgramFrameworkTest.setUp line ~527).
+        #   2. No other shared mutable state is mutated by ProgramFrameworkTest.setUp.
+        #
+        # This preserves test isolation without the O(N) per-test DB overhead.
+        ResourceType._get_or_create_cache = {}
         self.pm = ProgramModule.objects.get(handler='AdminCore')
         self.moduleobj = ProgramModuleObj.getFromProgModule(self.program, self.pm)
         self.moduleobj.user = self.students[0]
@@ -162,20 +175,37 @@ class JSONDataModuleTest(ProgramFrameworkTest):
         all_classes = self.program.classes().filter(status__gte=0)
         all_sections = self.program.sections().filter(status__gte=0)
 
+        # Pre-fetch grade ranges and parent-class IDs in exactly two flat
+        # queries, then compute per-grade counts in Python.  This avoids the
+        # O(grades) query overhead of calling .count() twice per grade.
+        class_grade_ranges = list(
+            all_classes.values_list('id', 'grade_min', 'grade_max')
+        )
+        section_class_ids = list(
+            all_sections.values_list('parent_class_id', flat=True)
+        )
+        sections_per_class = Counter(section_class_ids)
+
         expected_response = {"data": [], "id": "grades"}
         for g in range(self.program.grade_min, self.program.grade_max + 1):
-            grade_classes = all_classes.filter(grade_min__lte=g, grade_max__gte=g)
-            grade_sections = all_sections.filter(parent_class__in=grade_classes)
+            grade_class_ids = [
+                cid for cid, gmin, gmax in class_grade_ranges
+                if gmin <= g <= gmax
+            ]
             expected_response["data"].append({
                 "grade": g,
-                "num_subjects": grade_classes.count(),
-                "num_sections": grade_sections.count(),
+                "num_subjects": len(grade_class_ids),
+                "num_sections": sum(
+                    sections_per_class.get(cid, 0) for cid in grade_class_ids
+                ),
                 "num_students": 10 if g == 10 else 0,
             })
+        # Use the pre-parsed self.stats_data (cached in setUp) throughout to
+        # avoid redundant JSON reparsing.
         self.assertContains(self.stats_response, 'stats', status_code=200)
-        self.assertIn('stats', list(self.stats_response.json().keys()))
+        self.assertIn('stats', list(self.stats_data.keys()))
         grades_count = 0
-        for res in self.stats_response.json()['stats']:
+        for res in self.stats_data['stats']:
             self.assertIn('id', list(res.keys()))
             if res['id'] == 'grades':
                 grades_count += 1


### PR DESCRIPTION
## Description
Adds comprehensive unit tests covering the JSON dashboard endpoints used by the program admin dashboard. The existing `JSONDataModuleTest` only checked a small subset of stats; this change expands coverage for `/json/<prog>/stats` and `/json/<prog>/class_subjects`, tightens assertions to prevent regressions in response structure and authorization behavior, and fixes several test infrastructure problems that made the suite brittle.

## Files Changed
- `esp/esp/program/modules/tests/jsondatamodule.py` (+261 / -12)

## Key Additions and Fixes

### Infrastructure Fixes (applied in follow-up commits)
* **`setUpTestData` / `setUp` lifecycle:** Replaced the broken pattern of calling `ProgramFrameworkTest.setUp(cls)` as a classmethod and then skipping `super().setUp()` per-test. `setUp` now explicitly resets `ResourceType._get_or_create_cache` (the only per-test isolation step needed) without re-running the expensive program-creation form, which would fail because the program already exists.
* **Cached parsed JSON:** `setUp` now parses and caches `self.stats_data` and `self.classes_data` once per test; all test methods use these cached objects instead of calling `response.json()` repeatedly.
* **`setUp` guards:** `assertEqual` assertions on HTTP status codes before JSON parsing, with a descriptive `fail()` message on `ValueError` so CI output pinpoints the broken endpoint rather than raising an opaque exception.

### New Test Methods
* **`testStatsResponseStructure`:** Verifies the top-level `stats` list exists, that every entry has an `id` key, that IDs are unique (no duplicates), and that all expected section IDs are present: `vitals`, `shirtnum`, `categories`, `grades`, `accounting`.
* **`testVitalsSection`:** Asserts `vitals` contains `classnum`, `teachernum`, `studentnum`, `volunteernum`, `hournum` and that each is a list (of `[label, value]` pairs as produced by the handler).
* **`testClassNums`:** Verifies the total class count reported in `vitals["classnum"][0]` matches `self.program.classes().distinct().count()`.
* **`testCategoriesSection`:** Validates `categories["data"]` entries carry the required fields (`id`, `num_subjects`, `num_sections`, `num_class_hours`, `category`) and that `num_class_hours` is a float.
* **`testAccountingSection`:** Validates `accounting["data"]` contains `num_payments` (int) and `total_payments` (float), matching the handler's nested `["data"]` structure.
* **`testStatsRequiresAdmin`:** Asserts unauthenticated access returns 302 or 403 — not merely "non-200" — to avoid masking server errors with a passing test.
* **`testClassSubjectsFields`:** Ensures each class entry in `class_subjects` carries all required fields: `id`, `status`, `title`, `category`, `category_id`, `grade_min`, `grade_max`, `emailcode`, `sections`, `teachers`.
* **`testClassSubjectsSectionsAreLists`:** Ensures `sections` is a list of unique ints for each class.
* **`testClassSubjectsTeachersAreListed`:** Ensures the per-class `teachers` list contains ints (not just any list).
* **`testClassSubjectsTeachersBlock`:** Validates the top-level `teachers` block structure: `id`, `username`, `first_name`, `last_name`, `sections`.
* **`testClassSubjectsCatalogMode`:** Checks `/json/<prog>/class_subjects/catalog` includes `class_info`, `prereqs`, `difficulty`.
* **`testClassSubjectsGradeRange`:** Asserts `grade_min <= grade_max` and both values fall within the program's `grade_min`/`grade_max` range.

### `testGradesStats` Improvements
* Replaced O(grades) per-grade `COUNT` queries (two DB hits per grade) with two flat `values_list` fetches + a `Counter` + pure-Python arithmetic. Query overhead is now constant regardless of grade range.
* Replaced repeated `self.stats_response.json()` reparsing with the cached `self.stats_data`.

## Related Issue
Closes #599

## Type of Change
- [ ] Bug fix
- [x] New feature (new tests)
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / cleanup
- [ ] CI/CD or build change

## Testing
- [x] Existing tests pass
- [x] New tests added
- [x] Locally verified: all 16 tests in `JSONDataModuleTest` pass (Python 3.7, live PostgreSQL + memcached)

## AI Disclosure
This pull request was implemented with the assistance of GitHub Copilot.

## Checklist
- [x] Self-reviewed the code
- [ ] Updated documentation (N/A — test-only change)
- [x] No new warnings or errors introduced