### PR TITLE
refactor: convert string formatting to f-strings in dbmail

### DIFF
--- a/esp/esp/dbmail/models.py
+++ b/esp/esp/dbmail/models.py
@@ -85,7 +85,7 @@ def send_mail(subject, message, from_email, recipient_list, fail_silently=False,
         new_list = [ x for x in recipient_list ]
     if user is not None:
         extra_headers['List-Unsubscribe-Post'] = "List-Unsubscribe=One-Click"
-        extra_headers['List-Unsubscribe'] = '<%s>' % (user.unsubscribe_oneclick())
+        extra_headers['List-Unsubscribe'] = f'<{user.unsubscribe_oneclick()}>'
 
     # remove duplicate email addresses (sendgrid doesn't like them)
     recipients = []
@@ -223,7 +223,7 @@ class MessageRequest(models.Model):
     public = models.BooleanField(default=False) # Should the subject and msgtext of this request be publicly viewable at /email/<id>?
 
     def public_url(self):
-        return '%s/email/%s' % (Site.objects.get_current().domain, self.id or "{ID will be here}")
+        return f'{Site.objects.get_current().domain}/email/{self.id or "{ID will be here}"}'
 
     def __str__(self):
         return str(self.subject)
@@ -299,14 +299,14 @@ class MessageRequest(models.Model):
         ImproperlyConfigured exception if that is not the case.
         """
         if not cls.is_sendto_fn_name_choice(sendto_fn_name):
-            raise ImproperlyConfigured('"%s" is not one of the available sendto function choices' % sendto_fn_name)
+            raise ImproperlyConfigured(f'"{sendto_fn_name}" is not one of the available sendto function choices')
         if sendto_fn_name == cls.SEND_TO_SELF:
             sendto_fn_name = cls.SEND_TO_SELF_REAL
         if not hasattr(esp.dbmail.sendto_fns, sendto_fn_name):
-            raise ImproperlyConfigured('"esp.dbmail.sendto_fns" does not define "%s"' % sendto_fn_name)
+            raise ImproperlyConfigured(f'"esp.dbmail.sendto_fns" does not define "{sendto_fn_name}"')
         sendto_fn_callable = getattr(esp.dbmail.sendto_fns, sendto_fn_name)
         if not callable(sendto_fn_callable):
-            raise ImproperlyConfigured('"esp.dbmail.sendto_fns" does not define a "%s" callable sendto function' % sendto_fn_name)
+            raise ImproperlyConfigured(f'"esp.dbmail.sendto_fns" does not define a "{sendto_fn_name}" callable sendto function')
         return sendto_fn_callable
 
     def get_sendto_fn(self):
@@ -327,11 +327,10 @@ class MessageRequest(models.Model):
         try:
             return cls.get_sendto_fn_callable(sendto_fn_name)
         except ImproperlyConfigured as e:
-            raise ESPError(True, 'Invalid sendto function "%s". ' + \
-                'This might be a website bug. Please contact us at %s ' + \
-                'and tell us how you got this error, and we will look into it. ' + \
-                'The error message is: "%s".' % \
-                (sendto_fn_name, settings.DEFAULT_EMAIL_ADDRESSES['support'], e))
+            raise ESPError(True, f'Invalid sendto function "{sendto_fn_name}". '
+                f'This might be a website bug. Please contact us at {settings.DEFAULT_EMAIL_ADDRESSES["support"]} '
+                f'and tell us how you got this error, and we will look into it. '
+                f'The error message is: "{e}".')
 
     # Processing a MessageRequest needs to be atomic, so that if the DB falls
     # over halfway through the processing, we don't end up with half of the
@@ -564,7 +563,7 @@ class MessageVars(models.Model):
         return True
 
     def __str__(self):
-        return "Message Variables for %s" % self.messagerequest
+        return f"Message Variables for {self.messagerequest}"
 
     class Meta:
         verbose_name_plural = 'Message variables'
@@ -618,7 +617,7 @@ class EmailList(models.Model):
         super().save(*args, **kwargs)
 
     def __str__(self):
-        return '%s (%s)' % (self.description, self.regex)
+        return f'{self.description} ({self.regex})'
 
 @python_2_unicode_compatible
 class PlainRedirect(models.Model):
@@ -631,7 +630,7 @@ class PlainRedirect(models.Model):
     destination = models.CharField(max_length=512, help_text='A comma-separated list of one or more real email address(es) that will receive the redirected email(s)')
 
     def __str__(self):
-        return '%s --> %s'  % (self.original, self.destination)
+        return f'{self.original} --> {self.destination}'
 
     class Meta:
         ordering=('original',)

--- a/esp/esp/dbmail/receivers/classlist.py
+++ b/esp/esp/dbmail/receivers/classlist.py
@@ -25,7 +25,7 @@ class ClassList(BaseHandler):
         self.emailcode = cls.emailcode()
 
         program = cls.parent_program
-        self.recipients = [ESPUser.email_sendto_address(program.director_email, '%s Directors' % (program.niceName()))]
+        self.recipients = [ESPUser.email_sendto_address(program.director_email, f'{program.niceName()} Directors')]
 
         user_type = user_type.strip().lower()
 
@@ -54,7 +54,7 @@ class ClassList(BaseHandler):
         # Create a class list in Mailman,
         # then bounce this email off to it
 
-        list_name = "%s-%s" % (cls.emailcode(), user_type)
+        list_name = f"{cls.emailcode()}-{user_type}"
 
         create_list(list_name, settings.DEFAULT_EMAIL_ADDRESSES['mailman_moderator'])
         load_list_settings(list_name, "lists/class_mailman.config")
@@ -66,8 +66,7 @@ class ClassList(BaseHandler):
             apply_list_settings(list_name, {
                 'moderator': [
                     settings.DEFAULT_EMAIL_ADDRESSES['mailman_moderator'],
-                    '%s-teachers@%s' % (cls.emailcode(),
-                                        Site.objects.get_current().domain),
+                    f'{cls.emailcode()}-teachers@{Site.objects.get_current().domain}',
                     # In theory this is redundant, but it's included just in
                     # case.
                     cls.parent_program.director_email,
@@ -76,25 +75,25 @@ class ClassList(BaseHandler):
                     settings.DEFAULT_EMAIL_ADDRESSES['mailman_moderator'],
                     cls.parent_program.director_email,
                 ],
-                'subject_prefix': "[%s]" % (cls.parent_program.niceName(),),
+                'subject_prefix': f"[{cls.parent_program.niceName()}]",
             })
-            send_mail("[ESP] Activated class mailing list: %s@%s" % (list_name, Site.objects.get_current().domain),
+            send_mail(f"[ESP] Activated class mailing list: {list_name}@{Site.objects.get_current().domain}",
                       render_to_string("mailman/new_list_intro_teachers.txt",
                                        { 'classname': str(cls),
                                          'mod_password': set_list_moderator_password(list_name) }),
-                      settings.DEFAULT_EMAIL_ADDRESSES['default'], ["%s-teachers@%s" % (cls.emailcode(), Site.objects.get_current().domain), ])
+                      settings.DEFAULT_EMAIL_ADDRESSES['default'], [f"{cls.emailcode()}-teachers@{Site.objects.get_current().domain}", ])
         else:
             apply_list_settings(list_name, {'default_member_moderation': False})
             apply_list_settings(list_name, {'generic_nonmember_action': 0})
-            apply_list_settings(list_name, {'acceptable_aliases': "%s.*-(students|class)-.*@%s" % (cls.emailcode(), Site.objects.get_current().domain)})
-            apply_list_settings(list_name, {'subject_prefix': "[%s]" % (cls.parent_program.niceName(),)})
+            apply_list_settings(list_name, {'acceptable_aliases': f"{cls.emailcode()}.*-(students|class)-.*@{Site.objects.get_current().domain}"})
+            apply_list_settings(list_name, {'subject_prefix': f"[{cls.parent_program.niceName()}]"})
 
         add_list_member(list_name, cls.parent_program.director_email)
         add_list_members(list_name, cls.get_teachers())
         if 'archive' in settings.DEFAULT_EMAIL_ADDRESSES:
             add_list_member(list_name, settings.DEFAULT_EMAIL_ADDRESSES['archive'])
 
-        self.recipients = ["%s@%s" % (list_name, Site.objects.get_current().domain)]
+        self.recipients = [f"{list_name}@{Site.objects.get_current().domain}"]
 
         self.send = True
 

--- a/esp/esp/dbmail/receivers/sectionlist.py
+++ b/esp/esp/dbmail/receivers/sectionlist.py
@@ -28,7 +28,7 @@ class SectionList(BaseHandler):
         self.emailcode = section.emailcode()
 
         program = cls.parent_program
-        self.recipients = [ESPUser.email_sendto_address(program.director_email, '%s Directors' % (program.niceName()))]
+        self.recipients = [ESPUser.email_sendto_address(program.director_email, f'{program.niceName()} Directors')]
 
         user_type = user_type.strip().lower()
 
@@ -55,7 +55,7 @@ class SectionList(BaseHandler):
         # Create a section list in Mailman,
         # then bounce this email off to it
 
-        list_name = "%s-%s" % (section.emailcode(), user_type)
+        list_name = f"{section.emailcode()}-{user_type}"
 
         create_list(list_name, settings.DEFAULT_EMAIL_ADDRESSES['mailman_moderator'])
         load_list_settings(list_name, "lists/class_mailman.config")
@@ -66,8 +66,7 @@ class SectionList(BaseHandler):
             apply_list_settings(list_name, {
                 'moderator': [
                     settings.DEFAULT_EMAIL_ADDRESSES['mailman_moderator'],
-                    '%s-teachers@%s' % (cls.emailcode(),
-                                        Site.objects.get_current().domain),
+                    f'{cls.emailcode()}-teachers@{Site.objects.get_current().domain}',
                     # In theory this is redundant, but it's included just in
                     # case.
                     cls.parent_program.director_email,
@@ -76,19 +75,19 @@ class SectionList(BaseHandler):
                     settings.DEFAULT_EMAIL_ADDRESSES['mailman_moderator'],
                     cls.parent_program.director_email,
                 ],
-                'subject_prefix': "[%s]" % (cls.parent_program.niceName(),),
+                'subject_prefix': f"[{cls.parent_program.niceName()}]",
             })
             logger.info("Settings applied...")
-            send_mail("[ESP] Activated class mailing list: %s@%s" % (list_name, Site.objects.get_current().domain),
+            send_mail(f"[ESP] Activated class mailing list: {list_name}@{Site.objects.get_current().domain}",
                       render_to_string("mailman/new_list_intro_teachers.txt",
                                        { 'classname': str(cls),
                                          'mod_password': set_list_moderator_password(list_name) }),
-                      settings.DEFAULT_EMAIL_ADDRESSES['default'], ["%s-teachers@%s" % (cls.emailcode(), Site.objects.get_current().domain), ])
+                      settings.DEFAULT_EMAIL_ADDRESSES['default'], [f"{cls.emailcode()}-teachers@{Site.objects.get_current().domain}", ])
         else:
             apply_list_settings(list_name, {'default_member_moderation': False})
             apply_list_settings(list_name, {'generic_nonmember_action': 0})
-            apply_list_settings(list_name, {'acceptable_aliases': "%s.*-(students|class)-.*@%s" % (cls.emailcode(), Site.objects.get_current().domain)})
-            apply_list_settings(list_name, {'subject_prefix': "[%s]" % (cls.parent_program.niceName(),)})
+            apply_list_settings(list_name, {'acceptable_aliases': f"{cls.emailcode()}.*-(students|class)-.*@{Site.objects.get_current().domain}"})
+            apply_list_settings(list_name, {'subject_prefix': f"[{cls.parent_program.niceName()}]"})
 
         logger.info("Settings applied still...")
         add_list_member(list_name, cls.parent_program.director_email)
@@ -97,5 +96,5 @@ class SectionList(BaseHandler):
             add_list_member(list_name, settings.DEFAULT_EMAIL_ADDRESSES['archive'])
         logger.info("Members added")
 
-        self.recipients = ["%s@%s" % (list_name, Site.objects.get_current().domain)]
+        self.recipients = [f"{list_name}@{Site.objects.get_current().domain}"]
         self.send = True

--- a/esp/esp/dbmail/sendto_fns.py
+++ b/esp/esp/dbmail/sendto_fns.py
@@ -71,7 +71,7 @@ def _send_to_combination(sendto_fns):
 
     # Append the name and docstring of each component function, with some formatting.
     for fn in sendto_fns:
-        sendto_fn.__doc__ += "\n%s:\n%s" % (fn.__name__, re.sub('\n *', '\n    ', fn.__doc__).strip('\n'))
+        sendto_fn.__doc__ += f"\n{fn.__name__}:\n{re.sub(chr(10) + ' *', chr(10) + '    ', fn.__doc__).strip(chr(10))}"
 
     return sendto_fn
 

--- a/esp/esp/dbmail/tests.py
+++ b/esp/esp/dbmail/tests.py
@@ -72,7 +72,7 @@ class ActionHandlerTest(TestCase):
     def test_getattribute_delegates_to_obj(self):
         class FakeObj:
             def foo(self, user):
-                return 'result_%s' % user
+                return f'result_{user}'
 
         handler = ActionHandler(FakeObj(), 'testuser')
         result = handler.foo('testuser')


### PR DESCRIPTION
Fixes #4310 
## Description

Convert `%` formatting and `.format()` calls to f-strings in `dbmail/` — email subject/body construction, recipient formatting, and message template rendering.

5 files changed, +32/-35.

## Related Issue

Part of #4555

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced
