### PR TITLE
refactor: convert string formatting to f-strings in accounting, application, formstack

### DIFF
--- a/esp/esp/accounting/controllers.py
+++ b/esp/esp/accounting/controllers.py
@@ -270,7 +270,7 @@ class ProgramAccountingController(BaseAccountingController):
             return 'Sibling discount'
         elif transfer.destination == self.default_program_account():
             req_desc = "required" if line_item.required else "optional"
-            return "Cost ({})".format(req_desc)
+            return f"Cost ({req_desc})"
         else:
             return 'Unrelated!?'
 
@@ -400,13 +400,13 @@ class IndividualAccountingController(ProgramAccountingController):
     ##  and to recover their account status from such a string
 
     def get_id(self):
-        return '%d/%d' % (self.program.id, self.user.id)
+        return f'{self.program.id}/{self.user.id}'
 
     def get_identifier(self):
         #   A brief string containing information about the user and
         #   which purchases are included at this time
-        purchases_str = ';'.join(['%d,%.2f' % (t.line_item_id, t.amount) for t in self.get_transfers()])
-        return '%s:%s' % (self.get_id(), purchases_str)
+        purchases_str = ';'.join([f'{t.line_item_id},{t.amount:.2f}' for t in self.get_transfers()])
+        return f'{self.get_id()}:{purchases_str}'
 
     @staticmethod
     def from_id(id):
@@ -460,23 +460,22 @@ class IndividualAccountingController(ProgramAccountingController):
             # Line Item Type after it's been created.
             if transfer.line_item.program != iac.program:
                 raise ReconciliationError(
-                    "Failed on processing Transfer %d: program changed" % transfer.id)
+                    f"Failed on processing Transfer {transfer.id}: program changed")
 
             # Check for duplicate payment
             if transfer.paid_in:
                 raise DuplicatePaymentError(
-                    "Failed on processing Transfer %d: already paid" % transfer.id)
+                    f"Failed on processing Transfer {transfer.id}: already paid")
 
             # Check to see if the amount changed
             if '%.2f' % transfer.amount != saved_amount:
                 if trusted:
                     transfer.amount = float(saved_amount)
                 else:
-                    msg = "Failed on processing Transfer %d: amount changed while " + \
-                          "user was paying. The user was billed $%s for this item " + \
-                          "and paid, but the item is now $%.2f"
-                    raise ReconciliationError(
-                        msg % (transfer.id, saved_amount, transfer.amount))
+                    msg = f"Failed on processing Transfer {transfer.id}: amount changed while " \
+                          f"user was paying. The user was billed ${saved_amount} for this item " \
+                          f"and paid, but the item is now ${transfer.amount:.2f}"
+                    raise ReconciliationError(msg)
 
             # Mark as paid!
             transfer.paid_in = payment
@@ -633,7 +632,7 @@ class IndividualAccountingController(ProgramAccountingController):
 
         if total != target_full:
             # This will cause all changes to be rolled back
-            raise ValueError("Transfers do not sum to target: %.2f" % target_full)
+            raise ValueError(f"Transfers do not sum to target: {target_full:.2f}")
 
     @staticmethod
     def updatePaid(program, user, paid=True, in_full=False):
@@ -646,4 +645,4 @@ class IndividualAccountingController(ProgramAccountingController):
                 iac.submit_payment(iac.amount_due())
 
     def __str__(self):
-        return 'Accounting for %s at %s' % (self.user.name(), self.program.niceName())
+        return f'Accounting for {self.user.name()} at {self.program.niceName()}'

--- a/esp/esp/accounting/models.py
+++ b/esp/esp/accounting/models.py
@@ -85,9 +85,9 @@ class LineItemType(models.Model):
         result = []
         for option in self.lineitemoptions_set.all():
             if option.is_custom:
-                result.append((option.id, '%s -- enter amount below' % (option.description,)))
+                result.append((option.id, f'{option.description} -- enter amount below'))
             else:
-                result.append((option.id, '%s -- $%.2f' % (option.description, option.amount_dec_inherited)))
+                result.append((option.id, f'{option.description} -- ${option.amount_dec_inherited:.2f}'))
         return result
 
     @property
@@ -109,9 +109,9 @@ class LineItemType(models.Model):
 
     def __str__(self):
         if self.amount_dec:
-            return '%s for %s ($%s)' % (self.text, self.program, self.amount_dec)
+            return f'{self.text} for {self.program} (${self.amount_dec})'
         else:
-            return '%s for %s' % (self.text, self.program)
+            return f'{self.text} for {self.program}'
 
     class Meta:
         ordering = ('-program_id',)
@@ -140,7 +140,7 @@ class LineItemOptions(models.Model):
             return float(self.amount_dec)
 
     def __str__(self):
-        return '%s ($%s)' % (self.description, self.amount_dec)
+        return f'{self.description} (${self.amount_dec})'
 
 @python_2_unicode_compatible
 class FinancialAidGrant(models.Model):
@@ -182,13 +182,13 @@ class FinancialAidGrant(models.Model):
 
     def __str__(self):
         if self.percent and self.amount_max_dec:
-            return 'Grant %s (max $%s, %d%% discount) at %s' % (self.user, self.amount_max_dec, self.percent, self.program)
+            return f'Grant {self.user} (max ${self.amount_max_dec}, {self.percent}% discount) at {self.program}'
         elif self.percent:
-            return 'Grant %s (%d%% discount) at %s' % (self.user, self.percent, self.program)
+            return f'Grant {self.user} ({self.percent}% discount) at {self.program}'
         elif self.amount_max_dec:
-            return 'Grant %s (max $%s) at %s' % (self.user, self.amount_max_dec, self.program)
+            return f'Grant {self.user} (max ${self.amount_max_dec}) at {self.program}'
         else:
-            return 'Grant %s (no aid specified) at %s' % (self.user, self.program)
+            return f'Grant {self.user} (no aid specified) at {self.program}'
 
     class Meta:
         unique_together = ('request',)
@@ -287,7 +287,7 @@ class Transfer(models.Model):
     amount = property(get_amount, set_amount)
 
     def __str__(self):
-        return 'Transfer $%s from %s to %s' % (self.amount_dec, self.source, self.destination)
+        return f'Transfer ${self.amount_dec} from {self.source} to {self.destination}'
 
 @python_2_unicode_compatible
 class CybersourcePostback(models.Model):
@@ -299,7 +299,7 @@ class CybersourcePostback(models.Model):
                                  on_delete=models.SET_NULL)
 
     def __str__(self):
-        return '%d' % self.id
+        return str(self.id)
 
 def install():
     """Set up the default accounts."""

--- a/esp/esp/accounting/refund_views.py
+++ b/esp/esp/accounting/refund_views.py
@@ -128,12 +128,10 @@ def _send_refund_notification_email(program, refund_results, is_error=False):
     domain_name = Site.objects.get_current().domain
 
     if is_error:
-        subject = '[ ESP Refund ERROR ] Stripe refund error on %s for %s' % (
-            domain_name, program.niceName())
+        subject = f'[ ESP Refund ERROR ] Stripe refund error on {domain_name} for {program.niceName()}'
         template = 'accounting/refund_error_email.txt'
     else:
-        subject = '[ ESP Refund ] Stripe refunds issued on %s for %s' % (
-            domain_name, program.niceName())
+        subject = f'[ ESP Refund ] Stripe refunds issued on {domain_name} for {program.niceName()}'
         template = 'accounting/refund_success_email.txt'
 
     context = {

--- a/esp/esp/accounting/tests/test_models.py
+++ b/esp/esp/accounting/tests/test_models.py
@@ -374,7 +374,7 @@ class IndividualAccountingControllerTest(TestCase):
         self.iac = IndividualAccountingController(self.program, self.user)
 
     def test_get_id(self):
-        expected = '%d/%d' % (self.program.id, self.user.id)
+        expected = f'{self.program.id}/{self.user.id}'
         self.assertEqual(self.iac.get_id(), expected)
 
     def test_from_id(self):

--- a/esp/esp/application/admin.py
+++ b/esp/esp/application/admin.py
@@ -60,7 +60,7 @@ class FormstackAppSettingsAdmin(admin.ModelAdmin):
             return ''
         lines = []
         for form in get_forms_for_api_key(fsas.api_key):
-            line = '{0}: {1}'.format(form.id, form.name)
+            line = f'{form.id}: {form.name}'
             lines.append(line)
         return '<br />'.join(map(html.escape, lines))
     forms_for_api_key.allow_tags = True
@@ -72,7 +72,7 @@ class FormstackAppSettingsAdmin(admin.ModelAdmin):
         form = get_form_by_id(fsas.form_id, fsas.api_key)
         for field in form.field_info():
             if field['label']:
-                line = '{0}: {1}'.format(field['id'], field['label'])
+                line = f'{field["id"]}: {field["label"]}'
                 lines.append(line)
         return '<br />'.join(map(html.escape, lines))
     form_fields.allow_tags = True
@@ -84,7 +84,7 @@ class FormstackAppSettingsAdmin(admin.ModelAdmin):
         form = get_form_by_id(fsas.finaid_form_id, fsas.api_key)
         for field in form.field_info():
             if field['label']:
-                line = '{0}: {1}'.format(field['id'], field['label'])
+                line = f'{field["id"]}: {field["label"]}'
                 lines.append(line)
         return '<br />'.join(map(html.escape, lines))
     finaid_form_fields.allow_tags = True
@@ -116,7 +116,7 @@ class FormstackStudentProgramAppAdmin(admin.ModelAdmin):
     def choices_pretty(self, app):
         lines = []
         for pair in app.choices().items():
-            line = '{0}: {1}'.format(*pair)
+            line = f'{pair[0]}: {pair[1]}'
             lines.append(line)
         return '<br />'.join(map(html.escape, lines))
     choices_pretty.allow_tags = True
@@ -125,7 +125,7 @@ class FormstackStudentProgramAppAdmin(admin.ModelAdmin):
     def responses_pretty(self, app):
         lines = []
         for pair in app.get_responses():
-            line = '{0}: {1}'.format(*pair)
+            line = f'{pair[0]}: {pair[1]}'
             lines.append(line)
         return '<br />'.join(map(html.escape, lines))
     responses_pretty.allow_tags = True
@@ -135,10 +135,10 @@ class FormstackStudentProgramAppAdmin(admin.ModelAdmin):
         lines = []
         cls = app.admitted_to_class()
         if cls is not None:
-            line = 'Admitted: {0}'.format(cls)
+            line = f'Admitted: {cls}'
             lines.append(line)
         for cls in app.waitlisted_to_class():
-            line = 'Waitlisted: {0}'.format(cls)
+            line = f'Waitlisted: {cls}'
             lines.append(line)
         return '<br />'.join(map(html.escape, lines))
     admissions_pretty.allow_tags = True
@@ -183,7 +183,7 @@ class FormstackStudentClassAppAdmin(admin.ModelAdmin):
     def responses_pretty(self, classapp):
         lines = []
         for pair in classapp.get_responses():
-            line = '{0}: {1}'.format(*pair)
+            line = f'{pair[0]}: {pair[1]}'
             lines.append(line)
         return '<br />'.join(map(html.escape, lines))
     responses_pretty.allow_tags = True
@@ -193,10 +193,10 @@ class FormstackStudentClassAppAdmin(admin.ModelAdmin):
         lines = []
         cls = classapp.app.admitted_to_class()
         if cls is not None:
-            line = 'Admitted: {0}'.format(cls)
+            line = f'Admitted: {cls}'
             lines.append(line)
         for cls in classapp.app.waitlisted_to_class():
-            line = 'Waitlisted: {0}'.format(cls)
+            line = f'Waitlisted: {cls}'
             lines.append(line)
         return '<br />'.join(map(html.escape, lines))
     admissions_pretty.allow_tags = True

--- a/esp/esp/application/models.py
+++ b/esp/esp/application/models.py
@@ -116,7 +116,7 @@ class StudentProgramApp(models.Model):
     submission_id = models.IntegerField(null=True, unique=True)
 
     def __str__(self):
-        return "{}'s app for {}".format(self.user, self.program)
+        return f"{self.user}'s app for {self.program}"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -186,7 +186,7 @@ class StudentClassApp(models.Model):
             ])
 
     def __str__(self):
-        return "{}'s app for {}".format(self.app.user, self.subject)
+        return f"{self.app.user}'s app for {self.subject}"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -228,7 +228,7 @@ class FormstackStudentProgramAppManager(models.Manager):
         try:
             user = ESPUser.objects.get(username=username)
         except ESPUser.DoesNotExist:
-            raise LookupError("no matching user {0}".format(username))
+            raise LookupError(f"no matching user {username}")
 
         # define mapping from string to class subject
         def get_subject(s):

--- a/esp/esp/formstack/api.py
+++ b/esp/esp/formstack/api.py
@@ -120,4 +120,4 @@ class Formstack(object):
 
 class APIError(Exception):
     def __str__(self):
-        return 'Formstack API error: {0}'.format(self.message)
+        return f'Formstack API error: {self.message}'

--- a/esp/esp/formstack/objects.py
+++ b/esp/esp/formstack/objects.py
@@ -44,10 +44,10 @@ class FormstackForm(object):
 
 
     def __str__(self):
-        return '{0}'.format(self.id)
+        return str(self.id)
 
     def __repr__(self):
-        return '<FormstackForm: {0}>'.format(self)
+        return f'<FormstackForm: {self}>'
 
     @cache_function
     def info(self):
@@ -109,7 +109,7 @@ class FormstackSubmission(object):
         return str(self.id)
 
     def __repr__(self):
-        return '<FormstackSubmission: {0}>'.format(self)
+        return f'<FormstackSubmission: {self}>'
 
     @cache_function
     def data(self):


### PR DESCRIPTION
## Description

Convert `%` formatting and `.format()` calls to f-strings in `accounting/` (transaction descriptions, line items), `application/` (model representations), and `formstack/` (URL construction).

8 files changed, +43/-46.

## Related Issue

Part of #4555

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced