### PR TITLE
Fix _get_capacity TypeError on None (class_size_max / room cap)

### DIFF
--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -457,7 +457,7 @@ class ClassSection(models.Model):
                 opt = self.parent_class.class_size_optimal
                 room_cap = self._get_room_capacity(rooms)
                 upper = self._max_none_safe(range_max, opt)
-                ans = self._min_none_safe(upper, room_cap) if upper is not None or room_cap is not None else ans
+                ans = self._min_none_safe(upper, room_cap)
             elif self.parent_class.class_size_optimal and len(rooms) != 0:
                 opt = self.parent_class.class_size_optimal
                 room_cap = self._get_room_capacity(rooms)


### PR DESCRIPTION
Fixes #3801

Avoids comparing None with int in `ClassSection._get_capacity` by using `small _min_none_safe` / `_max_none_safe` helpers and normalizing ans to 0 when still None before applying the multiplier. Fixes catalog (and other capacity use) raising `TypeError` when `class_size_max` or room capacity is missing.