### PR TITLE
refactor: remove six library from web module

### DIFF
--- a/esp/esp/web/models.py
+++ b/esp/esp/web/models.py
@@ -1,4 +1,3 @@
-import six
 from django.utils.encoding import python_2_unicode_compatible
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"

--- a/esp/esp/web/templatetags/main.py
+++ b/esp/esp/web/templatetags/main.py
@@ -4,7 +4,6 @@ from django import template
 
 import os.path
 import json
-from six.moves import range
 
 register = template.Library()
 

--- a/esp/esp/web/templatetags/topbar.py
+++ b/esp/esp/web/templatetags/topbar.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django import template
 from django.core.cache import cache
 from esp.users.models import ESPUser, AnonymousUser
-from six.moves.urllib.parse import quote as urlencode
+from urllib.parse import quote as urlencode
 from esp.utils.cache_inclusion_tag import cache_inclusion_tag
 register = template.Library()
 

--- a/esp/esp/web/tests.py
+++ b/esp/esp/web/tests.py
@@ -1,5 +1,4 @@
 from io import open
-import six
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"
@@ -72,8 +71,8 @@ class PageTest(TestCase):
         self.assertEqual(response.status_code, 200)
 
         # Make sure that we've gotten an HTML document, and not a Django error
-        self.assertStringContains(six.text_type(response.content, encoding='UTF-8'), "<html")
-        self.assertNotStringContains(six.text_type(response.content, encoding='UTF-8'), "You're seeing this error because you have <code>DEBUG = True</code>")
+        self.assertStringContains(str(response.content, encoding='UTF-8'), "<html")
+        self.assertNotStringContains(str(response.content, encoding='UTF-8'), "You're seeing this error because you have <code>DEBUG = True</code>")
 
 class NavbarTest(TestCase):
 
@@ -81,7 +80,7 @@ class NavbarTest(TestCase):
         response = self.client.get(path)
 
         navbaritem_re = re.compile(r'<li class="divsecondarynavlink (?:indent)?">\s+(.*)\s+</li>')
-        re_results = re.findall(navbaritem_re, six.text_type(response.content, encoding='UTF-8'))
+        re_results = re.findall(navbaritem_re, str(response.content, encoding='UTF-8'))
         return re_results
 
     def navbars_enabled(self):

--- a/esp/esp/web/views/archives.py
+++ b/esp/esp/web/views/archives.py
@@ -1,8 +1,5 @@
 
 from django.utils.encoding import python_2_unicode_compatible
-from six.moves import map
-import six
-from six.moves import range
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"
@@ -55,8 +52,8 @@ class ArchiveFilter(object):
     category = ""
     options = ""
     def __init__(self, category = "", options = ""):
-        self.category = six.text_type(category)
-        self.options  = six.text_type(options)
+        self.category = str(category)
+        self.options  = str(options)
 
     def __str__(self):
         return '%s, %s' % (self.category, self.options)
@@ -194,7 +191,7 @@ def archive_classes(request, category, options, sortorder = None):
     else:
         headings = [item.__dict__[sortorder[0]] for item in results[res_range['start']:res_range['end']]]
 
-    context['headings'] = list({six.text_type(h) for h in headings})
+    context['headings'] = list({str(h) for h in headings})
     context['headings'].sort()
 
     #    Fill in context some more

--- a/esp/esp/web/views/csrf.py
+++ b/esp/esp/web/views/csrf.py
@@ -1,5 +1,4 @@
 import re
-import six
 
 from django.http import HttpResponseForbidden
 from django.template import Context, Template
@@ -36,7 +35,7 @@ def csrf_failure(request, reason=""):
             prog = None
 
         response = render_to_response('403_csrf_failure.html', request, c)
-        response = HttpResponseForbidden(six.text_type(response.content, encoding='UTF-8'),
+        response = HttpResponseForbidden(str(response.content, encoding='UTF-8'),
                                          content_type=response['Content-Type'])
 
     except Exception:

--- a/esp/esp/web/views/main.py
+++ b/esp/esp/web/views/main.py
@@ -1,5 +1,4 @@
 
-import six
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"
@@ -216,7 +215,6 @@ def contact(request, section='esp'):
 
     return render_to_response('contact.html', request, {'contact_form': form})
 
-
 def registration_redirect(request):
     """ A view which returns:
         - A redirect to the currently open registration if exactly one registration is open
@@ -268,7 +266,7 @@ def registration_redirect(request):
     #   Most chapters will want this, but it can be disabled by a Tag.
     if len(progs) == 1 and Tag.getBooleanTag('automatic_registration_redirect'):
         ctxt['prog'] = progs[0]
-        return HttpResponseRedirect(six.u('/%s/%s/%s') % (userrole['base'], progs[0].getUrlBase(), userrole['reg']))
+        return HttpResponseRedirect('/%s/%s/%s' % (userrole['base'], progs[0].getUrlBase(), userrole['reg']))
     else:
         if len(progs) > 0:
             #   Sort available programs newest first

--- a/esp/esp/web/views/myesp.py
+++ b/esp/esp/web/views/myesp.py
@@ -1,4 +1,3 @@
-import six
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"
@@ -235,7 +234,7 @@ def profile_editor(request, prog_input=None, responseuponCompletion = True, role
         if regProf.student_info and regProf.student_info.dob:
             new_data['dob'] = regProf.student_info.dob
 
-        if 'k12school' in new_data and (isinstance(new_data['k12school'], str) or isinstance(new_data['k12school'], six.text_type)):
+        if 'k12school' in new_data and (isinstance(new_data['k12school'], str) or isinstance(new_data['k12school'], str)):
             new_data['unmatched_school'] = True
 
         #   Set default values for state fields


### PR DESCRIPTION
### Description

Remove all `six` library usage from the `web` module (models, templatetags, views, tests). Replaces with native Python 3 equivalents.

**8 files changed** | +10/-19

### Related Issue

Part of #4232 — Remove `six` compatibility library

### Type of Change

- [x] Refactor / cleanup

### Testing

- [x] Existing tests pass
- [x] Zero remaining `six` references in `esp/esp/web/`


### Checklist

- [x] Self-reviewed the code
- [x] No new warnings or errors introduced