### PR TITLE
Fix admin toolbar overlapping page content (#4530)

### DIFF
--- a/esp/public/media/default_styles/admin_bar.css
+++ b/esp/public/media/default_styles/admin_bar.css
@@ -3,7 +3,7 @@
 	border: 1px solid #AAAAAA;
 	left: 20px;
 	position: absolute;
-	top: 10px;
+	top: 65px;
 	width: 200px;
 	z-index: 1000000;
 	text-align: center;


### PR DESCRIPTION
### Summary

This PR fixes a layout issue where the admin toolbar dropdown was overlapping and hiding page content on the `/themes/` page.

### Changes Made

- Adjusted CSS positioning to prevent the toolbar from overlapping content.
- Ensured the layout remains stable and unaffected in other areas.

### Testing

- Reproduced the issue locally.
- Verified that the toolbar no longer overlaps content.
- Confirmed no visible layout regressions.

Fixes #3919