### PR TITLE
Fix autoscheduler swap/save false “room occupied” conflicts

### DIFF
--- a/esp/esp/program/controllers/autoscheduler/db_interface.py
+++ b/esp/esp/program/controllers/autoscheduler/db_interface.py
@@ -242,7 +242,7 @@ def save(schedule, check_consistency=True, check_constraints=True):
         for so in section_objs:
             section = schedule.class_sections[so.id]
             ensure_section_not_moved(so, section)
-            if len(section_obj.get_meeting_times()) > 0:
+            if len(so.get_meeting_times()) > 0:
                 unschedule_section(so, ajax_change_log)
 
         check_can_schedule_sections(section_infos, schedule)


### PR DESCRIPTION
## Summary
This fixes an autoscheduler save edge case where swaps could fail with “room already occupied” even when the schedule was valid. The root cause was an incorrect variable reference that sometimes skipped unscheduling the actual section being processed.

## What Changed
- Ensures the save pipeline unschedules the correct section before conflict checks, preventing stale room assignments from triggering false conflicts.

## Why This Is Safe
- Minimal, localized change in the autoscheduler save path.
- No behavior changes outside the swap/save flow.

## Testing
- `deploy/lint`
- `./manage.py test esp.program.controllers.autoscheduler.test_db_interface` (blocked locally due to missing env/activate_this.py)

## Issue
Closes #4345