### PR TITLE
refactor: remove six library from customforms and survey modules

### DIFF
--- a/esp/esp/customforms/DynamicForm.py
+++ b/esp/esp/customforms/DynamicForm.py
@@ -24,9 +24,6 @@ from django.core.exceptions import ValidationError
 from esp.middleware import ESPError
 
 from datetime import datetime
-from six.moves import map
-import six
-from six.moves import range
 
 class BaseCustomForm(BetterForm):
     """
@@ -682,7 +679,7 @@ class FormHandler:
             # Add in user if form is not anonymous
             if not form.anonymous and response['user_id']:
                 user = users[response['user_id']]
-                response['user_id'] = six.text_type(response['user_id'])
+                response['user_id'] = str(response['user_id'])
                 response['user_display'] = user.name()
                 response['user_email'] = user.email
                 response['username'] = user.username
@@ -692,7 +689,7 @@ class FormHandler:
                 if only_fkey_model.objects.filter(pk=response["link_%s_id" % only_fkey_model.__name__]).exists():
                     inst = only_fkey_model.objects.get(pk=response["link_%s_id" % only_fkey_model.__name__])
                 else: inst = None
-                response["link_%s_id" % only_fkey_model.__name__] = six.text_type(inst)
+                response["link_%s_id" % only_fkey_model.__name__] = str(inst)
 
             # Now, put in the additional fields in response
             for qname, data in add_fields.items():

--- a/esp/esp/customforms/forms.py
+++ b/esp/esp/customforms/forms.py
@@ -3,7 +3,6 @@ from django import forms
 from collections import OrderedDict
 from localflavor.us.forms import USStateField, USStateSelect
 from django.utils.html import conditional_escape
-import six
 
 class CustomFileWidget(forms.ClearableFileInput):
     """
@@ -36,10 +35,10 @@ class NameWidget(forms.MultiWidget):
         return [None, None]
 
     def format_output(self, rendered_widgets):
-        html_string = six.u('<table class="combo_field name_field">')
-        html_string += six.u('<tr><td class="small_field">') + rendered_widgets[0] + six.u('</td><td class="small_field">') + rendered_widgets[1] + six.u('</td></tr>')
-        html_string += six.u('<tr class="subtext_row"><td>') + six.u('First') + six.u('</td><td>') + six.u('Last') + six.u('</td></tr>')
-        html_string += six.u('</table>')
+        html_string = '<table class="combo_field name_field">'
+        html_string += '<tr><td class="small_field">' + rendered_widgets[0] + '</td><td class="small_field">' + rendered_widgets[1] + '</td></tr>'
+        html_string += '<tr class="subtext_row"><td>' + 'First' + '</td><td>' + 'Last' + '</td></tr>'
+        html_string += '</table>'
         return html_string
 
 class HiddenNameWidget(NameWidget):
@@ -54,7 +53,7 @@ class HiddenNameWidget(NameWidget):
             widget.input_type = 'hidden'
 
     def format_output(self, rendered_widgets):
-        return six.u('').join(rendered_widgets)
+        return ''.join(rendered_widgets)
 
 class NameField(forms.MultiValueField):
     """
@@ -96,11 +95,11 @@ class AddressWidget(forms.MultiWidget):
         return [None, None, None, None]
 
     def format_output(self, rendered_widgets):
-        html_string = six.u('<table class="combo_field address_field">')
-        html_string += six.u('<tr><td>Street&nbsp;') + rendered_widgets[0] + '</td></tr>'
-        html_string += six.u('<tr><td>City&nbsp;') + rendered_widgets[1] + six.u('</td></tr><tr><td>State&nbsp;') + rendered_widgets[2] + six.u('</td></tr>')
-        html_string += six.u('<tr><td>Zip&nbsp;&nbsp;') + rendered_widgets[3] + six.u('</td></tr>')
-        html_string += six.u('</table>')
+        html_string = '<table class="combo_field address_field">'
+        html_string += '<tr><td>Street&nbsp;' + rendered_widgets[0] + '</td></tr>'
+        html_string += '<tr><td>City&nbsp;' + rendered_widgets[1] + '</td></tr><tr><td>State&nbsp;' + rendered_widgets[2] + '</td></tr>'
+        html_string += '<tr><td>Zip&nbsp;&nbsp;' + rendered_widgets[3] + '</td></tr>'
+        html_string += '</table>'
         return html_string
 
 class HiddenAddressWidget(AddressWidget):
@@ -114,7 +113,7 @@ class HiddenAddressWidget(AddressWidget):
         self.widgets = [forms.HiddenInput(), forms.HiddenInput(), forms.HiddenInput(), forms.HiddenInput()]
 
     def format_output(self, rendered_widgets):
-        return six.u('').join(rendered_widgets)
+        return ''.join(rendered_widgets)
 
 class AddressField(forms.MultiValueField):
     """

--- a/esp/esp/customforms/models.py
+++ b/esp/esp/customforms/models.py
@@ -1,7 +1,6 @@
 
 from django.utils.encoding import python_2_unicode_compatible
 import logging
-import six
 logger = logging.getLogger(__name__)
 
 from django.db import models, transaction, connection
@@ -41,7 +40,7 @@ class Section(models.Model):
     seq = models.IntegerField()
 
     def __str__(self):
-        return 'Sec. %d: %s' % (self.seq, six.text_type(self.title))
+        return 'Sec. %d: %s' % (self.seq, str(self.title))
 
 @python_2_unicode_compatible
 class Field(models.Model):

--- a/esp/esp/customforms/tests.py
+++ b/esp/esp/customforms/tests.py
@@ -1,4 +1,3 @@
-import six
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"
@@ -111,7 +110,7 @@ class CustomFormsTest(TestCase):
         #      need separate tests.)
         form_data = {
             'title': 'Test Form',
-            'perms': six.u(''),
+            'perms': '',
             'link_id': -1,
             'success_url': '/formsuccess.html',
             'success_message': 'Thank you!',
@@ -121,13 +120,13 @@ class CustomFormsTest(TestCase):
                 'sections': [{
                     'fields': [
                         {'data': {'field_type': 'textField', 'question_text': 'ShortText', 'seq': 0, 'required': True, 'parent_id': -1, 'attrs':{'correct_answer': 'Smart', 'charlimits': '0,100'}, 'help_text': 'Instructions'}},
-                        {'data': {'field_type': 'phone', 'question_text': 'Your phone no.', 'seq': 1, 'required': True, 'parent_id': -1, 'attrs': {}, 'help_text': six.u('')}},
-                        {'data': {'field_type': 'gender', 'question_text': 'Your gender', 'seq': 2, 'required': True, 'parent_id': -1, 'attrs': {}, 'help_text': six.u('')}},
-                        {'data': {'field_type': 'radio', 'question_text': 'Choose an option', 'seq': 3, 'required': True, 'parent_id': -1, 'attrs': {'correct_answer': '1', 'options': 'A|B|C|'}, 'help_text': six.u('')}},
-                        {'data': {'field_type': 'boolean', 'question_text': 'True/false', 'seq': 4, 'required': True, 'parent_id': -1, 'attrs': {}, 'help_text':six.u('')}},
-                        {'data': {'field_type': 'textField', 'question_text': 'NonRequired', 'seq': 5, 'required': False, 'parent_id': -1, 'attrs': {'correct_answer': six.u(''), 'charlimits': ','}, 'help_text': six.u('')}}
+                        {'data': {'field_type': 'phone', 'question_text': 'Your phone no.', 'seq': 1, 'required': True, 'parent_id': -1, 'attrs': {}, 'help_text': ''}},
+                        {'data': {'field_type': 'gender', 'question_text': 'Your gender', 'seq': 2, 'required': True, 'parent_id': -1, 'attrs': {}, 'help_text': ''}},
+                        {'data': {'field_type': 'radio', 'question_text': 'Choose an option', 'seq': 3, 'required': True, 'parent_id': -1, 'attrs': {'correct_answer': '1', 'options': 'A|B|C|'}, 'help_text': ''}},
+                        {'data': {'field_type': 'boolean', 'question_text': 'True/false', 'seq': 4, 'required': True, 'parent_id': -1, 'attrs': {}, 'help_text':''}},
+                        {'data': {'field_type': 'textField', 'question_text': 'NonRequired', 'seq': 5, 'required': False, 'parent_id': -1, 'attrs': {'correct_answer': '', 'charlimits': ','}, 'help_text': ''}}
                     ],
-                'data': {'help_text': six.u(''), 'question_text': six.u(''), 'seq': 0}
+                'data': {'help_text': '', 'question_text': '', 'seq': 0}
                 }],
                 'seq': 0
             }],
