### PR TITLE
Refactor TestUserSearchController tests

### DIFF
--- a/esp/esp/users/controllers/tests/test_usersearch.py
+++ b/esp/esp/users/controllers/tests/test_usersearch.py
@@ -1,38 +1,19 @@
 from __future__ import absolute_import
-import datetime
 import logging
-import six
 logger = logging.getLogger(__name__)
 
-from django import forms
-from django.contrib.auth import logout, login, authenticate
-from django.contrib.auth.models import Group
-from django.core import mail
-from django.conf import settings
-from django.test.client import Client
+from django.db.models.query import Q
 
-from esp.middleware import ESPError
-from esp.program.models import RegistrationProfile, Program
 from esp.program.tests import ProgramFrameworkTest
-from esp.tagdict.models import Tag
-from esp.tests.util import user_role_setup
-from esp.users.forms.user_reg import ValidHostEmailField
-from esp.users.models import User, ESPUser, PasswordRecoveryTicket, UserForwarder, StudentInfo, Permission
-from django.test import TestCase
-import esp.users.views as views
-from esp.program.models import Program
-
-import random
-import string
-
-#python manage.py test users.controllers.tests.test_usersearch:TestUserSearchController.test_overlap_bug
-
+from esp.users.models import ESPUser
 from esp.users.controllers.usersearch import UserSearchController
 
 
-class TestUserSearchController(TestCase):
-    controller = UserSearchController()
-    program = Program.objects.get(id=88)#Splash
+class TestUserSearchController(ProgramFrameworkTest):
+
+    def setUp(self):
+        super(TestUserSearchController, self).setUp()
+        self.controller = UserSearchController()
 
     def _get_combination_post_data(self, list_a, list_b):
         return {
@@ -58,14 +39,11 @@ class TestUserSearchController(TestCase):
             'zipdistance_exclude': '',
         }
 
-
-
     def test_student_confirmed(self):
         post_data = self._get_combination_post_data('Student', 'confirmed')
         qobject = self.controller.filter_from_postdata(self.program, post_data).getList(ESPUser)
 
         self.assertGreater(qobject.count(), 0)
-
 
     def test_teacher_classroom_tables(self):
         post_data = self._get_combination_post_data('Teacher', 'teacher_res_150_8')
@@ -73,31 +51,27 @@ class TestUserSearchController(TestCase):
         self.assertGreater(qobject.count(), 0)
 
     def test_teacher_classroom_tables_query_from_post(self):
-        post_data = {six.u('username'): six.u(''),
-                     six.u('zipdistance_exclude'): six.u(''),
-                     six.u('first_name'): six.u(''),
-                     six.u('last_name'): six.u(''),
-                     six.u('use_checklist'): six.u('0'),
-                     six.u('gradyear_max'): six.u(''),
-                     six.u('userid'): six.u(''),
-                     six.u('school'): six.u(''),
-                     six.u('combo_base_list'): six.u('Teacher:teacher_res_150_8'),
-                     six.u('zipcode'): six.u(''),
-                     six.u('states'): six.u(''),
-                     six.u('student_sendto_self'): six.u('1'),
-                     six.u('checkbox_and_teacher_res_152_0'): six.u(''),
-                     six.u('grade_min'): six.u(''),
-                     six.u('gradyear_min'): six.u(''),
-                     six.u('zipdistance'): six.u(''),
-                      six.u('csrfmiddlewaretoken'): six.u('GKk9biBZE2muppi7jcv2OnqQyIehiCuw'),
-                      six.u('grade_max'): six.u(''), six.u('email'): six.u('')}
+        post_data = {'username': '',
+                     'zipdistance_exclude': '',
+                     'first_name': '',
+                     'last_name': '',
+                     'use_checklist': '0',
+                     'gradyear_max': '',
+                     'userid': '',
+                     'school': '',
+                     'combo_base_list': 'Teacher:teacher_res_150_8',
+                     'zipcode': '',
+                     'states': '',
+                     'student_sendto_self': '1',
+                     'checkbox_and_teacher_res_152_0': '',
+                     'grade_min': '',
+                     'gradyear_min': '',
+                     'zipdistance': '',
+                     'csrfmiddlewaretoken': 'GKk9biBZE2muppi7jcv2OnqQyIehiCuw',
+                     'grade_max': '', 'email': ''}
 
-        query =  self.controller.query_from_postdata(self.program, post_data)
-        # TODO(benkraft): what is going on here?  Should these tests be getting
-        # run?
-        logger.info(query) # need to inspect why this is failing
-        assert False
-        #self.assertGreater(qobject.count(), 0)
+        query = self.controller.query_from_postdata(self.program, post_data)
+        self.assertIsInstance(query, Q)
 
     def test_teacher_interview(self):
         post_data = self._get_combination_post_data('Teacher', 'interview')


### PR DESCRIPTION
## Description

<!-- Brief summary of the changes and their purpose. -->

- removed objects which executed at import time and failed on fresh databases.

- replaced false debug statement verifying that query_from_postdata returns a Q object.

## Related Issue

<!-- Link the relevant issue. Use "Closes #123" to auto-close on merge. -->

Closes #4206

## Type of Change

- [ x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ x] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [ x] Existing tests pass
- [ ] New tests added (if applicable)
- [x ] Manually verified

## AI Disclosure

<!-- If you used AI tools for any part of this pull request, please disclose this here -->
tool: chat gpt
scope: django env setup
human verification: all changes implemented and tested manually

## Checklist

- [ x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x ] No new warnings or errors introduced
