### PR TITLE
Fix mismatched HTML tags in comm panel compose template

### DIFF
--- a/esp/templates/program/modules/commmodule/step2.html
+++ b/esp/templates/program/modules/commmodule/step2.html
@@ -52,7 +52,7 @@ Both email address fields also support named "mailboxes", such as "{{ default_fr
   <td>
   <label for="from">
   <strong>From:</strong>
-  <small>(If blank: {{ default_from }}</small>)</small>
+  <small>(If blank: {{ default_from }})</small>
   </label>
   <input type="text" size="30" name="from" id="from" value="{{from}}" pattern="(^.+@{{ current_site.domain|regexsite }}$)|(^.+<.+@{{ current_site.domain|regexsite }}>$)|(^.+@(\w+\.)?learningu\.org$)|(^.+<.+@(\w+\.)?learningu\.org>$)"/>
   <br /><br />


### PR DESCRIPTION
## Summary
Fixes #4318

## Problem
In `esp/templates/program/modules/commmodule/step2.html` line 55, the 'From' field label had:
```html
<small>(If blank: {{ default_from }}</small>)</small>
```

Two closing `</small>` tags but only one opening tag, with a closing parenthesis incorrectly placed outside the tag.

## Fix
Changed to:
```html
<small>(If blank: {{ default_from }})</small>
```

This ensures proper HTML structure and correct parenthesis placement.