### PR TITLE
refactor: convert string formatting to f-strings in users module

### DIFF
--- a/esp/esp/users/admin.py
+++ b/esp/esp/users/admin.py
@@ -98,8 +98,8 @@ class PermissionAdmin(admin.ModelAdmin):
         if rows_updated == 1:
             message_bit = "1 permission was"
         else:
-            message_bit = "%s permissions were" % rows_updated
-        self.message_user(request, "%s successfully expired." % message_bit)
+            message_bit = f"{rows_updated} permissions were"
+        self.message_user(request, f"{message_bit} successfully expired.")
     expire.short_description = "Expire permissions"
 
     def renew(self, request, queryset):
@@ -107,8 +107,8 @@ class PermissionAdmin(admin.ModelAdmin):
         if rows_updated == 1:
             message_bit = "1 permission was"
         else:
-            message_bit = "%s permissions were" % rows_updated
-        self.message_user(request, "%s successfully expired." % message_bit)
+            message_bit = f"{rows_updated} permissions were"
+        self.message_user(request, f"{message_bit} successfully renewed.")
     renew.short_description = "Renew permissions"
 
 admin_site.register(Permission, PermissionAdmin)
@@ -152,7 +152,7 @@ class K12SchoolAdmin(admin.ModelAdmin):
     list_filter = ['school_type']
     def contact_name(self, obj):
         if obj.contact:
-            return "%s %s" % (obj.contact.first_name, obj.contact.last_name)
+            return f"{obj.contact.first_name} {obj.contact.last_name}"
         return None
     contact_name.short_description = 'Contact name'
 

--- a/esp/esp/users/controllers/tests/test_usersearch.py
+++ b/esp/esp/users/controllers/tests/test_usersearch.py
@@ -34,7 +34,7 @@ class TestUserSearchController(ProgramFrameworkTest):
             'gradyear_max': '',
             'userid': '',
             'zipcode': '',
-            'combo_base_list': '%s:%s' % (list_a, list_b),
+            'combo_base_list': f'{list_a}:{list_b}',
             'email': '',
             'states': '',
             'zipdistance': '',

--- a/esp/esp/users/controllers/usersearch.py
+++ b/esp/esp/users/controllers/usersearch.py
@@ -144,9 +144,9 @@ class UserSearchController(object):
                     try:
                         rc = re.compile(criteria[field])
                     except re.error:
-                        raise ESPError('Invalid search expression, please check your syntax: %s' % criteria[field], log=False)
-                    filter_dict = {'%s__iregex' % field: criteria[field]}
-                    if '%s__not' % field in criteria:
+                        raise ESPError(f'Invalid search expression, please check your syntax: {criteria[field]}', log=False)
+                    filter_dict = {f'{field}__iregex': criteria[field]}
+                    if f'{field}__not' in criteria:
                         Q_exclude |= Q(**filter_dict)
                     else:
                         Q_include &= Q(**filter_dict)
@@ -157,7 +157,7 @@ class UserSearchController(object):
                 try:
                     zipc = ZipCode.objects.get(zip_code = criteria['zipcode'])
                 except ZipCode.DoesNotExist:
-                    raise ESPError('Zip code not found.  This may be because you didn\'t enter a valid US zipcode.  Tried: "%s"' % criteria['zipcode'], log=False)
+                    raise ESPError(f'Zip code not found.  This may be because you didn\'t enter a valid US zipcode.  Tried: "{criteria["zipcode"]}"', log=False)
                 zipcodes = zipc.close_zipcodes(criteria['zipdistance'])
                 # Excludes zipcodes within a certain radius, giving an annulus; can fail to exclude people who used to live outside the radius.
                 # This may have something to do with the Q_include line below taking more than just the most recent profile. -ageng, 2008-01-15
@@ -398,7 +398,7 @@ class UserSearchController(object):
         filterObj = PersistentQueryFilter.create_from_Q(ESPUser, query)
 
         if 'base_list' in data and 'recipient_type' in data:
-            filterObj.useful_name = 'Program list: %s' % data['base_list']
+            filterObj.useful_name = f'Program list: {data["base_list"]}'
         elif 'combo_base_list' in data:
             filterObj.useful_name = 'Custom user list'
         filterObj.save()
@@ -441,7 +441,7 @@ class UserSearchController(object):
             key = user_type.lower() + 's'
             if user_type not in category_lists:
                 category_lists[user_type] = []
-            category_lists[user_type].insert(0, {'name': 'all_%s' % user_type, 'list': ESPUser.getAllOfType(user_type), 'description': 'All %s in the database' % key, 'preferred': True, 'all_flag': True})
+            category_lists[user_type].insert(0, {'name': f'all_{user_type}', 'list': ESPUser.getAllOfType(user_type), 'description': f'All {key} in the database', 'preferred': True, 'all_flag': True})
 
         #   Add in mailing list accounts
         category_lists['emaillist'] = [{'name': 'all_emaillist', 'list': Q(password = 'emailuser'), 'description': 'Everyone signed up for the mailing list', 'preferred': True}]
@@ -453,7 +453,7 @@ class UserSearchController(object):
                 context['all_list_names'].append(item['name'])
 
         if target_path is None:
-            target_path = '/manage/%s/commpanel' % program.getUrlBase()
+            target_path = f'/manage/{program.getUrlBase()}/commpanel'
         context['action_path'] = target_path
         context['groups'] = Group.objects.all()
         context['regtypes'] = RegistrationType.objects.all().order_by("name")

--- a/esp/esp/users/forms/password_reset.py
+++ b/esp/esp/users/forms/password_reset.py
@@ -27,7 +27,7 @@ class PasswordResetForm(forms.Form):
         try:
             user = ESPUser.objects.get(username=self.cleaned_data['username'])
         except ESPUser.DoesNotExist:
-            raise forms.ValidationError("User '%s' does not exist." % self.cleaned_data['username'])
+            raise forms.ValidationError(f"User '{self.cleaned_data['username']}' does not exist.")
 
         return self.cleaned_data['username'].strip()
 
@@ -38,7 +38,7 @@ class PasswordResetForm(forms.Form):
         if len(ESPUser.objects.filter(email__iexact=self.cleaned_data['email']).values('id')[:1])>0:
             return self.cleaned_data['email'].strip()
 
-        raise forms.ValidationError('No user has email %s' % self.cleaned_data['email'])
+        raise forms.ValidationError(f'No user has email {self.cleaned_data["email"]}')
 
 class UserPasswdForm(FormWithRequiredCss):
     password = SizedCharField(length=12, max_length=32, widget=forms.PasswordInput())

--- a/esp/esp/users/forms/user_profile.py
+++ b/esp/esp/users/forms/user_profile.py
@@ -225,7 +225,7 @@ class StudentInfoForm(FormUnrestrictedOtherUser):
             new_choices = []
             for x in self.fields['graduation_year'].choices:
                 if len(x[0]) > 0:
-                    new_choices.append((str(x[0]), "%s (%sth grade)" % (x[0], x[1])))
+                    new_choices.append((str(x[0]), f"{x[0]} ({x[1]}th grade)"))
                 else:
                     new_choices.append(x)
             self.fields['graduation_year'].choices = new_choices
@@ -354,7 +354,7 @@ class TeacherInfoForm(FormWithRequiredCss):
 
     pronoun = forms.CharField(max_length=50, required=False)
     graduation_year = SizedCharField(length=4, max_length=4, required=False)
-    affiliation = DropdownOtherField(required=False, widget=DropdownOtherWidget(choices=AFFILIATION_CHOICES), label ='What is your affiliation with %s?' % settings.INSTITUTION_NAME)
+    affiliation = DropdownOtherField(required=False, widget=DropdownOtherWidget(choices=AFFILIATION_CHOICES), label =f'What is your affiliation with {settings.INSTITUTION_NAME}?')
     major = SizedCharField(length=30, max_length=32, required=False)
     shirt_size = forms.ChoiceField(choices=[], required=False)
     shirt_type = forms.ChoiceField(choices=[], required=False)
@@ -382,15 +382,15 @@ class TeacherInfoForm(FormWithRequiredCss):
             affiliation_field = self.fields['affiliation']
             affiliation, school = affiliation_field.widget.decompress(cleaned_data.get('affiliation'))
             if affiliation == '':
-                msg = 'Please select your affiliation with %s.' % settings.INSTITUTION_NAME
+                msg = f'Please select your affiliation with {settings.INSTITUTION_NAME}.'
                 self.add_error('affiliation', msg)
             elif affiliation in (AFFILIATION_UNDERGRAD, AFFILIATION_GRAD, AFFILIATION_POSTDOC):
                 cleaned_data['affiliation'] = affiliation_field.compress([affiliation, '']) # ignore the box
             else: # OTHER or NONE -- Make sure they entered something into the other box
                 if school.strip() == '':
-                    msg = 'Please select your affiliation with %s.' % settings.INSTITUTION_NAME
+                    msg = f'Please select your affiliation with {settings.INSTITUTION_NAME}.'
                     if affiliation == AFFILIATION_OTHER:
-                        msg = 'Please enter your affiliation with %s.' % settings.INSTITUTION_NAME
+                        msg = f'Please enter your affiliation with {settings.INSTITUTION_NAME}.'
                     elif affiliation == AFFILIATION_NONE:
                         msg = 'Please enter your school or employer.'
                     self.add_error('affiliation', msg)

--- a/esp/esp/users/forms/user_reg.py
+++ b/esp/esp/users/forms/user_reg.py
@@ -23,7 +23,7 @@ class ValidHostEmailField(forms.EmailField):
             try:
                 DNS.DiscoverNameServers()
                 if len(DNS.Request(qtype='a').req(email_host).answers) == 0 and len(DNS.Request(qtype='mx').req(email_host).answers) == 0:
-                    raise forms.ValidationError('"%s" is not a valid email host' % email_host)
+                    raise forms.ValidationError(f'"{email_host}" is not a valid email host')
             except (IOError, DNS.DNSError): # (no resolv.conf, no nameservers)
                 pass
         except ImportError: # no PyDNS

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -103,7 +103,7 @@ def admin_required(func):
     @functools.wraps(func)
     def wrapped(request, *args, **kwargs):
         if not request.user or not request.user.is_authenticated:
-            return HttpResponseRedirect('%s?%s=%s' % (settings.LOGIN_URL, REDIRECT_FIELD_NAME, quote(request.get_full_path())))
+            return HttpResponseRedirect(f'{settings.LOGIN_URL}?{REDIRECT_FIELD_NAME}={quote(request.get_full_path())}')
         elif not request.user.isAdministrator():
             raise PermissionDenied
         return func(request, *args, **kwargs)
@@ -121,7 +121,7 @@ class UserAvailability(models.Model):
         verbose_name_plural = 'User availabilities'
 
     def __str__(self):
-        return '%s available as %s at %s' % (self.user.username, self.role.name, str(self.event))
+        return f'{self.user.username} available as {self.role.name} at {self.event}'
 
     def save(self, *args, **kwargs):
         #   Assign default role if not set.
@@ -173,9 +173,9 @@ class BaseESPUser(object):
                 # override. Start by defining all the membership methods for
                 # the default types as returning False, and then overwrite them
                 # as necessary.
-                setattr(cls, 'is%s' % user_type, lambda user: False)
+                setattr(cls, f'is{user_type}', lambda user: False)
             for user_type in cls.getTypes() + ['Officer']:
-                setattr(cls, 'is%s' % user_type, cls.create_membership_method(user_type))
+                setattr(cls, f'is{user_type}', cls.create_membership_method(user_type))
 
     @staticmethod
     def grade_options():
@@ -270,7 +270,7 @@ class BaseESPUser(object):
         values = query_set.values('first_name', 'last_name', 'username', 'id')
 
         for value in values:
-            value['ajax_str'] = '%s, %s (%s)' % (value['last_name'], value['first_name'], value['username'])
+            value['ajax_str'] = f'{value["last_name"]}, {value["first_name"]} ({value["username"]})'
         return values
 
     @classmethod
@@ -298,13 +298,13 @@ class BaseESPUser(object):
         return cls.ajax_autocomplete(data, QObject, prog=prog, **kwargs)
 
     def ajax_str(self):
-        return "%s, %s (%s)" % (self.last_name, self.first_name, self.username)
+        return f"{self.last_name}, {self.first_name} ({self.username})"
 
     def name(self):
-        return '%s %s' % (self.first_name, self.last_name)
+        return f'{self.first_name} {self.last_name}'
 
     def name_last_first(self):
-        return '%s, %s' % (self.last_name, self.first_name)
+        return f'{self.last_name}, {self.first_name}'
 
     def nonblank_name(self):
         name = self.name()
@@ -324,9 +324,10 @@ class BaseESPUser(object):
         """
         if name:
             # enclose name in quotes per RFC 2822 so that special characters in names are handled properly
-            return '"%s" <%s>' % (name.replace('\\', '\\\\').replace('"', '\\"'), email)
+            escaped_name = name.replace("\\", "\\\\").replace('"', '\\"')
+            return f'"{escaped_name}" <{email}>'
         else:
-            return '<%s>' % email
+            return f'<{email}>'
 
     def get_email_sendto_address(self):
         """
@@ -401,7 +402,7 @@ class BaseESPUser(object):
             # Disallow morphing into Administrators.
             # It's too broken, from a security perspective.
             # -- aseering 1/29/2010
-            raise ESPError("User '%s' is an administrator; morphing into administrators is not permitted." % user.username, log=False)
+            raise ESPError(f"User '{user.username}' is an administrator; morphing into administrators is not permitted.", log=False)
 
         logout(request)
         user.backend = 'esp.utils.auth_backend.ESPAuthBackend'
@@ -456,15 +457,14 @@ class BaseESPUser(object):
             uid = urlsafe_base64_encode(force_bytes(otheruser.pk))
             token = default_token_generator.make_token(otheruser)
             scheme = 'http' if getattr(settings, 'DEBUG', False) else 'https'
-            return '%s://%s/myesp/resetpassword/%s/%s/' % \
-                         (scheme, settings.DEFAULT_HOST, uid, token)
+            return f'{scheme}://{settings.DEFAULT_HOST}/myesp/resetpassword/{uid}/{token}/'
         elif key == 'recover_query':
             from django.contrib.auth.tokens import default_token_generator
             from django.utils.http import urlsafe_base64_encode
             from django.utils.encoding import force_bytes
             uid = urlsafe_base64_encode(force_bytes(otheruser.pk))
             token = default_token_generator.make_token(otheruser)
-            return "?uid=%s&token=%s" % (uid, token)
+            return f"?uid={uid}&token={token}"
         elif key == 'unsubscribe_link':
             return otheruser.unsubscribe_link_full()
         return ''
@@ -627,11 +627,11 @@ class BaseESPUser(object):
         try:
             num = int(num)
         except (ValueError, TypeError):
-            raise ESPError('Could not find user "%s %s"' % (first, last))
+            raise ESPError(f'Could not find user "{first} {last}"')
         users = ESPUser.objects.filter(last_name__iexact = last,
                                     first_name__iexact = first).order_by('id')
         if len(users) <= num:
-            raise ESPError('"%s %s": Unknown User' % (first, last), log=False)
+            raise ESPError(f'"{first} {last}": Unknown User', log=False)
         return users[num]
 
     @cache_function
@@ -926,7 +926,7 @@ class BaseESPUser(object):
         # we have a lot of users with no email (??)
         #  let's at least display a sensible error message
         if self.email.strip() == '':
-            raise ESPError('User %s has blank email address; cannot recover password. Please contact webmasters to reset your password.' % self.username)
+            raise ESPError(f'User {self.username} has blank email address; cannot recover password. Please contact webmasters to reset your password.')
 
         # email addresses
         to_email = [self.get_email_sendto_address()]
@@ -938,7 +938,7 @@ class BaseESPUser(object):
 
         # email subject
         domainname = Site.objects.get_current().domain
-        subject = '[%s] Your Password Recovery For %s ' % (settings.ORGANIZATION_SHORT_NAME, domainname)
+        subject = f'[{settings.ORGANIZATION_SHORT_NAME}] Your Password Recovery For {domainname} '
 
         # generate the email text
         t = loader.get_template('email/password_recover')
@@ -1018,15 +1018,15 @@ class BaseESPUser(object):
         """
         def _new_method(user):
             return user.is_user_type(user_class)
-        _new_method.__name__    = str('is%s' % str(user_class))
-        _new_method.__doc__     = "Returns ``True`` if the user is a %s and False otherwise." % user_class
+        _new_method.__name__    = str(f'is{user_class}')
+        _new_method.__doc__     = f"Returns ``True`` if the user is a {user_class} and False otherwise."
         return _new_method
 
     def is_user_type(self, user_class):
         """
         Determines whether the user is a member of user_class.
         """
-        property_name = '_userclass_%s' % user_class
+        property_name = f'_userclass_{user_class}'
         if not hasattr(self, property_name):
             role_name = {'Officer': 'Administrator'}.get(user_class, user_class)
             setattr(self, property_name, self.groups.filter(name=role_name).exists())
@@ -1240,7 +1240,7 @@ class BaseESPUser(object):
 
     def userHash(self, program):
         user_hash = hash(str(self.id) + str(program.id))
-        return '{0:06d}'.format(abs(user_hash))[:6]
+        return f'{abs(user_hash):06d}'[:6]
 
     # modified from here:
     # https://www.grokcode.com/819/one-click-unsubscribes-for-django-apps/
@@ -1252,21 +1252,21 @@ class BaseESPUser(object):
     def unsubscribe_link_full(self):
         unsub_link = self.unsubscribe_link()
         protocol = 'http' if settings.DEBUG else 'https'
-        return '%s://%s%s' % (protocol, Site.objects.get_current().domain, unsub_link)
+        return f'{protocol}://{Site.objects.get_current().domain}{unsub_link}'
 
     # this is an insecure version that accepts a POST from external sources
     def unsubscribe_oneclick(self):
         unsub_link = self.unsubscribe_link()
         unsub_link = unsub_link.replace("unsubscribe", "unsubscribe_oneclick")
         protocol = 'http' if settings.DEBUG else 'https'
-        return '%s://%s%s' % (protocol, Site.objects.get_current().domain, unsub_link)
+        return f'{protocol}://{Site.objects.get_current().domain}{unsub_link}'
 
     def make_token(self):
         return TimestampSigner().sign(self.username)
 
     def check_token(self, token):
         try:
-            key = '%s:%s' % (self.username, token)
+            key = f'{self.username}:{token}'
             TimestampSigner().unsign(key, max_age=60 * 60 * 24 * 7) # Valid for 7 days
         except (BadSignature, SignatureExpired):
             return False
@@ -1497,11 +1497,11 @@ class StudentInfo(models.Model):
 
         for value in values:
             value['user'] = ESPUser.objects.get(id=value['user'])
-            value['ajax_str'] = '%s - %s %d' % (value['user'].ajax_str(), value['school'], value['graduation_year'])
+            value['ajax_str'] = f'{value["user"].ajax_str()} - {value["school"]} {value["graduation_year"]}'
         return values
 
     def ajax_str(self):
-        return "%s - %s %d" % (self.user.ajax_str(), self.school, self.graduation_year)
+        return f"{self.user.ajax_str()} - {self.school} {self.graduation_year}"
 
     def updateForm(self, form_dict):
         form_dict['graduation_year'] = self.graduation_year
@@ -1538,8 +1538,8 @@ class StudentInfo(models.Model):
         if not studentInfo.user:
             studentInfo.user = curUser
         elif studentInfo.user != curUser: # this should never happen, but you never know....
-            raise ESPError("Your registration profile is corrupted. Please contact" +
-                            "{}".format(settings.DEFAULT_EMAIL_ADDRESSES['support']) +
+            raise ESPError("Your registration profile is corrupted. Please contact " +
+                            f"{settings.DEFAULT_EMAIL_ADDRESSES['support']}" +
                             " with your name and username in the message to " +
                             "correct this issue.")
 
@@ -1580,9 +1580,9 @@ class StudentInfo(models.Model):
         studentInfo.save()
         if new_data.get('studentrep', False):
             #   Email membership notifying them of the student rep request.
-            subj = '[%s Membership] Student Rep Request: %s %s' % (settings.ORGANIZATION_SHORT_NAME, curUser.first_name, curUser.last_name)
+            subj = f'[{settings.ORGANIZATION_SHORT_NAME} Membership] Student Rep Request: {curUser.first_name} {curUser.last_name}'
             to_email = [settings.DEFAULT_EMAIL_ADDRESSES['membership']]
-            from_email = 'ESP Profile Editor <regprofile@%s>' % settings.DEFAULT_HOST
+            from_email = f'ESP Profile Editor <regprofile@{settings.DEFAULT_HOST}>'
             t = loader.get_template('email/studentreprequest')
             msgtext = t.render(Context({'user': curUser, 'info': studentInfo, 'prog': regProfile.program}))
             send_mail(subj, msgtext, from_email, to_email, fail_silently = True)
@@ -1609,7 +1609,7 @@ class StudentInfo(models.Model):
         username = "N/A"
         if self.user is not None:
             username = self.user.username
-        return 'ESP Student Info (%s) -- %s' % (username, str(self.school))
+        return f'ESP Student Info ({username}) -- {self.school}'
 
     def get_absolute_url(self):
         return self.user.get_absolute_url()
@@ -1684,11 +1684,11 @@ class TeacherInfo(models.Model, CustomFormsLinkModel):
 
         for value in values:
             value['user'] = ESPUser.objects.get(id=value['user'])
-            value['ajax_str'] = '%s - %s %s' % (value['user'].ajax_str(), value['college'], value['graduation_year'])
+            value['ajax_str'] = f'{value["user"].ajax_str()} - {value["college"]} {value["graduation_year"]}'
         return values
 
     def ajax_str(self):
-        return '%s - %s %s' % (self.user.ajax_str(), self.college, self.graduation_year)
+        return f'{self.user.ajax_str()} - {self.college} {self.graduation_year}'
 
     def updateForm(self, form_dict):
         form_dict['pronoun']         = self.pronoun
@@ -1729,7 +1729,7 @@ class TeacherInfo(models.Model, CustomFormsLinkModel):
         username = ""
         if self.user is not None:
             username = self.user.username
-        return 'ESP Teacher Info (%s)' % username
+        return f'ESP Teacher Info ({username})'
 
     def get_absolute_url(self):
         return self.user.get_absolute_url()
@@ -1764,11 +1764,11 @@ class GuardianInfo(models.Model):
 
         for value in values:
             value['user'] = ESPUser.objects.get(id=value['user'])
-            value['ajax_str'] = '%s - %s %d' % (value['user'].ajax_str(), value['year_finished'], value['num_kids'])
+            value['ajax_str'] = f'{value["user"].ajax_str()} - {value["year_finished"]} {value["num_kids"]}'
         return values
 
     def ajax_str(self):
-        return "%s - %s %d" % (self.user.ajax_str(), self.year_finished, self.num_kids)
+        return f"{self.user.ajax_str()} - {self.year_finished} {self.num_kids}"
 
     def updateForm(self, form_dict):
         form_dict['year_finished'] = self.year_finished
@@ -1792,7 +1792,7 @@ class GuardianInfo(models.Model):
         username = ""
         if self.user is not None:
             username = self.user.username
-        return 'ESP Guardian Info (%s)' % username
+        return f'ESP Guardian Info ({username})'
 
     def get_absolute_url(self):
         return self.user.get_absolute_url()
@@ -1827,11 +1827,11 @@ class EducatorInfo(models.Model):
 
         for value in values:
             value['user'] = ESPUser.objects.get(id=value['user'])
-            value['ajax_str'] = '%s - %s %s' % (value['user'].ajax_str(), value['position'], value['school'])
+            value['ajax_str'] = f'{value["user"].ajax_str()} - {value["position"]} {value["school"]}'
         return values
 
     def ajax_str(self):
-        return "%s - %s at %s" % (self.user.ajax_str(), self.position, self.school)
+        return f"{self.user.ajax_str()} - {self.position} at {self.school}"
 
     def updateForm(self, form_dict):
         form_dict['subject_taught'] = self.subject_taught
@@ -1869,7 +1869,7 @@ class EducatorInfo(models.Model):
         username = ""
         if self.user is not None:
             username = self.user.username
-        return 'ESP Educator Info (%s)' % username
+        return f'ESP Educator Info ({username})'
 
     def get_absolute_url(self):
         return self.user.get_absolute_url()
@@ -1914,7 +1914,7 @@ class ZipCode(models.Model):
             distance_decimal = Decimal(str(distance))
             distance_float = float(str(distance))
         except (ValueError, ArithmeticError):
-            raise ESPError('%s should be a valid decimal number!' % distance)
+            raise ESPError(f'{distance} should be a valid decimal number!')
 
         if distance < 0:
             distance *= -1
@@ -1938,9 +1938,7 @@ class ZipCode(models.Model):
         return winners
 
     def __str__(self):
-        return '%s (%s, %s)' % (self.zip_code,
-                                self.longitude,
-                                self.latitude)
+        return f'{self.zip_code} ({self.longitude}, {self.latitude})'
 
 
 class ZipCodeSearches(models.Model):
@@ -1954,8 +1952,7 @@ class ZipCodeSearches(models.Model):
         verbose_name_plural = 'Zip code searches'
 
     def __str__(self):
-        return '%s Zip Codes that are less than %s miles from %s' % \
-               (len(self.zipcodes.split(',')), self.distance, self.zip_code)
+        return f'{len(self.zipcodes.split(","))} Zip Codes that are less than {self.distance} miles from {self.zip_code}'
 
 class ContactInfo(models.Model, CustomFormsLinkModel):
     """ ESP-specific contact information for (possibly) a specific user """
@@ -2010,7 +2007,7 @@ class ContactInfo(models.Model, CustomFormsLinkModel):
         db_table = 'users_contactinfo'
 
     def name(self):
-        return '%s %s' % (self.first_name, self.last_name)
+        return f'{self.first_name} {self.last_name}'
 
     email = property(lambda self: self.e_mail)
 
@@ -2027,11 +2024,7 @@ class ContactInfo(models.Model, CustomFormsLinkModel):
         return ESPUser.email_sendto_address(self.email, self.name())
 
     def address(self):
-        return '%s, %s, %s %s' % \
-            (self.address_street,
-             self.address_city,
-             self.address_state,
-             self.address_zip)
+        return f'{self.address_street}, {self.address_city}, {self.address_state} {self.address_zip}'
 
     def items(self):
         return list(self.__dict__.items())
@@ -2047,11 +2040,11 @@ class ContactInfo(models.Model, CustomFormsLinkModel):
                 query_set = query_set.filter(first_name__istartswith = first.strip())
         values = query_set.order_by('last_name', 'first_name', 'id').values('first_name', 'last_name', 'e_mail', 'id')
         for value in values:
-            value['ajax_str'] = '%s, %s (%s)' % (value['last_name'], value['first_name'], value['e_mail'])
+            value['ajax_str'] = f'{value["last_name"]}, {value["first_name"]} ({value["e_mail"]})'
         return values
 
-        def ajax_str(self):
-            return "%s, %s (%s)" % (self.last_name, self.first_name, self.e_mail)
+    def ajax_str(self):
+        return f"{self.last_name}, {self.first_name} ({self.e_mail})"
 
     @staticmethod
     def addOrUpdate(curUser, regProfile, new_data, contactInfo, prefix=''):
@@ -2119,20 +2112,19 @@ class K12School(models.Model):
         query_set = cls.objects.filter(name__icontains = name)
         values = query_set.order_by('name', 'id').values('name', 'id')
         for value in values:
-            value['ajax_str'] = '%s' % (value['name'])
+            value['ajax_str'] = f'{value["name"]}'
         return values
 
     def __str__(self):
         if self.contact_id and self.contact.address_city and self.contact.address_state:
-            return '%s in %s, %s' % (self.name, self.contact.address_city,
-                                            self.contact.address_state)
+            return f'{self.name} in {self.contact.address_city}, {self.contact.address_state}'
         else:
-            return '%s' % self.name
+            return f'{self.name}'
 
     @classmethod
     def choicelist(cls, other_help_text=''):
         if other_help_text:
-            other_help_text = ' (%s)' % other_help_text
+            other_help_text = f' ({other_help_text})'
         o = cls.objects.other()
         lst = [ ( x.id, x.name ) for x in cls.objects.most() ]
         lst.append( (o.id, o.name + other_help_text) )
@@ -2270,7 +2262,7 @@ class DBList(object):
             If override is true, it will not retrieve the number from cache
             or from this instance. If it's true, it will try.
         """
-        cache_id = urlencode('DBListCount: %s' % (self.key))
+        cache_id = urlencode(f'DBListCount: {self.key}')
 
         retVal   = cache.get(cache_id) # get the cached result
         if self.QObject: # if there is a q object we can just
@@ -2706,8 +2698,7 @@ class Permission(ExpirableModel):
         else:
             program = "None"
 
-        return "GRANT %s ON %s TO %s" % (self.permission_type,
-                                         program, user)
+        return f"GRANT {self.permission_type} ON {program} TO {user}"
 
     @classmethod
     def nice_name_lookup(cls, perm_type):
@@ -2908,7 +2899,7 @@ class GradeChangeRequest(TimeStampedModel):
         subject, message = self._confirmation_email_content()
         send_mail(subject,
                   message,
-                  Tag.getTag('full_group_name') or '%s %s' % (settings.INSTITUTION_NAME, settings.ORGANIZATION_SHORT_NAME) + ' <info@' + settings.SITE_INFO[1] + '>',
+                  Tag.getTag('full_group_name') or f'{settings.INSTITUTION_NAME} {settings.ORGANIZATION_SHORT_NAME}' + ' <info@' + settings.SITE_INFO[1] + '>',
                   [self.requesting_student.email, ])
 
     def get_admin_url(self):
@@ -2917,7 +2908,7 @@ class GradeChangeRequest(TimeStampedModel):
 
 
     def __str__(self):
-        return  "%s requests a grade change to %s" % (self.requesting_student, self.claimed_grade) + (" (Approved)" if self.approved else "")
+        return  f"{self.requesting_student} requests a grade change to {self.claimed_grade}" + (" (Approved)" if self.approved else "")
 
 # We can't import these earlier because of circular stuff...
 from esp.users.models.forwarder import UserForwarder # Don't delete, needed for app loading

--- a/esp/esp/users/models/forwarder.py
+++ b/esp/esp/users/models/forwarder.py
@@ -108,4 +108,4 @@ class UserForwarder(models.Model):
             return (user, False)
 
     def __str__(self):
-        return '%s to %s' % (str(self.source), str(self.target))
+        return f'{self.source} to {self.target}'

--- a/esp/esp/users/tests.py
+++ b/esp/esp/users/tests.py
@@ -62,18 +62,18 @@ class ESPUserTest(TestCase):
         self.basic_user.backend = request.backend
 
         login(request, self.user)
-        self.assertEqual(request.user, self.user, "Failed to log in as '%s'" % self.user)
+        self.assertEqual(request.user, self.user, f"Failed to log in as '{self.user}'")
 
         request.user.switch_to_user(request, self.basic_user, None, None)
-        self.assertEqual(request.user, self.basic_user, "Failed to morph into '%s'" % self.basic_user)
+        self.assertEqual(request.user, self.basic_user, f"Failed to morph into '{self.basic_user}'")
 
         request.user.switch_back(request)
-        self.assertEqual(request.user, self.user, "Failed to morph back into '%s'" % self.user)
+        self.assertEqual(request.user, self.user, f"Failed to morph back into '{self.user}'")
 
         blocked_illegal_morph = True
         try:
             request.user.switch_to_user(request, self.basic_user, None, None)
-            self.assertEqual(request.user, self.basic_user, "Failed to morph into '%s'" % self.basic_user)
+            self.assertEqual(request.user, self.basic_user, f"Failed to morph into '{self.basic_user}'")
         except ESPError():
             blocked_illegal_morph = True
 
@@ -103,7 +103,7 @@ class ESPUserTest(TestCase):
         curYear = ESPUser.current_schoolyear()
         gradYear = curYear + (12 - testGrade)
         self.client.get("/manage/userview?username=student&graduation_year="+str(gradYear))
-        self.assertTrue(studentUser.getGrade() == testGrade, "Grades don't match: %s %s" % (studentUser.getGrade(), testGrade))
+        self.assertTrue(studentUser.getGrade() == testGrade, f"Grades don't match: {studentUser.getGrade()} {testGrade}")
 
         # Clean up
         if (c1):
@@ -288,7 +288,7 @@ class ValidHostEmailFieldTest(TestCase):
         # Hardcoding 'esp.mit.edu' here might be a bad idea
         # But at least it verifies that A records work in place of MX
         for domain in [ 'esp.mit.edu', 'gmail.com', 'yahoo.com' ]:
-            self.assertTrue( ValidHostEmailField().clean( 'fakeaddress@%s' % domain ) == 'fakeaddress@%s' % domain )
+            self.assertTrue( ValidHostEmailField().clean( f'fakeaddress@{domain}' ) == f'fakeaddress@{domain}' )
     def testFakeDomain(self):
         # If we have an internet connection, bad domains raise ValidationError.
         # This should be the *only* kind of error we ever raise!
@@ -305,7 +305,7 @@ class UserForwarderTest(TestCase):
         self.users = [self.ua, self.ub, self.uc]
     def test_run(self):
         def fwd_info(user):
-            return '%s forwards by: %s' % (user.username, user.forwarders_out.all())
+            return f'{user.username} forwards by: {user.forwarders_out.all()}'
         # Ensure that users have no forwarders by default
         for user in self.users:
             self.assertTrue(UserForwarder.follow(user) == (user, False), fwd_info(user))
@@ -388,11 +388,11 @@ class AjaxExistenceChecker(TestCase):
 
         response = self.client.get(self.path)
         for key in self.keys:
-            self.assertContains(response, key, msg_prefix="Key %s missing from Ajax response to %s" % (key, self.path), status_code=200)
+            self.assertContains(response, key, msg_prefix=f"Key {key} missing from Ajax response to {self.path}", status_code=200)
 
 class AjaxScheduleExistenceTest(AjaxExistenceChecker, ProgramFrameworkTest):
     def test_run(self):
-        self.path = '/learn/%s/ajax_schedule' % self.program.getUrlBase()
+        self.path = f'/learn/{self.program.getUrlBase()}/ajax_schedule'
         self.keys = ['student_schedule_html']
         user=self.students[0]
         self.assertTrue(self.client.login(username=user.username, password='password'))
@@ -554,7 +554,7 @@ class TestChangeRequestView(TestCase):
         self.password = "pass1234"
 
         #   May fail once in a while, but it's not critical.
-        self.unique_name = 'Test_UNIQUE%06d' % random.randint(0, 999999)
+        self.unique_name = f'Test_UNIQUE{random.randint(0, 999999):06d}'
         self.user, created = ESPUser.objects.get_or_create(first_name=self.unique_name, last_name="User", username="testuser123543", email="server@esp.mit.edu")
         if created:
             self.user.set_password(self.password)
@@ -926,7 +926,7 @@ class StudentInfoFormGradeTest(TestCase):
         errors = form.errors.get('graduation_year', [])
         self.assertTrue(
             any('required' in e.lower() for e in errors),
-            "Expected a 'required' error for graduation_year, got: %s" % errors,
+            f"Expected a 'required' error for graduation_year, got: {errors}",
         )
 
     def test_no_auto_default_to_lowest_grade(self):

--- a/esp/esp/users/views/__init__.py
+++ b/esp/esp/users/views/__init__.py
@@ -7,6 +7,7 @@ from django.contrib.auth.decorators import login_required
 from django.http import HttpResponseRedirect, HttpResponse, HttpResponseBadRequest
 from django.template import RequestContext
 from django.urls import reverse
+from django.utils.http import urlencode
 from django.views.decorators.csrf import csrf_exempt
 
 from esp.program.models import Program, RegistrationProfile
@@ -25,13 +26,13 @@ from esp.web.views.main import DefaultQSDView
 def HttpMetaRedirect(location='/'):
     response = HttpResponse()
     response.status = 200
-    response.content = """
+    response.content = f"""
     <html><head>
-    <meta http-equiv="refresh" content="0; url=%s">
+    <meta http-equiv="refresh" content="0; url={location}">
     </head>
-    <body>Thank you for logging in.  Please click <a href="%s">here</a> if you are not redirected.</body>
+    <body>Thank you for logging in.  Please click <a href="{location}">here</a> if you are not redirected.</body>
     </html>
-    """ % (location, location)
+    """
     return response
 
 mask_locations = ['/', '/myesp/signout', '/myesp/signout/', '/admin/logout/']
@@ -235,7 +236,8 @@ def unsubscribe(request, username, token, oneclick = False):
     # so show the login page (with a custom alert message)
     else:
         next_url = reverse('unsubscribe', kwargs={'username': username, 'token': token,})
-        return HttpResponseRedirect('%s?next=%s' % (reverse('login'), next_url))
+        query_string = urlencode({'next': next_url})
+        return HttpResponseRedirect(f'{reverse("login")}?{query_string}')
 
 # have an email client (etc) POST to this view to process a
 # "oneclick" unsubscribe
@@ -265,7 +267,7 @@ def morph_into_user(request):
                                 onsite is not None)
 
     if onsite is not None:
-        return HttpResponseRedirect('/learn/%s/studentreg' % onsite.getUrlBase())
+        return HttpResponseRedirect(f'/learn/{onsite.getUrlBase()}/studentreg')
     else:
         return HttpResponseRedirect(reverse('home'))
 

