### PR TITLE
Gate “Amount owed” on printable student schedules behind student_schedule_format

### DIFF
--- a/esp/esp/program/modules/handlers/programprintables.py
+++ b/esp/esp/program/modules/handlers/programprintables.py
@@ -1340,7 +1340,11 @@ class ProgramPrintables(ProgramModuleObj):
         if Tag.getProgramTag("student_schedule_format", prog):
             context["schedule_format"] = {x: True for x in json.loads(Tag.getProgramTag("student_schedule_format", prog))}
         else:
-            context["schedule_format"] = {choice[0]: True for choice in StudentScheduleFormatForm(program = prog).fields['schedule_fields'].choices}
+            context["schedule_format"] = {
+                choice[0]: True
+                for choice in StudentScheduleFormatForm(program=prog).fields["schedule_fields"].choices
+                if choice[0] != "amount_owed"
+            }
         context["pretext"] = Tag.getProgramTag("student_schedule_pretext", prog)
         context["posttext"] = Tag.getProgramTag("student_schedule_posttext", prog)
         if file_type == 'html':
@@ -2003,6 +2007,10 @@ class StudentScheduleFormatForm(forms.Form):
         if Tag.getProgramTag("student_schedule_format", program):
             self.fields['schedule_fields'].initial = json.loads(Tag.getProgramTag("student_schedule_format", program))
         else:
-            self.fields['schedule_fields'].initial = [choice[0] for choice in self.fields['schedule_fields'].choices]
+            self.fields["schedule_fields"].initial = [
+                choice[0]
+                for choice in self.fields["schedule_fields"].choices
+                if choice[0] != "amount_owed"
+            ]
         self.fields['pretext'].initial = Tag.getProgramTag("student_schedule_pretext", program)
         self.fields['posttext'].initial = Tag.getProgramTag("student_schedule_posttext", program)

--- a/esp/esp/program/modules/tests/programprintables.py
+++ b/esp/esp/program/modules/tests/programprintables.py
@@ -160,6 +160,24 @@ class ProgramPrintablesModuleTest(ProgramFrameworkTest):
             "attachment; filename=all_classes.csv"
         )
 
+    def testStudentSchedulesHtmlDoesNotShowAmountOwedByDefault(self):
+        import json
+        from esp.tagdict.models import Tag
+        Tag.unSetTag(key="student_schedule_format", target=self.program)
+        response = self.get_response("studentschedules/html", "students", "enrolled")
+        self.assertNotContains(response, "Amount owed:")
+
+    def testStudentSchedulesHtmlShowsAmountOwedWhenEnabled(self):
+        import json
+        from esp.tagdict.models import Tag
+        Tag.setTag(
+            key="student_schedule_format",
+            value=json.dumps(["username", "userid", "amount_owed"]),
+            target=self.program,
+        )
+        response = self.get_response("studentschedules/html", "students", "enrolled")
+        self.assertContains(response, "Amount owed:")
+
 
 class TestAllClassesSelectionForm(ProgramFrameworkTest):
 

--- a/esp/templates/program/modules/programprintables/singleschedule_student.html
+++ b/esp/templates/program/modules/programprintables/singleschedule_student.html
@@ -84,7 +84,7 @@ If you have any questions or would like to switch classes, please go to the prog
    <b>{{ student.name }}<br />{{ student.id }}</b>
   </td>
   <td width="30%">
-    <b>Amount owed: ${{ student.itemizedcosttotal|floatformat:"-2" }}</b>
+    {% if schedule_format.amount_owed %}<b>Amount owed: ${{ student.itemizedcosttotal|floatformat:"-2" }}</b>{% endif %}
   </td>
  </tr>
 {% endcomment %}


### PR DESCRIPTION
## Description

This PR prevents student schedule printouts from exposing sensitive financial information by hiding the “Amount owed” line by default in HTML/PNG student schedules. The display of “Amount owed” is now controlled by the existing student_schedule_format program setting (schedule_format.amount_owed), matching the PDF schedule behavior.

## Related Issue

Closes #4405

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [x] New tests added (if applicable)
- [x] Manually verified

## AI Disclosure


## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced
