### PR TITLE
refactor: remove six library from users module

### DIFF
--- a/esp/esp/users/controllers/tests/test_usersearch.py
+++ b/esp/esp/users/controllers/tests/test_usersearch.py
@@ -1,6 +1,5 @@
 import datetime
 import logging
-import six
 logger = logging.getLogger(__name__)
 
 from django import forms
@@ -71,24 +70,24 @@ class TestUserSearchController(TestCase):
         self.assertGreater(qobject.count(), 0)
 
     def test_teacher_classroom_tables_query_from_post(self):
-        post_data = {six.u('username'): six.u(''),
-                     six.u('zipdistance_exclude'): six.u(''),
-                     six.u('first_name'): six.u(''),
-                     six.u('last_name'): six.u(''),
-                     six.u('use_checklist'): six.u('0'),
-                     six.u('gradyear_max'): six.u(''),
-                     six.u('userid'): six.u(''),
-                     six.u('school'): six.u(''),
-                     six.u('combo_base_list'): six.u('Teacher:teacher_res_150_8'),
-                     six.u('zipcode'): six.u(''),
-                     six.u('states'): six.u(''),
-                     six.u('student_sendto_self'): six.u('1'),
-                     six.u('checkbox_and_teacher_res_152_0'): six.u(''),
-                     six.u('grade_min'): six.u(''),
-                     six.u('gradyear_min'): six.u(''),
-                     six.u('zipdistance'): six.u(''),
-                      six.u('csrfmiddlewaretoken'): six.u('GKk9biBZE2muppi7jcv2OnqQyIehiCuw'),
-                      six.u('grade_max'): six.u(''), six.u('email'): six.u('')}
+        post_data = {'username': '',
+                     'zipdistance_exclude': '',
+                     'first_name': '',
+                     'last_name': '',
+                     'use_checklist': '0',
+                     'gradyear_max': '',
+                     'userid': '',
+                     'school': '',
+                     'combo_base_list': 'Teacher:teacher_res_150_8',
+                     'zipcode': '',
+                     'states': '',
+                     'student_sendto_self': '1',
+                     'checkbox_and_teacher_res_152_0': '',
+                     'grade_min': '',
+                     'gradyear_min': '',
+                     'zipdistance': '',
+                      'csrfmiddlewaretoken': 'GKk9biBZE2muppi7jcv2OnqQyIehiCuw',
+                      'grade_max': '', 'email': ''}
 
         query =  self.controller.query_from_postdata(self.program, post_data)
         # TODO(benkraft): what is going on here?  Should these tests be getting

--- a/esp/esp/users/controllers/usersearch.py
+++ b/esp/esp/users/controllers/usersearch.py
@@ -1,7 +1,3 @@
-import six
-from six.moves import map
-from six.moves import range
-from six.moves import zip
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"
@@ -412,7 +408,7 @@ class UserSearchController(object):
         recipient_type = data.get('recipient_type', '') or data.get('combo_base_list', ':').split(':')[0]
         sendtos = []
         if recipient_type == 'Student':
-            for key, value in six.iteritems(data):
+            for key, value in data.items():
                 if ('student_sendto_' in key) and (value == '1'):
                     sendtos.append(key[1+key.rindex('_'):])
             if not sendtos:

--- a/esp/esp/users/forms/user_profile.py
+++ b/esp/esp/users/forms/user_profile.py
@@ -11,9 +11,6 @@ from django.conf import settings
 import json
 from pytz import country_names
 from phonenumber_field.formfields import PhoneNumberField
-import six
-from six.moves import range
-from six.moves import zip
 
 class DropdownOtherWidget(forms.MultiWidget):
     """
@@ -377,17 +374,17 @@ class TeacherInfoForm(FormWithRequiredCss):
             affiliation_field = self.fields['affiliation']
             affiliation, school = affiliation_field.widget.decompress(cleaned_data.get('affiliation'))
             if affiliation == '':
-                msg = six.u('Please select your affiliation with %s.') % settings.INSTITUTION_NAME
+                msg = 'Please select your affiliation with %s.' % settings.INSTITUTION_NAME
                 self.add_error('affiliation', msg)
             elif affiliation in (AFFILIATION_UNDERGRAD, AFFILIATION_GRAD, AFFILIATION_POSTDOC):
                 cleaned_data['affiliation'] = affiliation_field.compress([affiliation, '']) # ignore the box
             else: # OTHER or NONE -- Make sure they entered something into the other box
                 if school.strip() == '':
-                    msg = six.u('Please select your affiliation with %s.') % settings.INSTITUTION_NAME
+                    msg = 'Please select your affiliation with %s.' % settings.INSTITUTION_NAME
                     if affiliation == AFFILIATION_OTHER:
-                        msg = six.u('Please enter your affiliation with %s.') % settings.INSTITUTION_NAME
+                        msg = 'Please enter your affiliation with %s.' % settings.INSTITUTION_NAME
                     elif affiliation == AFFILIATION_NONE:
-                        msg = six.u('Please enter your school or employer.')
+                        msg = 'Please enter your school or employer.'
                     self.add_error('affiliation', msg)
         return cleaned_data
 

--- a/esp/esp/users/forms/user_reg.py
+++ b/esp/esp/users/forms/user_reg.py
@@ -5,7 +5,6 @@ from django.forms.fields import HiddenInput, TextInput
 from esp.users.models import ESPUser, GradeChangeRequest
 from esp.utils.forms import StrippedCharField
 from phonenumber_field.formfields import PhoneNumberField
-import six
 
 class ValidHostEmailField(forms.EmailField):
     """ An EmailField that runs a DNS query to make sure the host is valid. """
@@ -46,7 +45,7 @@ class EmailUserRegForm(forms.Form):
 
     def clean_initial_role(self):
         data = self.cleaned_data['initial_role']
-        if data == six.u(''):
+        if data == '':
             raise forms.ValidationError('Please select an initial role')
         return data
 
@@ -81,7 +80,7 @@ class UserRegForm(forms.Form):
 
     def clean_initial_role(self):
         data = self.cleaned_data['initial_role']
-        if data == six.u(''):
+        if data == '':
             raise forms.ValidationError('Please select an initial role')
         return data
 

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -1,7 +1,4 @@
 from django.utils.encoding import python_2_unicode_compatible
-import six
-from six.moves import range
-from six.moves import zip
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"
@@ -86,10 +83,10 @@ from esp.utils.query_utils import nest_Q
 from esp.program.class_status import ClassStatus
 from esp.utils import cmp
 
-from six.moves.urllib.parse import quote
+from urllib.parse import quote
 
 try:
-    import six.moves.cPickle as pickle
+    import pickle
 except ImportError:
     import pickle
 
@@ -124,7 +121,7 @@ class UserAvailability(models.Model):
         verbose_name_plural = 'User availabilities'
 
     def __str__(self):
-        return '%s available as %s at %s' % (self.user.username, self.role.name, six.text_type(self.event))
+        return '%s available as %s at %s' % (self.user.username, self.role.name, str(self.event))
 
     def save(self, *args, **kwargs):
         #   Assign default role if not set.
@@ -262,10 +259,10 @@ class BaseESPUser(object):
         return "%s, %s (%s)" % (self.last_name, self.first_name, self.username)
 
     def name(self):
-        return six.u('%s %s') % (self.first_name, self.last_name)
+        return '%s %s' % (self.first_name, self.last_name)
 
     def name_last_first(self):
-        return six.u('%s, %s') % (self.last_name, self.first_name)
+        return '%s, %s' % (self.last_name, self.first_name)
 
     def nonblank_name(self):
         name = self.name()
@@ -285,9 +282,9 @@ class BaseESPUser(object):
         """
         if name:
             # enclose name in quotes per RFC 2822 so that special characters in names are handled properly
-            return six.u('"%s" <%s>') % (name.replace('\\', '\\\\').replace('"', '\\"'), email)
+            return '"%s" <%s>' % (name.replace('\\', '\\\\').replace('"', '\\"'), email)
         else:
-            return six.u('<%s>') % email
+            return '<%s>' % email
 
     def get_email_sendto_address(self):
         """
@@ -415,7 +412,7 @@ class BaseESPUser(object):
             return "?code=%s" % otheruser.password
         elif key == 'unsubscribe_link':
             return otheruser.unsubscribe_link_full()
-        return six.u('')
+        return ''
 
     def getTaughtPrograms(self):
         taught_programs = Program.objects.filter(classsubject__teachers=self)
@@ -1542,7 +1539,7 @@ class StudentInfo(models.Model):
         username = "N/A"
         if self.user is not None:
             username = self.user.username
-        return six.u('ESP Student Info (%s) -- %s') % (username, six.text_type(self.school))
+        return 'ESP Student Info (%s) -- %s' % (username, str(self.school))
 
     def get_absolute_url(self):
         return self.user.get_absolute_url()
@@ -1618,11 +1615,11 @@ class TeacherInfo(models.Model, CustomFormsLinkModel):
 
         for value in values:
             value['user'] = ESPUser.objects.get(id=value['user'])
-            value['ajax_str'] = six.u('%s - %s %s') % (value['user'].ajax_str(), value['college'], value['graduation_year'])
+            value['ajax_str'] = '%s - %s %s' % (value['user'].ajax_str(), value['college'], value['graduation_year'])
         return values
 
     def ajax_str(self):
-        return six.u('%s - %s %s') % (self.user.ajax_str(), self.college, self.graduation_year)
+        return '%s - %s %s' % (self.user.ajax_str(), self.college, self.graduation_year)
 
     def updateForm(self, form_dict):
         form_dict['pronoun']         = self.pronoun
@@ -1663,7 +1660,7 @@ class TeacherInfo(models.Model, CustomFormsLinkModel):
         username = ""
         if self.user is not None:
             username = self.user.username
-        return six.u('ESP Teacher Info (%s)') % username
+        return 'ESP Teacher Info (%s)' % username
 
     def get_absolute_url(self):
         return self.user.get_absolute_url()
@@ -1727,7 +1724,7 @@ class GuardianInfo(models.Model):
         username = ""
         if self.user is not None:
             username = self.user.username
-        return six.u('ESP Guardian Info (%s)') % username
+        return 'ESP Guardian Info (%s)' % username
 
     def get_absolute_url(self):
         return self.user.get_absolute_url()
@@ -1805,7 +1802,7 @@ class EducatorInfo(models.Model):
         username = ""
         if self.user is not None:
             username = self.user.username
-        return six.u('ESP Educator Info (%s)') % username
+        return 'ESP Educator Info (%s)' % username
 
     def get_absolute_url(self):
         return self.user.get_absolute_url()
@@ -1951,7 +1948,7 @@ class ContactInfo(models.Model, CustomFormsLinkModel):
         db_table = 'users_contactinfo'
 
     def name(self):
-        return six.u('%s %s') % (self.first_name, self.last_name)
+        return '%s %s' % (self.first_name, self.last_name)
 
     email = property(lambda self: self.e_mail)
 
@@ -1968,7 +1965,7 @@ class ContactInfo(models.Model, CustomFormsLinkModel):
         return ESPUser.email_sendto_address(self.email, self.name())
 
     def address(self):
-        return six.u('%s, %s, %s %s') % \
+        return '%s, %s, %s %s' % \
             (self.address_street,
              self.address_city,
              self.address_state,
@@ -2084,15 +2081,15 @@ class K12School(models.Model):
 
     def __str__(self):
         if self.contact_id and self.contact.address_city and self.contact.address_state:
-            return six.u('%s in %s, %s') % (self.name, self.contact.address_city,
+            return '%s in %s, %s' % (self.name, self.contact.address_city,
                                             self.contact.address_state)
         else:
-            return six.u('%s') % self.name
+            return '%s' % self.name
 
     @classmethod
     def choicelist(cls, other_help_text=''):
         if other_help_text:
-            other_help_text = six.u(' (%s)') % other_help_text
+            other_help_text = ' (%s)' % other_help_text
         o = cls.objects.other()
         lst = [ ( x.id, x.name ) for x in cls.objects.most() ]
         lst.append( (o.id, o.name + other_help_text) )
@@ -2455,7 +2452,7 @@ class Record(models.Model):
             return True
 
     def __str__(self):
-        return six.text_type(self.user) + " has completed " + six.text_type(self.event) + " for " + six.text_type(self.program)
+        return str(self.user) + " has completed " + str(self.event) + " for " + str(self.program)
 
 #helper method for designing implications
 def flatten(choices):

--- a/esp/esp/users/models/forwarder.py
+++ b/esp/esp/users/models/forwarder.py
@@ -5,8 +5,6 @@ from django.db import models, transaction
 # esp dependencies
 from esp.db.fields import AjaxForeignKey
 from esp.users.models import ESPUser
-import six
-from six.moves import range
 
 MAX_DEPTH = 5
 
@@ -112,4 +110,4 @@ class UserForwarder(models.Model):
             return (user, False)
 
     def __str__(self):
-        return '%s to %s' % (six.text_type(self.source), six.text_type(self.target))
+        return '%s to %s' % (str(self.source), str(self.target))

--- a/esp/esp/users/tests.py
+++ b/esp/esp/users/tests.py
@@ -16,9 +16,6 @@ from esp.tagdict.models import Tag
 from esp.tests.util import CacheFlushTestCase as TestCase, user_role_setup
 from esp.users.forms.user_reg import ValidHostEmailField
 from esp.users.models import User, ESPUser, PasswordRecoveryTicket, UserForwarder, StudentInfo, Permission, Record, RecordType
-import six
-from six.moves import map
-from six.moves import filter
 
 class ESPUserTest(TestCase):
     def setUp(self):
@@ -268,12 +265,12 @@ class ValidHostEmailFieldTest(TestCase):
         # Hardcoding 'esp.mit.edu' here might be a bad idea
         # But at least it verifies that A records work in place of MX
         for domain in [ 'esp.mit.edu', 'gmail.com', 'yahoo.com' ]:
-            self.assertTrue( ValidHostEmailField().clean( six.u('fakeaddress@%s') % domain ) == six.u('fakeaddress@%s') % domain )
+            self.assertTrue( ValidHostEmailField().clean( 'fakeaddress@%s' % domain ) == 'fakeaddress@%s' % domain )
     def testFakeDomain(self):
         # If we have an internet connection, bad domains raise ValidationError.
         # This should be the *only* kind of error we ever raise!
         try:
-            ValidHostEmailField().clean( six.u('fakeaddress@idontex.ist') )
+            ValidHostEmailField().clean( 'fakeaddress@idontex.ist' )
         except forms.ValidationError:
             pass
 
@@ -692,7 +689,7 @@ class PermissionTestCase(TestCase):
         self.assertTrue(self.user_has_perm('test'))
 
     def testImplications(self):
-        for base, implications in six.iteritems(Permission.implications):
+        for base, implications in Permission.implications.items():
             perm = self.create_role_perm_for_program(base)
             for implication in implications:
                 self.assertTrue(self.user_has_perm_for_program(implication))

--- a/esp/esp/users/views/__init__.py
+++ b/esp/esp/users/views/__init__.py
@@ -17,7 +17,6 @@ from esp.users.views.registration import *
 from esp.users.views.usersearch import *
 from esp.utils.web import render_to_response
 from esp.web.views.main import DefaultQSDView
-import six
 
 
 #   This is a huge hack while we figure out what to do about logins and cookies.
@@ -247,9 +246,9 @@ def unsubscribe_oneclick(request, username, token):
 
 @admin_required
 def morph_into_user(request):
-    morph_user = ESPUser.objects.get(id=request.GET[six.u('morph_user')])
+    morph_user = ESPUser.objects.get(id=request.GET['morph_user'])
     try:
-        onsite = Program.objects.get(id=request.GET[six.u('onsite')])
+        onsite = Program.objects.get(id=request.GET['onsite'])
     except (KeyError, ValueError, Program.DoesNotExist):
         onsite = None
     request.user.switch_to_user(request,

--- a/esp/esp/users/views/registration.py
+++ b/esp/esp/users/views/registration.py
@@ -1,6 +1,6 @@
 import logging
 import random
-import six.moves.urllib.request, six.moves.urllib.parse, six.moves.urllib.error
+import urllib.request, urllib.parse, urllib.error
 
 log = logging.getLogger(__name__)
 
@@ -109,8 +109,8 @@ When there are already accounts with this email address (depending on some tags)
                     { 'accounts': existing_accounts,'awaitings':awaiting_activation_accounts, 'email':form.cleaned_data['email'], 'initial_role':form.cleaned_data['initial_role'], 'site': Site.objects.get_current(), 'form': form })
 
         #form is valid, and not caring about multiple accounts
-        email = six.moves.urllib.parse.quote(form.cleaned_data['email'])
-        initial_role = six.moves.urllib.parse.quote(form.cleaned_data['initial_role'])
+        email = urllib.parse.quote(form.cleaned_data['email'])
+        initial_role = urllib.parse.quote(form.cleaned_data['initial_role'])
         return HttpResponseRedirect(reverse('esp.users.views.user_registration_phase2')+'?email='+email+'&initial_role='+initial_role)
     else: #form is not valid
         return render_to_response('registration/newuser_phase1.html',
@@ -152,8 +152,8 @@ def user_registration_phase2(request):
         return HttpResponseRedirect(reverse("esp.users.views.user_registration_phase1"))
 
     try:
-        email = six.moves.urllib.parse.unquote(request.GET['email'])
-        initial_role = six.moves.urllib.parse.unquote(request.GET['initial_role'])
+        email = urllib.parse.unquote(request.GET['email'])
+        initial_role = urllib.parse.unquote(request.GET['initial_role'])
     except MultiValueDictKeyError:
         return HttpResponseRedirect(reverse("esp.users.views.user_registration_phase1"))
     form = UserRegForm(initial={'email':email,'confirm_email':email,'initial_role':initial_role})

--- a/esp/esp/users/views/usersearch.py
+++ b/esp/esp/users/views/usersearch.py
@@ -1,6 +1,4 @@
 
-import six
-from six.moves import range
 from functools import reduce
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
@@ -72,7 +70,6 @@ def get_user_list(request, listDict2, extra=''):
         listDict[key] = {'list': getQForUser(value['list']),
                          'description': value['description']}
 
-
     if 'select_mailman' in request.POST:
         from esp.mailman import list_members
         import operator
@@ -103,7 +100,6 @@ def get_user_list(request, listDict2, extra=''):
 
         return (filterObj, True) # We got the list, return it.
 
-
     if request.POST.get('submit_checklist') == 'true':
         # If we're coming back after having checked off users from a checklist...
         filterObj = PersistentQueryFilter.getFilterFromID(request.POST['extra'], ESPUser)
@@ -114,7 +110,6 @@ def get_user_list(request, listDict2, extra=''):
             return (newfilterObj, True)
         else:
             return (getUsers, False)
-
 
     if request.POST.get('submit_user_list') == 'true':
         # If a user list was submitted....
@@ -137,7 +132,6 @@ def get_user_list(request, listDict2, extra=''):
         # we or. This closely represents the sentence (it's not as powerful, but makes "sense")
         separated = {'or': [curList], 'and': []}
 
-
         # use double-commas because it's safer?
         keys = request.POST['keys'].split(',,')
 
@@ -146,7 +140,6 @@ def get_user_list(request, listDict2, extra=''):
                request.POST['operator_'+key] != 'ignore':     # and it's not ignore (it should be 'and' or 'or')
                 # We are adding to the list of 'and'd' lists and 'or'd' lists.
                 separated[request.POST['operator_'+key]].append(opmapping[request.POST['not_'+key]](listDict[key]['list']))
-
 
         # ^ - now separated has all the necessary Q objects.
 
@@ -162,9 +155,7 @@ def get_user_list(request, listDict2, extra=''):
         for List in separated['or'][1:]:
             curList = opmapping['or'](curList, List)
 
-
         filterObj = PersistentQueryFilter.getFilterFromQ(curList, ESPUser, request.POST['finalsent'])
-
 
         if request.POST['submitform'] == 'I want to search within this list':
             getUser, found = search_for_user(request, ESPUser.objects.filter(filterObj.get_Q()).distinct(), filterObj.id, True)
@@ -187,7 +178,6 @@ def get_user_list(request, listDict2, extra=''):
 
         return (filterObj, True) # We got the list, return it.
 
-
     # if we found a single user:
     if request.method == 'GET' and request.GET.get('op') == 'usersearch':
         filterObj = PersistentQueryFilter.getFilterFromID(request.GET['extra'], ESPUser)
@@ -206,7 +196,6 @@ def get_user_list(request, listDict2, extra=''):
 
         else:
             return (getUser, False)
-
 
     if 'advanced' in request.GET or not settings.USE_MAILMAN:
         # we're going to prepare a list to send out.
@@ -259,7 +248,6 @@ def get_user_checklist(request, userList, extra='', nextpage=None, extra_context
 
     return (render_to_response('users/userchecklist.html', request, context), False) # make the checklist
 
-
 def search_for_user(request, user_type='Any', extra='', returnList = False, add_to_context = None):
     """ Interface to search for a user. If you need a user, just use this.
         Returns (user or response, user returned?) """
@@ -268,7 +256,7 @@ def search_for_user(request, user_type='Any', extra='', returnList = False, add_
     error = False
 
     usc = UserSearchController()
-    if isinstance(user_type, six.string_types):
+    if isinstance(user_type, str):
         user_query = usc.query_from_criteria(user_type, request.GET)
         QSUsers = ESPUser.objects.filter(user_query).distinct()
     elif isinstance(user_type, QuerySet):


### PR DESCRIPTION
### Description

Remove all `six` library usage from the `users` module (controllers, forms, models, views, tests). Replaces with native Python 3 equivalents.

**10 files changed** | +57/-77

### Related Issue

Part of #4232 — Remove `six` compatibility library

### Type of Change

- [x] Refactor / cleanup

### Testing

- [x] Existing tests pass
- [x] Zero remaining `six` references in `esp/esp/users/`


### Checklist

- [x] Self-reviewed the code
- [x] No new warnings or errors introduced
