### PR TITLE
refactor: remove unnecessary __future__ imports from utils module

### DIFF
--- a/esp/esp/utils/__init__.py
+++ b/esp/esp/utils/__init__.py
@@ -8,7 +8,6 @@ The functions in this file are globally relevant, too annoying to inline,
     and too small to merit their own modules.
 """
 
-from __future__ import absolute_import
 import sys
 from six.moves.urllib.parse import quote_plus
 import six

--- a/esp/esp/utils/admin.py
+++ b/esp/esp/utils/admin.py
@@ -1,7 +1,6 @@
 
 """ Admin settings for esp.utils. """
 
-from __future__ import absolute_import
 from esp.utils.models import TemplateOverride, Printer, PrintRequest
 from esp.utils.admin_user_search import default_user_search
 

--- a/esp/esp/utils/apps.py
+++ b/esp/esp/utils/apps.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from django.apps import AppConfig
 from django.db.models import signals
 

--- a/esp/esp/utils/auth_backend.py
+++ b/esp/esp/utils/auth_backend.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from django.contrib.auth.backends import ModelBackend
 
 from esp.users.models import ESPUser

--- a/esp/esp/utils/cache_inclusion_tag.py
+++ b/esp/esp/utils/cache_inclusion_tag.py
@@ -1,5 +1,4 @@
 
-from __future__ import absolute_import
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"

--- a/esp/esp/utils/caches.py
+++ b/esp/esp/utils/caches.py
@@ -1,5 +1,4 @@
 # Make sure template override cache is registered
-from __future__ import absolute_import
 import esp.utils.template
 
 # Make sure all cached inclusion tags are registered

--- a/esp/esp/utils/debug_panels.py
+++ b/esp/esp/utils/debug_panels.py
@@ -1,5 +1,4 @@
 
-from __future__ import absolute_import
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"

--- a/esp/esp/utils/decorators.py
+++ b/esp/esp/utils/decorators.py
@@ -1,5 +1,4 @@
 
-from __future__ import absolute_import
 from six.moves import range
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"

--- a/esp/esp/utils/expirable_model.py
+++ b/esp/esp/utils/expirable_model.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"

--- a/esp/esp/utils/fields.py
+++ b/esp/esp/utils/fields.py
@@ -1,6 +1,5 @@
 """ Copied from: http://djangosnippets.org/snippets/1478/ """
 
-from __future__ import absolute_import
 from django.db import models
 from django.core.serializers.json import DjangoJSONEncoder
 import json

--- a/esp/esp/utils/formats.py
+++ b/esp/esp/utils/formats.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from django.utils.functional import lazy
 
 def format_lazy(string, substitution):

--- a/esp/esp/utils/forms.py
+++ b/esp/esp/utils/forms.py
@@ -1,5 +1,4 @@
 
-from __future__ import absolute_import
 import six
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"

--- a/esp/esp/utils/inclusion_tags.py
+++ b/esp/esp/utils/inclusion_tags.py
@@ -1,5 +1,4 @@
 
-from __future__ import absolute_import
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"

--- a/esp/esp/utils/latex.py
+++ b/esp/esp/utils/latex.py
@@ -1,5 +1,4 @@
 
-from __future__ import absolute_import
 from io import open
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"

--- a/esp/esp/utils/log.py
+++ b/esp/esp/utils/log.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import logging
 
 from django.conf import settings

--- a/esp/esp/utils/management/commands/clean_pyc.py
+++ b/esp/esp/utils/management/commands/clean_pyc.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from django.conf import settings
 from django.core.management.base import BaseCommand
 

--- a/esp/esp/utils/management/commands/flushcache.py
+++ b/esp/esp/utils/management/commands/flushcache.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from django.core.cache import cache
 from django.core.management.base import BaseCommand
 

--- a/esp/esp/utils/management/commands/install.py
+++ b/esp/esp/utils/management/commands/install.py
@@ -1,5 +1,4 @@
 
-from __future__ import absolute_import
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"

--- a/esp/esp/utils/management/commands/update.py
+++ b/esp/esp/utils/management/commands/update.py
@@ -1,5 +1,4 @@
 
-from __future__ import absolute_import
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"

--- a/esp/esp/utils/memcached_multikey.py
+++ b/esp/esp/utils/memcached_multikey.py
@@ -1,6 +1,5 @@
 "Memcached cache backend"
 
-from __future__ import absolute_import
 import logging
 logger = logging.getLogger(__name__)
 

--- a/esp/esp/utils/migrations/0001_initial.py
+++ b/esp/esp/utils/migrations/0001_initial.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 
-from __future__ import absolute_import
 from django.db import models, migrations
 import esp.db.fields
 

--- a/esp/esp/utils/models.py
+++ b/esp/esp/utils/models.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
 from django.utils.encoding import python_2_unicode_compatible
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"

--- a/esp/esp/utils/no_autocookie.py
+++ b/esp/esp/utils/no_autocookie.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from __future__ import absolute_import
 from functools import wraps
 
 def disable_csrf_cookie_update(fn):

--- a/esp/esp/utils/query_builder.py
+++ b/esp/esp/utils/query_builder.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import datetime
 import operator
 

--- a/esp/esp/utils/query_utils.py
+++ b/esp/esp/utils/query_utils.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from django.db.models.query_utils import Q
 from django.utils.tree import Node
 from django.db.models.constants import LOOKUP_SEP

--- a/esp/esp/utils/shell_utils.py
+++ b/esp/esp/utils/shell_utils.py
@@ -1,6 +1,5 @@
 '''Things that will be useful to have in shell_plus, which it will auto-import.'''
 
-from __future__ import absolute_import
 from django.db.models import F, Q, Count, Avg, Min, Max, Sum
 
 import datetime

--- a/esp/esp/utils/template.py
+++ b/esp/esp/utils/template.py
@@ -1,5 +1,4 @@
 
-from __future__ import absolute_import
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"

--- a/esp/esp/utils/templatetags/latex.py
+++ b/esp/esp/utils/templatetags/latex.py
@@ -1,6 +1,5 @@
 """ ESP Custom Filters for template """
 
-from __future__ import absolute_import
 import six
 from six.moves import range
 __author__    = "Individual contributors (see AUTHORS file)"
@@ -45,7 +44,6 @@ def texescape(value):
     """ This will escape a string according to the rules of LaTeX """
 
     value = six.text_type(value).strip()
-
 
 
     # we will make escape all the strings except those sandwiched between
@@ -99,8 +97,5 @@ def texescape(value):
     value = value.encode('ascii', 'ignore').decode('ascii')
 
     return value
-
-
-
 
 

--- a/esp/esp/utils/templatetags/markup.py
+++ b/esp/esp/utils/templatetags/markup.py
@@ -10,7 +10,6 @@ is only entered by "trusted" users.  The code is also simpler for us since we
 pin to a given version of markdown, and don't use markdown extensions.
 """
 
-from __future__ import absolute_import
 from django import template
 from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe

--- a/esp/esp/utils/templatetags/query_builder.py
+++ b/esp/esp/utils/templatetags/query_builder.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import random
 import json
 

--- a/esp/esp/utils/tests.py
+++ b/esp/esp/utils/tests.py
@@ -2,9 +2,7 @@
 Test cases for Django-ESP utilities
 """
 
-from __future__ import with_statement
 
-from __future__ import absolute_import
 import datetime
 import doctest
 from six.moves import map
@@ -453,6 +451,5 @@ def suite():
     # Add doctests from esp.utils.__init__.py
     s.addTest(doctest.DocTestSuite(utils))
     return s
-
 
 

--- a/esp/esp/utils/try_multi.py
+++ b/esp/esp/utils/try_multi.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from six.moves import range
 #!/usr/bin/env python
 
@@ -18,6 +17,5 @@ def try_multi(n_tries):
             return fn(*args, **kwargs)
         return retried_fn
     return try_multi_helper
-
 
 

--- a/esp/esp/utils/views.py
+++ b/esp/esp/utils/views.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from io import open
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"

--- a/esp/esp/utils/web.py
+++ b/esp/esp/utils/web.py
@@ -1,5 +1,4 @@
 
-from __future__ import absolute_import
 import six
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"

--- a/esp/esp/utils/widgets.py
+++ b/esp/esp/utils/widgets.py
@@ -2,7 +2,6 @@
 #   Modified to not force unicode
 #   - Michael P
 
-from __future__ import absolute_import
 from django import forms
 from django.conf import settings
 from django.forms import widgets


### PR DESCRIPTION
### Description

Remove unnecessary `__future__` imports from the `utils` module. These are all default behavior in Python 3.

**35 files changed** | -44 lines

### Related Issue

Part of #4241 — Remove unnecessary `__future__` imports

### Type of Change

- [x] Refactor / cleanup

### Testing

- [x] Existing tests pass
- [x] Zero remaining `__future__` imports in `esp/esp/utils/`

### Checklist

- [x] Self-reviewed the code
- [x] No new warnings or errors introduced
