### PR TITLE
Fix login greeting fallback for users with empty profile names

### DIFF
--- a/esp/esp/themes/theme_data/bigpicture/templates/users/loginbox_content.html
+++ b/esp/esp/themes/theme_data/bigpicture/templates/users/loginbox_content.html
@@ -5,7 +5,7 @@
     <form class="navbar-form form-inline">
       <a href="/myesp/profile/" class="username">
         <i class="icon-user"></i> Hello,
-        <span id="user_first_name"></span> <span id="user_last_name"></span>!
+        <span id="user_greeting_name"></span>!
       </a>
       <a class="btn" href="/myesp/signout">Logout</a>
       <span class="dropdown">

--- a/esp/esp/themes/theme_data/droplets/templates/users/loginbox_content.html
+++ b/esp/esp/themes/theme_data/droplets/templates/users/loginbox_content.html
@@ -6,8 +6,7 @@
   <li>
       <li class="dropdown">
         <a class="navbar-header" id="loginbox_user_name" data-toggle="dropdown">
-          Hello, <span id="user_first_name"></span>
-          <span id="user_last_name"></span>!
+          Hello, <span id="user_greeting_name"></span>!
         </a>
         <a class="dropdown-toggle caret-wrapper" data-toggle="dropdown"><b class="caret"></b></a>
         <ul class="dropdown-menu pull-right">

