### PR TITLE
Block public access to /server-status and /server-info endpoints

### DIFF
--- a/deploy/config_templates/apache2_vhost.conf
+++ b/deploy/config_templates/apache2_vhost.conf
@@ -15,4 +15,18 @@ NameVirtualHost *:%(APACHE_PORT)s
     ErrorLog /var/log/apache2/%(INSTANCE_NAME)s-error.log
     ErrorDocument 500 %(PROJECT_DIR)s/templates/500.html
     LogLevel error
+
+    # Security: Block Apache status endpoints from public access
+    <LocationMatch "^/(server-status|server-info)(/|$)">
+        # Apache 2.4+
+        <IfModule mod_authz_core.c>
+            Require all denied
+        </IfModule>
+
+        # Apache 2.2 (or 2.4 with mod_access_compat)
+        <IfModule !mod_authz_core.c>
+            Order allow,deny
+            Deny from all
+        </IfModule>
+    </LocationMatch>
 </VirtualHost>


### PR DESCRIPTION
## Description

This PR blocks public access to Apache diagnostic endpoints:

- `/server-status`
- `/server-info`

These endpoints can expose internal server diagnostics and should not be accessible to anonymous users.  
The change is implemented in the Apache vhost template and is compatible with both Apache 2.4 and Apache 2.2.>

## Related Issue

Closes #4207

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## AI Disclosure

I used to quill to elevate my pr and add some relevant and useful information to explain and understand easily!

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced
