### PR TITLE
Fix Python 3 CSV binary mode bug in generate_screwed_csv

### DIFF
--- a/esp/esp/program/controllers/lottery.py
+++ b/esp/esp/program/controllers/lottery.py
@@ -717,13 +717,13 @@ class LotteryAssignmentController(object):
 
         fullfilename = directory + '/screwed_csv_' + tday + '.csv'
 
-        csvfile = open(fullfilename, 'wb')
+        csvfile = open(fullfilename, 'w', newline='', encoding='utf-8')
         csvwriter = csv.writer(csvfile)
 
         csvwriter.writerow(["Student", "Student ID", "StudentScrewedScore", "#Classes"])
 
         for s in studentlist:
-            csvwriter.writerow([ESPUser.objects.get(id=s[1]).name().encode('ascii', 'ignore'), s[1], s[0], len(self.get_computed_schedule(s[1]))])
+            csvwriter.writerow([ESPUser.objects.get(id=s[1]).name(), s[1], s[0], len(self.get_computed_schedule(s[1]))])
 
         csvfile.close()
         logger.info('File can be found at: %s', fullfilename)


### PR DESCRIPTION
## Description
Fix Python 3 incompatibility in `generate_screwed_csv` within `LotteryAssignmentController`.

The CSV file was opened in binary mode (`'wb'`), which causes `csv.writer` to raise a
`TypeError` when writing string data in Python 3. Additionally, student names were
manually encoded to ASCII, which is unnecessary and may lead to data loss.

This PR updates file handling to text mode with proper newline and UTF-8 encoding,
and removes manual ASCII encoding.

## Related Issue
Closes #4429

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing
- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

Manual verification:
- Called `generate_screwed_csv()` successfully
- CSV file generated without errors
- Student names preserved with UTF-8 encoding

## AI Disclosure
AI assistance was used to help identify the Python 3 CSV compatibility issue and draft
the implementation approach. All code changes were reviewed and validated manually.

## Checklist
- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced