### PR TITLE
refactor: remove six library from misc modules

### DIFF
--- a/esp/esp/accounting/admin.py
+++ b/esp/esp/accounting/admin.py
@@ -1,4 +1,3 @@
-import six
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"
@@ -53,7 +52,7 @@ class TransferAdmin(admin.ModelAdmin):
         if obj.option:
             return obj.option.description
         else:
-            return six.u('--')
+            return '--'
 
     def formfield_for_foreignkey(self, db_field, request, **kwargs):
         if db_field.name == "line_item":

--- a/esp/esp/accounting/controllers.py
+++ b/esp/esp/accounting/controllers.py
@@ -1,6 +1,5 @@
 
 from django.utils.encoding import python_2_unicode_compatible
-from six.moves import range
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"

--- a/esp/esp/accounting/models.py
+++ b/esp/esp/accounting/models.py
@@ -1,6 +1,5 @@
 
 from django.utils.encoding import python_2_unicode_compatible
-import six
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"
@@ -110,9 +109,9 @@ class LineItemType(models.Model):
 
     def __str__(self):
         if self.amount_dec:
-            return six.u('%s for %s ($%s)') % (self.text, self.program, self.amount_dec)
+            return '%s for %s ($%s)' % (self.text, self.program, self.amount_dec)
         else:
-            return six.u('%s for %s') % (self.text, self.program)
+            return '%s for %s' % (self.text, self.program)
 
     class Meta:
         ordering = ('-program_id',)

--- a/esp/esp/application/admin.py
+++ b/esp/esp/application/admin.py
@@ -1,4 +1,3 @@
-from six.moves import map
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"

--- a/esp/esp/cal/models.py
+++ b/esp/esp/cal/models.py
@@ -1,7 +1,5 @@
 
 from django.utils.encoding import python_2_unicode_compatible
-import six
-from six.moves import range
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"
@@ -50,7 +48,7 @@ class EventType(models.Model):
     description = models.TextField() # Textual description; not computer-parseable
 
     def __str__(self):
-        return six.text_type(self.description)
+        return str(self.description)
 
     @cache_function
     def get_from_desc(cls, desc):
@@ -103,25 +101,25 @@ class Event(models.Model):
         dur = self.end - self.start
         hours = int(dur.seconds // 3600)
         minutes = int(dur.seconds // 60) - hours * 60
-        return six.u('%d hr %d min') % (hours, minutes)
+        return '%d hr %d min' % (hours, minutes)
 
     def __str__(self):
         return self.start.strftime('%a %b %d: ') + self.short_time()
 
     def short_time(self):
-        day_list = [six.u('Mon'), six.u('Tue'), six.u('Wed'), six.u('Thu'), six.u('Fri'), six.u('Sat'), six.u('Sun')]
+        day_list = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
 
-        start_minutes = six.u('')
-        end_minutes = six.u('')
-        start_ampm = six.u('')
+        start_minutes = ''
+        end_minutes = ''
+        start_ampm = ''
         if self.start.minute != 0:
-            start_minutes = six.u(':%02d') % self.start.minute
+            start_minutes = ':%02d' % self.start.minute
         if self.end.minute != 0:
-            end_minutes = six.u(':%02d') % self.end.minute
+            end_minutes = ':%02d' % self.end.minute
         if (self.start.hour < 12) != (self.end.hour < 12):
             start_ampm = self.start.strftime(' %p')
 
-        return six.u('%d%s%s to %d%s %s') % ( (self.start.hour % 12) or 12, start_minutes, start_ampm,
+        return '%d%s%s to %d%s %s' % ( (self.start.hour % 12) or 12, start_minutes, start_ampm,
             (self.end.hour % 12) or 12, end_minutes, self.end.strftime('%p') )
 
     @staticmethod
@@ -197,10 +195,10 @@ class Event(models.Model):
             s += self.start.strftime(', %b %d,')
             s2 += self.end.strftime(', %b %d,')
         if s != s2:
-            return s + six.u(' ') + self.start.strftime('%I:%M%p').lower().strip('0') + six.u('--') \
-               + s2 + six.u(' ') + self.end.strftime('%I:%M%p').lower().strip('0')
+            return s + ' ' + self.start.strftime('%I:%M%p').lower().strip('0') + '--' \
+               + s2 + ' ' + self.end.strftime('%I:%M%p').lower().strip('0')
         else:
-            return s + six.u(' ') + self.start.strftime('%I:%M%p').lower().strip('0') + six.u('--') \
+            return s + ' ' + self.start.strftime('%I:%M%p').lower().strip('0') + '--' \
                + self.end.strftime('%I:%M%p').lower().strip('0')
 
     def pretty_time_with_date(self):
@@ -210,7 +208,7 @@ class Event(models.Model):
         return self.start.strftime('%A, %B %d')
 
     def pretty_start_time(self):
-        return self.start.strftime('%a') + six.u(' ') + self.start.strftime('%I:%M%p').lower().strip('0')
+        return self.start.strftime('%a') + ' ' + self.start.strftime('%I:%M%p').lower().strip('0')
 
     def parent_program(self):
         return self.program

--- a/esp/esp/db/forms.py
+++ b/esp/esp/db/forms.py
@@ -4,7 +4,6 @@ from django.template.defaultfilters import addslashes
 from django.contrib.auth.models import User
 from django.utils.safestring import mark_safe
 import re
-import six
 
 get_id_re = re.compile('.*\((\d+)\)$')
 
@@ -25,10 +24,10 @@ class AjaxForeignKeyFieldBase:
                 obj = objects[0]
                 if hasattr(obj, 'ajax_str'):
                     init_val = obj.ajax_str() + " (%s)" % data
-                    old_init_val = six.text_type(obj)
+                    old_init_val = str(obj)
                 else:
-                    old_init_val = init_val = six.text_type(obj) + " (%s)" % data
-        elif isinstance(data, six.string_types):
+                    old_init_val = init_val = str(obj) + " (%s)" % data
+        elif isinstance(data, str):
             pass
         else:
             data = init_val = ''

--- a/esp/esp/miniblog/templatetags/preview.py
+++ b/esp/esp/miniblog/templatetags/preview.py
@@ -4,7 +4,6 @@ from django import template
 from django.contrib.auth.models import User, AnonymousUser
 
 from esp.miniblog.views import get_visible_announcements
-from six.moves import zip
 
 __all__ = ['MiniblogNode', 'miniblog_for_user']
 

--- a/esp/esp/qsd/models.py
+++ b/esp/esp/qsd/models.py
@@ -1,6 +1,4 @@
 from django.utils.encoding import python_2_unicode_compatible
-from six.moves import map
-import six
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"
@@ -78,9 +76,9 @@ class QSDManager(models.Manager):
             # will interpret this as a code block.  To avoid this, we assume
             # that the default content will never purposely use Markdown code
             # blocks, and we strip this unintended space.
-            content = six.text_type(qsd_obj.content.lstrip())
+            content = str(qsd_obj.content.lstrip())
             content = content.split('\n')
-            content = list(map(six.text_type.lstrip, content))
+            content = list(map(str.lstrip, content))
             content = '\n'.join(content)
             qsd_obj.content = content
         return qsd_obj

--- a/esp/esp/qsd/seltests.py
+++ b/esp/esp/qsd/seltests.py
@@ -1,4 +1,3 @@
-from six.moves import range
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"

--- a/esp/esp/qsd/templatetags/render_qsd.py
+++ b/esp/esp/qsd/templatetags/render_qsd.py
@@ -2,7 +2,6 @@ from django import template
 from esp.utils.cache_inclusion_tag import cache_inclusion_tag
 from esp.qsd.models import QuasiStaticData
 from esp.tagdict.models import Tag
-import six
 
 register = template.Library()
 
@@ -82,7 +81,7 @@ class InlineQSDNode(template.Node):
 
         title = self.url
         if program is not None:
-            title += ' - ' + six.text_type(program)
+            title += ' - ' + str(program)
 
         qsd_obj = QuasiStaticData.objects.get_by_url_else_init(url, {'name': '', 'title': title, 'content': self.nodelist.render(context)})
         context.update({'qsdrec': qsd_obj, 'inline': True})

--- a/esp/esp/qsd/tests.py
+++ b/esp/esp/qsd/tests.py
@@ -1,4 +1,3 @@
-import six
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"
@@ -130,16 +129,15 @@ class QSDCorrectnessTest(TestCase):
             #   Check that page now exists and has proper content
             response = self.client.get(self.url)
             self.assertEqual(response.status_code, 200)
-            self.assertTrue('Testing 123' in six.text_type(response.content, encoding='UTF-8'))
+            self.assertTrue('Testing 123' in str(response.content, encoding='UTF-8'))
 
             #   Edit QSD and check that page content has updated
             qsd_rec_new.content = "Testing 456"
             qsd_rec_new.save()
             response = self.client.get(self.url)
             self.assertEqual(response.status_code, 200)
-            self.assertTrue('Testing 456' in six.text_type(response.content, encoding='UTF-8'))
+            self.assertTrue('Testing 456' in str(response.content, encoding='UTF-8'))
 
             #   Delete the new QSD so we can start again.
             qsd_rec_new.delete()
-
 

--- a/esp/esp/qsdmedia/models.py
+++ b/esp/esp/qsdmedia/models.py
@@ -1,6 +1,5 @@
 
 from django.utils.encoding import python_2_unicode_compatible
-import six
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"
@@ -124,4 +123,4 @@ class Media(models.Model):
         self.friendly_name = new_name
 
     def __str__(self):
-        return six.text_type(self.friendly_name)
+        return str(self.friendly_name)

--- a/esp/esp/resources/forms.py
+++ b/esp/esp/resources/forms.py
@@ -1,4 +1,3 @@
-from six.moves import zip
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"
@@ -77,7 +76,6 @@ class ResourceRequestForm(forms.Form):
             self.fields['desired_value'].choices = list(zip(self.resource_type.choices, self.resource_type.choices))
 
             self.initial['resource_type'] = self.resource_type.id
-
 
 class ResourceRequestFormSet(formset_factory(ResourceRequestForm, extra=0)):
     """ Like a FormSet, but handles the list of resource_types for the forms to start out with. """

--- a/esp/esp/resources/models.py
+++ b/esp/esp/resources/models.py
@@ -1,5 +1,4 @@
 from django.utils.encoding import python_2_unicode_compatible
-import six
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"
@@ -154,7 +153,7 @@ class ResourceRequest(models.Model):
     desired_value = models.TextField()
 
     def __str__(self):
-        return 'Resource request of %s for %s: %s' % (six.text_type(self.res_type), self.target.emailcode(), self.desired_value)
+        return 'Resource request of %s for %s: %s' % (str(self.res_type), self.target.emailcode(), self.desired_value)
 
 @python_2_unicode_compatible
 class ResourceGroup(models.Model):
@@ -185,12 +184,12 @@ class Resource(models.Model):
 
     def __str__(self):
         if self.user is not None:
-            return 'For %s: %s (%s)' % (six.text_type(self.user), self.name, six.text_type(self.res_type))
+            return 'For %s: %s (%s)' % (str(self.user), self.name, str(self.res_type))
         else:
             if self.num_students != -1:
-                return 'For %d students: %s (%s)' % (self.num_students, self.name, six.text_type(self.res_type))
+                return 'For %d students: %s (%s)' % (self.num_students, self.name, str(self.res_type))
             else:
-                return '%s (%s)' % (self.name, six.text_type(self.res_type))
+                return '%s (%s)' % (self.name, str(self.res_type))
 
     def save(self, *args, **kwargs):
         if self.res_group is None:
@@ -314,7 +313,7 @@ class Resource(models.Model):
         return (len(self.available_times(program)) > 0)
 
     def available_times_html(self, program=None):
-        return '<br /> '.join([six.text_type(e) for e in Event.collapse(self.available_times(program))])
+        return '<br /> '.join([str(e) for e in Event.collapse(self.available_times(program))])
 
     def available_times(self, program=None):
         event_list = [x for x in list(self.matching_times(program)) if self.is_available(timeslot=x)]
@@ -370,7 +369,7 @@ class ResourceAssignment(models.Model):
     assignment_group = models.ForeignKey(AssignmentGroup, null=True, blank=True, on_delete=models.CASCADE)
 
     def __str__(self):
-        result = 'Resource assignment for %s' % six.text_type(self.getTargetOrSubject())
+        result = 'Resource assignment for %s' % str(self.getTargetOrSubject())
         if self.lock_level > 0:
             result += ' (locked)'
         return result

--- a/esp/esp/tagdict/__init__.py
+++ b/esp/esp/tagdict/__init__.py
@@ -7,7 +7,6 @@ from decimal import Decimal
 import datetime
 
 from esp.users.forms import _states
-from six.moves import zip
 
 import json
 

--- a/esp/esp/tagdict/models.py
+++ b/esp/esp/tagdict/models.py
@@ -1,6 +1,5 @@
 from django.utils.encoding import python_2_unicode_compatible
 import logging
-import six
 logger = logging.getLogger(__name__)
 
 from django.db import models
@@ -65,7 +64,7 @@ class Tag(models.Model):
                 elif key in all_global_tags:
                     result = all_global_tags[key].get('default')
 
-        if isinstance(result, six.string_types) and (result.lower() == "false" or
+        if isinstance(result, str) and (result.lower() == "false" or
                                                result.lower() == "true"):
             logger.warning("Tag %s set to boolean value; consider using getBooleanTag()",
                            key)
@@ -78,7 +77,7 @@ class Tag(models.Model):
         return the corresponding value as a string,
         or the value specified by the 'default' argument if no such value exists.
         """
-        if default is not None and not isinstance(default, six.string_types):
+        if default is not None and not isinstance(default, str):
             logger.warning("_getTag() called with non-string default for key %s",
                            key)
 
@@ -122,7 +121,7 @@ class Tag(models.Model):
                     res = all_program_tags[key].get('default')
                 elif key in all_global_tags:
                     res = all_global_tags[key].get('default')
-        if (not boolean) and isinstance(res, six.string_types) and \
+        if (not boolean) and isinstance(res, str) and \
            (res.lower() == "false" or res.lower() == "true"):
             logger.warning("Tag %s set to boolean value; consider using getBooleanTag()",
                            key)

--- a/esp/esp/themes/controllers.py
+++ b/esp/esp/themes/controllers.py
@@ -1,5 +1,4 @@
 
-import six
 from io import open
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
@@ -50,7 +49,7 @@ import distutils.dir_util
 import json
 import hashlib
 import copy
-from six.moves.urllib.parse import quote, unquote
+from urllib.parse import quote, unquote
 
 from django.conf import settings
 from django.template.loader import render_to_string
@@ -304,7 +303,7 @@ class ThemeController(object):
         css_data = self.compile_less(less_data)
 
         with open(output_filename, 'w') as output_file:
-            output_file.write(six.text_type(THEME_COMPILED_WARNING) + css_data.decode('UTF-8'))
+            output_file.write(str(THEME_COMPILED_WARNING) + css_data.decode('UTF-8'))
         logger.debug('Wrote %.1f KB CSS output to %s', len(css_data) / 1000., output_filename)
         Tag.setTag("current_theme_version", value = hex(random.getrandbits(16)))
 
@@ -592,7 +591,7 @@ class ThemeController(object):
         base_vars = self.find_less_variables()
         for varset in base_vars.values():
             for val in varset.values():
-                if isinstance(val, six.string_types) and val.startswith('#'):
+                if isinstance(val, str) and val.startswith('#'):
                     if len(val) == 4: # Convert to long form
                         val = '#' + val[1] + val[1] + val[2] + val[2] + val[3] + val[3]
                     palette_base.add(val)
@@ -607,7 +606,7 @@ class ThemeController(object):
         base_vars = self.find_less_variables()
         for varset in base_vars.values():
             for val in varset.values():
-                if isinstance(val, six.string_types) and val.startswith('#'):
+                if isinstance(val, str) and val.startswith('#'):
                     if len(val) == 4: # Convert to long form
                         val = '#' + val[1] + val[1] + val[2] + val[2] + val[3] + val[3]
                     if val in palette:

--- a/esp/esp/themes/forms.py
+++ b/esp/esp/themes/forms.py
@@ -1,5 +1,4 @@
 
-import six
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"
@@ -74,5 +73,5 @@ class ThemeConfigurationForm(forms.Form):
         """
         A dictionary of the initial values of the configuration form fields.
         """
-        return dict([(k_v[0], k_v[1].initial) for k_v in six.iteritems(cls().fields)])
+        return dict([(k_v[0], k_v[1].initial) for k_v in cls().fields.items()])
 

--- a/esp/esp/themes/tests.py
+++ b/esp/esp/themes/tests.py
@@ -2,7 +2,6 @@
 Tests for the theme editor.
 """
 
-import six
 import os
 import random
 import re
@@ -73,7 +72,7 @@ class ThemesTest(TestCase):
         #   Get the home page (this is a fresh site) and make sure it has a link to the theme landing.
         response = self.client.get('/')
         self.assertTrue(len(re.findall(r'<a href="/themes.*?Configure site appearance.*?</a>',
-                                       six.text_type(response.content, encoding='UTF-8'), flags=re.DOTALL)) == 1)
+                                       str(response.content, encoding='UTF-8'), flags=re.DOTALL)) == 1)
 
         #   Go to the themes landing page and theme selector, make sure neither errors out.
         response = self.client.get('/themes/')
@@ -120,9 +119,9 @@ class ThemesTest(TestCase):
                 self.assertEqual(response.status_code, 200)
 
                 #   Supply more settings if the theme asks for them.
-                if '<form id="theme_setup_form"' in six.text_type(response.content, encoding='UTF-8'):
+                if '<form id="theme_setup_form"' in str(response.content, encoding='UTF-8'):
                     field_matches = re.findall(r'<(input id="\S+"|textarea).*?name="(\S+)".*?>',
-                                               six.text_type(response.content, encoding='UTF-8'), flags=re.DOTALL)
+                                               str(response.content, encoding='UTF-8'), flags=re.DOTALL)
                     #   This is the union of all the theme configuration settings that
                     #   have a non-trivial form (e.g. key = value fails validation).
                     settings_dict = {
@@ -152,14 +151,14 @@ class ThemesTest(TestCase):
                     self.assertTrue(('/themes/', 302) in response.redirect_chain)
 
                 #   Check that the CSS stylesheet has been included in the page.
-                self.assertTrue('/media/styles/theme_compiled.css' in six.text_type(response.content, encoding='UTF-8'))
+                self.assertTrue('/media/styles/theme_compiled.css' in str(response.content, encoding='UTF-8'))
 
                 #   Check that the CSS stylesheet has been compiled.
                 self.assertTrue(os.path.exists(css_filename))
                 self.assertTrue(len(open(css_filename).read()) > 1000)  #   Hacky way to check that content is substantial
 
                 #   Check that the template override is marked with the theme name.
-                self.assertTrue(('<!-- Theme: %s -->' % theme_name) in six.text_type(response.content, encoding='UTF-8'))
+                self.assertTrue(('<!-- Theme: %s -->' % theme_name) in str(response.content, encoding='UTF-8'))
 
             self.client.logout()
 
@@ -200,7 +199,7 @@ class ThemesTest(TestCase):
                 variables = re.findall(r'@(\S+):\s+?(\S+);', open(variables_filename).read())
                 for (varname, value) in variables:
                     self.assertTrue(len(re.findall(r'<input.*?name="%s".*?value="%s".*?>',
-                                    six.text_type(response.content, encoding='UTF-8'), flags=re.I)) > 0)
+                                    str(response.content, encoding='UTF-8'), flags=re.I)) > 0)
 
         #   Test that we can change a parameter and the right value appears in the stylesheet
         def verify_linkcolor(color_str):

--- a/esp/esp/themes/views.py
+++ b/esp/esp/themes/views.py
@@ -1,7 +1,5 @@
 
-import six
 from io import open
-from six.moves import range
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"
@@ -316,7 +314,7 @@ def editor(request):
     context['last_used_setting'] = tc.get_current_customization()
 
     #   Load a bunch of preset fonts
-    context['sans_fonts'] = six.iteritems(themes_settings.sans_serif_fonts)
+    context['sans_fonts'] = themes_settings.sans_serif_fonts.items()
 
     #   Load the theme-specific options
     adv_vars = tc.find_less_variables(current_theme, theme_only=True)

--- a/esp/esp/varnish/varnish.py
+++ b/esp/esp/varnish/varnish.py
@@ -1,4 +1,4 @@
-import six.moves.http_client
+import http.client
 
 from django.conf import settings
 from django.contrib.sites.models import Site
@@ -17,7 +17,7 @@ def purge_page(url, host=None):
         if host is None:
             return None
 
-    conn = six.moves.http_client.HTTPConnection(host)
+    conn = http.client.HTTPConnection(host)
     cur_domain = Site.objects.get_current().domain
     conn.request("PURGE", url, "", {'Host': cur_domain, 'Accept-Encoding': 'gzip'})
     ret = conn.getresponse()
@@ -31,7 +31,7 @@ def purge_all(host=None):
         if host is None:
             return None
 
-    conn = six.moves.http_client.HTTPConnection(host)
+    conn = http.client.HTTPConnection(host)
     cur_domain = Site.objects.get_current().domain
     conn.request("BAN", "/", "", {'Host': cur_domain, 'Accept-Encoding': 'gzip'})
     ret = conn.getresponse()


### PR DESCRIPTION
### Description

Remove all `six` library usage from smaller modules: `accounting`, `application`, `cal`, `db`, `miniblog`, `qsd`, `qsdmedia`, `resources`, `tagdict`, `themes`, `varnish`. Replaces with native Python 3 equivalents.

**21 files changed** | +49/-72

### Related Issue

Part of #4232 — Remove `six` compatibility library

### Type of Change

- [x] Refactor / cleanup

### Testing

- [x] Existing tests pass
- [x] Zero remaining `six` references in affected modules


### Checklist

- [x] Self-reviewed the code
- [x] No new warnings or errors introduced