### PR TITLE
Comm panel template selector UI

### DIFF
--- a/esp/esp/program/modules/handlers/commmodule.py
+++ b/esp/esp/program/modules/handlers/commmodule.py
@@ -43,9 +43,11 @@ from esp.dbmail.models import ActionHandler
 from esp.tagdict.models import Tag
 from django.template import Template
 from django.template import Context as DjangoContext
+from django.template import TemplateDoesNotExist
 from django.template.loader import render_to_string
 from esp.middleware import ESPError
 
+import os
 import re
 
 class CommModule(ProgramModuleObj):
@@ -64,6 +66,79 @@ class CommModule(ProgramModuleObj):
             "seq": 10,
             "choosable": 1,
             }
+
+    EMAIL_TEMPLATE_DATA = {
+        'default': {
+            'display_name': 'Default',
+            'description': 'Standard layout with footer and unsubscribe details.',
+            'preview_style': 'default',
+        },
+        'minimal': {
+            'display_name': 'Minimal',
+            'description': 'Simpler layout with a short unsubscribe footer.',
+            'preview_style': 'minimal',
+        },
+    }
+    EMAIL_TEMPLATE_KEY_RE = re.compile(r'^[A-Za-z0-9_-]+$')
+
+    @classmethod
+    def _discover_email_template_keys(cls):
+        from django.conf import settings
+        from esp.utils.models import TemplateOverride
+
+        keys = set()
+        templates_path = os.path.join(settings.PROJECT_ROOT, 'templates', 'email')
+        if os.path.isdir(templates_path):
+            for name in os.listdir(templates_path):
+                if name.endswith('_email.html'):
+                    key = name[:-11]
+                    if cls.EMAIL_TEMPLATE_KEY_RE.match(key):
+                        keys.add(key)
+
+        override_names = TemplateOverride.objects.filter(
+            name__startswith='email/',
+            name__endswith='_email.html',
+        ).values_list('name', flat=True).distinct()
+        for override_name in override_names:
+            file_name = os.path.basename(override_name)
+            key = file_name[:-11]
+            if cls.EMAIL_TEMPLATE_KEY_RE.match(key):
+                keys.add(key)
+
+        # Keep default available even if it was accidentally removed from disk.
+        keys.add('default')
+        return keys
+
+    @classmethod
+    def available_email_templates(cls):
+        keys = cls._discover_email_template_keys()
+
+        def sort_key(k):
+            if k == 'default':
+                return (0, k)
+            if k == 'minimal':
+                return (1, k)
+            return (2, k)
+
+        templates = []
+        for key in sorted(keys, key=sort_key):
+            data = cls.EMAIL_TEMPLATE_DATA.get(key, {})
+            templates.append({
+                'key': key,
+                'display_name': data.get('display_name', key.replace('_', ' ').replace('-', ' ').title()),
+                'description': data.get('description', 'Custom chapter template.'),
+                'preview_style': data.get('preview_style', 'generic'),
+            })
+        return templates
+
+    @classmethod
+    def normalize_email_template(cls, candidate, templates=None):
+        if templates is None:
+            templates = cls.available_email_templates()
+        valid_keys = {t['key'] for t in templates}
+        if candidate in valid_keys and cls.EMAIL_TEMPLATE_KEY_RE.match(candidate):
+            return candidate
+        return 'default'
 
     @aux_call
     @needs_admin
@@ -122,10 +197,14 @@ class CommModule(ProgramModuleObj):
         if '<html>' not in body:
             body = '<html>' + body + '</html>'
 
-        # Use whichever template the user selected or the default (just an unsubscribe slug) if 'None'
-        template = request.POST.get('template', 'default')
-        rendered_text = render_to_string('email/{}_email.html'.format(template),
-                                        {'msgbody': body})
+        templates = self.available_email_templates()
+        template = self.normalize_email_template(request.POST.get('template', 'default'), templates)
+        try:
+            rendered_text = render_to_string('email/{}_email.html'.format(template),
+                                            {'msgbody': body})
+        except TemplateDoesNotExist:
+            template = 'default'
+            rendered_text = render_to_string('email/default_email.html', {'msgbody': body})
         # Render the text for the first user
         contextdict = {'user'   : ActionHandler(firstuser, firstuser),
                        'program': ActionHandler(self.program, firstuser),
@@ -185,10 +264,14 @@ class CommModule(ProgramModuleObj):
         sendto_fn_name = request.POST.get('sendto_fn_name', MessageRequest.SEND_TO_SELF_REAL)
         public_view = 'public_view' in request.POST
 
-        # Use whichever template the user selected or the default (just an unsubscribe slug) if 'None'
-        template = request.POST.get('template', 'default')
-        rendered_text = render_to_string('email/{}_email.html'.format(template),
-                                        {'msgbody': body})
+        templates = self.available_email_templates()
+        template = self.normalize_email_template(request.POST.get('template', 'default'), templates)
+        try:
+            rendered_text = render_to_string('email/{}_email.html'.format(template),
+                                            {'msgbody': body})
+        except TemplateDoesNotExist:
+            template = 'default'
+            rendered_text = render_to_string('email/default_email.html', {'msgbody': body})
 
         try:
             filterid = int(filterid)
@@ -236,6 +319,8 @@ class CommModule(ProgramModuleObj):
 
         context['sendto_fn_name'] = request.POST.get('sendto_fn_name', MessageRequest.SEND_TO_SELF_REAL)
         context['sendto_fn'] = MessageRequest.assert_is_valid_sendto_fn_or_ESPError(context['sendto_fn_name'])
+        context['email_templates'] = self.available_email_templates()
+        context['selected_template'] = 'default'
 
         context['default_from'] = '%s <%s@%s>' % (Tag.getTag('full_group_name') or '%s %s' % (settings.INSTITUTION_NAME, settings.ORGANIZATION_SHORT_NAME),
                                               "info", settings.SITE_INFO[1])
@@ -289,6 +374,8 @@ class CommModule(ProgramModuleObj):
                 if not prs.exists():
                     redirect = PlainRedirect.objects.create(original = "info", destination = settings.DEFAULT_EMAIL_ADDRESSES['default'])
                 context['from'] = context['default_from']
+                context['email_templates'] = self.available_email_templates()
+                context['selected_template'] = self.normalize_email_template(data.get('template', 'default'), context['email_templates'])
                 return render_to_response(self.baseDir()+'step2.html', request, context)
 
             ##  Prepare a message starting from an earlier request
@@ -302,6 +389,8 @@ class CommModule(ProgramModuleObj):
                 context['subject'] = msgreq.subject
                 context['replyto'] = msgreq.special_headers_dict.get('Reply-To', '')
                 context['body'] = msgreq.msgtext
+                context['email_templates'] = self.available_email_templates()
+                context['selected_template'] = 'default'
                 return render_to_response(self.baseDir()+'step2.html', request, context)
 
             else:
@@ -326,6 +415,8 @@ class CommModule(ProgramModuleObj):
         sendto_fn_name = request.POST.get('sendto_fn_name', MessageRequest.SEND_TO_SELF_REAL)
         selected = request.POST.get('selected')
         public_view = 'public_view' in request.POST
+        templates = self.available_email_templates()
+        selected_template = self.normalize_email_template(request.POST.get('template', 'default'), templates)
 
         return render_to_response(self.baseDir()+'step2.html', request,
                                               {'listcount': listcount,
@@ -336,6 +427,8 @@ class CommModule(ProgramModuleObj):
                                                'replyto': replytoemail,
                                                'subject': subject,
                                                'body': body,
+                                               'email_templates': templates,
+                                               'selected_template': selected_template,
                                                'public_view': public_view})
 
     def isStep(self):

--- a/esp/esp/program/modules/tests/commpanel.py
+++ b/esp/esp/program/modules/tests/commpanel.py
@@ -72,26 +72,31 @@ class CommunicationsPanelTest(ProgramFrameworkTest):
         m = ProgramModule.objects.get(handler='CommModule', module_type='manage')
         self.moduleobj = ProgramModuleObj.getFromProgModule(self.program, m)
 
-    def runTest(self):
-        #   Log in an administrator
-        self.assertTrue(self.client.login(username=self.admins[0].username, password='password'), "Failed to log in admin user.")
+    def _login_admin_and_get_filter_data(self):
+        self.assertTrue(
+            self.client.login(username=self.admins[0].username, password='password'),
+            "Failed to log in admin user.",
+        )
 
-        #   Select users to fetch
-        post_data = {
+        response = self.client.post('/manage/%s/%s' % (self.program.getUrlBase(), 'commpanel_old'), {
             'submit_user_list': 'true',
             'base_list': 'enrolled',
             'keys': '',
             'finalsent': 'Test List',
             'submitform': 'I have my list, go on!',
-        }
-        response = self.client.post('/manage/%s/%s' % (self.program.getUrlBase(), 'commpanel_old'), post_data)
+        })
         self.assertEqual(response.status_code, 200)
 
-        #   Extract filter ID from response
-        s = re.search(r'<input type="hidden" name="filterid" value="([0-9]+)" />', response.content.decode('UTF-8'))
-        filterid = s.groups()[0]
-        s = re.search(r'<input type="hidden" name="listcount" value="([0-9]+)" />', response.content.decode('UTF-8'))
-        listcount = s.groups()[0]
+        content = response.content.decode('UTF-8')
+        filter_match = re.search(r'<input type="hidden" name="filterid" value="([0-9]+)" />', content)
+        listcount_match = re.search(r'<input type="hidden" name="listcount" value="([0-9]+)" />', content)
+        self.assertIsNotNone(filter_match, 'Expected filterid hidden input in step2 response')
+        self.assertIsNotNone(listcount_match, 'Expected listcount hidden input in step2 response')
+
+        return filter_match.groups()[0], listcount_match.groups()[0], content
+
+    def runTest(self):
+        filterid, listcount, unused_content = self._login_admin_and_get_filter_data()
 
         #   Enter email information
         post_data = {
@@ -136,6 +141,69 @@ class CommunicationsPanelTest(ProgramFrameworkTest):
         m = MessageRequest.objects.filter(recipients__id=filterid, subject='Test Subject 123')
         self.assertTrue(m.count() == 1)
         self.assertTrue(m[0].processed)
+
+    def test_step2_includes_template_selector(self):
+        filterid, listcount, content = self._login_admin_and_get_filter_data()
+
+        self.assertIn('Email Template:', content)
+        self.assertIn('data-template-key="default"', content)
+        self.assertIn('data-template-key="minimal"', content)
+        self.assertIn('name="template" id="selected_template" value="default"', content)
+
+    def test_template_selection_persists_preview_to_edit(self):
+        filterid, listcount, unused_content = self._login_admin_and_get_filter_data()
+
+        preview_response = self.client.post('/manage/%s/%s' % (self.program.getUrlBase(), 'commprev'), {
+            'subject': 'Template persistence test',
+            'body': 'Hello from preview',
+            'from': 'info@testserver.learningu.org',
+            'replyto': 'replyto@testserver.learningu.org',
+            'filterid': filterid,
+            'listcount': listcount,
+            'template': 'minimal',
+        })
+        self.assertEqual(preview_response.status_code, 200)
+        self.assertIn('name="template" value="minimal"', preview_response.content.decode('UTF-8'))
+
+        edit_response = self.client.post('/manage/%s/%s' % (self.program.getUrlBase(), 'maincomm2'), {
+            'subject': 'Template persistence test',
+            'body': 'Hello from preview',
+            'from': 'info@testserver.learningu.org',
+            'replyto': 'replyto@testserver.learningu.org',
+            'filterid': filterid,
+            'listcount': listcount,
+            'template': 'minimal',
+        })
+        self.assertEqual(edit_response.status_code, 200)
+        self.assertIn('name="template" id="selected_template" value="minimal"', edit_response.content.decode('UTF-8'))
+
+    def test_commfinal_uses_selected_template_wrapper(self):
+        filterid, listcount, unused_content = self._login_admin_and_get_filter_data()
+
+        response = self.client.post('/manage/%s/%s' % (self.program.getUrlBase(), 'commfinal'), {
+            'subject': 'Template wrapper test',
+            'body': 'Body in minimal template',
+            'from': 'info@testserver.learningu.org',
+            'replyto': 'replyto@testserver.learningu.org',
+            'filterid': filterid,
+            'template': 'minimal',
+        })
+        self.assertEqual(response.status_code, 200)
+
+        req = MessageRequest.objects.get(recipients__id=filterid, subject='Template wrapper test')
+        self.assertIn('user.unsubscribe_link', req.msgtext, 'Minimal wrapper should include unsubscribe footer')
+
+        process_messages()
+        send_email_requests()
+
+        msg = mail.outbox[0]
+        context_dict = {'user': ActionHandler(self.students[0], self.students[0]),
+                        'program': ActionHandler(self.program, self.students[0]),
+                        'request': ActionHandler(MessageRequest(), self.students[0]),
+                        'EMAIL_HOST_SENDER': settings.EMAIL_HOST_SENDER}
+        rendered_text = render_to_string('email/minimal_email.html', {'msgbody': 'Body in minimal template'})
+        rendered_text = Template(rendered_text).render(DjangoContext(context_dict))
+        self.assertEqual(msg.body, strip_tags(rendered_text).strip())
 
     def test_program_date_variables_in_comms(self):
         """Test that {{ program.date }}, {{ program.date_range }}, {{ program.teacher_reg_deadline }} work in email templates."""

--- a/esp/templates/email/minimal_email.html
+++ b/esp/templates/email/minimal_email.html
@@ -5,6 +5,14 @@
 
 <body>
 {% autoescape off %}{{msgbody|safe}}{% endautoescape %}
+<br /><br />
+<small>
+You are receiving this email because you have an account on
+<a href="https://{% templatetag openvariable %}EMAIL_HOST_SENDER{% templatetag closevariable %}">
+{% templatetag openvariable %}EMAIL_HOST_SENDER{% templatetag closevariable %}</a>.
+To unsubscribe this account ({% templatetag openvariable %}user.username{% templatetag closevariable %}),
+<a href="{% templatetag openvariable %}user.unsubscribe_link{% templatetag closevariable %}">click here</a>.
+</small>
 </body>
 
 </html>

--- a/esp/templates/program/modules/commmodule/step2.html
+++ b/esp/templates/program/modules/commmodule/step2.html
@@ -18,6 +18,78 @@
 /*Fix css for template tag button*/
 .jodit_icon_insertDate { width: 16px; height: 16px}
 .jodit_toolbar_list>.jodit_toolbar { max-height: 150px; }
+.email-template-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 14px;
+  margin-top: 10px;
+}
+.email-template-card {
+  border: 1px solid #bbb;
+  border-radius: 4px;
+  background: #fff;
+  padding: 10px;
+  text-align: left;
+  width: 100%;
+}
+.email-template-card.is-selected {
+  border-color: #337ab7;
+  box-shadow: 0 0 0 2px rgba(51,122,183,0.15);
+}
+.email-template-card h4 {
+  margin: 0 0 4px 0;
+  font-size: 14px;
+}
+.email-template-card p {
+  margin: 0 0 8px 0;
+  color: #555;
+  font-size: 12px;
+}
+.email-template-preview {
+  border: 1px solid #ddd;
+  background: #f8f8f8;
+  border-radius: 3px;
+  padding: 8px;
+  min-height: 92px;
+}
+.email-template-preview .line {
+  display: block;
+  height: 8px;
+  background: #d6d6d6;
+  border-radius: 3px;
+  margin-bottom: 5px;
+}
+.email-template-preview .line.wide { width: 100%; }
+.email-template-preview .line.med { width: 74%; }
+.email-template-preview .line.short { width: 45%; }
+.email-template-preview .block {
+  display: block;
+  height: 26px;
+  background: #cfcfcf;
+  border-radius: 3px;
+  margin-top: 6px;
+}
+.email-template-preview-default .footer {
+  display: block;
+  height: 9px;
+  width: 85%;
+  background: #dcdcdc;
+  border-radius: 3px;
+  margin-top: 8px;
+}
+.email-template-preview-minimal .block {
+  background: #d9d9d9;
+  height: 22px;
+}
+.email-template-preview-generic .block {
+  background: repeating-linear-gradient(
+    45deg,
+    #d0d0d0,
+    #d0d0d0 6px,
+    #d8d8d8 6px,
+    #d8d8d8 12px
+  );
+}
 </style>
 {% endblock %}
 
@@ -74,6 +146,31 @@ Both email address fields also support named "mailboxes", such as "{{ default_fr
   </label> <br />
   <textarea cols="80" rows="20" name="body" id="emailbody">{{body}}</textarea>
   <br />
+
+  <strong>Email Template:</strong>
+  <small>Choose a wrapper style for this email body.</small>
+  <input type="hidden" name="template" id="selected_template" value="{{ selected_template|default:'default' }}" />
+  <div class="email-template-grid">
+    {% for tpl in email_templates %}
+    <button type="button"
+            class="email-template-card{% if tpl.key == selected_template %} is-selected{% endif %}"
+            data-template-key="{{ tpl.key }}"
+            aria-pressed="{% if tpl.key == selected_template %}true{% else %}false{% endif %}">
+      <h4>{{ tpl.display_name }}</h4>
+      <p>{{ tpl.description }}</p>
+      <div class="email-template-preview email-template-preview-{{ tpl.preview_style }}">
+        <span class="line wide"></span>
+        <span class="line med"></span>
+        <span class="line short"></span>
+        <span class="block"></span>
+        {% if tpl.preview_style == 'default' %}
+        <span class="footer"></span>
+        {% endif %}
+      </div>
+    </button>
+    {% endfor %}
+  </div>
+  <br />
   </td>
 </tr>
 </table>
@@ -127,6 +224,28 @@ var editor = new Jodit("#emailbody", {
       tooltip: "Insert a template tag",
     }
   ],
+});
+
+$j(function() {
+  var selectedTemplateField = document.getElementById('selected_template');
+
+  function updateSelectedTemplate(templateKey) {
+    if (!templateKey) {
+      return;
+    }
+
+    selectedTemplateField.value = templateKey;
+    $j('.email-template-card').removeClass('is-selected').attr('aria-pressed', 'false');
+    $j('.email-template-card[data-template-key="' + templateKey + '"]')
+      .addClass('is-selected')
+      .attr('aria-pressed', 'true');
+  }
+
+  $j('.email-template-card').on('click', function() {
+    updateSelectedTemplate($j(this).data('template-key'));
+  });
+
+  updateSelectedTemplate(selectedTemplateField.value || 'default');
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Description
Adds an MVP template selector in the comm panel compose step, aligned with #2885.

## What this changes
- Adds an email template selector UI in comm panel step 2 with card-style options.
- Discovers available templates from `templates/email/*_email.html` (including template overrides), validates selection server-side, and falls back safely to `default`.
- Persists selected template through compose -> preview -> edit -> send.
- Updates `minimal_email.html` to include an unsubscribe footer.
- Adds tests for selector rendering, persistence, and selected-template wrapping behavior.

## UI Screenshot
![Comm panel template selector UI](https://github.com/user-attachments/assets/2197941c-6e90-42f1-90d6-af04feeda774)

## Testing
- `python -m py_compile esp/esp/program/modules/handlers/commmodule.py esp/esp/program/modules/tests/commpanel.py`
- GitHub Actions `Lint` and `Unit Tests` workflows are configured for this PR and currently show `action_required` (awaiting maintainer approval to run for fork PRs).
