### PR TITLE
Generate all favicon variants when a new favicon is selected (fixes #4466)

### DIFF
--- a/esp/esp/themes/views.py
+++ b/esp/esp/themes/views.py
@@ -114,8 +114,8 @@ def _generate_favicon_variants(ico_path, images_dir):
                 out_path = os.path.join(images_dir, filename)
                 resized = img.resize((size, size), resample)
                 resized.save(out_path, 'PNG')
-        name = Tag.getTag('site_name') or Tag.getTag('full_group_name') or getattr(settings, 'INSTITUTION_NAME', 'ESP Website')
-        short_name = Tag.getTag('site_short_name') or Tag.getTag('full_group_name') or getattr(settings, 'ORGANIZATION_SHORT_NAME', 'ESP')
+        name = Tag.getTag('full_group_name') or getattr(settings, 'INSTITUTION_NAME', 'ESP Website')
+        short_name = Tag.getTag('full_group_name') or getattr(settings, 'ORGANIZATION_SHORT_NAME', 'ESP')
         if name is None:
             name = 'ESP Website'
         elif not isinstance(name, str):


### PR DESCRIPTION
## Summary
Implements the follow-up from #4304: whenever a new favicon is **uploaded** or **selected** in the theme logo editor, we now generate all the PNG variants and `site.webmanifest` under `/media/images/` so modern browsers and mobile get the correct icons.

## Changes
- **`_generate_favicon_variants(ico_path, images_dir)`** in `esp/esp/themes/views.py`:
  - Uses Pillow to open `favicon.ico` and generate: `favicon-16x16.png`, `favicon-32x32.png`, `apple-touch-icon.png` (180×180), `android-chrome-192x192.png`, `android-chrome-512x512.png`.
  - Writes `site.webmanifest` with `/media/images/` icon paths; `name`/`short_name` from Tag or settings (default "ESP Website" / "ESP").
- **Call generator** after:
  1. `new_favicon` upload (after saving ico and backup)
  2. `favicon_select` (after copying selected backup to favicon.ico)
- If Pillow is missing or generation fails (e.g. corrupt ico), the theme flow is unchanged (no-op / exception swallowed).

## Testing
- Upload or select a favicon at theme logos; check that `media/images/` contains the new PNGs and `site.webmanifest`.
- With #4304 merged, browser tab and "Add to home screen" should show the updated icon.

Fixes #4466.