### PR TITLE
Replace Raven with sentry-sdk for Sentry error reporting

### DIFF
--- a/esp/esp/settings.py
+++ b/esp/esp/settings.py
@@ -87,17 +87,9 @@ STATIC_ROOT = os.path.join(PROJECT_ROOT, STATIC_ROOT_DIR)
 # DisallowedHost errors and deprecation warnings don't go to email ever.
 # In scripts, we log to the console in a shorter format, to a separate log
 # file, and not to email or sentry.
-if SENTRY_DSN:
-    sentry_handler = {
-        'level': 'WARNING',
-        'filters': ['require_not_in_script'],
-        'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler',
-        'dsn': SENTRY_DSN,
-    }
-else:
-    sentry_handler = {
-        'class': 'logging.NullHandler',
-    }
+sentry_handler = {
+    'class': 'logging.NullHandler',
+}
 
 warnings.simplefilter("default", PendingDeprecationWarning)
 
@@ -250,16 +242,28 @@ if not getattr(tempfile, 'alreadytwiddled', False): # Python appears to run this
 CSRF_COOKIE_NAME = 'esp_csrftoken'
 
 if SENTRY_DSN:
-    # If SENTRY_DSN is set, send errors to Sentry via the Raven exception
-    # handler. Note that our exception middleware (i.e., ESPErrorMiddleware)
-    # will remain enabled and will receive exceptions before Raven does.
-    import raven
+    import logging
+    import sentry_sdk
+    from sentry_sdk.integrations.django import DjangoIntegration
+    from sentry_sdk.integrations.logging import LoggingIntegration
 
-    INSTALLED_APPS += (
-        'raven.contrib.django.raven_compat',
+    try:
+        import subprocess
+        release = subprocess.check_output(
+            ['git', 'rev-parse', 'HEAD'],
+            cwd=os.path.join(PROJECT_ROOT, '..'),
+            stderr=subprocess.DEVNULL,
+        ).decode('utf-8').strip()
+    except (subprocess.CalledProcessError, OSError, FileNotFoundError):
+        release = None
+
+    sentry_sdk.init(
+        dsn=SENTRY_DSN,
+        integrations=[
+            DjangoIntegration(),
+            LoggingIntegration(level=logging.INFO, event_level=logging.WARNING),
+        ],
+        release=release,
+        environment='development' if DEBUG else 'production',
     )
-    RAVEN_CONFIG = {
-        'dsn': SENTRY_DSN,
-        'release': raven.fetch_git_sha(os.path.join(PROJECT_ROOT, '..')),
-    }
 

--- a/esp/requirements.txt
+++ b/esp/requirements.txt
@@ -33,7 +33,7 @@ Pygments==2.10.0 # django-extensions dependency
 pylibmc==1.5.0 # Talks to memcached
 pytz==2015.4 # Required for timezone support
 # pywatchman # Makes dev servers auto-reload
-raven # Required for Sentry error reporting
+sentry-sdk[django,logging] # Required for Sentry error reporting
 setuptools==57.5.0 # For building packages from source; stripe and a few others don't work with v58+
 selenium==2.44.0 # Runs selenium tests which probably don't work anymore
 shortuuid==0.4.2 # django-extensions dependency


### PR DESCRIPTION
## Description

This PR replaces the deprecated Raven Sentry client with sentry-sdk.

Changes made:
- Replaced `raven` with `sentry-sdk[django,logging]` in requirements
- Removed Raven Django integration from installed apps
- Removed legacy `RAVEN_CONFIG` usage
- Updated Sentry setup to `sentry_sdk.init` with:
  - `DjangoIntegration` for exception capture
  - `LoggingIntegration` with INFO/WARNING levels to preserve warning+ event forwarding
- Kept release tagging using git SHA with safe fallback
- Added environment tagging (`development`/`production`)

## Related Issue

Closes #4143

## Type of Change

- [x] Refactor / cleanup
- [x] Dependency modernization

## Testing

- [x] Syntax check passed for settings update
- [x] Manual verification of configuration paths and imports
- [ ] Full test suite run

## Checklist

- [x] Self-reviewed the code
- [x] No unrelated files included in this PR