### PR TITLE
refactor: convert string formatting to f-strings in resources and survey

### DIFF
--- a/esp/esp/resources/admin.py
+++ b/esp/esp/resources/admin.py
@@ -39,7 +39,7 @@ from esp.resources.models import ResourceType, ResourceRequest, Resource, Resour
 
 class ResourceTypeAdmin(admin.ModelAdmin):
     def rt_choices(self, obj):
-        return "%s" % str(obj.choices)
+        return str(obj.choices)
     rt_choices.short_description = 'Choices'
 
     list_display = ('name', 'description', 'only_one', 'consumable', 'autocreated', 'hidden', 'priority_default', 'rt_choices', 'program')

--- a/esp/esp/resources/forms.py
+++ b/esp/esp/resources/forms.py
@@ -41,7 +41,7 @@ from esp.tagdict.models import Tag
 
 class IDBasedModelChoiceField(forms.ModelChoiceField):
     def label_from_instance(self, obj):
-        return "%d" % obj.id
+        return str(obj.id)
 
 class ResourceRequestForm(forms.Form):
     resource_type = IDBasedModelChoiceField(queryset=ResourceType.objects.all(), widget=forms.HiddenInput)

--- a/esp/esp/resources/models.py
+++ b/esp/esp/resources/models.py
@@ -141,7 +141,7 @@ class ResourceType(models.Model):
         return ret
 
     def __str__(self):
-        return 'Resource Type "%s", priority=%d' % (self.name, self.priority_default)
+        return f'Resource Type "{self.name}", priority={self.priority_default}'
 
 @python_2_unicode_compatible
 class ResourceRequest(models.Model):
@@ -153,14 +153,14 @@ class ResourceRequest(models.Model):
     desired_value = models.TextField()
 
     def __str__(self):
-        return 'Resource request of %s for %s: %s' % (str(self.res_type), self.target.emailcode(), self.desired_value)
+        return f'Resource request of {self.res_type} for {self.target.emailcode()}: {self.desired_value}'
 
 @python_2_unicode_compatible
 class ResourceGroup(models.Model):
     """ A hack to make the database handle resource group ID creation """
 
     def __str__(self):
-        return 'Resource group %d' % (self.id,)
+        return f'Resource group {self.id}'
 
 @python_2_unicode_compatible
 class Resource(models.Model):
@@ -184,12 +184,12 @@ class Resource(models.Model):
 
     def __str__(self):
         if self.user is not None:
-            return 'For %s: %s (%s)' % (str(self.user), self.name, str(self.res_type))
+            return f'For {self.user}: {self.name} ({self.res_type})'
         else:
             if self.num_students != -1:
-                return 'For %d students: %s (%s)' % (self.num_students, self.name, str(self.res_type))
+                return f'For {self.num_students} students: {self.name} ({self.res_type})'
             else:
-                return '%s (%s)' % (self.name, str(self.res_type))
+                return f'{self.name} ({self.res_type})'
 
     def save(self, *args, **kwargs):
         if self.res_group is None:
@@ -271,7 +271,7 @@ class Resource(models.Model):
                 new_ra.assignment_group = group
             new_ra.save()
         else:
-            raise ESPError('Attempted to assign class section %d to conflicted resource; and constraint check was on.' % section.id, log=True)
+            raise ESPError(f'Attempted to assign class section {section.id} to conflicted resource; and constraint check was on.', log=True)
         return new_ra
 
     assign_to_class = assign_to_section
@@ -353,7 +353,7 @@ class AssignmentGroup(models.Model):
     """ A hack to make the database handle assignment group ID creation """
 
     def __str__(self):
-        return 'Assignment group %d' % (self.id,)
+        return f'Assignment group {self.id}'
 
 @python_2_unicode_compatible
 class ResourceAssignment(models.Model):
@@ -369,7 +369,7 @@ class ResourceAssignment(models.Model):
     assignment_group = models.ForeignKey(AssignmentGroup, null=True, blank=True, on_delete=models.CASCADE)
 
     def __str__(self):
-        result = 'Resource assignment for %s' % str(self.getTargetOrSubject())
+        result = f'Resource assignment for {self.getTargetOrSubject()}'
         if self.lock_level > 0:
             result += ' (locked)'
         return result

--- a/esp/esp/resources/templatetags/resources.py
+++ b/esp/esp/resources/templatetags/resources.py
@@ -54,7 +54,7 @@ def matrix_td(status_str):
     else:
         tdcolor = '#CCFFDD'
 
-    return '<td style="background-color: %s">%s</td>' % (tdcolor, status_str)
+    return f'<td style="background-color: {tdcolor}">{status_str}</td>'
 
 
 @register.filter
@@ -65,4 +65,4 @@ def color_needs(status_str):
     else:
         color = '#330033'
 
-    return '<span style="color: %s">%s</span>' % (color, status_str)
+    return f'<span style="color: {color}">{status_str}</span>'

--- a/esp/esp/survey/models.py
+++ b/esp/esp/survey/models.py
@@ -102,7 +102,7 @@ class Survey(models.Model):
     category = models.CharField(max_length = 10, choices = survey_choices)
 
     def __str__(self):
-        return '%s (%s) for %s' % (self.name, self.category, str(self.program))
+        return f'{self.name} ({self.category}) for {self.program}'
 
     def num_participants(self):
         #   If there is a program for this survey, select the appropriate number
@@ -147,7 +147,7 @@ class SurveyResponse(models.Model):
             if len(value) == 1: value = value[0]
             str_list = key.split('_')
             if len(str_list) < 2 or len(str_list) > 3:
-                raise ESPError('Inappropriate question key: %s' % key)
+                raise ESPError(f'Inappropriate question key: {key}')
 
             new_answer = Answer()
             new_answer.survey_response = self
@@ -163,11 +163,11 @@ class SurveyResponse(models.Model):
                     question = Question.objects.get(id=qid)
                     sec = ClassSection.objects.get(id=cid)
                 except ClassSection.DoesNotExist:
-                    raise ESPError('Error finding class from %s' % key)
+                    raise ESPError(f'Error finding class from {key}')
                 except Question.DoesNotExist:
-                    raise ESPError('Error finding question from %s' % key)
+                    raise ESPError(f'Error finding question from {key}')
                 except ValueError:
-                    raise ESPError('Error getting IDs from %s' % key)
+                    raise ESPError(f'Error getting IDs from {key}')
 
                 new_answer.target = sec
 
@@ -176,9 +176,9 @@ class SurveyResponse(models.Model):
                     qid = int(str_list[1])
                     question = Question.objects.get(id=qid)
                 except Question.DoesNotExist:
-                    raise ESPError('Error finding question from %s' % key)
+                    raise ESPError(f'Error finding question from {key}')
                 except ValueError:
-                    raise ESPError('Error getting IDs from %s' % key)
+                    raise ESPError(f'Error getting IDs from {key}')
                 new_answer.target = self.survey.program
 
             new_answer.answer = value
@@ -192,8 +192,7 @@ class SurveyResponse(models.Model):
         return answers
 
     def __str__(self):
-        return "Survey for %s filled out at %s" % (str(self.survey.program),
-                                                   self.time_filled)
+        return f"Survey for {self.survey.program} filled out at {self.time_filled}"
 
 @python_2_unicode_compatible
 class QuestionType(models.Model):
@@ -214,13 +213,13 @@ class QuestionType(models.Model):
 
     @property
     def template_file(self):
-        return 'survey/questions/%s.html' % self.name.replace(' ', '_').lower()
+        return f'survey/questions/{self.name.replace(" ", "_").lower()}.html'
 
     def __str__(self):
         if len(self.param_names) > 0:
-            return '%s: includes %s' % (self.name, self._param_names.replace('|', ', '))
+            return f'{self.name}: includes {self._param_names.replace("|", ", ")}'
         else:
-            return '%s' % (self.name)
+            return str(self.name)
 
 @python_2_unicode_compatible
 class Question(models.Model):
@@ -245,10 +244,10 @@ class Question(models.Model):
         return params
 
     def __str__(self):
-        return '%s, %d: "%s" (%s)' % (self.survey.name, self.seq, self.name, self.question_type.name)
+        return f'{self.survey.name}, {self.seq}: "{self.name}" ({self.question_type.name})'
 
     def get_value(self, data_dict):
-        question_key = 'question_%s' % self.id
+        question_key = f'question_{self.id}'
 
         try:
             value = data_dict.getlist(question_key)
@@ -354,4 +353,4 @@ class Answer(models.Model):
     answer = property(_answer_getter, _answer_setter)
 
     def __str__(self):
-        return "Answer for question #%d: %s" % (self.question.id, self.value)
+        return f"Answer for question #{self.question.id}: {self.value}"

--- a/esp/esp/survey/templatetags/survey.py
+++ b/esp/esp/survey/templatetags/survey.py
@@ -102,7 +102,7 @@ def intrange(min_val, max_val):
 
 @register.filter
 def field_width(min_val, max_val):
-    return '%d%%' % (70 // (int(max_val) - int(min_val) + 1))
+    return f'{70 // (int(max_val) - int(min_val) + 1)}%'
 
 @register.filter
 def substitute(input_str, item):
@@ -229,7 +229,7 @@ def histogram(answer_list, args='format=html'):
 
     #   We have the necessary EPS file, now we do any necessary conversions and include
     #   it into the output.
-    png_filename = "%s.png" % file_base
+    png_filename = f"{file_base}.png"
     if args_dict.get('format') == 'tex':
         image_path = os.path.join(tempfile.gettempdir(), png_filename)
     elif args_dict.get('format') == 'html':
@@ -240,9 +240,9 @@ def histogram(answer_list, args='format=html'):
                          '-sDEVICE=png16m', '-R96',
                          '-sOutputFile=' + image_path, file_name])
     if args_dict.get('format') == 'tex':
-        return '\includegraphics[width=%fin]{%s}' % (image_width, image_path)
+        return f'\\includegraphics[width={image_width}in]{{{image_path}}}'
     if args_dict.get('format') == 'html':
-        return '<img src="%s" />' % ('/media/' + HISTOGRAM_PATH + png_filename)
+        return f'<img src="/media/{HISTOGRAM_PATH}{png_filename}" />'
 
 @register.filter
 def answer_to_list(ans):
@@ -283,7 +283,7 @@ def favorite_classes(answer_list, limit=20):
     for key in key_list[:max_count]:
         cl = ClassSubject.objects.filter(id=key)
         if cl.count() == 1:
-            result_list.append({'title': '%s: %s' % (cl[0].emailcode(), cl[0].title), 'votes': class_dict[key]})
+            result_list.append({'title': f'{cl[0].emailcode()}: {cl[0].title}', 'votes': class_dict[key]})
 
     return result_list
 

--- a/esp/esp/survey/views.py
+++ b/esp/esp/survey/views.py
@@ -316,7 +316,7 @@ def dump_survey_xlsx(user, prog, surveys, request, tl):
             # The length of sheet names is limited to 31 characters
             survey_index += 1
             if len(s.name) > 31:
-                ws = wb.create_sheet("%d %s... (%s)" % (survey_index, s.name[:17], s.category[:5]))
+                ws = wb.create_sheet(f"{survey_index} {s.name[:17]}... ({s.category[:5]})")
             else:
                 ws = wb.create_sheet(s.name)
 
@@ -345,7 +345,7 @@ def dump_survey_xlsx(user, prog, surveys, request, tl):
 
             # PER-CLASS QUESTIONS
             if len(s.name) > 19:
-                ws_perclass = wb.create_sheet("%d %s... (%s, per-class)" % (survey_index, s.name[:5], s.category[:5]))
+                ws_perclass = wb.create_sheet(f"{survey_index} {s.name[:5]}... ({s.category[:5]}, per-class)")
             else:
                 ws_perclass = wb.create_sheet(s.name + " (per-class)")
             ws_perclass.cell(row=1, column=1, value="Response ID")
@@ -393,7 +393,7 @@ def dump_survey_xlsx(user, prog, surveys, request, tl):
         wb.close()
         response = HttpResponse(out.getvalue(), content_type='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
         out.close()
-        response['Content-Disposition'] = 'attachment; filename=dump-%s.xlsx' % (prog.name)
+        response['Content-Disposition'] = f'attachment; filename=dump-{prog.name}.xlsx'
         return response
     else:
         raise ESPError("You need to be an administrator to dump survey results.", log=False)
@@ -426,7 +426,7 @@ def survey_review_single(request, tl, program, instance, template = 'survey/revi
         prog = Program.by_prog_inst(program, instance)
     except Program.DoesNotExist:
         #raise Http404
-        raise ESPError("Can't find the program %s/%s" % (program, instance))
+        raise ESPError(f"Can't find the program {program}/{instance}")
 
     user = request.user
 
@@ -481,9 +481,7 @@ def top_classes(request, tl, program, instance):
             pass
 
     if len(surveys) < 1:
-        raise ESPError('Sorry, no student survey {}exists for this program!'.format('with any of the following IDs ['
-                                                                                    + ','.join(s_id) + '] ' if 's_id'
-                                                                                    in locals() else ''), log=False)
+        raise ESPError(f'Sorry, no student survey {"with any of the following IDs [" + ",".join(str(x) for x in [s_id]) + "] " if "s_id" in locals() else ""}exists for this program!', log=False)
 
     if len(surveys) > 1:
         return render_to_response('survey/choose_survey.html', request, { 'surveys': surveys, 'error': request.POST }) # if request.POST, then we shouldn't have more than one survey any more...


### PR DESCRIPTION
## Description

Convert `%` formatting and `.format()` calls to f-strings in `resources/` (models, admin, forms) and `survey/` (question rendering, result formatting).

7 files changed, +37/-40.

## Related Issue

Part of #4555

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced