### PR TITLE
Fix missing else clause in classes selection logic

### DIFF
--- a/esp/esp/program/views.py
+++ b/esp/esp/program/views.py
@@ -164,6 +164,7 @@ def lsr_submit(request, program=None):
             secid = parts[0]
             if reg_status:
                 classes_interest.add(int(secid))
+            else:
                 classes_no_interest.add(int(secid))
 
     errors = []


### PR DESCRIPTION
## Summary
Fixes #4320

## The Bug
In `lsr_submit()` function (`esp/esp/program/views.py`), when processing class registrations, the code was incorrectly adding section IDs to **both** `classes_interest` AND `classes_no_interest` when `reg_status` was truthy.

### Before (buggy):
```python
if reg_status:
    classes_interest.add(int(secid))
    classes_no_interest.add(int(secid))  # Wrong indentation - always executed
```

### After (fixed):
```python
if reg_status:
    classes_interest.add(int(secid))
else:
    classes_no_interest.add(int(secid))
```

## Impact
This mirrors the correct if/else pattern already used for `classes_flagged` vs `classes_not_flagged` in the same function (lines 159-162). The bug would cause students' interested classes to also be marked as "no interest" which could affect lottery placement.