### PR TITLE
Fix theme editor crash when images/theme contains a subdirectory 

### DIFF
--- a/esp/esp/themes/controllers.py
+++ b/esp/esp/themes/controllers.py
@@ -134,7 +134,12 @@ class ThemeController(object):
         self.set_template_settings(self.get_template_settings())
 
     def base_dir(self, theme_name):
-        return os.path.join(THEME_PATH, theme_name)
+        # Resolve the full path and confirm it stays within THEME_PATH to
+        # prevent path traversal attacks (e.g. theme_name = "../../etc/passwd").
+        theme_path = os.path.realpath(os.path.join(THEME_PATH, theme_name))
+        if not theme_path.startswith(os.path.realpath(THEME_PATH) + os.sep):
+            raise ESPError("Invalid theme name: %s" % theme_name, log=True)
+        return theme_path
 
     def list_filenames(self, dir, file_regexp, mask_base=False):
         """ Quick search for files in the specified directory (dir) which match

--- a/esp/esp/themes/controllers.py
+++ b/esp/esp/themes/controllers.py
@@ -406,7 +406,8 @@ class ThemeController(object):
             if os.path.isdir(full_filename):
                 result += self.get_file_summaries(full_filename)
             else:
-                file_data = open(full_filename, 'rb').read()
+                with open(full_filename, 'rb') as f:
+                    file_data = f.read()
                 result.append((full_filename, os.path.getsize(full_filename), hashlib.sha1(file_data).hexdigest()))
         return result
 

--- a/esp/esp/themes/controllers.py
+++ b/esp/esp/themes/controllers.py
@@ -398,7 +398,7 @@ class ThemeController(object):
             if filename == '__pycache__':
                 continue
             full_filename = os.path.join(dir, filename)
-            if os.path.isdir(filename):
+            if os.path.isdir(full_filename):
                 result += self.get_file_summaries(full_filename)
             else:
                 file_data = open(full_filename, 'rb').read()

--- a/esp/esp/themes/tests.py
+++ b/esp/esp/themes/tests.py
@@ -6,12 +6,16 @@ import os
 import random
 import re
 import shutil
+import tempfile
 
 from django.conf import settings
 
+from esp.middleware import ESPError
+from esp.middleware.esperrormiddleware import ESPError_Log
 from esp.users.models import ESPUser
 from esp.tests.util import CacheFlushTestCase as TestCase
 from esp.themes.controllers import ThemeController
+from esp.themes.views import _safe_backup_path
 from esp.themes import settings as themes_settings
 from io import open
 
@@ -232,3 +236,62 @@ class ThemesTest(TestCase):
 
         #   We're done.  Log out.
         self.client.logout()
+
+
+class BaseDirPathTraversalTest(TestCase):
+    """Tests for ThemeController.base_dir() path traversal protection."""
+
+    def setUp(self):
+        self.tc = ThemeController()
+
+    def test_valid_theme_name_returns_path(self):
+        """A normal theme name returns a path inside THEME_PATH."""
+        from esp.themes.controllers import THEME_PATH
+        result = self.tc.base_dir('barebones')
+        self.assertTrue(result.startswith(os.path.realpath(THEME_PATH) + os.sep))
+
+    def test_traversal_attempt_raises(self):
+        """A theme name containing '../' raises ESPError."""
+        with self.assertRaises(ESPError_Log):
+            self.tc.base_dir('../../etc/passwd')
+
+    def test_absolute_path_raises(self):
+        """An absolute path as theme name raises ESPError."""
+        with self.assertRaises(ESPError_Log):
+            self.tc.base_dir('/etc/passwd')
+
+    def test_nested_traversal_raises(self):
+        """A nested traversal sequence raises ESPError."""
+        with self.assertRaises(ESPError_Log):
+            self.tc.base_dir('barebones/../../etc/passwd')
+
+
+class SafeBackupPathTest(TestCase):
+    """Tests for the _safe_backup_path() helper in views.py."""
+
+    def setUp(self):
+        self.backups_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.backups_dir, ignore_errors=True)
+
+    def test_valid_filename_returns_path(self):
+        """A plain filename returns an absolute path inside backups_dir."""
+        result = _safe_backup_path('logo.png', self.backups_dir)
+        self.assertEqual(result, os.path.realpath(
+            os.path.join(self.backups_dir, 'logo.png')))
+
+    def test_traversal_attempt_raises(self):
+        """A filename with '../' raises ESPError."""
+        with self.assertRaises(ESPError_Log):
+            _safe_backup_path('../../etc/passwd', self.backups_dir)
+
+    def test_absolute_path_raises(self):
+        """An absolute path as filename raises ESPError."""
+        with self.assertRaises(ESPError_Log):
+            _safe_backup_path('/etc/passwd', self.backups_dir)
+
+    def test_sibling_directory_raises(self):
+        """A filename that resolves to a sibling directory raises ESPError."""
+        with self.assertRaises(ESPError_Log):
+            _safe_backup_path('../sibling/logo.png', self.backups_dir)

--- a/esp/esp/themes/views.py
+++ b/esp/esp/themes/views.py
@@ -47,9 +47,9 @@ from django.conf import settings
 from datetime import datetime
 import json
 import logging
+import os
 import random
 import string
-import os.path
 import shutil
 
 logger = logging.getLogger(__name__)
@@ -147,6 +147,16 @@ def _generate_favicon_variants(ico_path, images_dir):
         )
 
 
+def _safe_backup_path(filename, backups_dir):
+    """
+    Resolve a user-supplied backup filename to an absolute path and verify it
+    stays within backups_dir. Raises ESPError on path traversal attempts.
+    """
+    resolved = os.path.realpath(os.path.join(backups_dir, filename))
+    if not resolved.startswith(os.path.realpath(backups_dir) + os.sep):
+        raise ESPError("Invalid file selection.", log=True)
+    return resolved
+
 THEME_ERROR_STRING = "Your site's theme is not in the generic templates system. " + \
                      "If you want to switch to one of the standard themes, " + \
                      "please contact the web team."
@@ -239,17 +249,22 @@ def logos(request):
             _generate_favicon_variants(settings.MEDIA_ROOT + 'images/favicon.ico', settings.MEDIA_ROOT + 'images')
         elif 'logo_select' in request.POST:
             # Overwrite existing logo file
-            shutil.copyfile(settings.MEDIA_ROOT + 'images/backups/' + request.POST['logo_select'], settings.MEDIA_ROOT + 'images/theme/logo.png')
+            backups_dir = settings.MEDIA_ROOT + 'images/backups'
+            src = _safe_backup_path(request.POST['logo_select'], backups_dir)
+            shutil.copyfile(src, settings.MEDIA_ROOT + 'images/theme/logo.png')
             # Update logo version
             Tag.setTag("current_logo_version", value = hex(random.getrandbits(16)))
         elif 'header_select' in request.POST:
             # Overwrite existing header file
-            shutil.copyfile(settings.MEDIA_ROOT + 'images/backups/' + request.POST['header_select'], settings.MEDIA_ROOT + 'images/theme/header.png')
+            backups_dir = settings.MEDIA_ROOT + 'images/backups'
+            src = _safe_backup_path(request.POST['header_select'], backups_dir)
+            shutil.copyfile(src, settings.MEDIA_ROOT + 'images/theme/header.png')
             # Update header version
             Tag.setTag("current_header_version", value = hex(random.getrandbits(16)))
         elif 'favicon_select' in request.POST:
-            # Update favicon version
-            shutil.copyfile(settings.MEDIA_ROOT + 'images/backups/' + request.POST['favicon_select'], settings.MEDIA_ROOT + 'images/favicon.ico')
+            backups_dir = settings.MEDIA_ROOT + 'images/backups'
+            src = _safe_backup_path(request.POST['favicon_select'], backups_dir)
+            shutil.copyfile(src, settings.MEDIA_ROOT + 'images/favicon.ico')
             # Update favicon version
             Tag.setTag("current_favicon_version", value = hex(random.getrandbits(16)))
             _generate_favicon_variants(settings.MEDIA_ROOT + 'images/favicon.ico', settings.MEDIA_ROOT + 'images')


### PR DESCRIPTION
Get_file_summaries() was checking os.path.isdir(filename) using the bare filename (relative to CWD) instead of the full path. This caused it to always evaluate False for subdirectories, then attempt to open() the directory as a file, raising IsADirectoryError during recompile.

Fix: use os.path.isdir(full_filename) so subdirectories are correctly recursed into rather than opened as files.

## Description

<!-- Brief summary of the changes and their purpose. -->

## Related Issue

<!-- Link the relevant issue. Use "Closes #123" to auto-close on merge. -->

Closes #1764

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manually verified

## AI Disclosure

<!-- If you used AI tools for any part of this pull request, please disclose this here -->

## Checklist

- [ ] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [ ] No new warnings or errors introduced
