### PR TITLE
Fix race condition in student class registration

### DIFF
--- a/esp/esp/program/modules/handlers/studentclassregmodule.py
+++ b/esp/esp/program/modules/handlers/studentclassregmodule.py
@@ -40,6 +40,7 @@ from datetime import datetime
 from decimal import Decimal
 
 from django.contrib.auth.models import User
+from django.db import transaction
 from django.db.models.query import Q, QuerySet
 from django.http import HttpResponse, Http404
 from django.views.decorators.cache import cache_control
@@ -381,26 +382,27 @@ class StudentClassRegModule(ProgramModuleObj):
         else:
             raise ESPError("We've lost track of your chosen class's ID!  Please try again; make sure that you've clicked the \"Add Class\" button, rather than just typing in a URL.  Also, please make sure that your Web browser has JavaScript enabled.", log=False)
 
-        section = ClassSection.objects.get(id=sectionid)
-        if not scrmi.use_priority:
-            error = section.cannotAdd(request.user, scrmi.enforce_max, webapp=webapp)
-        if scrmi.use_priority or not error:
-            cobj = ClassSubject.objects.get(id=classid)
-            error = cobj.cannotAdd(request.user, scrmi.enforce_max, webapp=webapp) or section.cannotAdd(request.user, scrmi.enforce_max, webapp=webapp)
+        with transaction.atomic():
+            section = ClassSection.objects.select_for_update().get(id=sectionid)
+            if not scrmi.use_priority:
+                error = section.cannotAdd(request.user, scrmi.enforce_max, webapp=webapp)
+            if scrmi.use_priority or not error:
+                cobj = ClassSubject.objects.get(id=classid)
+                error = cobj.cannotAdd(request.user, scrmi.enforce_max, webapp=webapp) or section.cannotAdd(request.user, scrmi.enforce_max, webapp=webapp)
 
-        if scrmi.use_priority:
-            priority = request.user.getRegistrationPriority(prog, section.meeting_times.all())
-        else:
-            priority = 1
+            if scrmi.use_priority:
+                priority = request.user.getRegistrationPriority(prog, section.meeting_times.all())
+            else:
+                priority = 1
 
-        if error and not request.user.onsite_local:
-            raise ESPError(error, log=False)
+            if error and not request.user.onsite_local:
+                raise ESPError(error, log=False)
 
-        #   Desired priority level is 1 above current max
-        if section.preregister_student(request.user, request.user.onsite_local, priority, webapp=webapp):
-            return True
-        else:
-            raise ESPError('According to our latest information, this class is full. Please go back and choose another class.', log=False)
+            #   Desired priority level is 1 above current max
+            if section.preregister_student(request.user, request.user.onsite_local, priority, webapp=webapp):
+                return True
+            else:
+                raise ESPError('According to our latest information, this class is full. Please go back and choose another class.', log=False)
 
     @aux_call
     @needs_student_in_grade


### PR DESCRIPTION
## Description

Fixes a TOCTOU (Time-of-Check to Time-of-Use) race condition in `addclass_logic()` where the capacity check (`cannotAdd()`) and the actual registration (`preregister_student()`) were not wrapped in a single atomic transaction. During high-traffic registration periods, concurrent requests could both pass the capacity check before either registers, resulting in over-enrollment beyond class capacity.

The fix wraps the entire check-and-register block in `transaction.atomic()` with `select_for_update()` on the `ClassSection` row, acquiring a row-level database lock so concurrent requests are serialized.

## Related Issue

Closes #4492 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## AI Disclosure

 AI tools were used in testing.

## Checklist

- [x] Self-reviewed the code
- [x] Updated documentation (if needed)
- [x] No new warnings or errors introduced
