### PR TITLE
style:Add responsive CSS for BigBoard on tablets and mobile devices

### DIFF
--- a/esp/public/media/default_styles/bigboard.css
+++ b/esp/public/media/default_styles/bigboard.css
@@ -121,6 +121,7 @@
   .popular-classes-block {
     width: 100%;
     padding: 10px 15px;
+    box-sizing: border-box;
   }
 
   #highcharts-placeholder {
@@ -131,7 +132,8 @@
 /* Responsive: Phone (≤480px) */
 @media screen and (max-width: 480px) {
   .bigboard-number-block {
-    min-width: 100%;
+    width: 100%;
+    box-sizing: border-box;
     height: auto;
     padding: 6px 10px;
   }
@@ -180,6 +182,7 @@
   .popular-classes-block {
     width: 100%;
     padding: 5px 10px;
+    box-sizing: border-box;
   }
 
   .popular-classes-heading {


### PR DESCRIPTION
## Description
Add responsive CSS breakpoints to the BigBoard (Student Registration Big Board) 
for tablet and phone screens. The BigBoard currently uses hardcoded widths 
(300px, 250px, 400px) and has no media queries, causing layout overflow on 
mobile devices. This adds two breakpoints:
- **Tablet (≤768px):** Scaled-down stat blocks (75px→48px font), smaller gauges 
  (300px→200px), full-width charts
- **Phone (≤480px):** Stacked stat blocks (100% width), compact fonts (36px), 
  smaller gauges (140px), reduced margins
## Related Issue
Fixes #4278

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / cleanup
- [ ] CI/CD or build change
## Testing
- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified
Tested at 1280px (desktop), 768px (tablet), and 375px (phone) viewport widths. 
No horizontal overflow at any size. Existing desktop layout unchanged.

## Checklist
- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced