### PR TITLE
Revert apt pip caching

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,22 +63,25 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache pip packages
-      id: pip-cache
       uses: actions/cache@v4
       with:
-        path: |
-          ~/.cache/pip
-          /usr/local/lib/python${{ matrix.python-version }}/dist-packages
+        path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('esp/requirements.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-${{ matrix.python-version }}-
+          ${{ runner.os }}-pip-
+    - name: Get apt packages list
+      if: ${{ matrix.ci_job == 'test' }}
+      id: apt-action
+      run: |
+        PKGS=$(cat esp/packages_base.txt | grep -v '^memcached' | grep -v '^postgres' | grep -v '^libpq-dev' | grep -v '^.*pip' | tr '\n' ' ')
+        echo "packages=$PKGS" >> $GITHUB_OUTPUT
     - name: Cache apt packages
-      uses: actions/cache@v4
+      if: ${{ matrix.ci_job == 'test' }}
+      uses: awalsh128/cache-apt-pkgs-action@latest
       with:
-        path: /var/cache/apt/archives/*.deb
-        key: ${{ runner.os }}-apt-${{ hashFiles('esp/packages_base.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-apt-
+        packages: ${{ steps.apt-action.outputs.packages }}
+        version: 1.0
     - name: Prepare for Installing Dependencies
       run: deploy/ci/before_install
       env:
@@ -87,7 +90,6 @@ jobs:
       env:
         CI_JOB: test
         PYTHON_VERSION: ${{ matrix.python-version }}
-        PIP_CACHE_HIT: ${{ steps.pip-cache.outputs.cache-hit }}
       run: deploy/ci/install
     - name: Prepare for Test
       env:

--- a/deploy/ci/before_script
+++ b/deploy/ci/before_script
@@ -1,14 +1,21 @@
 #!/bin/bash
 set -euf -o pipefail
 
-cp esp/esp/local_settings.py.ci esp/esp/local_settings.py
-ln -f -s `pwd`/esp/public/media/default_images esp/public/media/images
-ln -f -s `pwd`/esp/public/media/default_styles esp/public/media/styles
-# the postgres service in Github Actions sets up the database for us
-if [ "$GITHUB_ACTIONS" != true ]; then
-    psql -c "DROP DATABASE IF EXISTS test_test_django;" -U postgres
-    psql -c "DROP DATABASE IF EXISTS test_django;" -U postgres
-    psql -c "DROP ROLE IF EXISTS testuser;" -U postgres
-    psql -c "CREATE ROLE testuser PASSWORD 'testpassword' LOGIN CREATEDB;" -U postgres
-    psql -c "CREATE DATABASE test_django OWNER testuser;" -U postgres
+if [ "$CI_JOB" = "test" ]; then
+    cp esp/esp/local_settings.py.ci esp/esp/local_settings.py
+    ln -f -s `pwd`/esp/public/media/default_images esp/public/media/images
+    ln -f -s `pwd`/esp/public/media/default_styles esp/public/media/styles
+    # the postgres service in Github Actions sets up the database for us
+    if [ "$GITHUB_ACTIONS" != true ]; then
+        psql -c "DROP DATABASE IF EXISTS test_test_django;" -U postgres
+        psql -c "DROP DATABASE IF EXISTS test_django;" -U postgres
+        psql -c "DROP ROLE IF EXISTS testuser;" -U postgres
+        psql -c "CREATE ROLE testuser PASSWORD 'testpassword' LOGIN CREATEDB;" -U postgres
+        psql -c "CREATE DATABASE test_django OWNER testuser;" -U postgres
+    fi
+elif [ "$CI_JOB" = "lint" ]; then
+    :
+else
+    echo "Unknown CI_JOB: $CI_JOB"
+    exit 1
 fi

--- a/deploy/ci/install
+++ b/deploy/ci/install
@@ -1,12 +1,15 @@
 #!/bin/bash
 set -euf -o pipefail
 
-sudo apt-get remove -y libhashkit2 || true
-sudo apt-get install -y $(cat esp/packages_base.txt | grep -v ^memcached | grep -v ^postgres | grep -v ^libpq-dev | grep -v ^.*pip)
-# always run this — npm install is not covered by apt cache
-esp/packages_base_manual_install.sh
-
-if [ "${PIP_CACHE_HIT:-}" != "true" ]; then
+if [ "$CI_JOB" = "test" ]; then
+    sudo apt-get remove -y libhashkit2
+    sudo apt-get install -y $(cat esp/packages_base.txt | grep -v ^memcached | grep -v ^postgres | grep -v ^libpq-dev | grep -v ^.*pip)
+    esp/packages_base_manual_install.sh
     pip3 install -r esp/requirements.txt -q --log pip.log || (tail pip.log && exit 1)
     pip3 install coverage
+elif [ "$CI_JOB" = "lint" ]; then
+    pip3 install flake8
+else
+    echo "Unknown CI_JOB: $CI_JOB"
+    exit 1
 fi

--- a/esp/esp/program/modules/tests/testallviews.py
+++ b/esp/esp/program/modules/tests/testallviews.py
@@ -193,7 +193,7 @@ class AllViewsTest(ProgramFrameworkTest):
                     except Exception as e:
                         failed_modules[module_view]['GET event'] = f'{module_view} is throwing a {response.status_code} error:\n{e}'
                     try: # Use a user ID as the extra argument
-                        response = self.client.get('/' + tl + '/' + self.program.getUrlBase() + '/' + view + '/' + str(self.adminUser.id))
+                        response = self.client.get('/' + tl + '/' + self.program.getUrlBase() + '/' + view + '/' + self.adminUser.id)
                         if str(response.status_code)[:1] in ['2', '3']:
                             passes = True
                     except Exception as e:

--- a/esp/packages_base.txt
+++ b/esp/packages_base.txt
@@ -2,7 +2,6 @@ npm
 build-essential
 texlive
 texlive-latex-extra
-ghostscript
 imagemagick
 dvipng
 python3.7


### PR DESCRIPTION
## Description

All unit tests are currently failing, [for example here](https://github.com/learning-unlimited/ESP-Website/actions/runs/22295749059/job/64497232889?pr=4321), with django not installing.

```
Run deploy/ci/script
Traceback (most recent call last):
  File "./manage.py", line 27, in <module>
    from django.core.management import execute_from_command_line
ModuleNotFoundError: No module named 'django'
Error: Process completed with exit code 1.
```
Reverting #4316 and #4269 to see if it helps

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manually verified

## AI Disclosure

<!-- If you used AI tools for any part of this pull request, please disclose this here -->

## Checklist

- [ ] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [ ] No new warnings or errors introduced