--- a/esp/esp/users/views/password_reset.py
+++ b/esp/esp/users/views/password_reset.py
@@ -39,7 +39,7 @@ def initial_passwd_request(request, success=None):
             for user in users:
                 user.recoverPassword()
 
-            return HttpResponseRedirect('/%s/success/' % request.path.strip('/'))
+            return HttpResponseRedirect(f'/{request.path.strip("/")}/success/')
 
 
     else:

--- a/esp/esp/users/views/registration.py
+++ b/esp/esp/users/views/registration.py
@@ -64,7 +64,7 @@ This function is overloaded to handle either one or two phase reg"""
         #   Append key to password and disable until activation if desired
         if Tag.getBooleanTag('require_email_validation'):
             userkey = random.randint(0, 2**31 - 1)
-            user.password += "_%d" % userkey
+            user.password += f"_{userkey}"
             user.is_active = False
 
         user.save()
@@ -173,10 +173,10 @@ def activate_account(request):
     if u.is_active:
         raise ESPError('The user account supplied has already been activated. If you have lost your password, visit the <a href="/myesp/passwdrecover/">password recovery form</a>.  Otherwise, please <a href="/accounts/login/?next=/myesp/profile/">log in</a>.', log=False)
 
-    if not u.password.endswith("_%s" % request.GET['key']):
+    if not u.password.endswith(f"_{request.GET['key']}"):
         raise ESPError("Incorrect key.  Please try again to click the link in your email, or copy the url into your browser.  If this error persists, please contact us using the contact information on the top or bottom of this page.", log=False)
 
-    u.password = u.password[:-(len("_%s" % request.GET['key']))]
+    u.password = u.password[:-(len(f"_{request.GET['key']}"))]
     u.is_active = True
     u.save()
 

--- a/esp/esp/users/views/usersearch.py
+++ b/esp/esp/users/views/usersearch.py
@@ -83,7 +83,7 @@ def get_user_list(request, listDict2, extra=''):
             getUser, found = search_for_user(request, ESPUser.objects.filter(filterObj.get_Q()).distinct(), filterObj.id, True)
             if found:
                 if isinstance(getUser, User):
-                    newfilterObj = PersistentQueryFilter.getFilterFromQ(Q(id = getUser.id), ESPUser, 'User %s' % getUser.username)
+                    newfilterObj = PersistentQueryFilter.getFilterFromQ(Q(id = getUser.id), ESPUser, f'User {getUser.username}')
                 else:
                     newfilterObj = PersistentQueryFilter.getFilterFromQ(filterObj.get_Q() & getUser, ESPUser, 'Custom user filter')
                 return (newfilterObj, True)
@@ -126,7 +126,7 @@ def get_user_list(request, listDict2, extra=''):
         if request.POST['base_list'] in listDict:
             curList = listDict[request.POST['base_list']]['list']
         else:
-            raise ESPError('I do not know of list "%s".' % request.POST['base_list'])
+            raise ESPError(f'I do not know of list "{request.POST["base_list"]}".')
 
         # we start with all the separated lists, and apply the and'd lists onto the or'd lists before
         # we or. This closely represents the sentence (it's not as powerful, but makes "sense")
@@ -161,7 +161,7 @@ def get_user_list(request, listDict2, extra=''):
             getUser, found = search_for_user(request, ESPUser.objects.filter(filterObj.get_Q()).distinct(), filterObj.id, True)
             if found:
                 if isinstance(getUser, User):
-                    newfilterObj = PersistentQueryFilter.getFilterFromQ(Q(id = getUser.id), ESPUser, 'User %s' % getUser.username)
+                    newfilterObj = PersistentQueryFilter.getFilterFromQ(Q(id = getUser.id), ESPUser, f'User {getUser.username}')
                 else:
                     newfilterObj = PersistentQueryFilter.getFilterFromQ(filterObj.get_Q() & getUser, ESPUser, 'Custom user filter')
                 return (newfilterObj, True)
@@ -184,7 +184,7 @@ def get_user_list(request, listDict2, extra=''):
         getUser, found = search_for_user(request, ESPUser.objects.filter(filterObj.get_Q()).distinct(), filterObj.id, True)
         if found:
             if isinstance(getUser, ESPUser):
-                newfilterObj = PersistentQueryFilter.getFilterFromQ(Q(id = getUser.id), ESPUser, 'User %s' % getUser.username)
+                newfilterObj = PersistentQueryFilter.getFilterFromQ(Q(id = getUser.id), ESPUser, f'User {getUser.username}')
             else:
                 newfilterObj = PersistentQueryFilter.getFilterFromQ(filterObj.get_Q() & getUser, ESPUser, 'Custom user filter')
 
@@ -262,7 +262,7 @@ def search_for_user(request, user_type='Any', extra='', returnList = False, add_
     elif isinstance(user_type, QuerySet):
         QSUsers = usc.filter_from_criteria(user_type, request.GET)
     else:
-        raise ESPError('Invalid user_type: %s' % type(user_type), log=True)
+        raise ESPError(f'Invalid user_type: {type(user_type)}', log=True)
 
     #   We need to ask for more user input if no filtering options were selected
     if not usc.updated:


### PR DESCRIPTION
Fixes #4310 
## Description

Convert `%` formatting and `.format()` calls to f-strings in `users/` — user model string representations, authentication messages, email formatting, profile rendering, admin views, form validation, and merge utilities.

13 files changed, +106/-116.

## Related Issue

Part of #4555

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced
