### PR TITLE
Fix: FixIEMiddleware crash on Django 2.2

### DIFF
--- a/esp/esp/middleware/fixiemiddleware.py
+++ b/esp/esp/middleware/fixiemiddleware.py
@@ -31,7 +31,14 @@ class FixIEMiddleware(MiddlewareMixin):
 
 
         # IE will break
-        if response.mimetype.lower() not in safe_mime_types:
+        try:
+            content_type = response['Content-Type']
+        except KeyError:
+            return response
+
+        content_type = content_type.split(';', 1)[0].strip().lower()
+
+        if content_type not in safe_mime_types:
             try:
                 del response['Vary']
                 response['Pragma'] = 'no-cache'
@@ -40,4 +47,3 @@ class FixIEMiddleware(MiddlewareMixin):
                 return response
 
         return response
-

--- a/esp/esp/middleware/tests.py
+++ b/esp/esp/middleware/tests.py
@@ -1,0 +1,34 @@
+from __future__ import absolute_import
+
+from django.http import HttpResponse
+from django.test import TestCase, RequestFactory
+
+from esp.middleware.fixiemiddleware import FixIEMiddleware
+
+
+class FixIEMiddlewareTest(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.middleware = FixIEMiddleware()
+
+    def test_ie_user_agent_does_not_crash_for_default_html(self):
+        request = self.factory.get("/", HTTP_USER_AGENT="Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1)")
+        response = HttpResponse("ok")
+
+        result = self.middleware.process_response(request, response)
+
+        self.assertEqual(result.status_code, 200)
+        self.assertEqual(result.content, b"ok")
+
+    def test_ie_user_agent_strips_vary_for_unsafe_content_type(self):
+        request = self.factory.get("/", HTTP_USER_AGENT="Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1)")
+        response = HttpResponse("ok", content_type="application/json; charset=utf-8")
+        response["Vary"] = "User-Agent"
+
+        result = self.middleware.process_response(request, response)
+
+        self.assertEqual(result.status_code, 200)
+        self.assertNotIn("Vary", result)
+        self.assertEqual(result["Pragma"], "no-cache")
+        self.assertEqual(result["Cache-Control"], "no-cache, must-revalidate")
+


### PR DESCRIPTION
## Summary

`FixIEMiddleware` currently assumes that `HttpResponse` instances have a `mimetype` attribute. That attribute was removed in Django 2.2, so for IE-style user agents the middleware calls `response.mimetype.lower()` and raises an `AttributeError`, returning a 500 instead of the expected page.

This PR replaces the use of `response.mimetype` with logic based on the standard `Content-Type` header and adds a small regression test to cover this behavior.

Fixes #4236.

---

## Changes

1. **Update FixIEMiddleware to use Content-Type**

   File: `esp/esp/middleware/fixiemiddleware.py`

   - Stop calling `response.mimetype.lower()`.
   - Read `response['Content-Type']`, strip any parameters (e.g. `; charset=utf-8`), and compare the normalized MIME type (lowercased, without parameters) against the existing `safe_mime_types` tuple.
   - If `Content-Type` is missing for some reason, bail out and return the response unchanged instead of raising.

   This keeps the original intent of the middleware (only certain MIME types are “Vary-safe” for IE) while making it compatible with Django 2.2’s `HttpResponse` API.

2. **Add regression tests for FixIEMiddleware**

   File: `esp/esp/middleware/tests.py`

   - `test_ie_user_agent_does_not_crash_for_default_html`  
     - Uses `RequestFactory` with an IE-style `User-Agent` and a simple `HttpResponse("ok")`.
     - Verifies that `FixIEMiddleware.process_response` returns a 200 response and does not alter the content.
   - `test_ie_user_agent_strips_vary_for_unsafe_content_type`  
     - Uses an IE-style `User-Agent` with an `application/json; charset=utf-8` response and an existing `Vary: User-Agent` header.
     - Verifies that the middleware removes `Vary` and sets `Pragma: no-cache` and `Cache-Control: no-cache, must-revalidate`, matching the original intent.

The tests are intentionally narrow and only exercise the behavior described in #4236.

---

## Rationale

- Django 2.2 removed the `mimetype` attribute from `HttpResponse`, but the middleware was still relying on it.
- Using the `Content-Type` header directly is the recommended and stable way to inspect the response’s MIME type.
- The change is minimal (one small block in the middleware), keeps the existing behavior for non-IE user agents, and only softens behavior in the unlikely case of missing `Content-Type` by doing nothing instead of throwing an error.

---

## Testing

Locally (with a working env):

```bash
cd esp
./manage.py test esp.middleware
```

Additionally, for a full check you can run the usual CI commands:

```bash
cd esp
./manage.py collectstatic --noinput -v 0
coverage run --source=. ./manage.py test
# and in the repo root:
deploy/lint
```

All new tests pass, and the middleware no longer crashes on Django 2.2 when handling IE-style `User-Agent` strings.