### PR TITLE
Fix: validate that placeholder is a string

### DIFF
--- a/esp/public/media/scripts/select2-3.4.3/select2.js
+++ b/esp/public/media/scripts/select2-3.4.3/select2.js
@@ -2365,8 +2365,10 @@ the specific language governing permissions and limitations under the Apache Lic
                 self=this;
 
             
-            if (opts.placeholder && typeof opts.placeholder !== 'string') {
-                console.error("Select2: placeholder must be a string");
+            if (opts.placeholder != null && typeof opts.placeholder !== 'string') {
+                if (typeof console !== "undefined" && console && typeof console.error === "function") {
+                    console.error("Select2: placeholder must be a string");
+                }
                 delete opts.placeholder;
             }
             


### PR DESCRIPTION
## Description

TODO: Added a validation check in select2.js to ensure the placeholder property is a string. If a non-string value is provided, it logs an error to the console and prevents potential crashes by deleting the invalid property.

## Related Issue

<!-- Link the relevant issue. Use "Closes #123" to auto-close on merge. -->

Closes #4902

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [ ] No new warnings or errors introduced
