### PR TITLE
Validate PlainRedirect destination emails at model level

### DIFF
--- a/esp/esp/dbmail/models.py
+++ b/esp/esp/dbmail/models.py
@@ -60,7 +60,8 @@ from django.utils.html import strip_tags
 from django.core.mail import get_connection
 from django.core.mail.backends.smtp import EmailBackend as SMTPEmailBackend
 from django.core.mail.message import sanitize_address
-from django.core.exceptions import ImproperlyConfigured
+from django.core.exceptions import ImproperlyConfigured, ValidationError
+from django.core.validators import validate_email
 
 # `user` is required for marketing and subscribed messages to add unsubscribe headers
 # this includes all comm panel emails
@@ -629,6 +630,26 @@ class PlainRedirect(models.Model):
     original = models.CharField(max_length=512, help_text='A real or custom email address name (e.g., "directors" or "splash"). Any emails to &lt;original&gt;@&lt;yourdomain&gt; will be redirected to the destination email address(es).')
 
     destination = models.CharField(max_length=512, help_text='A comma-separated list of one or more real email address(es) that will receive the redirected email(s)')
+
+    def clean(self):
+        super().clean()
+
+        invalid_emails = []
+        for item in self.destination.split(','):
+            email = item.strip()
+            if not email:
+                invalid_emails.append('<empty>')
+                continue
+
+            try:
+                validate_email(email)
+            except ValidationError:
+                invalid_emails.append(email)
+
+        if invalid_emails:
+            raise ValidationError({
+                'destination': 'Invalid email address(es): %s' % ', '.join(invalid_emails)
+            })
 
     def __str__(self):
         return '%s --> %s'  % (self.original, self.destination)

--- a/esp/esp/dbmail/tests.py
+++ b/esp/esp/dbmail/tests.py
@@ -1,20 +1,42 @@
-"""
-Tests for esp.dbmail.models
-Source: esp/esp/dbmail/models.py
+__author__    = "Individual contributors (see AUTHORS file)"
+__date__      = "$DATE$"
+__rev__       = "$REV$"
+__license__   = "AGPL v.3"
+__copyright__ = """
+This file is part of the ESP Web Site
+Copyright (c) 2007 by the individual contributors
+  (see AUTHORS file)
 
-Tests send_mail functionality, ActionHandler dynamic dispatch,
-and MessageRequest validation methods.
+The ESP Web Site is free software; you can redistribute it and/or
+modify it under the terms of the GNU Affero General Public License
+as published by the Free Software Foundation; either version 3
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public
+License along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+Contact information:
+MIT Educational Studies Program
+  84 Massachusetts Ave W20-467, Cambridge, MA 02139
+  Phone: 617-253-4882
+  Email: esp-webmasters@mit.edu
+Learning Unlimited, Inc.
+  527 Franklin St, Cambridge, MA 02139
+  Phone: 617-379-0178
+  Email: web-team@learningu.org
 """
-from unittest.mock import patch, MagicMock
 
 from django.contrib.auth.models import Group
 from django.core import mail
+from django.core.exceptions import ValidationError
 
-from esp.dbmail.models import (
-    ActionHandler,
-    MessageRequest,
-    send_mail,
-)
+from esp.dbmail.models import ActionHandler, MessageRequest, PlainRedirect, send_mail
 from esp.tests.util import CacheFlushTestCase as TestCase
 from esp.users.models import ESPUser
 
@@ -89,22 +111,6 @@ class MessageRequestTest(TestCase):
 
     def test_is_sendto_fn_name_choice_invalid(self):
         self.assertFalse(MessageRequest.is_sendto_fn_name_choice('not_a_real_choice'))
-"""
-Tests for esp.dbmail.cronmail
-Source: esp/esp/dbmail/cronmail.py
-
-Tests the process_messages and send_email_requests functions.
-"""
-from unittest.mock import patch, MagicMock
-
-from django.contrib.auth.models import Group
-
-from esp.tests.util import CacheFlushTestCase as TestCase
-
-
-def _setup_roles():
-    for name in ['Student', 'Teacher', 'Educator', 'Guardian', 'Volunteer', 'Administrator']:
-        Group.objects.get_or_create(name=name)
 
 
 class CronmailImportTest(TestCase):
@@ -117,3 +123,40 @@ class CronmailImportTest(TestCase):
     def test_process_messages_callable(self):
         from esp.dbmail.cronmail import process_messages
         self.assertTrue(callable(process_messages))
+
+
+class PlainRedirectValidationTest(TestCase):
+    def test_valid_single_destination(self):
+        redirect = PlainRedirect(original='directors', destination='user@example.com')
+        redirect.full_clean()
+
+    def test_valid_multiple_destinations(self):
+        redirect = PlainRedirect(
+            original='announcements',
+            destination='user1@example.com, user2@example.com',
+        )
+        redirect.full_clean()
+
+    def test_invalid_destination_email_fails_validation(self):
+        redirect = PlainRedirect(
+            original='directors',
+            destination='user@example.com, not-an-email',
+        )
+
+        with self.assertRaises(ValidationError) as error:
+            redirect.full_clean()
+
+        self.assertIn('destination', error.exception.message_dict)
+        self.assertIn('not-an-email', error.exception.message_dict['destination'][0])
+
+    def test_empty_destination_entry_fails_validation(self):
+        redirect = PlainRedirect(
+            original='directors',
+            destination='user@example.com,',
+        )
+
+        with self.assertRaises(ValidationError) as error:
+            redirect.full_clean()
+
+        self.assertIn('destination', error.exception.message_dict)
+        self.assertIn('<empty>', error.exception.message_dict['destination'][0])


### PR DESCRIPTION
## Description
Adds model-level validation for `PlainRedirect.destination` so invalid destination emails are caught before save.

## What changed
- Added `PlainRedirect.clean()` in `esp/esp/dbmail/models.py`.
- Validates each comma-separated destination entry with Django's `validate_email`.
- Treats empty entries (e.g. trailing comma) as invalid.
- Raises field-specific `ValidationError` on `destination` with the invalid entries listed.
- Added regression tests in `esp/esp/dbmail/tests.py` for:
  - valid single destination
  - valid multiple destinations
  - invalid destination email
  - empty destination entry (trailing comma)

## Testing
- `python -m py_compile esp/esp/dbmail/models.py esp/esp/dbmail/tests.py`
- Attempted to run `esp.dbmail.tests.PlainRedirectValidationTest`, but this shell cannot resolve/install `django-argcache` from GitHub (`Could not resolve host: github.com` during `pip` clone), so full Django test execution is blocked in this environment.

Closes #4324
