### PR TITLE
Django data migration to clean up duplicate registration profiles

### DIFF
--- a/esp/esp/program/migrations/0033_cleanup_duplicate_registration_profiles.py
+++ b/esp/esp/program/migrations/0033_cleanup_duplicate_registration_profiles.py
@@ -74,7 +74,7 @@ def reverse_migration(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('program', '0030_auto_20260106_2204'),
+        ('program', '0032_auto_20260302_0348'),
     ]
 
     operations = [


### PR DESCRIPTION
This pull request adds a new Django data migration to clean up duplicate registration profiles in the `program` app. The migration identifies and deletes all but the most recent registration profile for each `(user, program)` pair, addressing a previous issue where multiple duplicate profiles were created for users.

**Database cleanup:**

* Added migration `0031_cleanup_duplicate_registration_profiles.py` to delete all duplicate `RegistrationProfile` entries, keeping only the most recent one per `(user, program)` pair. 
* Logic: Queries the database for all `(user_id, program_id)` pairs that have more than one `(RegistrationProfile)`. For each duplicate set, orders profiles by `(last_ts)` descending, with `(id)` as a tiebreaker. Retains only the first profile (most recently updated) as it contains the most current user information. Removes all older duplicate profiles for that user-program pair. Outputs the number of user-program pairs processed and total profiles deleted

## Related Issue

<!-- Link the relevant issue. Use "Closes #123" to auto-close on merge. -->

Closes #3846

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [ ] No new warnings or errors introduced

## Effect
### Before Running Migration
<img width="1565" height="924" alt="Screenshot from 2026-02-22 22-29-47" src="https://github.com/user-attachments/assets/8d71af3a-6b79-4369-8f36-a8d946a3c1ed" />

### After Running Migration
<img width="1533" height="909" alt="Screenshot from 2026-02-22 22-36-25" src="https://github.com/user-attachments/assets/91bf57cc-63fb-426d-9eb7-5bde174bdd0e" />