@@ -137,7 +136,7 @@ class CustomFormsTest(TestCase):
 
         response = self.client.post("/customforms/submit/", json.dumps(form_data), content_type='application/json', HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(six.text_type(response.content, encoding='UTF-8'), "OK")
+        self.assertEqual(str(response.content, encoding='UTF-8'), "OK")
 
         #   - Make sure the form and its fields exist and match what was specified
         forms = Form.objects.filter(title='Test Form')

--- a/esp/esp/customforms/views.py
+++ b/esp/esp/customforms/views.py
@@ -19,7 +19,6 @@ from django.contrib.auth.decorators import user_passes_test
 from esp.users.models import ESPUser
 from esp.middleware import ESPError
 from esp.utils.web import render_to_response, zip_download
-import six
 
 def test_func(user):
     return user.is_authenticated and (user.is_morphed() or user.isTeacher() or user.isAdministrator())
@@ -447,7 +446,7 @@ def get_links(request):
             link_objects = link_model.objects.all().order_by('-id')
             retval = []
             for obj in link_objects:
-                retval.append({'id': obj.id, 'name': six.text_type(obj)})
+                retval.append({'id': obj.id, 'name': str(obj)})
 
             return HttpResponse(json.dumps(retval))
     return HttpResponse(status=400)

--- a/esp/esp/survey/models.py
+++ b/esp/esp/survey/models.py
@@ -1,9 +1,6 @@
 " Survey models for Educational Studies Program. "
 
 from django.utils.encoding import python_2_unicode_compatible
-import six
-from six.moves import map
-from six.moves import zip
 __author__    = "$LastChangedBy$"
 __date__      = "$LastChangedDate$"
 __rev__       = "$LastChangedRevision$"
@@ -105,7 +102,7 @@ class Survey(models.Model):
     category = models.CharField(max_length = 10, choices = survey_choices)
 
     def __str__(self):
-        return '%s (%s) for %s' % (self.name, self.category, six.text_type(self.program))
+        return '%s (%s) for %s' % (self.name, self.category, str(self.program))
 
     def num_participants(self):
         #   If there is a program for this survey, select the appropriate number
@@ -195,7 +192,7 @@ class SurveyResponse(models.Model):
         return answers
 
     def __str__(self):
-        return "Survey for %s filled out at %s" % (six.text_type(self.survey.program),
+        return "Survey for %s filled out at %s" % (str(self.survey.program),
                                                    self.time_filled)
 
 @python_2_unicode_compatible

--- a/esp/esp/survey/templatetags/survey.py
+++ b/esp/esp/survey/templatetags/survey.py
@@ -1,6 +1,4 @@
-import six
 from io import open
-from six.moves import range
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"
@@ -42,12 +40,11 @@ from django.template import loader
 from esp.program.models import Program, ClassSubject, ClassSection
 from esp.utils.cache_inclusion_tag import cache_inclusion_tag
 
-
 import os
 import subprocess
 
 try:
-    import six.moves.cPickle as pickle
+    import pickle
 except ImportError:
     import pickle
 
@@ -129,7 +126,7 @@ def unpack_answers(lst):
 @register.filter
 def drop_empty_answers(lst):
     #   Takes a list of answers and drops empty ones. Whitespace-only is empty.
-    return [ ans for ans in lst if (not isinstance(ans.answer, six.string_types)) or ans.answer.strip() ]
+    return [ ans for ans in lst if (not isinstance(ans.answer, str)) or ans.answer.strip() ]
 
 @register.filter
 def average(lst):

--- a/esp/esp/survey/views.py
+++ b/esp/esp/survey/views.py
@@ -1,6 +1,5 @@
 " A view to show surveys. "
 
-import six
 __author__    = "$LastChangedBy$"
 __date__      = "$LastChangedDate$"
 __rev__       = "$LastChangedRevision$"
@@ -243,7 +242,6 @@ def get_survey_info(request, tl, program, instance):
 
     return (user, prog, surveys)
 
-
 def display_survey(user, prog, surveys, request, tl, format, template = 'survey/review.html', context = {}):
     """ Wrapper doing the necessary work for the survey output. """
     from esp.program.models import ClassSubject, ClassSection
@@ -303,7 +301,6 @@ def delist(x):
         return ', '.join(x)
     else:
         return x
-
 
 def dump_survey_xlwt(user, prog, surveys, request, tl):
     from esp.program.models import ClassSubject, ClassSection
@@ -479,7 +476,6 @@ def top_classes(request, tl, program, instance):
         return render_to_response('survey/choose_survey.html', request, { 'surveys': surveys, 'error': request.POST }) # if request.POST, then we shouldn't have more than one survey any more...
 
     survey = surveys[0]
-
 
     if tl == 'manage':
         classes = prog.classes()


### PR DESCRIPTION
### Description

Remove all `six` library usage from the `customforms` and `survey` modules. Replaces with native Python 3 equivalents.

**8 files changed** | +27/-40

### Related Issue

Part of #4232 — Remove `six` compatibility library

### Type of Change

- [x] Refactor / cleanup

### Testing

- [x] Existing tests pass
- [x] Zero remaining `six` references in `esp/esp/customforms/` and `esp/esp/survey/`


### Checklist

- [x] Self-reviewed the code
- [x] No new warnings or errors introduced
