### PR TITLE
Fix IndexError in StatisticsQueryForm when no programs exist

### DIFF
--- a/esp/esp/program/forms.py
+++ b/esp/esp/program/forms.py
@@ -279,7 +279,10 @@ class StatisticsQueryForm(forms.Form):
         super().__init__(*args, **kwargs)
 
         self.fields['program_type'].choices = StatisticsQueryForm.get_program_type_choices()
-        self.fields['program_instances'].choices = StatisticsQueryForm.get_program_instance_choices(self.fields['program_type'].choices[0][0])
+        if self.fields['program_type'].choices:
+            self.fields['program_instances'].choices = StatisticsQueryForm.get_program_instance_choices(self.fields['program_type'].choices[0][0])
+        else:
+            self.fields['program_instances'].choices = []
 
         school_choices = StatisticsQueryForm.get_school_choices()
         if len(school_choices) > 0:


### PR DESCRIPTION
## Description

Visiting `/manage/statistics/` on a site with an empty database (no programs)
raises an `IndexError: list index out of range`.

`get_program_type_choices()` returns `[]` when no programs exist.
The next line accesses `choices[0][0]` without checking if the list is empty.

**Fix:** Guard against the empty list before accessing index 0.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor/cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## Screenshot after fix
<img width="1803" height="1096" alt="fix indexerror" src="https://github.com/user-attachments/assets/9caf2673-3d9a-4ec3-a551-a365e78e2137" />

## AI Disclosure

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [X] No new warnings or errors introduced

## Related Issue

Closes #4338 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor/cleanup
- [ ] CI/CD or build change


