### PR TITLE
Feature/updatable module properties 1690

### DIFF
--- a/esp/esp/program/modules/models.py
+++ b/esp/esp/program/modules/models.py
@@ -57,15 +57,14 @@ def updateModules(update_data, overwriteExisting=False, deleteExtra=False, model
     mods = []
     global_defaults = {'seq': 0, 'required': False}
     for datum in update_data:
+        #   Remove non-model-field keys before any DB operations
+        datum.pop('main_call', None)
+        datum.pop('aux_calls', None)
         query_kwargs = {'handler': datum["handler"], 'module_type': datum["module_type"]}
         qs = model.objects.filter(**query_kwargs)
         if qs.exists():
             mods.append((datum, (qs[0], False)))
         else:
-            if 'main_call' in datum:
-                datum.pop('main_call')
-            if 'aux_calls' in datum:
-                datum.pop('aux_calls')
             #   Ensure that all of the required fields are present when calling get_or_create
             new_obj_defaults = global_defaults.copy()
             new_obj_defaults.update(datum)
@@ -85,7 +84,7 @@ def updateModules(update_data, overwriteExisting=False, deleteExtra=False, model
         for (datum, (mod, created)) in mods:
             ids.append(mod.id)
 
-        ProgramModule.objects.exclude(id__in=ids).delete()
+        model.objects.exclude(id__in=ids).delete()
 
     for (datum, (mod, created)) in mods:
         #   If the module exists but the provided data adds fields that
@@ -109,6 +108,6 @@ def install(model=None):
     for module in modules:
         table_data += module.module_properties_autopopulated()
 
-    updateModules(table_data, deleteExtra=True, model=model)
+    updateModules(table_data, overwriteExisting=True, deleteExtra=True, model=model)
 
 from esp.program.modules.module_ext import *


### PR DESCRIPTION
## Description

Since #4059, `link_title`, `seq`, and `required` are now editable on `ProgramModuleObj` (per-program customization). This means `ProgramModule` fields should just serve as code defaults and always be kept in sync with what developers define in `module_properties()`.

Previously, `install()` called `updateModules()` without `overwriteExisting`, so existing `ProgramModule` rows were never updated when developers changed defaults in code.

### Changes

- **Pass `overwriteExisting=True`** in `install()` so `ProgramModule` defaults always reflect the latest code
- **Fix `deleteExtra` bug**: used hardcoded `ProgramModule.objects` instead of `model.objects`, which would fail when called with a different model

## Related Issue

Closes #1690

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests passed (218 tests, 89 program/module tests all pass)
- [x] No new tests needed — the change is minimal and covered by existing `install()`/`updateModules()` usage

## AI Disclosure

No AI assistance.

## Checklist

- [x] Self-reviewed the code
- [x] No new warnings or errors introduced