### PR TITLE
Hide common searches for user types not available in the program 

### DIFF
--- a/esp/templates/users/usersearch/list_selector.html
+++ b/esp/templates/users/usersearch/list_selector.html
@@ -8,12 +8,18 @@ $j(document).ready(function() {
 <h3>Commonly used searches:</h3>
 <div id="common_searches">
     <ul>
+        {% if "Student" in user_types %}
         <li><a href="?recipient_type=Student&base_list=all_Student&grade_min={{ program.grade_min }}&grade_max={{ program.grade_max }}">All students within the age range of the program</a></li>
         <li><a href="?recipient_type=Student&base_list=enrolled">All students enrolled in at least one class</a></li>
+        {% endif %}
+        {% if "Teacher" in user_types %}
         <li><a href="?recipient_type=Teacher&base_list=all_Teacher&gradyear_min={% now 'Y' %}">All teachers who have not graduated</a></li>
         <li><a href="?recipient_type=Teacher&base_list=class_approved">All teachers teaching at least one approved class</a></li>
+        {% endif %}
+        {% if "Volunteer" in user_types %}
         <li><a href="?recipient_type=Volunteer&base_list=all_Volunteer">All volunteers in the database</a></li>
         <li><a href="?recipient_type=Volunteer&base_list=volunteer_all">All volunteers signed up for this program</a></li>
+        {% endif %}
     </ul>
 </div>
 {% endif %}


### PR DESCRIPTION
Wrap each group of common search links in a check against user_types so that e.g. volunteer searches are omitted when the program has no volunteer user type configured. The user_types list is already present in the template context via UserSearchController.prepare_context().

## Description

<!-- Brief summary of the changes and their purpose. -->

## Related Issue

<!-- Link the relevant issue. Use "Closes #123" to auto-close on merge. -->

Closes #3941

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manually verified

## AI Disclosure

<!-- If you used AI tools for any part of this pull request, please disclose this here -->

## Checklist

- [ ] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [ ] No new warnings or errors introduced
