### PR TITLE
refactor: remove unnecessary __future__ imports from useful_scripts

### DIFF
--- a/esp/useful_scripts/add_lunches.py
+++ b/esp/useful_scripts/add_lunches.py
@@ -3,8 +3,6 @@
 # Adds lunches in an empty block for users who don't have one.  Chooses the
 # lunch randomly for users with both lunch blocks free.
 
-from __future__ import absolute_import
-from __future__ import print_function
 from script_setup import *
 
 import random

--- a/esp/useful_scripts/all_classes_ever.py
+++ b/esp/useful_scripts/all_classes_ever.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from esp.program.models import Program, ClassSubject
 from six.moves import map
 from io import open

--- a/esp/useful_scripts/change-capacities-move-rooms-june-2013.py
+++ b/esp/useful_scripts/change-capacities-move-rooms-june-2013.py
@@ -12,8 +12,6 @@
 # Warning: if the class does not have a time set, this script will not assign it a room.
 #
 
-from __future__ import absolute_import
-from __future__ import print_function
 import csv
 from esp.program.models.class_ import ClassSubject
 from esp.resources.models import Resource

--- a/esp/useful_scripts/check_conflicts.py
+++ b/esp/useful_scripts/check_conflicts.py
@@ -12,8 +12,6 @@
 #
 # Step 4 takes much longer to run than the others (O(n^2) where n is the number of scheduled classes).
 
-from __future__ import absolute_import
-from __future__ import print_function
 from esp.program.models import ClassSubject, ClassSection, Program
 from six.moves import range
 
@@ -78,7 +76,5 @@ for i in range(0, numsections):
         if len(s2_used_resources) > 0:
             if s1_used_resources.intersection(s2_used_resources) != set():
                 print(str(s1.emailcode()) + ' and ' + str(s2.emailcode()) + ' are both using: ' + str([[x.name, x.event] for x in set(s1_used_resources).intersection(s2_used_resources)]))
-
-
 
 

--- a/esp/useful_scripts/code_relicensing.py
+++ b/esp/useful_scripts/code_relicensing.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import absolute_import
-from __future__ import print_function
 import re
 import os
 from io import open

--- a/esp/useful_scripts/crlf-merge-driver.py
+++ b/esp/useful_scripts/crlf-merge-driver.py
@@ -16,7 +16,6 @@
 #
 
 
-from __future__ import absolute_import
 import sys
 import subprocess
 from io import open

--- a/esp/useful_scripts/csv_classroom_import.py
+++ b/esp/useful_scripts/csv_classroom_import.py
@@ -10,8 +10,6 @@
 # choice. Note that the 'Sound system' resource should now be called 'Speakers'.
 #
 
-from __future__ import absolute_import
-from __future__ import print_function
 from script_setup import *
 
 import csv

--- a/esp/useful_scripts/csv_fresh_classroom_import.py
+++ b/esp/useful_scripts/csv_fresh_classroom_import.py
@@ -9,8 +9,6 @@
 #   Classroom: 1-115
 #
 
-from __future__ import absolute_import
-from __future__ import print_function
 from script_setup import EventType, ResourceType, Program, Event, Resource
 
 import csv

--- a/esp/useful_scripts/csv_student_payment.py
+++ b/esp/useful_scripts/csv_student_payment.py
@@ -7,8 +7,6 @@
 # (which contains student usernames or user ids). Any other columns will be ignored.
 #
 
-from __future__ import absolute_import
-from __future__ import print_function
 from script_setup import *
 
 from esp.program.models import Program

--- a/esp/useful_scripts/deduplicate_classrooms.py
+++ b/esp/useful_scripts/deduplicate_classrooms.py
@@ -4,8 +4,6 @@
 # and time).
 #
 
-from __future__ import absolute_import
-from __future__ import print_function
 from script_setup import *
 from six.moves import input
 

--- a/esp/useful_scripts/disable_users.py
+++ b/esp/useful_scripts/disable_users.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # Given a list of email addresses, disable the corresponding user accounts.
 
-from __future__ import absolute_import
-from __future__ import print_function
 from script_setup import *
 from six.moves import input
 

--- a/esp/useful_scripts/excitement_sep6.py
+++ b/esp/useful_scripts/excitement_sep6.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import division
 from esp.survey.models import *
 
 def get_excitement(question_id, threshold):

--- a/esp/useful_scripts/export_all_surveys.py
+++ b/esp/useful_scripts/export_all_surveys.py
@@ -1,6 +1,4 @@
 
-from __future__ import absolute_import
-from __future__ import print_function
 from collections import defaultdict
 from esp.survey.models import Answer, SurveyResponse, Survey
 from esp.program.models import Program, ClassSubject, ClassSection

--- a/esp/useful_scripts/extend_walkins.py
+++ b/esp/useful_scripts/extend_walkins.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import absolute_import
 from script_setup import *
 import sys
 

--- a/esp/useful_scripts/finaid_approve.py
+++ b/esp/useful_scripts/finaid_approve.py
@@ -5,8 +5,6 @@
 # Approves not-yet-approved requests where both answers are non-blank/None/whitespace
 # and prints the email address of these users to the screen.
 
