### PR TITLE
refactor: remove six library from utils module

### DIFF
--- a/esp/esp/utils/__init__.py
+++ b/esp/esp/utils/__init__.py
@@ -9,8 +9,7 @@ The functions in this file are globally relevant, too annoying to inline,
 """
 
 import sys
-from six.moves.urllib.parse import quote_plus
-import six
+from urllib.parse import quote_plus
 
 def force_str(x):
     """
@@ -22,9 +21,9 @@ def force_str(x):
     '\\xc3\\x85ngstrom'
 
     """
-    if isinstance(x, str) or isinstance(x, six.text_type):
+    if isinstance(x, str) or isinstance(x, str):
         return x
-    return six.text_type(x).encode('utf8')
+    return str(x).encode('utf8')
 
 def ascii(x):
     """

--- a/esp/esp/utils/decorators.py
+++ b/esp/esp/utils/decorators.py
@@ -1,5 +1,4 @@
 
-from six.moves import range
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"
@@ -112,7 +111,6 @@ def json_response(field_map={}):
         return _evaluate
 
     return dec
-
 
 class CachedModuleViewDecorator(object):
     """ Employs some of the techniques used by the cached inclusion tag to

--- a/esp/esp/utils/fields.py
+++ b/esp/esp/utils/fields.py
@@ -3,7 +3,6 @@
 from django.db import models
 from django.core.serializers.json import DjangoJSONEncoder
 import json
-import six
 
 class JSONField(models.TextField):
     """JSONField is a generic textfield that neatly serializes/unserializes
@@ -16,7 +15,7 @@ class JSONField(models.TextField):
             return None
 
         try:
-            if isinstance(value, six.string_types):
+            if isinstance(value, str):
                 return json.loads(value)
         except ValueError:
             pass

--- a/esp/esp/utils/forms.py
+++ b/esp/esp/utils/forms.py
@@ -1,5 +1,4 @@
 
-import six
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"
@@ -39,7 +38,6 @@ from django import forms
 from esp.tagdict.models import Tag
 from esp.utils.widgets import DummyWidget
 
-
 class SizedCharField(forms.CharField):
     """ Just like CharField, but you can set the width of the text widget. """
     def __init__(self, length=None, *args, **kwargs):
@@ -57,7 +55,7 @@ class FormWithRequiredCss(forms.Form):
     """ Form that adds the "required" class to every required widget, to restore oldforms behavior. """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        for field in six.itervalues(self.fields):
+        for field in self.fields.values():
             if field.required:
                 if 'class' in field.widget.attrs:
                     field.widget.attrs['class'] += ' required'
@@ -98,7 +96,7 @@ class FormUnrestrictedOtherUser(FormWithRequiredCss):
         if user is None or not (hasattr(user, 'other_user') and user.other_user):
             pass
         else:
-            for field in six.itervalues(self.fields):
+            for field in self.fields.values():
                 if field.required:
                     field.required = False
                     field.widget.attrs['class'] = None # GAH!

--- a/esp/esp/utils/memcached_multikey.py
+++ b/esp/esp/utils/memcached_multikey.py
@@ -12,7 +12,7 @@ from esp.utils import ascii
 import hashlib
 
 try:
-    import six.moves.cPickle as pickle
+    import pickle
 except:
     import pickle
 

--- a/esp/esp/utils/query_builder.py
+++ b/esp/esp/utils/query_builder.py
@@ -4,9 +4,6 @@ import operator
 from django.db.models.query import Q
 
 from esp.middleware import ESPError
-from six.moves import map
-import six
-from six.moves import zip
 from functools import reduce
 
 
@@ -28,7 +25,7 @@ class QueryBuilder(object):
     def __init__(self, base, filters, english_name=None):
         self.base = base
         if english_name is None:
-            self.english_name = six.text_type(base.model._meta.verbose_name_plural)
+            self.english_name = str(base.model._meta.verbose_name_plural)
         else:
             self.english_name = english_name
         self.filters = filters

--- a/esp/esp/utils/query_utils.py
+++ b/esp/esp/utils/query_utils.py
@@ -3,7 +3,6 @@ from django.utils.tree import Node
 from django.db.models.constants import LOOKUP_SEP
 
 from copy import deepcopy
-import six
 
 def shallow_copy_Q(q_object):
     obj = Node(connector=q_object.connector, negated=q_object.negated)
@@ -28,7 +27,7 @@ def nest_Q(q_object, root=''):
     return obj
 
 def _append_to_child(child, root):
-    if root and isinstance(child, tuple) and len(child)==2 and isinstance(child[0], six.string_types):
+    if root and isinstance(child, tuple) and len(child)==2 and isinstance(child[0], str):
         return (root + LOOKUP_SEP + child[0], child[1])
     elif isinstance(child, Q):
         return nest_Q(child, root)

--- a/esp/esp/utils/templatetags/latex.py
+++ b/esp/esp/utils/templatetags/latex.py
@@ -1,7 +1,5 @@
 """ ESP Custom Filters for template """
 
-import six
-from six.moves import range
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"
@@ -43,8 +41,7 @@ register = template.Library()
 def texescape(value):
     """ This will escape a string according to the rules of LaTeX """
 
-    value = six.text_type(value).strip()
-
+    value = str(value).strip()
 
     # we will make escape all the strings except those sandwiched between
     # $$ and $$. Thus you can write math symbols like $$\sqrt{3}$$ and
@@ -76,7 +73,6 @@ def texescape(value):
 
     value = '$'.join(strings)
 
-
     # now we have to make quotes pretty...
     strings = value.split('"')
 
@@ -97,5 +93,4 @@ def texescape(value):
     value = value.encode('ascii', 'ignore').decode('ascii')
 
     return value
-
 

--- a/esp/esp/utils/tests.py
+++ b/esp/esp/utils/tests.py
@@ -5,8 +5,6 @@ Test cases for Django-ESP utilities
 
 import datetime
 import doctest
-from six.moves import map
-from six.moves import range
 try:
     import pylibmc as memcache
 except:

--- a/esp/esp/utils/try_multi.py
+++ b/esp/esp/utils/try_multi.py
@@ -1,4 +1,3 @@
-from six.moves import range
 #!/usr/bin/env python
 
 def try_multi(n_tries):
@@ -17,5 +16,4 @@ def try_multi(n_tries):
             return fn(*args, **kwargs)
         return retried_fn
     return try_multi_helper
-
 

--- a/esp/esp/utils/web.py
+++ b/esp/esp/utils/web.py
@@ -1,5 +1,4 @@
 
-import six
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"
@@ -77,7 +76,7 @@ def esp_context_stuff():
     return context
 
 def render_to_response(template, request, context, content_type=None, use_request_context=True):
-    if isinstance(template, (six.string_types,)):
+    if isinstance(template, str):
         template = [ template ]
 
     section = request.path.split('/')[1]

--- a/esp/esp/utils/widgets.py
+++ b/esp/esp/utils/widgets.py
@@ -15,9 +15,6 @@ import datetime
 import time
 import json
 import logging
-import six
-from six.moves import range
-from six.moves import zip
 logger = logging.getLogger(__name__)
 
 class DateTimeWidget(forms.widgets.DateTimeInput):
@@ -43,7 +40,7 @@ class DateTimeWidget(forms.widgets.DateTimeInput):
     def get_context(self, name, value, attrs):
         context = super().get_context(name, value, attrs)
         context.update({
-            'id': attrs['id'] if 'id' in attrs else six.u('%s_id') % (name),
+            'id': attrs['id'] if 'id' in attrs else '%s_id' % (name),
             'jquerywidget': self.jquerywidget,
             'media_url': settings.MEDIA_URL,
             'date_format': self.dformat,
@@ -82,7 +79,7 @@ class ClassAttrMergingSelect(forms.Select):
         #   Merge 'class' attributes - this is the difference from Django's default implementation
         if extra_attrs:
             if 'class' in attrs and 'class' in extra_attrs \
-                    and (isinstance(extra_attrs['class'], str) or isinstance(extra_attrs['class'], six.text_type)):
+                    and isinstance(extra_attrs['class'], str):
                 attrs['class'] += ' ' + extra_attrs['class']
                 del extra_attrs['class']
             attrs.update(extra_attrs)
@@ -141,7 +138,6 @@ class SplitDateWidget(forms.MultiWidget):
     def format_output(self, rendered_widgets):
         return '\n'.join(rendered_widgets)
 
-
 class BlankSelectWidget(forms.Select):
     """ A <select> widget whose first entry is blank. """
     template_name = 'django/forms/widgets/blankselect.html'
@@ -153,9 +149,8 @@ class BlankSelectWidget(forms.Select):
 
 class NullRadioSelect(forms.RadioSelect):
     def __init__(self, *args, **kwargs):
-        kwargs['choices'] = ((True, six.u('Yes')), (False, six.u('No')))
+        kwargs['choices'] = ((True, 'Yes'), (False, 'No'))
         super().__init__(*args, **kwargs)
-
 
 class NullCheckboxSelect(forms.CheckboxInput):
     def __init__(self, *args, **kwargs):
@@ -167,7 +162,7 @@ class NullCheckboxSelect(forms.CheckboxInput):
             return False
         value = data.get(name)
         values =  {'on': True, 'true': True, 'false': False}
-        if isinstance(value, str) or isinstance(value, six.text_type):
+        if isinstance(value, str):
             value = values.get(value.lower(), value)
         logger.info('NullCheckboxSelect converted %s to %s', data.get(name), value)
         return value
@@ -179,7 +174,7 @@ class DummyWidget(widgets.Input):
         return True
 
     def render(self, name, value, attrs=None, choices=(), renderer=None):
-        output = six.u('')
+        output = ''
         if attrs and 'text' in attrs:
             output += attrs['text']
         return mark_safe(output)
@@ -463,7 +458,7 @@ class RadioSelectWithData(forms.RadioSelect):
         context = super().get_context(name, value, attrs)
         for optgroup in context['widget'].get('optgroups', []):
             for option in optgroup[1]:
-                for k, v in six.iteritems(self.option_data.get(option['value'], {})):
+                for k, v in self.option_data.get(option['value'], {}).items():
                     option['attrs']['data-' + k] = v
         return context
 
@@ -503,10 +498,9 @@ class ChoiceWithOtherField(forms.MultiValueField):
         else:
             super().__init__(*args, **kwargs)
 
-
     def compress(self, value):
         if not value:
-            return [None, six.u('')]
+            return [None, '']
 
         option_value, other_value = value
         if self._was_required and not value or option_value in (None, ''):


### PR DESCRIPTION
### Description

Remove all `six` library usage from the `utils` module (forms, widgets, web, query_builder, decorators, templatetags, tests). Includes cleanup of redundant `isinstance()` checks caused by `six.text_type` → `str` conversion.

**12 files changed** | +18/-35

### Related Issue

Part of #4232 — Remove `six` compatibility library

### Type of Change

- [x] Refactor / cleanup

### Testing

- [x] Existing tests pass
- [x] Zero remaining `six` references in `esp/esp/utils/`


### Checklist

- [x] Self-reviewed the code
- [x] No new warnings or errors introduced