### PR TITLE
feat: Add skeleton onsite admin dashboard module (Issue #2672)

### DIFF
--- a/esp/esp/program/modules/handlers/onsiteadmindashboard.py
+++ b/esp/esp/program/modules/handlers/onsiteadmindashboard.py
@@ -1,0 +1,64 @@
+__author__    = "Individual contributors (see AUTHORS file)"
+__date__      = "$DATE$"
+__rev__       = "$REV$"
+__license__   = "AGPL v.3"
+__copyright__ = """
+This file is part of the ESP Web Site
+Copyright (c) 2026 by the individual contributors
+  (see AUTHORS file)
+
+The ESP Web Site is free software; you can redistribute it and/or
+modify it under the terms of the GNU Affero General Public License
+as published by the Free Software Foundation; either version 3
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program; if not, write to the Free Software Foundation,
+Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+Contact information:
+MIT Educational Studies Program
+  84 Massachusetts Ave W20-467, Cambridge, MA 02139
+  Phone: 617-253-4882
+  Email: esp-webmasters@mit.edu
+Learning Unlimited, Inc.
+  527 Franklin St, Cambridge, MA 02139
+  Phone: 617-379-0178
+  Email: web-team@learningu.org
+"""
+
+from esp.program.modules.base import ProgramModuleObj, needs_onsite, main_call
+from esp.utils.web import render_to_response
+
+
+class OnSiteAdminDashboard(ProgramModuleObj):
+    doc = """Admin dashboard for onsite management."""
+
+    @classmethod
+    def module_properties(cls):
+        return {
+            "admin_title": "Onsite Admin Dashboard",
+            "link_title": "Admin Dashboard",
+            "module_type": "onsite",
+            "seq": 15,
+            "choosable": 1,
+            }
+
+    @main_call
+    @needs_onsite
+    def dashboard(self, request, tl, one, two, module, extra, prog):
+        context = {
+            'program': self.program,
+            'one': one,
+            'two': two,
+        }
+        return render_to_response(self.baseDir() + 'dashboard.html', request, context)
+
+    class Meta:
+        proxy = True
+        app_label = 'modules'

--- a/esp/esp/program/modules/tests/__init__.py
+++ b/esp/esp/program/modules/tests/__init__.py
@@ -51,3 +51,4 @@ from esp.program.modules.tests.classsearchmodule import ClassSearchModuleTest
 from esp.program.modules.tests.auth import ProgramModuleAuthTest
 from esp.program.modules.tests.unenrollmodule import UnenrollModuleTest
 from esp.program.modules.tests.testallviews import AllViewsTest
+from esp.program.modules.tests.onsiteadmindashboard import OnSiteAdminDashboardTest

--- a/esp/esp/program/modules/tests/onsiteadmindashboard.py
+++ b/esp/esp/program/modules/tests/onsiteadmindashboard.py
@@ -1,0 +1,56 @@
+__author__    = "Individual contributors (see AUTHORS file)"
+__date__      = "$DATE$"
+__rev__       = "$REV$"
+__license__   = "AGPL v.3"
+__copyright__ = """
+This file is part of the ESP Web Site
+Copyright (c) 2026 by the individual contributors
+  (see AUTHORS file)
+
+The ESP Web Site is free software; you can redistribute it and/or
+modify it under the terms of the GNU Affero General Public License
+as published by the Free Software Foundation; either version 3
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program; if not, write to the Free Software Foundation,
+Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+Contact information:
+MIT Educational Studies Program
+  84 Massachusetts Ave W20-467, Cambridge, MA 02139
+  Phone: 617-253-4882
+  Email: esp-webmasters@mit.edu
+Learning Unlimited, Inc.
+  527 Franklin St, Cambridge, MA 02139
+  Phone: 617-379-0178
+  Email: web-team@learningu.org
+"""
+
+from esp.program.models import ProgramModule
+from esp.program.tests import ProgramFrameworkTest
+
+
+class OnSiteAdminDashboardTest(ProgramFrameworkTest):
+    def setUp(self, *args, **kwargs):
+        modules = [
+            ProgramModule.objects.get(handler='OnsiteCore'),
+            ProgramModule.objects.get(handler='OnSiteAdminDashboard'),
+        ]
+        super().setUp(modules=modules, *args, **kwargs)
+        self.admin = self.admins[0]
+        self.admin.set_password('password')
+        self.admin.save()
+
+    def test_dashboard_page_loads_for_admin(self):
+        logged_in = self.client.login(username=self.admin.username, password='password')
+        self.assertTrue(logged_in, "Couldn't log in as admin %s" % self.admin.username)
+        url = '/onsite/%s/%s/dashboard/' % (self.program.program_type, self.program.program_instance)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Onsite Admin Dashboard')

--- a/esp/templates/program/modules/onsiteadmindashboard/dashboard.html
+++ b/esp/templates/program/modules/onsiteadmindashboard/dashboard.html
@@ -1,0 +1,15 @@
+{% extends "main.html" %} {% block title %}Onsite Admin Dashboard - {{
+program.niceName }}{% endblock %} {% block content %}
+<h1>Onsite Admin Dashboard</h1>
+<h2>{{ program.niceName }}</h2>
+
+<div class="alert alert-info">
+  <h4 style="text-align: center">
+    This is the initial dashboard shell for onsite admin management.
+  </h4>
+  <p style="text-align: center">
+    Next steps: class status overview, enrollment/check-in bars, and quick
+    actions.
+  </p>
+</div>
+{% endblock %}

--- a/esp/templates/program/modules/onsitecore/mainpage.html
+++ b/esp/templates/program/modules/onsitecore/mainpage.html
@@ -92,6 +92,20 @@
 </div>
 <div class="module_group" id="module_group_2">
     <div class="module_group_header">
+        Onsite Admin
+    </div>
+    <div class="button_wrapper">
+        {% if program|hasModule:"OnSiteAdminDashboard" %}
+        <div class="module_button">
+            <a href="/onsite/{{ program.getUrlBase }}/dashboard"><button type="button" class="module_link_large">
+                <div class="module_link_main"><i class="glyphicon glyphicon-dashboard"></i> Admin Dashboard</div>
+            </button></a>
+        </div>
+        {% endif %}
+    </div>
+</div>
+<div class="module_group" id="module_group_2">
+    <div class="module_group_header">
         Student Information
     </div>
     <div class="button_wrapper">


### PR DESCRIPTION
- Create OnSiteAdminDashboard module handler with @main_call and @needs_onsite decorators
- Add dashboard.html template with placeholder content for future features
- Integrate admin dashboard button into onsite main page navigation
- Add test case for dashboard page load validation

This implements the first step toward Issue #2672 (Admin onsite webapp). Future PRs will add JSON endpoints, frontend polling, and status visualizations.

## Description

Implements the initial skeleton for the Onsite Admin Dashboard module. This PR establishes the routing, module handler, template, navigation entry point, and basic test coverage required to support future feature development.

The dashboard currently renders placeholder content and serves as the structural foundation for subsequent enhancements such as live enrollment data, check-in tracking, and administrative controls.

## Related Issue



## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [x] New tests added (if applicable)
- [x] Manually verified

## AI Disclosure

This pull request was developed with assistance from ChatGPT 5.2.

Scope of assistance:
- scaffolding suggestions for the module structure
- guidance on template placeholder structure
- Basic assistance drafting the initial test case structure

All architectural decisions, integrations, and validations were completed and reviewed by the contributor. Tests were executed locally and verified manually.

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced