### PR TITLE
Replace deprecated assertEquals with assertEqual in tests

### DIFF
--- a/esp/esp/program/modules/tests/jsondatamodule.py
+++ b/esp/esp/program/modules/tests/jsondatamodule.py
@@ -216,7 +216,7 @@ class JSONDataModuleTest(ProgramFrameworkTest):
         ## Make sure all classes are listed
         json_classes = self.classes_response.json()
         classes = ClassSubject.objects.filter(parent_program=self.program)
-        self.assertEquals(len(json_classes["classes"]), classes.count())
+        self.assertEqual(len(json_classes["classes"]), classes.count())
 
         json_classes_dict = dict()
         for json_cls in json_classes["classes"]:
@@ -224,7 +224,7 @@ class JSONDataModuleTest(ProgramFrameworkTest):
         for cls in classes:
             # Very basic check that we're getting the data correctly
             self.assertTrue(cls.id in json_classes_dict)
-            self.assertEquals(json_classes_dict[cls.id]['emailcode'], cls.emailcode())
+            self.assertEqual(json_classes_dict[cls.id]['emailcode'], cls.emailcode())
 
     # ------------------------------------------------------------------
     # Additional tests for issue #599: Dashboard stats JSON interface

--- a/esp/esp/program/modules/tests/programprintables.py
+++ b/esp/esp/program/modules/tests/programprintables.py
@@ -72,14 +72,14 @@ class ProgramPrintablesModuleTest(ProgramFrameworkTest):
 
         #   Select users to fetch
         response = self.client.get('/manage/%s/%s' % (self.program.getUrlBase(), view_name))
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         post_data = {
             'recipient_type': user_type,
             'base_list': list_name,
             'use_checklist': 0,
         }
         response = self.client.post('/manage/%s/%s' % (self.program.getUrlBase(), view_name), post_data)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         return response
 
     def get_userlist_views(self):
@@ -125,7 +125,7 @@ class ProgramPrintablesModuleTest(ProgramFrameworkTest):
         """
         self._login_admin()
         response = self.client.get(self.all_classes_csv_url)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'program/modules/programprintables/all_classes_select_fields.html')
 
     def test_all_classes_spreadsheet_invalid_post(self):
@@ -136,7 +136,7 @@ class ProgramPrintablesModuleTest(ProgramFrameworkTest):
 
         #Test empty form
         response = self.client.post(self.all_classes_csv_url)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         self.assertFormError(response, 'form', 'subject_fields', 'This field is required.')
 
         #Test invalid fieldname
@@ -153,9 +153,9 @@ class ProgramPrintablesModuleTest(ProgramFrameworkTest):
         post_data = {'subject_fields':[field.name for field in ClassSubject._meta.fields if field.name not in exclude_fields]}
 
         response = self.client.post(self.all_classes_csv_url, post_data)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
-        self.assertEquals(
+        self.assertEqual(
             response.get('Content-Disposition'),
             "attachment; filename=all_classes.csv"
         )
@@ -203,8 +203,8 @@ class TestAllClassesFieldConverter(ProgramFrameworkTest):
         """
         class_subject = self.class_subjects[0]
         for fieldname in self.class_subject_fieldnames:
-            self.assertEquals(self.converter.fieldvalue(class_subject, fieldname), \
-                              getattr(class_subject, fieldname))
+            self.assertEqual(self.converter.fieldvalue(class_subject, fieldname), \
+                             getattr(class_subject, fieldname))
 
     def test_class_subject_teachers_format(self):
         class_subject = self.class_subjects[0]
@@ -212,7 +212,7 @@ class TestAllClassesFieldConverter(ProgramFrameworkTest):
         teacher_names = [t.name() for t in class_subject.get_teachers()]
         formatted_teachers = [t.strip() for t in self.converter. \
                               fieldvalue(class_subject, 'teachers').split(',')]
-        self.assertEquals(set(formatted_teachers), set(teacher_names))
+        self.assertEqual(set(formatted_teachers), set(teacher_names))
 
     def test_class_times_format(self):
         class_subject = self.class_subjects[0]

--- a/esp/esp/program/tests.py
+++ b/esp/esp/program/tests.py
@@ -263,8 +263,8 @@ class ProfileTest(TestCase):
         self.group=Group(name='Test Group')
         self.group.save()
         self.u.groups.add(self.group)
-        self.assertEquals(ESPUser.objects.get(username='bjones'), self.u)
-        self.assertEquals(Group.objects.get(name='Test Group'), self.group)
+        self.assertEqual(ESPUser.objects.get(username='bjones'), self.u)
+        self.assertEqual(Group.objects.get(name='Test Group'), self.group)
 
 class ProgramHappenTest(TestCase):
     """


### PR DESCRIPTION
`assertEquals` has been deprecated since Python 3.2 in favor of `assertEqual`.

This replaces all 12 occurrences across 3 test files:
- `esp/program/tests.py` (2)
- `esp/program/modules/tests/jsondatamodule.py` (2)
- `esp/program/modules/tests/programprintables.py` (8)

No behavioral change — `assertEquals` is just an alias for `assertEqual`.