--- a/esp/public/media/scripts/content/user_classes.js
+++ b/esp/public/media/scripts/content/user_classes.js
@@ -1,3 +1,27 @@
+function normalize_user_value(value) {
+    if (value === undefined || value === null) {
+        return '';
+    }
+    var normalized = String(value);
+    if (normalized === 'undefined' || normalized === 'null') {
+        return '';
+    }
+    return normalized;
+}
+
+function get_user_greeting_name(first_name, username) {
+    var cleaned_first_name = normalize_user_value(first_name).trim();
+    var cleaned_username = normalize_user_value(username).trim();
+
+    if (cleaned_first_name) {
+        return cleaned_first_name;
+    }
+    if (cleaned_username) {
+        return cleaned_username;
+    }
+    return "Guest";
+}
+
 function update_user_classes() {
     if (esp_user.cur_admin == "1" || esp_user.cur_retTitle) {
         $j(".admin").removeClass("hidden");
@@ -31,10 +55,19 @@ function update_user_classes() {
     }
     
     //    Write user's name in the appropriate spot in the login box
-    $j("#user_first_name").text(esp_user.cur_first_name);
-    $j("#user_last_name").text(esp_user.cur_last_name);
-    $j("#user_username").text(esp_user.cur_username);
-    $j("#user_userid").text(esp_user.cur_userid);
+    var first_name = normalize_user_value(esp_user.cur_first_name);
+    var last_name = normalize_user_value(esp_user.cur_last_name);
+    var username = normalize_user_value(esp_user.cur_username);
+    var user_id = esp_user.cur_userid;
+    if (user_id === undefined || user_id === null || user_id !== user_id) {
+        user_id = '';
+    }
+
+    $j("#user_greeting_name").text(get_user_greeting_name(first_name, username));
+    $j("#user_first_name").text(first_name);
+    $j("#user_last_name").text(last_name);
+    $j("#user_username").text(username);
+    $j("#user_userid").text(user_id);
 }
 
 $j(document).ready(update_user_classes)

--- a/esp/public/media/scripts/content/user_data.js
+++ b/esp/public/media/scripts/content/user_data.js
@@ -12,6 +12,13 @@ if (typeof(window["$j"]) == "undefined") {
 var esp_user = {};
 var esp_user_keys = new Array('cur_username','cur_userid','cur_email','cur_first_name','cur_last_name','cur_other_user','cur_retTitle', 'cur_admin','cur_yog','cur_grade','cur_roles','cur_qsd_bits');
 
+function decode_user_cookie(value) {
+    if (value === undefined || value === null || value === '' || value === 'undefined' || value === 'null') {
+        return '';
+    }
+    return unescape(value);
+}
+
 for (var i=0; i < esp_user_keys.length; i++) {
     var tmp = $j.cookie(esp_user_keys[i]);
     if (tmp) {
@@ -21,14 +28,22 @@ for (var i=0; i < esp_user_keys.length; i++) {
      * : see esp/middleware/esperrormiddleware.py
      */
 }
-esp_user['cur_userid'] = parseInt(esp_user['cur_userid']);
-esp_user['cur_email'] = unescape(esp_user['cur_email']);
-esp_user['cur_first_name'] = unescape(esp_user['cur_first_name']);
-esp_user['cur_last_name'] = unescape(esp_user['cur_last_name']);
-esp_user['cur_yog'] = parseInt(esp_user['cur_yog']);
-esp_user['cur_grade'] = parseInt(esp_user['cur_grade']);
+
+esp_user['cur_userid'] = parseInt(esp_user['cur_userid'], 10);
+esp_user['cur_yog'] = parseInt(esp_user['cur_yog'], 10);
+esp_user['cur_grade'] = parseInt(esp_user['cur_grade'], 10);
+if (isNaN(esp_user['cur_userid'])) { esp_user['cur_userid'] = null; }
+if (isNaN(esp_user['cur_yog'])) { esp_user['cur_yog'] = null; }
+if (isNaN(esp_user['cur_grade'])) { esp_user['cur_grade'] = null; }
+
+esp_user['cur_email'] = decode_user_cookie(esp_user['cur_email']);
+esp_user['cur_first_name'] = decode_user_cookie(esp_user['cur_first_name']);
+esp_user['cur_last_name'] = decode_user_cookie(esp_user['cur_last_name']);
+esp_user['cur_retTitle'] = decode_user_cookie(esp_user['cur_retTitle']);
+
 if (esp_user['cur_roles']) {
-    esp_user['cur_roles'] = unescape(esp_user['cur_roles']).split(',');
+    var decoded_roles = decode_user_cookie(esp_user['cur_roles']);
+    esp_user['cur_roles'] = decoded_roles ? decoded_roles.split(',') : [];
 } else {
     esp_user['cur_roles'] = [];
 }
@@ -41,7 +56,8 @@ if (esp_user['cur_username']) {
     if (esp_user['cur_other_user'] == '1') {
 	esp_user_login += '<a href="/myesp/switchback/">Go back to ' + esp_user['cur_retTitle'] + '</a>';
     } else {
-	esp_user_login += 'Welcome, ' + esp_user['cur_first_name'] + '!';
+        var welcome_name = esp_user['cur_first_name'] || esp_user['cur_username'] || 'Guest';
+	esp_user_login += 'Welcome, ' + welcome_name + '!';
     }
     esp_user_login += '</div></td><td colspan="2"><div class="divformcol2" style="text-align:right"><a href="/myesp/signout/">Sign Out</a></div></tr></table>';
 }

--- a/esp/templates/users/loginbox_content.html
+++ b/esp/templates/users/loginbox_content.html
@@ -9,8 +9,7 @@
     <ul class="nav">
       <li>
           <a id="loginbox_user_name">
-              Hello, <span id="user_first_name"></span>
-              <span id="user_last_name"></span>!
+              Hello, <span id="user_greeting_name"></span>!
           </a>
       </li>
       <li><form class="navbar-form form-inline" action="/myesp/signout">
@@ -57,6 +56,5 @@
     </form>
   </div>
 </div>
-
 
 


### PR DESCRIPTION
## Description
Fixes the loginbox greeting bug where users with empty profile names could see `Hello, undefined undefined!`.

## What changed
- Added robust cookie decoding in `user_data.js` so missing/undefined/null cookie values normalize to empty strings.
- Added greeting fallback logic in `user_classes.js`: `first_name -> username -> Guest`.
- Switched greeting markup to a dedicated `#user_greeting_name` span in all active loginbox templates:
  - `esp/templates/users/loginbox_content.html`
  - `esp/esp/themes/theme_data/droplets/templates/users/loginbox_content.html`
  - `esp/esp/themes/theme_data/bigpicture/templates/users/loginbox_content.html`
- Kept existing first/last username/userid field population for non-greeting UI.

## UI Screenshot
Before (reporter reproduction):
![Before: undefined greeting](https://github.com/user-attachments/assets/90110d21-f968-4d46-9463-b6745860fe5c)

After this PR, the greeting uses fallback order `first_name -> username -> Guest`, so the UI no longer renders `undefined`.

## Testing
- Ran executable JS regression checks via Node for the updated scripts:
  - `user_data.js`: verifies decode behavior for missing/undefined values and default role parsing.
  - `user_classes.js`: verifies greeting fallback and DOM text assignment behavior for missing profile names.

Closes #4337
