### PR TITLE
Add contrast toggle button to Jodit WYSIWYG editors (#2812)

### DIFF
--- a/esp/templates/inclusion/qsd/render_qsd.html
+++ b/esp/templates/inclusion/qsd/render_qsd.html
@@ -53,9 +53,24 @@ $j(document).ready(function() {
 
 var editor = new Jodit("#qsd_content_{{ qsdrec.edit_id }}", {
   "enter": "BR",
-  "buttons": "source,|,bold,strikethrough,underline,italic,|,superscript,subscript,|,ul,ol,outdent,indent,align,|,font,fontsize,brush,paragraph,|,image,video,table,link,hr,|,undo,redo,cut,eraser,copyformat,|,symbol,fullsize,selectall",
+  "buttons": "source,|,bold,strikethrough,underline,italic,|,superscript,subscript,|,ul,ol,outdent,indent,align,|,font,fontsize,brush,paragraph,|,image,video,table,link,hr,|,undo,redo,cut,eraser,copyformat,|,symbol,fullsize,selectall,|",
   "toolbarAdaptive": false,
   "saveModeInStorage": true,
+  extraButtons: [
+    {
+      name: 'contrastToggle',
+      icon: 'eye',
+      tooltip: 'Toggle dark/light editor background',
+      exec: function(ed) {
+        var area = ed.editor;
+        if (area.style.backgroundColor === 'rgb(51, 51, 51)') {
+          area.style.backgroundColor = '';
+        } else {
+          area.style.backgroundColor = '#333333';
+        }
+      },
+    }
+  ],
 });
 </script>
 <br />

--- a/esp/templates/program/modules/commmodule/step2.html
+++ b/esp/templates/program/modules/commmodule/step2.html
@@ -125,6 +125,19 @@ var editor = new Jodit("#emailbody", {
         editor.selection.insertHTML(key);
     },
       tooltip: "Insert a template tag",
+    },
+    {
+      name: 'contrastToggle',
+      icon: 'eye',
+      tooltip: 'Toggle dark/light editor background',
+      exec: function(ed) {
+        var area = ed.editor;
+        if (area.style.backgroundColor === 'rgb(51, 51, 51)') {
+          area.style.backgroundColor = '';
+        } else {
+          area.style.backgroundColor = '#333333';
+        }
+      },
     }
   ],
 });

--- a/esp/templates/qsd/qsd_edit.html
+++ b/esp/templates/qsd/qsd_edit.html
@@ -67,9 +67,24 @@ var commandBar = new TinyMDE.CommandBar({element: 'tinymde_commandbar', editor: 
 {% else %}
 var editor = new Jodit("#qsd_content", {
   "enter": "BR",
-  "buttons": "source,|,bold,strikethrough,underline,italic,|,superscript,subscript,|,ul,ol,outdent,indent,align,|,font,fontsize,brush,paragraph,|,image,video,table,link,hr,|,undo,redo,cut,eraser,copyformat,|,symbol,fullsize,selectall",
+  "buttons": "source,|,bold,strikethrough,underline,italic,|,superscript,subscript,|,ul,ol,outdent,indent,align,|,font,fontsize,brush,paragraph,|,image,video,table,link,hr,|,undo,redo,cut,eraser,copyformat,|,symbol,fullsize,selectall,|",
   "toolbarAdaptive": false,
   "saveModeInStorage": true,
+  extraButtons: [
+    {
+      name: 'contrastToggle',
+      icon: 'eye',
+      tooltip: 'Toggle dark/light editor background',
+      exec: function(ed) {
+        var area = ed.editor;
+        if (area.style.backgroundColor === 'rgb(51, 51, 51)') {
+          area.style.backgroundColor = '';
+        } else {
+          area.style.backgroundColor = '#333333';
+        }
+      },
+    }
+  ],
 });
 {% endif %}
 


### PR DESCRIPTION
## Summary
Fixes #2812

Adds a dark/light background toggle button (eye icon) to all Jodit WYSIWYG editors. This allows chapters with light-colored text to see their content while editing.

## Changes
- Added a `contrastToggle` extra button to the Jodit toolbar in:
  - `esp/templates/inclusion/qsd/render_qsd.html` (inline QSD editor)
  - `esp/templates/qsd/qsd_edit.html` (QSD page editor)
  - `esp/templates/program/modules/commmodule/step2.html` (comm panel)
- Clicking the eye icon toggles the editor background between white and dark gray (#333333)
- Clicking again returns to the default white background

## How it works
- Uses Jodit's `extraButtons` API to add a custom toolbar button
- Toggles the editor area's `backgroundColor` inline style
- No changes to saved content — purely a visual aid while editing

## Test plan
- [ ] Open a QSD editable page, click to edit, verify eye icon appears in toolbar
- [ ] Click eye icon — editor background should turn dark gray
- [ ] Click again — background returns to white
- [ ] Verify comm panel (step 2) eye icon works the same
- [ ] Verify saved content is not affected by toggle state

## Known limitation
When the dark background is active, text without explicit color styling (default black text) 
will not be visible. This is expected — the toggle is designed for chapters that use 
light-colored text on dark backgrounds (the original issue). A future improvement could 
invert the default text color as well.