### PR TITLE
Replace custom JsonResponse with django.http.JsonResponse (fixes Content-Type bug)

### DIFF
--- a/esp/esp/program/modules/handlers/studentregphasezero.py
+++ b/esp/esp/program/modules/handlers/studentregphasezero.py
@@ -40,10 +40,9 @@ from esp.program.models import PhaseZeroRecord
 from esp.program.modules.forms.phasezero import SubmitForm
 from esp.dbmail.models import send_mail
 from esp.tagdict.models import Tag
-from esp.web.views.json_utils import JsonResponse
 
 from django.conf import settings
-from django.http import HttpResponseRedirect
+from django.http import HttpResponseRedirect, JsonResponse
 from django.template.loader import render_to_string
 from django.db.models.query import Q
 
@@ -234,7 +233,7 @@ class StudentRegPhaseZero(ProgramModuleObj):
         else:
             obj_list = []
 
-        return JsonResponse(obj_list)
+        return JsonResponse(obj_list, safe=False)
 
     def send_confirmation_email(self, student, note=None):
         email_title = 'Student Lottery Confirmation for %s: %s' % (self.program.niceName(), student.name())

--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -1012,7 +1012,7 @@ class TeacherClassRegModule(ProgramModuleObj):
     @staticmethod
     def teacherlookup_logic(request, tl, one, two, module, extra, prog, newclass = None):
         limit = 10
-        from esp.web.views.json_utils import JsonResponse
+        from django.http import JsonResponse
 
         Q_teacher = Q(groups__name="Teacher")
 
@@ -1059,7 +1059,7 @@ class TeacherClassRegModule(ProgramModuleObj):
         else:
             obj_list = []
 
-        return JsonResponse(obj_list)
+        return JsonResponse(obj_list, safe=False)
 
     def get_msg_vars(self, user, key):
         if key == 'full_classes':

--- a/esp/esp/program/modules/handlers/teachermoderatormodule.py
+++ b/esp/esp/program/modules/handlers/teachermoderatormodule.py
@@ -85,7 +85,7 @@ class TeacherModeratorModule(ProgramModuleObj):
     @staticmethod
     def moderatorlookup_logic(request, tl, one, two, module, extra, prog, newclass = None):
         limit = 10
-        from esp.web.views.json_utils import JsonResponse
+        from django.http import JsonResponse
 
         queryset = prog.teachers()['will_moderate']
 
@@ -130,7 +130,7 @@ class TeacherModeratorModule(ProgramModuleObj):
         else:
             obj_list = []
 
-        return JsonResponse(obj_list)
+        return JsonResponse(obj_list, safe=False)
 
     class Meta:
         proxy = True

--- a/esp/esp/web/views/json_utils.py
+++ b/esp/esp/web/views/json_utils.py
@@ -36,13 +36,8 @@ import json
 
 from django.http import HttpResponse
 
-# TODO(benkraft): replace users of this with @json_response, and remove.
-class JsonResponse(HttpResponse):
-    def __init__(self, obj):
-        self.original_obj = obj
-        HttpResponse.__init__(self, self.serialize())
-#self["Content-Type"] = "application/json"
-        self["Content-Type"] = "text/plain"
-
-    def serialize(self):
-        return(json.dumps(self.original_obj))
+# The custom JsonResponse class that was defined here has been removed.
+# It incorrectly set Content-Type to "text/plain" instead of "application/json".
+# All callers now use django.http.JsonResponse, which sets the correct
+# Content-Type. For views that return JSON via a decorator, see
+# esp.utils.decorators.json_response.


### PR DESCRIPTION
The custom `JsonResponse` class in `web/views/json_utils.py` incorrectly sets `Content-Type: text/plain` instead of `application/json`. The correct header was commented out, and a TODO from `@benkraft` explicitly called for this replacement.

This PR removes the buggy custom class and migrates all 3 consumers to Django's built-in `django.http.JsonResponse` (available since Django 1.7), passing `safe=False` for list serialization.

### Problem

```python
# web/views/json_utils.py (before this PR)
class JsonResponse(HttpResponse):
    def __init__(self, obj):
        self.original_obj = obj
        HttpResponse.__init__(self, self.serialize())
        #self["Content-Type"] = "application/json"   # correct — but commented out
        self["Content-Type"] = "text/plain"           # incorrect
```

This caused three AJAX endpoints — teacher lookup, moderator lookup, and student phase-zero registration — to return JSON with the wrong MIME type. While most browsers/JS clients tolerate this, it violates the HTTP spec and can break strict consumers.

### Changes

- **`web/views/json_utils.py`** — Removed the custom `JsonResponse` class (as requested in the existing TODO).
- **`program/modules/handlers/studentregphasezero.py`** — Switched import to `django.http.JsonResponse`.
- **`program/modules/handlers/teacherclassregmodule.py`** — Switched import to `django.http.JsonResponse`.
- **`program/modules/handlers/teachermoderatormodule.py`** — Switched import to `django.http.JsonResponse`.

> **Note:** `customforms/views.py` already uses `django.http.JsonResponse`, and the `@json_response` decorator in `utils/decorators.py` already sets `application/json`. This PR brings the remaining 3 call sites in line with the rest of the codebase.

### Testing

- All four modified files pass Python syntax checks.
- Verified that `JsonResponse(data, safe=False)` correctly serializes list payloads with `Content-Type: application/json`.
- No behavioral change beyond the corrected Content-Type header.


LINK:
https://github.com/adityasuhane-06/ESP-Website/pull/new/fix/replace-custom-jsonresponse