-from __future__ import print_function
-from __future__ import absolute_import
 from script_setup import *
 
 from esp.program.models import FinancialAidRequest

--- a/esp/useful_scripts/finaid_autoapproved.py
+++ b/esp/useful_scripts/finaid_autoapproved.py
@@ -7,8 +7,6 @@
 # PROGRAM_ID before running.
 #
 
-from __future__ import absolute_import
-from __future__ import print_function
 from script_setup import *
 from esp.program.models import FinancialAidRequest
 

--- a/esp/useful_scripts/formstack_download.py
+++ b/esp/useful_scripts/formstack_download.py
@@ -10,8 +10,6 @@
 # directory and named cacert.pem - see http://curl.haxx.se/ca/cacert.pem
 #
 
-from __future__ import absolute_import
-from __future__ import print_function
 import json
 import pycurl
 import sys

--- a/esp/useful_scripts/get_chapter_classreg_stats.py
+++ b/esp/useful_scripts/get_chapter_classreg_stats.py
@@ -2,7 +2,6 @@
 
 Best run with run_queries.sh.
 """
-from __future__ import absolute_import
 import csv
 import logging
 

--- a/esp/useful_scripts/get_emails.py
+++ b/esp/useful_scripts/get_emails.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import datetime
 import numpy as np
 from esp.dbmail.models import TextOfEmail

--- a/esp/useful_scripts/get_tag_data.py
+++ b/esp/useful_scripts/get_tag_data.py
@@ -1,6 +1,5 @@
 """Script to get tags the site has set as JSON for later processing."""
 
-from __future__ import absolute_import
 from script_setup import *
 
 import json

--- a/esp/useful_scripts/increase_caps.py
+++ b/esp/useful_scripts/increase_caps.py
@@ -3,8 +3,6 @@
 # Find classes which capacity below the room capacity, and send the teacher an email asking if
 # they want to increase their class capacity to the room capacity
 
-from __future__ import absolute_import
-from __future__ import print_function
 from script_setup import *
 
 from esp.dbmail.models import send_mail

--- a/esp/useful_scripts/mailman_migration.py
+++ b/esp/useful_scripts/mailman_migration.py
@@ -12,8 +12,6 @@ corresponds to an active user on the website, and all associated user accounts
 are active, we add it to mailman.
 """
 
-from __future__ import absolute_import
-from __future__ import print_function
 from script_setup import *
 from esp import mailman
 from esp.users.models import ESPUser

--- a/esp/useful_scripts/merging_sep6.py
+++ b/esp/useful_scripts/merging_sep6.py
@@ -8,8 +8,6 @@ UNIQUENESS CRITERIA: (full name, date of birth)
 FILTERING: Only student-only accounts with valid names and DOBs are considered for merging.
 """
 
-from __future__ import absolute_import
-from __future__ import print_function
 from esp.users.models import *
 from esp.users.models.forwarder import *
 from esp.program.models import *

--- a/esp/useful_scripts/mitalert.py
+++ b/esp/useful_scripts/mitalert.py
@@ -2,8 +2,6 @@
 # Write student emergency contact information (name, email address and, if
 # known, cell number) to a CSV file.
 
-from __future__ import absolute_import
-from __future__ import print_function
 from script_setup import *
 
 import csv

--- a/esp/useful_scripts/onsite_apr17.py
+++ b/esp/useful_scripts/onsite_apr17.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-from __future__ import print_function
 from esp.program.models import *
 from esp.datatree.models import *
 from esp.users.models import *

--- a/esp/useful_scripts/oversubscribed.py
+++ b/esp/useful_scripts/oversubscribed.py
@@ -1,8 +1,6 @@
 #Exports as csv file with how oversubscribed a class is.
 # %run filename to run
 
-from __future__ import absolute_import
-from __future__ import division
 from esp.program.models import Program
 import csv
 from io import open

--- a/esp/useful_scripts/parents_apr15.py
+++ b/esp/useful_scripts/parents_apr15.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-from __future__ import print_function
 from esp.program.models import *
 from esp.dbmail.models import PlainRedirect
 from io import open

--- a/esp/useful_scripts/pqf_from_emails.py
+++ b/esp/useful_scripts/pqf_from_emails.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import absolute_import
-from __future__ import print_function
 from esp.users.models import User, ESPUser, PersistentQueryFilter
 from django.db.models.query import Q
 from io import open

--- a/esp/useful_scripts/program_modules_diff.py
+++ b/esp/useful_scripts/program_modules_diff.py
@@ -1,7 +1,5 @@
 """Script to check which programs have modified their ProgramModules."""
 
-from __future__ import absolute_import
-from __future__ import print_function
 from script_setup import *
 from esp.program.models import ProgramModule
 

--- a/esp/useful_scripts/register_users/generators.py
+++ b/esp/useful_scripts/register_users/generators.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import os
 import csv
 import random
@@ -77,8 +76,6 @@ def random_email(first, last):
     return '%s%s@%s' % (first.lower()[0],
                         last.lower(),
                         random.choice(email_domains))
-
-
 
 
 RandomClass = collections.namedtuple('RandomClass',

--- a/esp/useful_scripts/register_users/register_user.py
+++ b/esp/useful_scripts/register_users/register_user.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import datetime
 import random
 
@@ -10,7 +9,6 @@ base_host = 'http://dev2.learningu.org'
 splash_name = 'Splash/2011_Spring'
 
 people_generator = random_people('Teacher')
-
 
 
 def register_users():

--- a/esp/useful_scripts/schedule_check_sep30.py
+++ b/esp/useful_scripts/schedule_check_sep30.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import absolute_import
-from __future__ import print_function
 from esp.program.models import *
 
 splash=Program.objects.get(id=12)
@@ -16,8 +14,6 @@ for r in rooms:
     elif ct > 1:
         print('ERROR: %s at %s has conflict: %s' % (r.name, r.event.pretty_time(), r.resourceassignment_set.all().values_list('target', flat=True)))
         num_conflicts += 1
-
-
 
 
 print(' ')

--- a/esp/useful_scripts/scheduling_feb22.py
+++ b/esp/useful_scripts/scheduling_feb22.py
@@ -3,8 +3,6 @@
 """
 
 #   Run-specific stuff
-from __future__ import absolute_import
-from __future__ import print_function
 from io import open
 prog_id = 11
 filename = '/home/pricem/scheduling/scheduling_%d.txt' % prog_id

--- a/esp/useful_scripts/schools_apr7.py
+++ b/esp/useful_scripts/schools_apr7.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-from __future__ import print_function
 from esp.program.models import *
 import six
 

--- a/esp/useful_scripts/script_setup.py
+++ b/esp/useful_scripts/script_setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import absolute_import
 import os, sys
 from io import open
 

--- a/esp/useful_scripts/send_text_messages.py
+++ b/esp/useful_scripts/send_text_messages.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-from __future__ import print_function
 import sys
 from twilio.rest import Client
 

--- a/esp/useful_scripts/single_query.py
+++ b/esp/useful_scripts/single_query.py
@@ -5,8 +5,6 @@
 #            $0 /lu/sites/smith "$(cat script.py)"
 # Intended primarily to be used by run_queries.sh.
 
-from __future__ import absolute_import
-from __future__ import print_function
 import sys
 sys.path.insert(0, sys.argv[1]+'/esp/useful_scripts')
 

--- a/esp/useful_scripts/survey_apr7.py
+++ b/esp/useful_scripts/survey_apr7.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-from __future__ import print_function
 from esp.program.models import *
 from esp.survey.models import *
 from esp.datatree.models import *

--- a/esp/useful_scripts/survey_dump_nov18.py
+++ b/esp/useful_scripts/survey_dump_nov18.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-from __future__ import print_function
 from esp.program.models import *
 from esp.survey.models import *
 from esp.datatree.models import *

--- a/esp/useful_scripts/survey_load_nov18.py
+++ b/esp/useful_scripts/survey_load_nov18.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-from __future__ import print_function
 from esp.program.models import *
 from esp.survey.models import *
 from esp.datatree.models import *

--- a/esp/useful_scripts/total_donation.py
+++ b/esp/useful_scripts/total_donation.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-from __future__ import print_function
 from esp.accounting.controllers import ProgramAccountingController
 from esp.program.models import Program
 from six.moves import input

--- a/esp/useful_scripts/unenroll_students.py
+++ b/esp/useful_scripts/unenroll_students.py
@@ -4,8 +4,6 @@ Kick students out of their classes (or only next hour's classes, if the
 --per-hour option is used) if they haven't checked in yet.
 """
 
-from __future__ import absolute_import
-from __future__ import print_function
 import argparse
 
 from script_setup import *

--- a/esp/useful_scripts/unscheduled_nov9.py
+++ b/esp/useful_scripts/unscheduled_nov9.py
@@ -2,8 +2,6 @@
     that have students enrolled in them.
 """
 
-from __future__ import absolute_import
-from __future__ import print_function
 from esp.program.models import *
 
 splash = Program.objects.get(id=12)

--- a/esp/useful_scripts/zip_data.py
+++ b/esp/useful_scripts/zip_data.py
@@ -6,7 +6,6 @@ each zip code, with the number of students from that zip code at that program
 in the cell.
 """
 
-from __future__ import absolute_import
 from script_setup import *
 
 import collections


### PR DESCRIPTION
### Description

Remove unnecessary `__future__` imports from the `useful_scripts/` directory. These are all default behavior in Python 3.

**44 files changed** | -87 lines

### Related Issue

Part of #4241 — Remove unnecessary `__future__` imports

### Type of Change

- [x] Refactor / cleanup

### Testing

- [x] Zero remaining `__future__` imports in `esp/useful_scripts/`

### Checklist

- [x] Self-reviewed the code
- [x] No new warnings or errors introduced
