### PR TITLE
Add initial tests for SchedulingCheckRunner lunch_blocks_setup

### DIFF
--- a/tests/test_scheduling_checks.py
+++ b/tests/test_scheduling_checks.py
@@ -6,7 +6,6 @@ from esp.program.modules.handlers.schedulingcheckmodule import (
 )
 
 class DummyProgram:
-    """Minimal stub program object for testing."""
     def getTimeSlots(self):
         return []
 
@@ -15,12 +14,22 @@ class DummyProgram:
 
 
 def test_lunch_blocks_setup_empty():
-    """Should return empty list when no lunch blocks exist."""
     program = DummyProgram()
     runner = SchedulingCheckRunner(program, formatter=RawSCFormatter())
 
-    runner.lunch_blocks = []  # simulate no lunch blocks
+    runner.lunch_blocks = []
 
     result = runner.lunch_blocks_setup()
 
     assert result == []
+
+
+def test_lunch_blocks_setup_with_blocks():
+    program = DummyProgram()
+    runner = SchedulingCheckRunner(program, formatter=RawSCFormatter())
+
+    runner.lunch_blocks = [["Block A", "Block B"]]
+
+    result = runner.lunch_blocks_setup()
+
+    assert result == ["Block A", "Block B"]


### PR DESCRIPTION
## Description

This PR adds an initial unit test for the Scheduling Checks module, specifically for the SchedulingCheckRunner.lunch_blocks_setup method.

The test verifies that the method returns an empty list when no lunch blocks are configured. A minimal dummy program stub is used to isolate the logic and avoid dependencies on database or Django internals.

This serves as a starting point to improve test coverage for scheduling diagnostics. 


## Related Issue
Closes #3773

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [x] New tests added (if applicable)
- [x] Manually verified

## AI Disclosure

I used AI assistance to help understand the codebase, design the test structure, and draft the PR description. All code was reviewed and validated manually before submission.

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced
