### PR TITLE
fix: Compatability: replace request.is_ajax() with forward-compatible…

### DIFF
--- a/esp/esp/customforms/views.py
+++ b/esp/esp/customforms/views.py
@@ -49,7 +49,7 @@ def formBuilder(request):
 
 @user_passes_test(test_func)
 def formBuilderData(request):
-    if request.is_ajax():
+    if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
         if request.method == 'GET':
             data = {}
             data['only_fkey_models'] = list(cf_cache.only_fkey_models.keys())
@@ -65,7 +65,7 @@ def getPerms(request):
     """
     Returns the various permissions available for the current program via AJAX.
     """
-    if request.is_ajax():
+    if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
         if request.method == 'GET':
             try:
                 prog_id = int(request.GET['prog_id'])
@@ -90,7 +90,7 @@ def getPerms(request):
 def onSubmit(request):
     #Stores form metadata in the database.
 
-    if request.is_ajax():
+    if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
         if request.method == 'POST':
             try:
                 metadata = json.loads(request.body)
@@ -179,7 +179,7 @@ def onModify(request):
     """
     Handles form modifications
     """
-    if request.is_ajax():
+    if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
         if request.method == 'POST':
             try:
                 metadata = json.loads(request.body)
@@ -380,7 +380,7 @@ def getData(request):
     """
     Returns response data via Ajax
     """
-    if request.is_ajax():
+    if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
         if request.method == 'GET':
             try:
                 form_id = int(request.GET['form_id'])
@@ -415,7 +415,7 @@ def getRebuildData(request):
     """
     Returns form metadata for rebuilding via AJAX
     """
-    if request.is_ajax():
+    if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
         if request.method == 'GET':
             try:
                 form_id = int(request.GET['form_id'])
@@ -434,7 +434,7 @@ def get_links(request):
     """
     Returns the instances for the specified model, to link to in the form builder.
     """
-    if request.is_ajax():
+    if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
         if request.method == 'GET':
             try:
                 link_model = cf_cache.only_fkey_models[request.GET['link_model']]
@@ -460,7 +460,7 @@ def get_modules(request):
     # so we'll just need to update these if they change
     teach_handlers = ['TeacherCustomFormModule', 'TeacherQuizModule']
     learn_handlers = ['StudentCustomFormModule']
-    if request.is_ajax():
+    if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
         if request.method == 'GET':
             try:
                 prog = Program.objects.get(id=request.GET.get('program'))

--- a/esp/esp/middleware/esperrormiddleware.py
+++ b/esp/esp/middleware/esperrormiddleware.py
@@ -114,7 +114,7 @@ class AjaxErrorMiddleware(MiddlewareMixin):
     def process_exception(self, request, exception):
         #   This line has been commented out for debugging so that requests
         #   can be made using a normal browser like Firefox with UrlParams.
-        if not request.is_ajax(): return
+        if request.headers.get('X-Requested-With') != 'XMLHttpRequest': return
 
         if isinstance(exception, (ObjectDoesNotExist, Http404)):
             return self.not_found(request, exception)

--- a/esp/esp/program/modules/handlers/onsitecheckinmodule.py
+++ b/esp/esp/program/modules/handlers/onsitecheckinmodule.py
@@ -226,11 +226,11 @@ class OnSiteCheckinModule(ProgramModuleObj):
                         rec = Record(user=student, event=rt, program=prog)
                         rec.save()
                     context['message'] = '%s %s marked as attended.' % (student.first_name, student.last_name)
-                    if request.is_ajax():
+                    if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
                         return self.ajax_status(request, tl, one, two, module, extra, prog, context)
                 else:
                     context['message'] = '%s %s is not a student and has not been checked in' % (student.first_name, student.last_name)
-                    if request.is_ajax():
+                    if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
                         return self.ajax_status(request, tl, one, two, module, extra, prog, context)
                 form = StudentSearchForm(initial={'target_user': student.id})
         else:

--- a/esp/esp/program/modules/handlers/studentclassregmodule.py
+++ b/esp/esp/program/modules/handlers/studentclassregmodule.py
@@ -414,7 +414,7 @@ class StudentClassRegModule(ProgramModuleObj):
     @meets_cap
     def ajax_addclass(self, request, tl, one, two, module, extra, prog):
         """ Preregister a student for the specified class and return an updated inline schedule """
-        if not request.is_ajax():
+        if request.headers.get('X-Requested-With') != 'XMLHttpRequest':
             return self.addclass(request, tl, one, two, module, extra, prog)
         try:
             success = self.addclass_logic(request, tl, one, two, module, extra, prog)
@@ -669,7 +669,7 @@ class StudentClassRegModule(ProgramModuleObj):
     @meets_any_deadline(['/Classes', '/Removal'])
     def ajax_clearslot(self, request, tl, one, two, module, extra, prog):
         """ Clear the specified timeslot from a student registration and return an updated inline schedule """
-        if not request.is_ajax():
+        if request.headers.get('X-Requested-With') != 'XMLHttpRequest':
             return self.clearslot(request, tl, one, two, module, extra, prog)
 
         cleared_ids = self.clearslot_logic(request, tl, one, two, module, extra, prog)

--- a/esp/esp/program/modules/handlers/studentregtwophase.py
+++ b/esp/esp/program/modules/handlers/studentregtwophase.py
@@ -318,7 +318,7 @@ class StudentRegTwoPhase(ProgramModuleObj):
             subject__pk__in=json_data['not_interested'])
         to_expire.update(end_date=datetime.datetime.now())
 
-        if request.is_ajax():
+        if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
             return HttpResponse()
         else:
             return self.goToCore(tl)

--- a/esp/esp/program/views.py
+++ b/esp/esp/program/views.py
@@ -1120,7 +1120,7 @@ def statistics(request, program=None):
             context['clear_first'] = False
             context['field_ids'] = get_field_ids(form)
 
-            if request.is_ajax():
+            if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
                 result = {}
                 result['result_html'] = context['result']
                 result['script'] = render_to_string('program/statistics/script.js', context)
@@ -1133,7 +1133,7 @@ def statistics(request, program=None):
             context = {'form': form}
             context['clear_first'] = False
             context['field_ids'] = get_field_ids(form)
-            if request.is_ajax():
+            if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
                 return HttpResponse(json.dumps(result), content_type='application/json')
             else:
                 return render_to_response('program/statistics.html', request, context)
@@ -1145,7 +1145,7 @@ def statistics(request, program=None):
     context['clear_first'] = False
     context['field_ids'] = get_field_ids(form)
 
-    if request.is_ajax():
+    if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
         return HttpResponse(json.dumps(context), content_type='application/json')
     else:
         return render_to_response('program/statistics.html', request, context)


### PR DESCRIPTION
… header check

## Description
HttpRequest.is_ajax() was deprecated in Django 3.1 and removed in Django 4.0. All 17 call sites across 6 files now use the equivalent request.headers.get('X-Requested-With') == 'XMLHttpRequest' check, which is supported from Django 2.2 onward and will remain functional through future Django upgrades.

## Related Issue

Closes #4436 

## Type of Change

- [x] Bug fix

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manually verified

## AI Disclosure

NA

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced
