### PR TITLE
refactor: remove six library from useful_scripts

### DIFF
--- a/esp/useful_scripts/add_lunches.py
+++ b/esp/useful_scripts/add_lunches.py
@@ -11,7 +11,6 @@ from esp.cal.models import Event
 from esp.program.models import Program, StudentRegistration, RegistrationType
 from esp.program.models.class_ import ClassSection
 from esp.users.models import ESPUser
-import six
 
 program = Program.objects.get(id=115)  # Change me! (Splash 2014)
 relationship = RegistrationType.objects.get(name='Enrolled')
@@ -53,7 +52,7 @@ for timeblock_id, section_id in lunches:
         lunchtimes_by_day[date].append(timeblock_id)
 
 for user in users:
-    for day, lunchtimes in six.iteritems(lunchtimes_by_day):
+    for day, lunchtimes in lunchtimes_by_day.items():
         # If the user has any lunch already, continue to the next day/user
         if any(sections_by_user_timeblock.get((user.id, lunchtime_id), 0)
                in lunch_ids for lunchtime_id in lunchtimes):

--- a/esp/useful_scripts/all_classes_ever.py
+++ b/esp/useful_scripts/all_classes_ever.py
@@ -1,5 +1,4 @@
 from esp.program.models import Program, ClassSubject
-from six.moves import map
 from io import open
 
 programs = Program.objects.order_by('id')

--- a/esp/useful_scripts/change-capacities-move-rooms-june-2013.py
+++ b/esp/useful_scripts/change-capacities-move-rooms-june-2013.py
@@ -15,7 +15,6 @@
 import csv
 from esp.program.models.class_ import ClassSubject
 from esp.resources.models import Resource
-from six.moves import map
 from io import open
 
 def makeChanges(filename,override=False):

--- a/esp/useful_scripts/check_conflicts.py
+++ b/esp/useful_scripts/check_conflicts.py
@@ -13,7 +13,6 @@
 # Step 4 takes much longer to run than the others (O(n^2) where n is the number of scheduled classes).
 
 from esp.program.models import ClassSubject, ClassSection, Program
-from six.moves import range
 
 program_name = '2011_Spring'  # change to your program
 program = Program.objects.get(anchor__name = program_name)

--- a/esp/useful_scripts/code_relicensing.py
+++ b/esp/useful_scripts/code_relicensing.py
@@ -3,7 +3,6 @@
 import re
 import os
 from io import open
-from six.moves import range
 
 direction = 'forward'
 #direction = 'backward'

--- a/esp/useful_scripts/csv_classroom_import.py
+++ b/esp/useful_scripts/csv_classroom_import.py
@@ -17,7 +17,6 @@ import os
 
 from datetime import datetime
 from io import open
-from six.moves import input
 
 ETYPE_CLASSBLOCK = EventType.objects.get(description='Class Time Block')
 RTYPE_CLASSROOM = ResourceType.get_or_create('Classroom')

--- a/esp/useful_scripts/csv_fresh_classroom_import.py
+++ b/esp/useful_scripts/csv_fresh_classroom_import.py
@@ -17,9 +17,7 @@ import re
 import argparse
 
 from datetime import datetime
-import six
 from io import open
-from six.moves import input
 
 
 ETYPE_CLASSBLOCK = EventType.objects.get(description='Class Time Block')
@@ -121,7 +119,7 @@ def do_match(items_to_match, possible_options, description,
             matching_idx[item] = match_attempt
         print("We have the following matchings:")
         print(matching_idx)
-        for item, match_idx in six.iteritems(matching_idx):
+        for item, match_idx in matching_idx.items():
             match_name = None if match_idx is None else \
                 possible_options[match_idx]
             print("{}: {} ({})".format(item, match_name, match_idx))
@@ -151,8 +149,8 @@ for rtype in RESOURCE_TYPES:
             resource_value_matching[rtype.name] = {
                     known: (possible_values[idx] if idx is not None else "")
                     for known, idx in
-                    six.iteritems(do_match(
-                        known_values, possible_values, rtype.name))}
+                    do_match(
+                        known_values, possible_values, rtype.name).items()}
 
 
 def parse_time(date, time):

--- a/esp/useful_scripts/deduplicate_classrooms.py
+++ b/esp/useful_scripts/deduplicate_classrooms.py
@@ -5,7 +5,6 @@
 #
 
 from script_setup import *
-from six.moves import input
 
 ETYPE_CLASSBLOCK = EventType.objects.get(description='Class Time Block')
 RTYPE_CLASSROOM = ResourceType.get_or_create('Classroom')

--- a/esp/useful_scripts/disable_users.py
+++ b/esp/useful_scripts/disable_users.py
@@ -2,7 +2,6 @@
 # Given a list of email addresses, disable the corresponding user accounts.
 
 from script_setup import *
-from six.moves import input
 
 def yn(prompt):
     print(prompt, end=' ')

--- a/esp/useful_scripts/export_all_surveys.py
+++ b/esp/useful_scripts/export_all_surveys.py
@@ -5,7 +5,6 @@ from esp.program.models import Program, ClassSubject, ClassSection
 from datetime import datetime, date, time
 
 from django.contrib.contenttypes.models import ContentType
-import six
 from functools import reduce
 
 try:
@@ -166,7 +165,7 @@ def auto_cell_type(val):
         pass
 
     # Give up; not a type that Excel likes
-    val = six.text_type(val)
+    val = str(val)
 
     # Are we something that looks like a boolean?
     if val.upper() in ("TRUE", "FALSE", "T", "F"):

--- a/esp/useful_scripts/formstack_download.py
+++ b/esp/useful_scripts/formstack_download.py
@@ -14,7 +14,6 @@ import json
 import pycurl
 import sys
 from io import open
-from six.moves import input
 
 SUBMISSIONS_PER_PAGE = 100
 #  when enumerating form submissions, the maximum number of metadatas

--- a/esp/useful_scripts/get_emails.py
+++ b/esp/useful_scripts/get_emails.py
@@ -1,7 +1,6 @@
 import datetime
 import numpy as np
 from esp.dbmail.models import TextOfEmail
-from six.moves import map
 from io import open
 msgs = [x['sent'] for x in TextOfEmail.objects.values('sent') if x is not None and x['sent'] is not None]
 to_timestamp = np.vectorize(lambda x: (x - datetime.datetime(1970, 1, 1)).total_seconds())

--- a/esp/useful_scripts/increase_caps.py
+++ b/esp/useful_scripts/increase_caps.py
@@ -6,7 +6,6 @@
 from script_setup import *
 
 from esp.dbmail.models import send_mail
-from six.moves import input
 
 program = Program.objects.get(url='Splash/2015')
 

--- a/esp/useful_scripts/merging_sep6.py
+++ b/esp/useful_scripts/merging_sep6.py
@@ -11,7 +11,6 @@ FILTERING: Only student-only accounts with valid names and DOBs are considered f
 from esp.users.models import *
 from esp.users.models.forwarder import *
 from esp.program.models import *
-import six
 
 def get_dob(user):
     try:
@@ -40,7 +39,7 @@ def get_duplicate_users():
     for user in users:
         #   Only consider users that are only students (hence skipping teachers and admins).
         ut = user.getUserTypes()
-        if not (len(ut) == 1 and ut[0] == six.u('Student')):
+        if not (len(ut) == 1 and ut[0] == 'Student'):
             continue
 
         num_students += 1

--- a/esp/useful_scripts/mitalert.py
+++ b/esp/useful_scripts/mitalert.py
@@ -8,7 +8,6 @@ import csv
 import re
 import sys
 from io import open
-from six.moves import input
 
 prog = Program.objects.get(url=input("Program URL (e.g. Spark/2014): "))
 rawfile = open(os.path.expanduser(input("Output CSV: ")), "wb")

--- a/esp/useful_scripts/onsite_apr17.py
+++ b/esp/useful_scripts/onsite_apr17.py
@@ -4,7 +4,6 @@ from esp.users.models import *
 
 import string
 from io import open
-from six.moves import range
 
 def ascii_sanitize(s):
     return [x for x in s if x in string.printable]

--- a/esp/useful_scripts/register_users/register_user.py
+++ b/esp/useful_scripts/register_users/register_user.py
@@ -3,7 +3,6 @@ import random
 
 from twill.commands import *
 from generators import *
-from six.moves import range
 
 base_host = 'http://dev2.learningu.org'
 splash_name = 'Splash/2011_Spring'

--- a/esp/useful_scripts/schools_apr7.py
+++ b/esp/useful_scripts/schools_apr7.py
@@ -1,5 +1,4 @@
 from esp.program.models import *
-import six
 
 splash = Program.objects.get(id=2)
 
@@ -18,7 +17,7 @@ for student in students:
 
 schools = list(school_dict.keys())
 def school_key(school):
-    if isinstance(school, six.string_types):
+    if isinstance(school, str):
         return school.lower()
     else:
         return 'N/A'

--- a/esp/useful_scripts/total_donation.py
+++ b/esp/useful_scripts/total_donation.py
@@ -1,6 +1,5 @@
 from esp.accounting.controllers import ProgramAccountingController
 from esp.program.models import Program
-from six.moves import input
 
 
 def get_donation_total(prog_name):

--- a/esp/useful_scripts/unenroll_students.py
+++ b/esp/useful_scripts/unenroll_students.py
@@ -13,7 +13,6 @@ from esp.program.models import Program, StudentRegistration, RegistrationType
 from esp.users.models import ESPUser
 from datetime import datetime, timedelta
 from django.db.models.aggregates import Min
-from six.moves import input
 
 parser = argparse.ArgumentParser(description='Unenroll missing students from classes.')
 parser.add_argument('program_id', type=int, help='ID of the current program')


### PR DESCRIPTION
### Description

Remove all `six` library usage from the `useful_scripts/` directory. Primarily removes `from six.moves import input/range` and a few `six.string_types`/`six.iteritems` calls.

**20 files changed** | +7/-28

### Related Issue

Part of #4232 — Remove `six` compatibility library

### Type of Change

- [x] Refactor / cleanup

### Testing

- [x] Zero remaining `six` references in `esp/useful_scripts/`


### Checklist

- [x] Self-reviewed the code
- [x] No new warnings or errors introduced
