### PR TITLE
Fix: Replace deprecated assert_ and failUnless/failIf in tests

### DIFF
--- a/esp/esp/program/modules/tests/ajaxschedulingmodule.py
+++ b/esp/esp/program/modules/tests/ajaxschedulingmodule.py
@@ -181,7 +181,7 @@ class AJAXSchedulingModuleTest(AJAXSchedulingModuleTestBase):
         self.clearScheduleAvailability()
 
         (section, times, rooms, success) = self.program_manager.scheduleClass()
-        self.failUnless(success)
+        self.assertTrue(success)
 
         self.program_manager.unschedule_class(section.id)
 
@@ -195,7 +195,7 @@ class AJAXSchedulingModuleTest(AJAXSchedulingModuleTestBase):
         #change log should not include failed scheduling of classes
         self.clearScheduleAvailability()
         (s1, times, rooms, success) = self.program_manager.scheduleClass()
-        self.failUnless(success)
+        self.assertTrue(success)
 
         #Long setup to create an unsuccessful scheduling attempt
         #choose another section taught by the same teacher
@@ -206,7 +206,7 @@ class AJAXSchedulingModuleTest(AJAXSchedulingModuleTestBase):
         s2 = sections[0]
         #schedule it
         (section, times, rooms, success) = self.program_manager.scheduleClass(section=s2, timeslots=times, rooms=rooms)
-        self.failIf(success)
+        self.assertFalse(success)
 
         #change log should not include it
         changelog_response = self.client.get(self.changelog_url, {'last_fetched_index': 1 })

--- a/esp/esp/program/modules/tests/programprintables.py
+++ b/esp/esp/program/modules/tests/programprintables.py
@@ -62,7 +62,7 @@ class ProgramPrintablesModuleTest(ProgramFrameworkTest):
         """
         Login admin user
         """
-        self.failUnless(self.client.login(username=self.admins[0].username, password='password'), "Failed to log in admin user.")
+        self.assertTrue(self.client.login(username=self.admins[0].username, password='password'), "Failed to log in admin user.")
 
     def get_response(self, view_name, user_type, list_name):
         #   Log in an administrator

--- a/esp/esp/program/tests.py
+++ b/esp/esp/program/tests.py
@@ -94,11 +94,11 @@ class ViewUserInfoTest(TestCase):
 
     def assertStringContains(self, string, contents):
         if not (contents in string):
-            self.assert_(False, "'%s' not in '%s'" % (contents, string))
+            self.assertTrue(False, "'%s' not in '%s'" % (contents, string))
 
     def assertNotStringContains(self, string, contents):
         if contents in string:
-            self.assert_(False, "'%s' are in '%s' and shouldn't be" % (contents, string))
+            self.assertTrue(False, "'%s' are in '%s' and shouldn't be" % (contents, string))
 
     def testIssue1448UsernameMatchesFirstName(self):
         """
@@ -226,10 +226,10 @@ class ViewUserInfoTest(TestCase):
         response = c.get("/manage/userview", { 'username': self.user.username })
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['user'].id, self.user.id)
-        self.assert_(self.user.username in str(response.content, encoding='UTF-8'))
-        self.assert_(self.user.first_name in str(response.content, encoding='UTF-8'))
-        self.assert_(self.user.last_name in str(response.content, encoding='UTF-8'))
-        self.assert_(str(self.user.id) in str(response.content, encoding='UTF-8'))
+        self.assertTrue(self.user.username in str(response.content, encoding='UTF-8'))
+        self.assertTrue(self.user.first_name in str(response.content, encoding='UTF-8'))
+        self.assertTrue(self.user.last_name in str(response.content, encoding='UTF-8'))
+        self.assertTrue(str(self.user.id) in str(response.content, encoding='UTF-8'))
 
         # Test to make sure we get an error on an unknown user
         response = c.get("/manage/userview", { 'username': "NotARealUser" })

--- a/esp/esp/utils/tests.py
+++ b/esp/esp/utils/tests.py
@@ -91,7 +91,7 @@ class DependenciesTestCase(unittest.TestCase):
         self.tryImport("psycopg2")  # Used for talking with PostgreSQL.  Someday, we'll support psycopg2, but not today...
         self.tryImport("openpyxl")  # Used in our giant statistics spreadsheet-generating code
         self.tryImport("form_utils")     #Used to create better forms.
-        self.assert_(not self._failed_import)
+        self.assertTrue(not self._failed_import)
 
         # Make sure that we're actually using pylibmc.
         # Note that this requires a patch to Django (or Django version 1.3 or later).
@@ -99,9 +99,9 @@ class DependenciesTestCase(unittest.TestCase):
         from pylibmc import Client
         from django.core.cache import cache
         if hasattr(cache, "_cache"):
-            self.assert_(isinstance(cache._cache, Client))
+            self.assertTrue(isinstance(cache._cache, Client))
         elif hasattr(cache, "_wrapped_cache") and hasattr(cache._wrapped_cache, "_cache"):
-            self.assert_(isinstance(cache._wrapped_cache._cache, Client))
+            self.assertTrue(isinstance(cache._wrapped_cache._cache, Client))
 
         self.tryExecutable("latex")  # Used for a whole pile of program printables, as well as inline LaTeX
         self.tryExecutable("dvips")  # Used to convert LaTeX output (.dvi) to .ps files
@@ -110,7 +110,7 @@ class DependenciesTestCase(unittest.TestCase):
         self.tryExecutable("ps2pdf")  # Used to convert LaTeX output (.dvi) to .pdf files (must go to .ps first because we use some LaTeX packages that depend on Postscript)
         self.tryExecutable("inkscape")  # Used to render LaTeX output (once converted to .pdf) to .svg image files
 
-        self.assert_(not self._exe_not_found)
+        self.assertTrue(not self._exe_not_found)
 
 class MemcachedTestCase(unittest.TestCase):
     """

--- a/esp/esp/web/tests.py
+++ b/esp/esp/web/tests.py
@@ -58,11 +58,11 @@ class PageTest(TestCase):
     # Util Functions
     def assertStringContains(self, string, contents):
         if not (contents in string):
-            self.assert_(False, "'%s' not in '%s'" % (contents, string))
+            self.assertTrue(False, "'%s' not in '%s'" % (contents, string))
 
     def assertNotStringContains(self, string, contents):
         if contents in string:
-            self.assert_(False, "'%s' are in '%s' and shouldn't be" % (contents, string))
+            self.assertTrue(False, "'%s' are in '%s' and shouldn't be" % (contents, string))
 
 
     def testHomePage(self):


### PR DESCRIPTION

### 📝 Description
This PR modernizes the testing suite by updating deprecated assertion methods from the `unittest` module to their modern equivalents. These updates are meant to prevent future deprecation warnings and ensure maximum compatibility without modifying any underlying test logic or coverage.

Specifically, the following changes were made:
- Replaced `assert_()` with `assertTrue()`
- Replaced `failUnless()` with `assertTrue()`
- Replaced `failIf()` with `assertFalse()`

### 📂 Files Modified
1. [esp/esp/program/modules/tests/ajaxschedulingmodule.py](cci:7://file:///e:/new%202/ESP-Website/esp/esp/program/modules/tests/ajaxschedulingmodule.py:0:0-0:0)
2. [esp/esp/program/modules/tests/programprintables.py](cci:7://file:///e:/new%202/ESP-Website/esp/esp/program/modules/tests/programprintables.py:0:0-0:0)
3. [esp/esp/program/tests.py](cci:7://file:///e:/new%202/ESP-Website/esp/esp/program/tests.py:0:0-0:0)
4. [esp/esp/utils/tests.py](cci:7://file:///e:/new%202/ESP-Website/esp/esp/utils/tests.py:0:0-0:0)
5. [esp/esp/web/tests.py](cci:7://file:///e:/new%202/ESP-Website/esp/esp/web/tests.py:0:0-0:0)

### ✅ Type of change
- [x] Code Modernization / Maintenance

### 🧠 Testing / Verification
- Verified that all replaced methods correctly map to their modern boolean logic equivalents (`assertTrue`/`assertFalse`).
- No core application logic was touched, preventing adverse side-effects.

