### PR TITLE
Support multi-role contact info editing on /myesp/profile

### DIFF
--- a/esp/esp/web/views/myesp.py
+++ b/esp/esp/web/views/myesp.py
@@ -47,8 +47,6 @@ from esp.users.forms.user_profile import TeacherInfoForm, StudentInfoForm, Educa
 from esp.utils.web import render_to_response
 from django.db.models.query import Q
 
-# Mapping from role name to the standalone info form class for that role.
-# Used by profile_editor() to create extra forms for multi-role users.
 ROLE_INFO_FORMS = {
     'student': StudentInfoForm,
     'teacher': TeacherInfoForm,
@@ -56,8 +54,6 @@ ROLE_INFO_FORMS = {
     'educator': EducatorInfoForm,
 }
 
-# Roles that require additional sub-forms (guardian contact, emergency contact)
-# when rendered as an extra (non-primary) form.
 ROLE_EXTRA_SUBFORMS = {
     'student': [GuardContactForm, EmergContactForm],
 }
@@ -105,12 +101,10 @@ def edit_profile(request):
 
     curUser = request.user
 
-    # Collect all roles this user has, filtered to known ESP user types.
     valid_types = [t.lower() for t in ESPUser.getTypes()]
     user_roles = [t.lower() for t in curUser.getUserTypes() if t.lower() in valid_types]
 
     if not user_roles:
-        # Fallback: try group names directly
         user_types = curUser.groups.all().order_by('-id')
         user_roles = [user_types[0].name.lower()] if user_types else ['']
 
@@ -135,6 +129,17 @@ def profile_editor(request, prog_input=None, responseuponCompletion = True, role
 
     curUser.updateOnsite(request)
 
+    # Normalize role: accept both a single string (backward compat from
+    # RegProfileModule) and a list of strings (from the new edit_profile).
+    if isinstance(role, str):
+        roles = [role]
+    else:
+        roles = list(role)
+
+    # Primary role is the first one; extra roles get their own info forms.
+    primary_role = roles[0] if roles else ''
+    extra_roles = roles[1:] if len(roles) > 1 else []
+
     #   Get the profile form from the user's type, although we need to handle
     #   a couple of extra possibilities for the 'role' variable.
     user_types = ESPUser.getAllUserTypes()
@@ -144,15 +149,37 @@ def profile_editor(request, prog_input=None, responseuponCompletion = True, role
     additional_type_labels = [x[0] for x in additional_types]
     #   Handle all-lowercase versions of role being passed in by calling title()
     user_type_labels = [x[0] for x in user_types]
-    if role.title() in user_type_labels:
-        target_type = user_types[user_type_labels.index(role.title())][1]
+    if primary_role.title() in user_type_labels:
+        target_type = user_types[user_type_labels.index(primary_role.title())][1]
     else:
-        target_type = additional_types[additional_type_labels.index(role.title())][1]
+        target_type = additional_types[additional_type_labels.index(primary_role.title())][1]
     mod = __import__('esp.users.forms.user_profile', (), (), target_type['profile_form'])
     FormClass = getattr(mod, target_type['profile_form'])
 
-    context['profiletype'] = role
+    context['profiletype'] = primary_role
 
+    # Build list of extra info form classes for additional roles.
+    # Each entry is {'role': str, 'form_class': FormClass, 'prefix': str}
+    extra_form_specs = []
+    for extra_role in extra_roles:
+        if extra_role in ROLE_INFO_FORMS:
+            info_form_cls = ROLE_INFO_FORMS[extra_role]
+            prefix = extra_role + '_extra'
+            extra_form_specs.append({
+                'role': extra_role,
+                'form_class': info_form_cls,
+                'prefix': prefix,
+            })
+            # Also add any sub-forms (e.g., guardian/emergency contacts for students)
+            for sub_form_cls in ROLE_EXTRA_SUBFORMS.get(extra_role, []):
+                sub_prefix = extra_role + '_' + sub_form_cls.__name__.lower()
+                extra_form_specs.append({
+                    'role': extra_role,
+                    'form_class': sub_form_cls,
+                    'prefix': sub_prefix,
+                    'is_subform': True,
+                })
+    extra_forms = []
     if request.method == 'POST' and 'profile_page' in request.POST:
         form = FormClass(curUser, request.POST)
 
@@ -161,7 +188,24 @@ def profile_editor(request, prog_input=None, responseuponCompletion = True, role
             if hasattr(form, 'repress_studentrep_expl_error'):
                 form.repress_studentrep_expl_error()
 
-        if form.is_valid():
+        # Instantiate extra forms with POST data
+        extra_forms = []
+        for spec in extra_form_specs:
+            if hasattr(spec['form_class'], 'user'):
+                ef = spec['form_class'](curUser, request.POST, prefix=spec['prefix'])
+            else:
+                ef = spec['form_class'](request.POST, prefix=spec['prefix'])
+            extra_forms.append({
+                'form': ef,
+                'role': spec['role'],
+                'prefix': spec['prefix'],
+                'is_subform': spec.get('is_subform', False),
+            })
+
+        # Check if all forms are valid
+        all_extra_valid = all(ef['form'].is_valid() for ef in extra_forms)
+
+        if form.is_valid() and all_extra_valid:
             new_data = form.cleaned_data
 
             if prog_input is None:
@@ -179,16 +223,42 @@ def profile_editor(request, prog_input=None, responseuponCompletion = True, role
             if new_data.get('dietary_restrictions'):
                 regProf.dietary_restrictions = new_data['dietary_restrictions']
 
-            if role == 'student':
+            # Save primary role's info
+            if primary_role == 'student':
                 regProf.student_info = StudentInfo.addOrUpdate(curUser, regProf, new_data)
                 regProf.contact_guardian = ContactInfo.addOrUpdate(curUser, regProf, new_data, regProf.contact_guardian, 'guard_')
                 regProf.contact_emergency = ContactInfo.addOrUpdate(curUser, regProf, new_data, regProf.contact_emergency, 'emerg_')
-            elif role == 'teacher':
+            elif primary_role == 'teacher':
                 regProf.teacher_info = TeacherInfo.addOrUpdate(curUser, regProf, new_data)
-            elif role == 'guardian':
+            elif primary_role == 'guardian':
                 regProf.guardian_info = GuardianInfo.addOrUpdate(curUser, regProf, new_data)
-            elif role == 'educator':
+            elif primary_role == 'educator':
                 regProf.educator_info = EducatorInfo.addOrUpdate(curUser, regProf, new_data)
+
+            # Save extra role info
+            for ef in extra_forms:
+                if ef['is_subform']:
+                    continue  # Sub-forms are handled below with their parent role
+                extra_data = ef['form'].cleaned_data
+                extra_role_name = ef['role']
+                if extra_role_name == 'student':
+                    regProf.student_info = StudentInfo.addOrUpdate(curUser, regProf, extra_data)
+                elif extra_role_name == 'teacher':
+                    regProf.teacher_info = TeacherInfo.addOrUpdate(curUser, regProf, extra_data)
+                elif extra_role_name == 'guardian':
+                    regProf.guardian_info = GuardianInfo.addOrUpdate(curUser, regProf, extra_data)
+                elif extra_role_name == 'educator':
+                    regProf.educator_info = EducatorInfo.addOrUpdate(curUser, regProf, extra_data)
+
+            # Save student sub-forms (guardian contact, emergency contact) from extra roles
+            for ef in extra_forms:
+                if ef['is_subform'] and ef['role'] == 'student':
+                    sub_data = ef['form'].cleaned_data
+                    if 'guard_first_name' in sub_data or ef['prefix'].endswith('guardcontactform'):
+                        regProf.contact_guardian = ContactInfo.addOrUpdate(curUser, regProf, sub_data, regProf.contact_guardian, 'guard_')
+                    elif 'emerg_first_name' in sub_data or ef['prefix'].endswith('emergcontactform'):
+                        regProf.contact_emergency = ContactInfo.addOrUpdate(curUser, regProf, sub_data, regProf.contact_emergency, 'emerg_')
+
             regProf.save()
 
             curUser.first_name = new_data.get('first_name')
@@ -237,7 +307,7 @@ def profile_editor(request, prog_input=None, responseuponCompletion = True, role
         new_data['first_name'] = curUser.first_name
         new_data['last_name']  = curUser.last_name
         new_data['e_mail']     = curUser.email
-        new_data = regProf.updateForm(new_data, role)
+        new_data = regProf.updateForm(new_data, primary_role)
 
         if regProf.student_info and regProf.student_info.dob:
             new_data['dob'] = regProf.student_info.dob
@@ -252,10 +322,27 @@ def profile_editor(request, prog_input=None, responseuponCompletion = True, role
             state_tag_map[field] = 'local_state'
         form = FormClass(curUser, initial=new_data, tag_map=state_tag_map)
 
+        # Build extra forms with initial data from the registration profile
+        extra_forms = []
+        extra_data = {}
+        extra_data = regProf.updateForm(extra_data)
+        for spec in extra_form_specs:
+            if hasattr(spec['form_class'], 'user'):
+                ef = spec['form_class'](curUser, initial=extra_data, prefix=spec['prefix'])
+            else:
+                ef = spec['form_class'](initial=extra_data, prefix=spec['prefix'])
+            extra_forms.append({
+                'form': ef,
+                'role': spec['role'],
+                'prefix': spec['prefix'],
+                'is_subform': spec.get('is_subform', False),
+            })
+
     context['new_user'] = regProf.id is None
     context['request'] = request
     context['form'] = form
     context['require_student_phonenum'] = Tag.getBooleanTag('require_student_phonenum')
+    context['extra_forms'] = extra_forms
     return render_to_response('users/profile.html', request, context)
 
 @login_required

--- a/esp/esp/web/views/myesp.py
+++ b/esp/esp/web/views/myesp.py
@@ -47,15 +47,18 @@ from esp.users.forms.user_profile import TeacherInfoForm, StudentInfoForm, Educa
 from esp.utils.web import render_to_response
 from django.db.models.query import Q
 
+# Mapping from role name to (FormClass, takes_user_arg).
+# takes_user_arg is True for forms inheriting from FormUnrestrictedOtherUser.
 ROLE_INFO_FORMS = {
-    'student': StudentInfoForm,
-    'teacher': TeacherInfoForm,
-    'guardian': GuardianInfoForm,
-    'educator': EducatorInfoForm,
+    'student': (StudentInfoForm, True),
+    'teacher': (TeacherInfoForm, False),
+    'guardian': (GuardianInfoForm, False),
+    'educator': (EducatorInfoForm, False),
 }
 
+# Sub-forms for specific roles: list of (FormClass, takes_user_arg) tuples.
 ROLE_EXTRA_SUBFORMS = {
-    'student': [GuardContactForm, EmergContactForm],
+    'student': [(GuardContactForm, True), (EmergContactForm, True)],
 }
 
 @login_required
@@ -129,14 +132,11 @@ def profile_editor(request, prog_input=None, responseuponCompletion = True, role
 
     curUser.updateOnsite(request)
 
-    # Normalize role: accept both a single string (backward compat from
-    # RegProfileModule) and a list of strings (from the new edit_profile).
     if isinstance(role, str):
         roles = [role]
     else:
         roles = list(role)
 
-    # Primary role is the first one; extra roles get their own info forms.
     primary_role = roles[0] if roles else ''
     extra_roles = roles[1:] if len(roles) > 1 else []
 
@@ -159,25 +159,26 @@ def profile_editor(request, prog_input=None, responseuponCompletion = True, role
     context['profiletype'] = primary_role
 
     # Build list of extra info form classes for additional roles.
-    # Each entry is {'role': str, 'form_class': FormClass, 'prefix': str}
     extra_form_specs = []
     for extra_role in extra_roles:
         if extra_role in ROLE_INFO_FORMS:
-            info_form_cls = ROLE_INFO_FORMS[extra_role]
+            info_form_cls, takes_user = ROLE_INFO_FORMS[extra_role]
             prefix = extra_role + '_extra'
             extra_form_specs.append({
                 'role': extra_role,
                 'form_class': info_form_cls,
                 'prefix': prefix,
+                'takes_user': takes_user,
             })
             # Also add any sub-forms (e.g., guardian/emergency contacts for students)
-            for sub_form_cls in ROLE_EXTRA_SUBFORMS.get(extra_role, []):
+            for sub_form_cls, sub_takes_user in ROLE_EXTRA_SUBFORMS.get(extra_role, []):
                 sub_prefix = extra_role + '_' + sub_form_cls.__name__.lower()
                 extra_form_specs.append({
                     'role': extra_role,
                     'form_class': sub_form_cls,
                     'prefix': sub_prefix,
                     'is_subform': True,
+                    'takes_user': sub_takes_user,
                 })
     extra_forms = []
     if request.method == 'POST' and 'profile_page' in request.POST:
@@ -188,10 +189,9 @@ def profile_editor(request, prog_input=None, responseuponCompletion = True, role
             if hasattr(form, 'repress_studentrep_expl_error'):
                 form.repress_studentrep_expl_error()
 
-        # Instantiate extra forms with POST data
         extra_forms = []
         for spec in extra_form_specs:
-            if hasattr(spec['form_class'], 'user'):
+            if spec.get('takes_user', False):
                 ef = spec['form_class'](curUser, request.POST, prefix=spec['prefix'])
             else:
                 ef = spec['form_class'](request.POST, prefix=spec['prefix'])
@@ -223,7 +223,6 @@ def profile_editor(request, prog_input=None, responseuponCompletion = True, role
             if new_data.get('dietary_restrictions'):
                 regProf.dietary_restrictions = new_data['dietary_restrictions']
 
-            # Save primary role's info
             if primary_role == 'student':
                 regProf.student_info = StudentInfo.addOrUpdate(curUser, regProf, new_data)
                 regProf.contact_guardian = ContactInfo.addOrUpdate(curUser, regProf, new_data, regProf.contact_guardian, 'guard_')
@@ -238,7 +237,7 @@ def profile_editor(request, prog_input=None, responseuponCompletion = True, role
             # Save extra role info
             for ef in extra_forms:
                 if ef['is_subform']:
-                    continue  # Sub-forms are handled below with their parent role
+                    continue
                 extra_data = ef['form'].cleaned_data
                 extra_role_name = ef['role']
                 if extra_role_name == 'student':
@@ -250,7 +249,6 @@ def profile_editor(request, prog_input=None, responseuponCompletion = True, role
                 elif extra_role_name == 'educator':
                     regProf.educator_info = EducatorInfo.addOrUpdate(curUser, regProf, extra_data)
 
-            # Save student sub-forms (guardian contact, emergency contact) from extra roles
             for ef in extra_forms:
                 if ef['is_subform'] and ef['role'] == 'student':
                     sub_data = ef['form'].cleaned_data
@@ -321,13 +319,11 @@ def profile_editor(request, prog_input=None, responseuponCompletion = True, role
         for field in state_fields:
             state_tag_map[field] = 'local_state'
         form = FormClass(curUser, initial=new_data, tag_map=state_tag_map)
-
-        # Build extra forms with initial data from the registration profile
         extra_forms = []
         extra_data = {}
         extra_data = regProf.updateForm(extra_data)
         for spec in extra_form_specs:
-            if hasattr(spec['form_class'], 'user'):
+            if spec.get('takes_user', False):
                 ef = spec['form_class'](curUser, initial=extra_data, prefix=spec['prefix'])
             else:
                 ef = spec['form_class'](initial=extra_data, prefix=spec['prefix'])

--- a/esp/esp/web/views/myesp.py
+++ b/esp/esp/web/views/myesp.py
@@ -43,8 +43,24 @@ from django.http import Http404, HttpResponseRedirect
 import datetime
 from esp.middleware import ESPError
 from esp.users.forms.password_reset import UserPasswdForm
+from esp.users.forms.user_profile import TeacherInfoForm, StudentInfoForm, EducatorInfoForm, GuardianInfoForm, EmergContactForm, GuardContactForm
 from esp.utils.web import render_to_response
 from django.db.models.query import Q
+
+# Mapping from role name to the standalone info form class for that role.
+# Used by profile_editor() to create extra forms for multi-role users.
+ROLE_INFO_FORMS = {
+    'student': StudentInfoForm,
+    'teacher': TeacherInfoForm,
+    'guardian': GuardianInfoForm,
+    'educator': EducatorInfoForm,
+}
+
+# Roles that require additional sub-forms (guardian contact, emergency contact)
+# when rendered as an extra (non-primary) form.
+ROLE_EXTRA_SUBFORMS = {
+    'student': [GuardContactForm, EmergContactForm],
+}
 
 @login_required
 def myesp_passwd(request):
@@ -89,24 +105,16 @@ def edit_profile(request):
 
     curUser = request.user
 
-    if curUser.isTeacher():
-        return profile_editor(request, None, True, 'teacher')
+    # Collect all roles this user has, filtered to known ESP user types.
+    valid_types = [t.lower() for t in ESPUser.getTypes()]
+    user_roles = [t.lower() for t in curUser.getUserTypes() if t.lower() in valid_types]
 
-    elif curUser.isStudent():
-        return profile_editor(request, None, True, 'student')
-
-    elif curUser.isGuardian():
-        return profile_editor(request, None, True, 'guardian')
-
-    elif curUser.isEducator():
-        return profile_editor(request, None, True, 'educator')
-
-    elif curUser.isVolunteer():
-        return profile_editor(request, None, True, 'volunteer')
-
-    else:
+    if not user_roles:
+        # Fallback: try group names directly
         user_types = curUser.groups.all().order_by('-id')
-        return profile_editor(request, None, True, user_types[0].name if user_types else '')
+        user_roles = [user_types[0].name.lower()] if user_types else ['']
+
+    return profile_editor(request, None, True, user_roles)
 
 @login_required
 def profile_editor(request, prog_input=None, responseuponCompletion = True, role=''):

--- a/esp/templates/users/profile.html
+++ b/esp/templates/users/profile.html
@@ -5,15 +5,15 @@
 {% block stylesheets %}
 {{ block.super }}
 <style>
-div.required label.control-label:after {
-  content:"*";
-  color:red;
-}
+  div.required label.control-label:after {
+    content: "*";
+    color: red;
+  }
 
-#id_receive_txt_message {
-  list-style-type: none;
-  margin-left: 0px;
-}
+  #id_receive_txt_message {
+    list-style-type: none;
+    margin-left: 0px;
+  }
 </style>
 {% endblock %}
 
@@ -26,61 +26,74 @@ div.required label.control-label:after {
     <div class="span12">
       {% load render_qsd %}
       {% inline_qsd_block "account_creation_basic_info" %}
-<p>First, please tell us a bit about yourself!  The fields with red asterisks are required.  After you have filled out everything, click the "{% if new_user %}submit{% else %}update{% endif %}" button at the bottom of the page to continue.</p>
+      <p>First, please tell us a bit about yourself! The fields with red asterisks are required. After you have filled
+        out everything, click the "{% if new_user %}submit{% else %}update{% endif %}" button at the bottom of the page
+        to continue.</p>
 
-{% if not new_user %}
-<p>Email addresses have a tendency to change regularly, so we are asking that you re-enter your email address each time you visit this form. Please take the time to also correct any other information that may be old or incorrect.  Thanks!</p>
-{% endif %}
+      {% if not new_user %}
+      <p>Email addresses have a tendency to change regularly, so we are asking that you re-enter your email address each
+        time you visit this form. Please take the time to also correct any other information that may be old or
+        incorrect. Thanks!</p>
+      {% endif %}
       {% end_inline_qsd_block %}
     </div>
   </div>
 </div>
 <div class="row-fluid">
   <div class="span10">
-      {% if form.errors %}
-            <div class="alert alert-danger">
-                <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
-                    Please fix the following error{{ form.errors|pluralize }} in the form.
-            </div>
-      <ul>
-	{% for error in form.errors.items %}
-	{% ifequal error.0 '__all__' %}
-	{{ error.1 }}
-	{% endifequal %}
-	{% endfor %}
-      </ul>
-      <br />
-      {% endif %}
+    {% if form.errors %}
+    <div class="alert alert-danger">
+      <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+      Please fix the following error{{ form.errors|pluralize }} in the form.
+    </div>
+    <ul>
+      {% for error in form.errors.items %}
+      {% ifequal error.0 '__all__' %}
+      {{ error.1 }}
+      {% endifequal %}
+      {% endfor %}
+    </ul>
+    <br />
+    {% endif %}
+
+    {% for extra in extra_forms %}
+    {% if extra.form.errors %}
+    <div class="alert alert-danger">
+      <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+      Please fix the error{{ extra.form.errors|pluralize }} in the {{ extra.role|capfirst }} section.
+    </div>
+    {% endif %}
+    {% endfor %}
 
     <form action="{{request.path}}" method="post" class="form-horizontal">
-        <fieldset>
+      <fieldset>
         <input type="hidden" name="profile_page" value="true" />
         <input type="hidden" name="current_role" value="{{ profiletype }}" />
 
         {% ifequal profiletype "teacher" %}
-            {% include "users/profiles/usercontact.html" %}
-            {% include "users/profiles/teacherinfo.html" %}
+        {% include "users/profiles/usercontact.html" %}
+        {% include "users/profiles/teacherinfo.html" %}
         {% else %}
-        
+
         {% ifequal profiletype "student" %}
-            {% include "users/profiles/usercontact.html" %}
-            {% include "users/profiles/studentinfo.html" %}
-            {% include "users/profiles/guardiancontact.html" %}
-            {% include "users/profiles/emergencycontact.html" %}
+        {% include "users/profiles/usercontact.html" %}
+        {% include "users/profiles/studentinfo.html" %}
+        {% include "users/profiles/guardiancontact.html" %}
+        {% include "users/profiles/emergencycontact.html" %}
         {% else %}
 
         {% ifequal profiletype "educator" %}
-            {% include "users/profiles/usercontact.html" %}
-            {% include "users/profiles/educatorinfo.html" %}
+        {% include "users/profiles/usercontact.html" %}
+        {% include "users/profiles/educatorinfo.html" %}
         {% else %}
 
         {% ifequal profiletype "guardian" %}
-            {% include "users/profiles/usercontact.html" %}
-            {% include "users/profiles/guardianinfo.html" %}
+        {% include "users/profiles/usercontact.html" %}
+        {% include "users/profiles/guardianinfo.html" %}
         {% else %}
-        
+
         {% ifequal profiletype "volunteer" %}
-            {% include "users/profiles/usercontact.html" %}
+        {% include "users/profiles/usercontact.html" %}
         {% else %}
 
         {% include "themes/bs_form.html" %}
@@ -91,51 +104,78 @@ div.required label.control-label:after {
         {% endifequal %}
         {% endifequal %}
 
-        <div class="form-actions"><input type="submit" class="btn btn-primary" value="{% if new_user %}Submit{% else %}Update{% endif %} Your Information!" /></div>
+        {% for extra in extra_forms %}
+        {% if not extra.is_subform %}
+        {% ifequal extra.role "teacher" %}
+        {% include "users/profiles/teacherinfo.html" with form=extra.form %}
+        {% endifequal %}
+        {% ifequal extra.role "student" %}
+        {% include "users/profiles/studentinfo.html" with form=extra.form %}
+        {% endifequal %}
+        {% ifequal extra.role "guardian" %}
+        {% include "users/profiles/guardianinfo.html" with form=extra.form %}
+        {% endifequal %}
+        {% ifequal extra.role "educator" %}
+        {% include "users/profiles/educatorinfo.html" with form=extra.form %}
+        {% endifequal %}
+        {% else %}
+        {% ifequal extra.role "student" %}
+        {% if "guardcontactform" in extra.prefix %}
+        {% include "users/profiles/guardiancontact.html" with form=extra.form %}
+        {% endif %}
+        {% if "emergcontactform" in extra.prefix %}
+        {% include "users/profiles/emergencycontact.html" with form=extra.form %}
+        {% endif %}
+        {% endifequal %}
+        {% endif %}
+        {% endfor %}
 
-        </fieldset>
+        <div class="form-actions"><input type="submit" class="btn btn-primary"
+            value="{% if new_user %}Submit{% else %}Update{% endif %} Your Information!" /></div>
+
+      </fieldset>
     </form>
   </div>
 </div>
 
 <script>
-function check_state() {
-  if ($j("#id_address_state").val() == "International") {
-    $j("#id_address_country").removeClass("hidden");
-    if ($j("#id_address_country").val() == "US") {
-      $j("#id_address_country").val("");
+  function check_state() {
+    if ($j("#id_address_state").val() == "International") {
+      $j("#id_address_country").removeClass("hidden");
+      if ($j("#id_address_country").val() == "US") {
+        $j("#id_address_country").val("");
+      }
+    } else {
+      $j("#id_address_country").addClass("hidden");
+      $j("#id_address_country").val("US");
     }
-  } else {
-    $j("#id_address_country").addClass("hidden");
-    $j("#id_address_country").val("US");
   }
-}
-function check_emerg_state() {
-  if ($j("#id_emerg_address_state").val() == "International") {
-    $j("#id_emerg_address_country").removeClass("hidden");
-    if ($j("#id_emerg_address_country").val() == "US") {
-      $j("#id_emerg_address_country").val("");
+  function check_emerg_state() {
+    if ($j("#id_emerg_address_state").val() == "International") {
+      $j("#id_emerg_address_country").removeClass("hidden");
+      if ($j("#id_emerg_address_country").val() == "US") {
+        $j("#id_emerg_address_country").val("");
+      }
+    } else {
+      $j("#id_emerg_address_country").addClass("hidden");
+      $j("#id_emerg_address_country").val("US");
     }
-  } else {
-    $j("#id_emerg_address_country").addClass("hidden");
-    $j("#id_emerg_address_country").val("US");
   }
-}
-$j(document).ready(function() {
-  $j(":required").each(function() {
-    $j(this).closest(".control-group").addClass("required");
-  });
-  
-  check_state();
-  check_emerg_state();
-  
-  $j("#id_address_state").change(function() {
+  $j(document).ready(function () {
+    $j(":required").each(function () {
+      $j(this).closest(".control-group").addClass("required");
+    });
+
     check_state();
-  });
-  $j("#id_emerg_address_state").change(function() {
     check_emerg_state();
+
+    $j("#id_address_state").change(function () {
+      check_state();
+    });
+    $j("#id_emerg_address_state").change(function () {
+      check_emerg_state();
+    });
   });
-});
 </script>
 
 {% endblock %}


### PR DESCRIPTION
## Description

Users with multiple roles (e.g., Student + Teacher) currently see only the highest-priority role’s contact info form on `/myesp/profile`. This change updates the profile editor so **all role-specific contact information sections are displayed and editable**.

The first role acts as the **primary role** and provides shared contact fields (name, email, address, phone). Additional roles display **role-specific information forms only**, avoiding duplication of shared contact fields.

### Key Changes

**Backend**

* Modified `edit_profile()` to pass all user roles to `profile_editor()` instead of selecting a single role.
* Updated `profile_editor()` to:

  * Accept either a single role or a list of roles (backward compatible)
  * Create one primary profile form
  * Create additional role-specific info forms using prefixes
  * Save data for all roles on submission
  * Provide `extra_forms` in the template context.

**Frontend**

* Updated `profile.html` to render additional role-specific sections.
* Added validation error display for extra forms.

### Behavior Changes

Before:

* Only one role’s contact info could be edited.

After:

* All role-specific sections are visible and editable.

Single-role users experience **no change in behavior**.

## Related Issue

Closes #2748 

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Documentation update
* [ ] Refactor / cleanup
* [ ] CI/CD or build change

## Testing

* [x] Existing tests pass
* [ ] New tests added (if applicable)
* [x] Manually verified

### Manual Verification

* Logged in as a user with multiple roles (Student + Teacher)
* Verified both sections appear on `/myesp/profile`
* Updated fields in both sections
* Confirmed saved data persists after reload
* Verified single-role users behave unchanged

## AI Disclosure

No AI assistance has been used in this PR, just code-completion of my IDE.

## Checklist

* [x] Self-reviewed the code
* [ ] Updated documentation (if needed)
* [x] No new warnings or errors introduced

## Video Demo

To help the reviewer in reviewing the PR, I have added the demo of this implemented functionality , do check it out.

[Screencast from 2026-02-28 01-07-08.webm](https://github.com/user-attachments/assets/0c1596e1-09c1-4df7-8328-4abbebda5b29)


