### PR TITLE
Fix make virtualenv no sudo

### DIFF
--- a/esp/make_virtualenv.sh
+++ b/esp/make_virtualenv.sh
@@ -94,8 +94,12 @@ if ! "$PYTHON" -c "import virtualenv" >/dev/null 2>&1; then
     fi
 
     if [[ "$EUID" -eq 0 ]]; then
-        echo "Installing virtualenv into system site-packages (running as root)."
-        "$PYTHON" -m pip install "virtualenv>=1.10"
+        echo "ERROR: This script must not be run as root, because it would install Python packages into system site-packages."
+        echo "Please rerun as a non-root user (without sudo)."
+        echo "If you need to use a different interpreter, you can do for example:"
+        echo "  PYTHON=python3 bash esp/make_virtualenv.sh"
+        echo "Aborting to avoid modifying system Python."
+        exit 1
     else
         echo "Installing virtualenv into user site-packages (no sudo)."
         if ! "$PYTHON" -m pip install --user "virtualenv>=1.10"; then


### PR DESCRIPTION
## Description
This PR improves `esp/make_virtualenv.sh` so it no longer installs `virtualenv` via `sudo pip`, which can pollute/break system Python and fails on locked-down setups.
<!-- Brief summary of the changes and their purpose. -->
- Removed the `sudo python3.7 -m pip install ...` path and replaced it with a non-sudo approach (user-site install when needed).
- Added a `PYTHON` override (`PYTHON=python3.11 bash esp/make_virtualenv.sh`) so developers aren’t blocked if `python3.7` is not installed.
- Added a friendly early error message when the configured Python interpreter is missing (instead of failing later with `command not found`).

## Related Issue

<!-- Link the relevant issue. Use "Closes #123" to auto-close on merge. -->

Closes #4212

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified
 Manual verification
- Confirmed `esp/make_virtualenv.sh` no longer invokes `sudo` and does not prompt for admin password.
- Confirmed script prints a clear error when `python3.7` is missing and suggests using `PYTHON=...`.
- Confirmed `PYTHON=python3 ...` path proceeds on systems where `python3` is available.
- Full dependency install / server run were not verified in my current environment due to missing Linux tools (`lsb_release`), restricted sudo, and blocked network access.
## AI Disclosure
I used ChatGPT to help draft the issue/PR text . All code changes were implemented and reviewed manually.
<!-- If you used AI tools for any part of this pull request, please disclose this here -->

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [ ] No new warnings or errors introduced
