### PR TITLE
Replace unmaintained jquery.initialize with native MutationObserver

### DIFF
--- a/esp/public/media/scripts/onElementAdded.js
+++ b/esp/public/media/scripts/onElementAdded.js
@@ -1,0 +1,36 @@
+/**
+ * Observes the DOM for elements matching a CSS selector and calls a callback
+ * when they are added. Replaces the unmaintained jquery.initialize plugin
+ * using the native MutationObserver API.
+ *
+ * @param {string} selector - CSS selector to match
+ * @param {function} callback - Function called with each matching element as 'this'
+ * @param {Element} [target=document] - Root element to observe
+ * @returns {MutationObserver} The observer instance
+ */
+function onElementAdded(selector, callback, target) {
+    var root = target || document;
+    // Process any existing matching elements
+    root.querySelectorAll(selector).forEach(function(el) {
+        callback.call(el);
+    });
+    // Watch for new elements being added to the DOM
+    var observer = new MutationObserver(function(mutations) {
+        mutations.forEach(function(mutation) {
+            mutation.addedNodes.forEach(function(node) {
+                if (node.nodeType === 1) {
+                    if (node.matches && node.matches(selector)) {
+                        callback.call(node);
+                    }
+                    if (node.querySelectorAll) {
+                        node.querySelectorAll(selector).forEach(function(el) {
+                            callback.call(el);
+                        });
+                    }
+                }
+            });
+        });
+    });
+    observer.observe(root, { childList: true, subtree: true });
+    return observer;
+}

--- a/esp/public/media/scripts/program/modules/classsearch.js
+++ b/esp/public/media/scripts/program/modules/classsearch.js
@@ -45,9 +45,9 @@ function checkInput(inp){
 }
 
 //Set up choices if resource type already chosen on page load
-$j.initialize("input.qb-input", function() {
+onElementAdded("input.qb-input", function() {
     checkInput(this);
-}, { target: document.getElementsByClassName('query-builder')[0] });
+}, document.getElementsByClassName('query-builder')[0]);
 
 //Update choices when resource type is changed
 $j(document).on('change', 'select.qb-input', function() {

--- a/esp/public/media/scripts/program/modules/resources.js
+++ b/esp/public/media/scripts/program/modules/resources.js
@@ -51,7 +51,7 @@ function update_furnishing_choices(furnishing_select_obj, value) {
 }
 
 //Upon page load and dynamic creation of new selects
-$j.initialize("select", function() {
+onElementAdded("select", function() {
     //Selects start with (option) or (furnishing) by default, but we want to hide these as options in the dropdown.
     var opt = $j(this).find("option")[0];
     $j(opt).hide();
@@ -64,7 +64,7 @@ $j.initialize("select", function() {
         var value = $j('#id_furnishings-' + num + '-choice').val();
         update_furnishing_choices($j(this), value);
     }
-}, { target: document.getElementById('furnishing_formset') });
+}, document.getElementById('furnishing_formset'));
 
 //Whenever a new furnishing is selected, update the respective option field
 $j('.furnishing-dynamic-form select').change(function() {

--- a/esp/templates/inclusion/qsd/render_qsd.html
+++ b/esp/templates/inclusion/qsd/render_qsd.html
@@ -1,7 +1,6 @@
 <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/jodit/3.2.36/jodit.min.css">
 <script src="//cdnjs.cloudflare.com/ajax/libs/jodit/3.2.36/jodit.min.js"></script>
-<!--jQuery.initialize plugin is created to help maintain dynamically created elements on the page-->
-<script src="https://cdn.jsdelivr.net/gh/pie6k/jquery.initialize@eb28c24e2eef256344777b45a455173cba36e850/jquery.initialize.js"></script>
+<script src="/media/scripts/onElementAdded.js"></script>
 
 {% load markup %}
 <div class="qsd_header qsd_bits hidden" id="inline_edit_msg_{{ qsdrec.edit_id }}" onclick="qsd_inline_edit('{{ qsdrec.url }}', '{{ qsdrec.edit_id }}');">
@@ -44,7 +43,7 @@ $j(document).ready(function() {
     $j(".qsd_view_visible").removeClass("qsd_view_visible");
   }
   
-  $j.initialize(".jodit_toolbar_btn-image input[name=url]", function() {
+  onElementAdded(".jodit_toolbar_btn-image input[name=url]", function() {
     if ($j(this).next().is("input")) {
       $j(this).after("Upload files <a href='/admin/filebrowser/browse/' target='_blank'>here");
     }

--- a/esp/templates/inclusion/qsd/render_qsd_md.html
+++ b/esp/templates/inclusion/qsd/render_qsd_md.html
@@ -1,8 +1,7 @@
 <script src="https://unpkg.com/tiny-markdown-editor/dist/tiny-mde.min.js"></script>
 <link rel="stylesheet" type="text/css" href="https://unpkg.com/tiny-markdown-editor/dist/tiny-mde.min.css"/>
 
-<!--jQuery.initialize plugin is created to help maintain dynamically created elements on the page-->
-<script src="https://cdn.jsdelivr.net/gh/pie6k/jquery.initialize@eb28c24e2eef256344777b45a455173cba36e850/jquery.initialize.js"></script>
+<script src="/media/scripts/onElementAdded.js"></script>
 
 {% load markup %}
 <div class="qsd_header qsd_bits hidden" id="inline_edit_msg_{{ qsdrec.edit_id }}" onclick="qsd_inline_edit('{{ qsdrec.url }}', '{{ qsdrec.edit_id }}');">
@@ -48,7 +47,7 @@ $j(document).ready(function() {
     $j(".qsd_view_visible").removeClass("qsd_view_visible");
   }
   
-  $j.initialize(".jodit_toolbar_btn-image input[name=url]", function() {
+  onElementAdded(".jodit_toolbar_btn-image input[name=url]", function() {
     if ($j(this).next().is("input")) {
       $j(this).after("Upload files <a href='/admin/filebrowser/browse/' target='_blank'>here");
     }

--- a/esp/templates/program/modules/classsearchmodule/class_search.html
+++ b/esp/templates/program/modules/classsearchmodule/class_search.html
@@ -22,8 +22,7 @@
     <script type="text/jsx" src="/media/scripts/query-builder.jsx"></script>
     <script type="text/javascript" src="/media/scripts/program/modules/flag-results-page.js"></script>
     <script type="text/javascript" src="/media/scripts/program/modules/flag-edit.js"></script>
-    <!--jQuery.initialize plugin is created to help maintain dynamically created elements on the page-->
-    <script src="https://cdn.jsdelivr.net/gh/pie6k/jquery.initialize@eb28c24e2eef256344777b45a455173cba36e850/jquery.initialize.js"></script>
+    <script src="/media/scripts/onElementAdded.js"></script>
     <script id="classsearchscript" src="/media/scripts/program/modules/classsearch.js" data-prog_url="{{ program.url }}"></script>
 {% endblock %}
 

--- a/esp/templates/program/modules/resourcemodule/resource_main.html
+++ b/esp/templates/program/modules/resourcemodule/resource_main.html
@@ -11,8 +11,7 @@
 {% block xtrajs %}
     <!--This branch has a fix for when formsets are originally hidden-->
     <script src="https://cdn.jsdelivr.net/gh/elo80ka/django-dynamic-formset@f5f68c818953ddf43ffa7cb2e9aa391c3d4dfb47/src/jquery.formset.js"></script>
-    <!--jQuery.initialize plugin is created to help maintain dynamically created elements on the page-->
-    <script src="https://cdn.jsdelivr.net/gh/pie6k/jquery.initialize@eb28c24e2eef256344777b45a455173cba36e850/jquery.initialize.js"></script>
+    <script src="/media/scripts/onElementAdded.js"></script>
 {% endblock %}
 
 {% block content %}

--- a/esp/templates/qsd/qsd_edit.html
+++ b/esp/templates/qsd/qsd_edit.html
@@ -18,8 +18,7 @@
 {% else %}
 <script src="//cdnjs.cloudflare.com/ajax/libs/jodit/3.2.36/jodit.min.js"></script>
 {% endif %}
-<!--jQuery.initialize plugin is created to help maintain dynamically created elements on the page-->
-<script src="https://cdn.jsdelivr.net/gh/pie6k/jquery.initialize@eb28c24e2eef256344777b45a455173cba36e850/jquery.initialize.js"></script>
+<script src="/media/scripts/onElementAdded.js"></script>
 {% endblock %}
 
 
@@ -74,7 +73,7 @@ var editor = new Jodit("#qsd_content", {
 {% endif %}
 
 $j(document).ready(function() {
-  $j.initialize(".jodit_toolbar_btn-image input[name=url]", function() {
+  onElementAdded(".jodit_toolbar_btn-image input[name=url]", function() {
     $j(this).after("Upload files <a href='/admin/filebrowser/browse/' target='_blank'>here");
   });
 });


### PR DESCRIPTION
Fixes #4323
## Summary
- Removed the `jquery.initialize` plugin which was loaded from an unpinned GitHub commit URL and caused known browser console errors (referenced in #2745)
- Added a lightweight `onElementAdded()` utility using the native `MutationObserver` API
- Updated all 5 call sites across 7 files

## Changes
- New file: `esp/public/media/scripts/onElementAdded.js` — MutationObserver-based utility that replicates `$.initialize()` behavior
- Updated templates (removed CDN script tag, replaced `$j.initialize` calls):
  - `esp/templates/qsd/qsd_edit.html`
  - `esp/templates/inclusion/qsd/render_qsd.html`
  - `esp/templates/inclusion/qsd/render_qsd_md.html`
  - `esp/templates/program/modules/resourcemodule/resource_main.html`
  - `esp/templates/program/modules/classsearchmodule/class_search.html`
- Updated JS files (replaced `$j.initialize` calls):
  - `esp/public/media/scripts/program/modules/resources.js`
  - `esp/public/media/scripts/program/modules/classsearch.js`

## Test plan
- [ ] Edit a QSD page as admin — verify "Upload files here" link appears in the Jodit image dialog
- [ ] Edit a markdown QSD page — verify same behavior
- [ ] Manage Resources page — verify furnishing formset select elements initialize correctly when adding new rows
- [ ] Class Search page — verify resource type query builder inputs initialize correctly
- [ ] Check browser console for absence of jquery.initialize errors
