### PR TITLE
refactor: convert string formatting to f-strings in program autoscheduler

### DIFF
--- a/esp/esp/program/controllers/autoscheduler/config.py
+++ b/esp/esp/program/controllers/autoscheduler/config.py
@@ -109,11 +109,11 @@ SCORER_DESCRIPTIONS = {
 # create another with the same name in an override dict. To delete a criterion
 # in an override, use None (either None or 'None' is okay) for the
 # specification.
+_STAR_CLASSROOM_PATTERN = r'^\*.*$'
 DEFAULT_RESOURCE_CONSTRAINTS = {
     # If you don't want to use a classroom, mark its name with a star.
     "restrict_star_classrooms":
-        "if any section then not classroom matches {}".format(
-            r"^\*.*$"),
+        f"if any section then not classroom matches {_STAR_CLASSROOM_PATTERN}",
     "restrict_star_classrooms_comment":
         "Ignore all classrooms with names marked with a star, e.g. *16-628.",
 }

--- a/esp/esp/program/controllers/autoscheduler/consistency_checks.py
+++ b/esp/esp/program/controllers/autoscheduler/consistency_checks.py
@@ -30,7 +30,7 @@ class ConsistencyChecker:
         which are named check_[something]_consistency."""
         for attr in dir(self):
             if attr.startswith("check_") and attr.endswith("_consistency"):
-                logger.info("Running: {}".format(attr))
+                logger.info(f"Running: {attr}")
                 getattr(self, attr)(schedule)
 
     def check_availability_dict_consistency(self, schedule):
@@ -40,24 +40,22 @@ class ConsistencyChecker:
             for time, roomslot in room.availability_dict.items():
                 if time != (roomslot.timeslot.start, roomslot.timeslot.end):
                     raise ConsistencyError(
-                        ("Room availability dict key/value mismatch for "
-                         "room {}").format(room.name))
+                        (f"Room availability dict key/value mismatch for "
+                         f"room {room.name}"))
             if set(room.availability) != set(
                     room.availability_dict.values()):
                 raise ConsistencyError(
-                    "Room {} availability list and dict don't match"
-                    .format(room.name))
+                    f"Room {room.name} availability list and dict don't match")
         for teacher in schedule.teachers.values():
             for time, timeslot in teacher.availability_dict.items():
                 if time != (timeslot.start, timeslot.end):
                     raise ConsistencyError(
-                        ("Teacher availability dict key/value mismatch for "
-                         "teacher {}").format(teacher.id))
+                        (f"Teacher availability dict key/value mismatch for "
+                         f"teacher {teacher.id}"))
             if set(t.id for t in teacher.availability) != set(
                     t.id for t in teacher.availability_dict.values()):
                 raise ConsistencyError(
-                    "Teacher {} availability list and dict don't match"
-                    .format(teacher.id))
+                    f"Teacher {teacher.id} availability list and dict don't match")
 
     def check_lunch_consistency(self, schedule):
         """Checks that lunch dictionary maps correctly,
@@ -96,14 +94,12 @@ class ConsistencyChecker:
             for restype_name, request in section.resource_requests.items():
                 if request.name != restype_name:
                     raise ConsistencyError(
-                        "Section {} had request {} listed under name {}"
-                        .format(section.id, request.name, restype_name))
+                        f"Section {section.id} had request {request.name} listed under name {restype_name}")
         for room in schedule.classrooms.values():
             for restype_name, furnishing in room.furnishings.items():
                 if furnishing.name != restype_name:
                     raise ConsistencyError(
-                        "Room {} had furnishing {} listed under name {}"
-                        .format(room.name, furnishing.name, restype_name))
+                        f"Room {room.name} had furnishing {furnishing.name} listed under name {restype_name}")
 
     def check_roomslots_consistency(self, schedule):
         """Check to make sure that roomslots, are consistent with timeslots,
@@ -163,19 +159,16 @@ class ConsistencyChecker:
         for room in schedule.classrooms.values():
             for i, roomslot in enumerate(room.availability):
                 if i != roomslot.index():
-                    raise ConsistencyError((
-                            "Roomslot index for room {} was {} instead of {}."
-                    ).format(room.name, roomslot.index(), i))
+                    raise ConsistencyError(
+                            f"Roomslot index for room {room.name} was {roomslot.index()} instead of {i}.")
                 if i < len(room.availability) - 1:
                     if room.availability[i + 1] != roomslot.next():
                         raise ConsistencyError(
-                            "Roomslot next for room {} was wrong.".format(
-                                room.name))
+                            f"Roomslot next for room {room.name} was wrong.")
                 else:
                     if roomslot.next() is not None:
-                        raise ConsistencyError((
-                                "Last roomslot next for room {} was not None."
-                        ).format(room.name))
+                        raise ConsistencyError(
+                                f"Last roomslot next for room {room.name} was not None.")
 
     def roomslot_sorting_helper(self, roomslots):
         """Returns True if the roomslots are sorted by timeslot, False
@@ -189,18 +182,15 @@ class ConsistencyChecker:
         for section_id, section in schedule.class_sections.items():
             if section.id != section_id:
                 raise ConsistencyError(
-                    "Section {} was listed under id {}".format(
-                        section.id, section_id))
+                    f"Section {section.id} was listed under id {section_id}")
         for teacher_id, teacher in schedule.teachers.items():
             if teacher.id != teacher_id:
                 raise ConsistencyError(
-                    "Teacher {} was listed under id {}".format(
-                        teacher.id, teacher_id))
+                    f"Teacher {teacher.id} was listed under id {teacher_id}")
         for room_name, room in schedule.classrooms.items():
             if room.name != room_name:
                 raise ConsistencyError(
-                    "Room {} was listed under name {}".format(
-                        room.name, room_name))
+                    f"Room {room.name} was listed under name {room_name}")
 
     def check_sorting_consistency(self, schedule):
         """Checks whether section assigned roomslots, classroom availability,
@@ -226,18 +216,16 @@ class ConsistencyChecker:
             for section_id, section in teacher.taught_sections.items():
                 if section_id != section.id:
                     raise ConsistencyError(
-                        "Teacher {} taught_sections had key/value mismatch"
-                        .format(teacher.id))
+                        f"Teacher {teacher.id} taught_sections had key/value mismatch")
                 if teacher not in section.teachers:
                     raise ConsistencyError(
-                        ("Teacher {} taught_sections listed a section the "
-                         "teacher wasn't teaching").format(teacher.id))
+                        (f"Teacher {teacher.id} taught_sections listed a section the "
+                         "teacher wasn't teaching"))
         for section in schedule.class_sections.values():
             for teacher in section.teachers:
                 if section.id not in teacher.taught_sections:
                     raise ConsistencyError(
-                        "Teacher{} is teaching section {} but didn't know it"
-                        .format(teacher.id, section.id))
+                        f"Teacher{teacher.id} is teaching section {section.id} but didn't know it")
 
     def check_timeslot_consistency(self, schedule):
         """Checks that timeslots are sorted and non-overlapping."""
@@ -259,8 +247,7 @@ class ConsistencyChecker:
                     timeslot.start, timeslot.end)
             if abs(timeslot.duration - actual_duration) > 1e-4:
                 raise ConsistencyError(
-                    "Timeslot actual duration {} didn't match advertised {}"
-                    .format(actual_duration, timeslot.duration))
+                    f"Timeslot actual duration {actual_duration} didn't match advertised {timeslot.duration}")
 
     def check_timeslot_span_consistency(self, schedule):
         """Ensure timeslots don't span multiple days."""
@@ -270,8 +257,7 @@ class ConsistencyChecker:
             if (start.year, start.month, start.day) != \
                     (end.year, end.month, end.day):
                 raise ConsistencyError(
-                    "Timeslot ({}, {}) spans multiple days".format(
-                        start, end))
+                    f"Timeslot ({start}, {end}) spans multiple days")
 
     def check_timeslots_list_and_dict_consistency(self, schedule):
         """Check that the timeslot dict has consistent keys and values,

--- a/esp/esp/program/controllers/autoscheduler/consistency_checks.py
+++ b/esp/esp/program/controllers/autoscheduler/consistency_checks.py
@@ -225,7 +225,7 @@ class ConsistencyChecker:
             for teacher in section.teachers:
                 if section.id not in teacher.taught_sections:
                     raise ConsistencyError(
-                        f"Teacher{teacher.id} is teaching section {section.id} but didn't know it")
+                        f"Teacher {teacher.id} is teaching section {section.id} but didn't know it")
 
     def check_timeslot_consistency(self, schedule):
         """Checks that timeslots are sorted and non-overlapping."""

--- a/esp/esp/program/controllers/autoscheduler/constraints.py
+++ b/esp/esp/program/controllers/autoscheduler/constraints.py
@@ -46,8 +46,7 @@ class ConstraintViolation(object):
         self.reason = reason
 
     def __str__(self):
-        return "Constraint {} was violated because {}".format(
-            self.constraint_name, self.reason)
+        return f"Constraint {self.constraint_name} was violated because {self.reason}"
 
 
 class BaseConstraint(object):
@@ -106,7 +105,7 @@ class CompositeConstraint(BaseConstraint):
         else:
             constraints_to_use = set(constraint_names + required_constraints)
         for constraint in constraints_to_use:
-            logger.info("Using constraint {}".format(constraint))
+            logger.info(f"Using constraint {constraint}")
             self.constraints.append(
                 available_constraints[constraint](**kwargs))
 
@@ -171,13 +170,11 @@ class ContiguousConstraint(BaseConstraint):
                             prev_timeslot, roomslot.timeslot):
                         return ConstraintViolation(
                             self.__class__.__name__,
-                            "Section id {} had noncontiguous rooms"
-                            .format(section.id))
+                            f"Section id {section.id} had noncontiguous rooms")
                     if roomslot.room.name != section_room.name:
                         return ConstraintViolation(
                             self.__class__.__name__,
-                            "Section id {} is in 2 different rooms"
-                            .format(section.id))
+                            f"Section id {section.id} is in 2 different rooms")
                     prev_timeslot = roomslot.timeslot
         return None
 
@@ -235,8 +232,7 @@ class LunchConstraint(BaseConstraint):
                         and end_section >= end_lunch:
                             return ConstraintViolation(
                                 self.__class__.__name__,
-                                "Section id {} is scheduled over lunch"
-                                .format(section.id))
+                                f"Section id {section.id} is scheduled over lunch")
         return None
 
     def check_schedule_section(self, section, start_roomslot, schedule):
@@ -352,8 +348,7 @@ class ResourceCriteriaConstraint(BaseConstraint):
                     section, start_roomslot.room):
                 return ConstraintViolation(
                     self.__class__.__name__,
-                    "Violates resource criterion '{}'.".format(
-                        resource_criterion))
+                    f"Violates resource criterion '{resource_criterion}'.")
         return None
 
     def check_move_section(self, section, start_roomslot, schedule):
@@ -504,10 +499,8 @@ class SectionDurationConstraint(BaseConstraint):
                         > config.DELTA_TIME:
                     return ConstraintViolation(
                         self.__class__.__name__,
-                        ("Section {} is scheduled for {} hours but "
-                         "should be scheduled for {} hours"
-                         .format(section.id, scheduled_duration,
-                                 section.duration)))
+                        (f"Section {section.id} is scheduled for {scheduled_duration} hours but "
+                         f"should be scheduled for {section.duration} hours"))
         return None
 
     def check_schedule_section(self, section, start_roomslot, schedule):
@@ -528,8 +521,7 @@ class SectionDurationConstraint(BaseConstraint):
         if abs(scheduled_duration - section.duration) > config.DELTA_TIME:
             return ConstraintViolation(
                 self.__class__.__name__,
-                "Section would be scheduled for {} hours instead of {}"
-                .format(scheduled_duration, section.duration))
+                f"Section would be scheduled for {scheduled_duration} hours instead of {section.duration}")
         return None
 
     def check_move_section(self, section, start_roomslot, schedule):
@@ -569,11 +561,8 @@ class TeacherAvailabilityConstraint(BaseConstraint):
                                 not in teacher.availability_dict:
                             return ConstraintViolation(
                                 self.__class__.__name__,
-                                ("User {} is teaching from {} to {} but isn't "
-                                 "available".format(
-                                     teacher.id,
-                                     str(start_time),
-                                     str(end_time))))
+                                (f"User {teacher.id} is teaching from {start_time} to {end_time} but isn't "
+                                 "available"))
 
         return None
 
@@ -687,8 +676,7 @@ class TeacherConcurrencyConstraint(BaseConstraint):
                     if (start_time, end_time) in already_teaching:
                         return ConstraintViolation(
                             self.__class__.__name__,
-                            "Teacher id {} is teaching twice at once"
-                            .format(teacher.id))
+                            f"Teacher id {teacher.id} is teaching twice at once")
                     already_teaching.add((start_time, end_time))
         return None
 

--- a/esp/esp/program/controllers/autoscheduler/constraints.py
+++ b/esp/esp/program/controllers/autoscheduler/constraints.py
@@ -105,7 +105,7 @@ class CompositeConstraint(BaseConstraint):
         else:
             constraints_to_use = set(constraint_names + required_constraints)
         for constraint in constraints_to_use:
-            logger.info("Using constraint %s", constraint)
+            logger.info(f"Using constraint {constraint}")
             self.constraints.append(
                 available_constraints[constraint](**kwargs))
 

--- a/esp/esp/program/controllers/autoscheduler/constraints.py
+++ b/esp/esp/program/controllers/autoscheduler/constraints.py
@@ -105,7 +105,7 @@ class CompositeConstraint(BaseConstraint):
         else:
             constraints_to_use = set(constraint_names + required_constraints)
         for constraint in constraints_to_use:
-            logger.info(f"Using constraint {constraint}")
+            logger.info("Using constraint %s", constraint)
             self.constraints.append(
                 available_constraints[constraint](**kwargs))
 

--- a/esp/esp/program/controllers/autoscheduler/controller.py
+++ b/esp/esp/program/controllers/autoscheduler/controller.py
@@ -134,47 +134,32 @@ class AutoschedulerController(object):
                 self.optimizer.manipulator.history):
             row = []
             if action["action"] == "schedule":
-                row.append(["Scheduled {}:".format(
-                                self.section_identifier(action["section"])),
+                row.append([f"Scheduled {self.section_identifier(action['section'])}:",
                            self.section_info(action["section"])])
-                row.append(["In {}:".format(
-                                self.roomslot_identifier(
-                                    action["start_roomslot"])),
+                row.append([f"In {self.roomslot_identifier(action['start_roomslot'])}:",
                            self.roomslot_info(action["start_roomslot"])])
             elif action["action"] == "move":
-                row.append(["Moved {}:".format(
-                                self.section_identifier(action["section"])),
+                row.append([f"Moved {self.section_identifier(action['section'])}:",
                            self.section_info(action["section"])])
-                row.append(["From {}:".format(
-                                self.roomslot_identifier(
-                                    action["prev_start_roomslot"])),
+                row.append([f"From {self.roomslot_identifier(action['prev_start_roomslot'])}:",
                            self.roomslot_info(action["prev_start_roomslot"])])
-                row.append(["To {}:".format(
-                                self.roomslot_identifier(
-                                    action["start_roomslot"])),
+                row.append([f"To {self.roomslot_identifier(action['start_roomslot'])}:",
                            self.roomslot_info(action["start_roomslot"])])
             elif action["action"] == "unschedule":
-                row.append(["Unscheduled {}:".format(
-                                self.section_identifier(action["section"])),
+                row.append([f"Unscheduled {self.section_identifier(action['section'])}:",
                            self.section_info(action["section"])])
-                row.append(["From {}:".format(
-                                self.roomslot_identifier(
-                                    action["prev_start_roomslot"])),
+                row.append([f"From {self.roomslot_identifier(action['prev_start_roomslot'])}:",
                            self.roomslot_info(action["prev_start_roomslot"])])
             elif action["action"] == "swap":
                 sec1, sec2 = action["sections"]
                 rs2, rs1 = action["original_roomslots"]
-                row.append(["Swapped {}:".format(
-                                self.section_identifier(sec1)),
+                row.append([f"Swapped {self.section_identifier(sec1)}:",
                            self.section_info(sec1)])
-                row.append(["Now in {}:".format(
-                                self.roomslot_identifier(rs1)),
+                row.append([f"Now in {self.roomslot_identifier(rs1)}:",
                            self.roomslot_info(rs1)])
-                row.append(["and {}:".format(
-                                self.section_identifier(sec2)),
+                row.append([f"and {self.section_identifier(sec2)}:",
                            self.section_info(sec2)])
-                row.append(["Now in {}:".format(
-                                self.roomslot_identifier(rs2)),
+                row.append([f"Now in {self.roomslot_identifier(rs2)}:",
                            self.roomslot_info(rs2)])
             else:
                 raise SchedulingError("History was broken.")
@@ -199,16 +184,15 @@ class AutoschedulerController(object):
 
             def format_row(row):
                 scorer, weight, delta = row
-                return "{} (wt {}): chg {:.3f} -> {:.3f}".format(
-                    scorer, weight, delta, weight * delta // total_wt)
+                return f"{scorer} (wt {weight}): chg {delta:.3f} -> {weight * delta // total_wt:.3f}"
             new_row = []
             if len(diffs) > 6:
                 new_row += [format_row(r) for r in diffs[:3]]
-                new_row += ["[{} more truncated]".format(len(diffs) - 6)]
+                new_row += [f"[{len(diffs) - 6} more truncated]"]
                 new_row += [format_row(r) for r in diffs[-3:]]
             else:
                 new_row += [format_row(r) for r in diffs]
-            new_row += ["Total change: {}".format(total_change)]
+            new_row += [f"Total change: {total_change}"]
             rows.append([[
                 "Major score changes (weight, change, contribution):",
                 new_row]])
@@ -216,62 +200,48 @@ class AutoschedulerController(object):
 
     def section_identifier(self, section):
         section_obj = ClassSection.objects.get(id=section.id)
-        manage = "/manage/{}/manageclass/{}".format(
-            section_obj.parent_class.parent_program.getUrlBase(),
-            section.parent_class)
-        manage_link = "<a href='{}'>Manage</a>".format(manage)
-        edit = "/manage/{}/editclass/{}".format(
-            section_obj.parent_class.parent_program.getUrlBase(),
-            section.parent_class)
-        edit_link = "<a href='{}'>Edit</a>".format(edit)
-        return "{}: {} (id: {}) ({}, {})".format(
-            section_obj.emailcode(), section_obj.parent_class.title,
-            section.id, manage_link, edit_link)
+        manage = f"/manage/{section_obj.parent_class.parent_program.getUrlBase()}/manageclass/{section.parent_class}"
+        manage_link = f"<a href='{manage}'>Manage</a>"
+        edit = f"/manage/{section_obj.parent_class.parent_program.getUrlBase()}/editclass/{section.parent_class}"
+        edit_link = f"<a href='{edit}'>Edit</a>"
+        return f"{section_obj.emailcode()}: {section_obj.parent_class.title} (id: {section.id}) ({manage_link}, {edit_link})"
 
     def section_info(self, section):
         info = []
         teachers_list = [ESPUser.objects.get(id=teacher.id).name()
                          for teacher in section.teachers]
-        info.append("<b>Teachers:</b> {}".format(
-            ", ".join(teachers_list)))
-        info.append("<b>Capacity: </b>{}".format(section.capacity))
-        info.append("<b>Duration: </b>{}".format(section.duration))
-        info.append("<b>Grades: </b>{}-{}".format(
-            section.grade_min, section.grade_max))
+        info.append(f"<b>Teachers:</b> {', '.join(teachers_list)}")
+        info.append(f"<b>Capacity: </b>{section.capacity}")
+        info.append(f"<b>Duration: </b>{section.duration}")
+        info.append(f"<b>Grades: </b>{section.grade_min}-{section.grade_max}")
         resources = ""
         for restype in section.resource_requests.values():
             resources += "<li>"
             if restype.value == "":
                 resources += restype.name
             else:
-                resources += "{}: {}".format(restype.name, restype.value)
+                resources += f"{restype.name}: {restype.value}"
             resources += "</li>"
-        info.append("<b>Resource requests:</b><ul>{}</ul>".format(
-            resources))
+        info.append(f"<b>Resource requests:</b><ul>{resources}</ul>")
         cls = ClassSection.objects.get(id=section.id).parent_class
-        info.append("<b>Class Flags: </b>{}".format(", ".join(
-            cls.flags.values_list(
-                'flag_type__name', flat=True))))
+        info.append(f"<b>Class Flags: </b>{', '.join(cls.flags.values_list('flag_type__name', flat=True))}")
         return info
 
     def roomslot_identifier(self, roomslot):
-        return "{} starting at {}".format(
-                roomslot.room.name,
-                roomslot.timeslot.start.strftime("%A %-I:%M%p"))
+        return f"{roomslot.room.name} starting at {roomslot.timeslot.start.strftime('%A %-I:%M%p')}"
 
     def roomslot_info(self, roomslot):
         info = []
-        info.append("<b>Capacity:</b> {}".format(roomslot.room.capacity))
+        info.append(f"<b>Capacity:</b> {roomslot.room.capacity}")
         resources = ""
         for restype in roomslot.room.furnishings.values():
             resources += "<li>"
             if restype.value == "":
                 resources += restype.name
             else:
-                resources += "{}: {}".format(restype.name, restype.value)
+                resources += f"{restype.name}: {restype.value}"
             resources += "</li>"
-        info.append("<b>Furnishings:</b><ul>{}</ul>".format(
-            resources))
+        info.append(f"<b>Furnishings:</b><ul>{resources}</ul>")
         return info
 
     def simplify_history(self, history):
@@ -363,7 +333,7 @@ class AutoschedulerController(object):
                 emailcode = ClassSection.objects.get(
                         id=int(section)).emailcode()
                 raise SchedulingError(
-                    "Section {} was moved.".format(emailcode))
+                    f"Section {emailcode} was moved.")
         if not self.optimizer.manipulator.load_history(history):
             raise SchedulingError("Unable to replay assignments.")
 
@@ -382,7 +352,7 @@ def load_all_resource_criteria(prog, use_comments=False):
             ignore_comments=(not use_comments))
     if use_comments:
         for k in resource_criteria:
-            comment = "{}_comment".format(k)
+            comment = f"{k}_comment"
             if comment in resource_criteria:
                 resource_criteria[k] = \
                     (resource_criteria[comment][0], resource_criteria[k][1])

--- a/esp/esp/program/controllers/autoscheduler/controller.py
+++ b/esp/esp/program/controllers/autoscheduler/controller.py
@@ -184,7 +184,7 @@ class AutoschedulerController(object):
 
             def format_row(row):
                 scorer, weight, delta = row
-                return f"{scorer} (wt {weight}): chg {delta:.3f} -> {weight * delta // total_wt:.3f}"
+                return f"{scorer} (wt {weight}): chg {delta:.3f} -> {weight * delta / total_wt:.3f}"
             new_row = []
             if len(diffs) > 6:
                 new_row += [format_row(r) for r in diffs[:3]]

--- a/esp/esp/program/controllers/autoscheduler/data_model.py
+++ b/esp/esp/program/controllers/autoscheduler/data_model.py
@@ -84,9 +84,8 @@ class AS_Schedule(object):
         violation = self.constraints.check_schedule(self)
         if violation is not None:
             raise SchedulingError(
-                ("Schedule violated constraints: {}. If this is intended, "
-                 "consider locking the offending class(es)."
-                 .format(violation)))
+                (f"Schedule violated constraints: {violation}. If this is intended, "
+                 "consider locking the offending class(es)."))
 
 
 class AS_ClassSection(object):
@@ -197,7 +196,7 @@ class AS_Classroom(object):
                                   for r in self.availability}
         if len(self.availability_dict) != len(self.availability):
             raise SchedulingError(
-                "Room {} has duplicate resources".format(name))
+                f"Room {name} has duplicate resources")
 
     @util.timed_func("AS_Classroom_get_roomslots_by_duration")
     @util.memoize
@@ -250,7 +249,7 @@ class AS_Timeslot(object):
             if associated_roomslots is not None else set()
         if self.duration < config.DELTA_TIME:
             raise SchedulingError(
-                "Timeslot duration {} is too short".format(self.duration))
+                f"Timeslot duration {self.duration} is too short")
 
     def __eq__(self, other):
         if isinstance(other, type(self)):

--- a/esp/esp/program/controllers/autoscheduler/db_interface.py
+++ b/esp/esp/program/controllers/autoscheduler/db_interface.py
@@ -275,8 +275,7 @@ def check_can_schedule_sections(section_infos, schedule):
     for section, section_obj, possible_conflicts, meeting_times, room_objs \
             in section_infos:
         if section.id in locked_sections:
-            raise SchedulingError("Section {} is locked!".format(
-                section_obj.emailcode()))
+            raise SchedulingError(f"Section {section_obj.emailcode()} is locked!")
         if section.is_scheduled():
             start_time = section.assigned_roomslots[0].timeslot.start
             end_time = section.assigned_roomslots[-1].timeslot.end
@@ -287,10 +286,8 @@ def check_can_schedule_sections(section_infos, schedule):
                         if not (other_time.start >= end_time
                                 or other_time.end <= start_time):
                             raise SchedulingError(
-                                "Teacher {} of section {} is already teaching "
-                                "section {}".format(
-                                    teacher_id, section_obj.emailcode(),
-                                    other_section.emailcode()))
+                                f"Teacher {teacher_id} of section {section_obj.emailcode()} is already teaching "
+                                f"section {other_section.emailcode()}")
 
             # Make sure the room is available
             for room_obj in room_objs:
@@ -300,10 +297,8 @@ def check_can_schedule_sections(section_infos, schedule):
                         other_section = occupier.target
                         if other_section.id != section.id:
                             raise SchedulingError(
-                                "Destination room {} of section {} was "
-                                "already occupied by section {}".format(
-                                    room_obj.name, section_obj.emailcode(),
-                                    other_section.emailcode()))
+                                f"Destination room {room_obj.name} of section {section_obj.emailcode()} was "
+                                f"already occupied by section {other_section.emailcode()}")
 
 
 @util.timed_func("db_interface_ensure_section_not_moved")
@@ -315,14 +310,14 @@ def ensure_section_not_moved(section, as_section):
     assert section.id == as_section.id, "Unexpected ID mismatch"
     if scheduling_hash_of(section) != as_section.initial_state:
         raise SchedulingError(
-                "Section {} was moved.".format(section.emailcode()))
+                f"Section {section.emailcode()} was moved.")
 
 
 @util.timed_func("db_interface_unschedule_section")
 def unschedule_section(
         section, ajax_change_log, unscheduled_sections_log=None):
     """Unschedules a ClassSection and records it as needed."""
-    logger.info("Unscheduling {}".format(section.emailcode()))
+    logger.info(f"Unscheduling {section.emailcode()}")
     section.clear_meeting_times()
     section.clearRooms()
     if unscheduled_sections_log is not None:
@@ -369,8 +364,7 @@ def convert_classection_obj(
     of timeslots for availabilities. """
     if not section_satisfies_constraints(
             section, rooms_by_section, meeting_times_by_section):
-        logger.info("Warning: Autoscheduler can't handle section {}"
-                    .format(section.emailcode()))
+        logger.info(f"Warning: Autoscheduler can't handle section {section.emailcode()}")
         return None
 
     teachers = teachers_by_section[section.id]
@@ -397,8 +391,8 @@ def convert_classection_obj(
     assert (scheduling_hash_of(
             section, rooms_by_section, meeting_times_by_section) ==
             as_section.initial_state), (
-        "AS_ClassSection state doesn't match ClassSection state "
-        "for section {}".format(section.emailcode()))
+        f"AS_ClassSection state doesn't match ClassSection state "
+        f"for section {section.emailcode()}")
 
     return as_section
 
@@ -499,8 +493,7 @@ def load_constraints(program, constraints_overrides=None):
         tag_overrides = json.loads(tag_value)
     except ValueError as e:
         raise SchedulingError(
-                "Constraints Tag is malformatted with error {}: {}" .format(
-                    e, tag_value))
+                f"Constraints Tag is malformatted with error {e}: {tag_value}")
 
     return util.override(
         [config.DEFAULT_CONSTRAINTS_ENABLED,
@@ -520,8 +513,7 @@ def load_scorers(program, scorer_overrides=None):
     try:
         tag_overrides = json.loads(tag_value)
     except ValueError as e:
-        raise SchedulingError("Scoring Tag is malformatted with error {}: {}"
-                              .format(e, tag_value))
+        raise SchedulingError(f"Scoring Tag is malformatted with error {e}: {tag_value}")
 
     return util.override(
         [config.DEFAULT_SCORER_WEIGHTS, tag_overrides, scorer_overrides])
@@ -544,8 +536,7 @@ def load_resource_constraints(
                 if "_comment" not in k}
     except ValueError as e:
         raise SchedulingError(
-            "Resource constraints Tag is malformatted with error {}: {}"
-            .format(e, tag_value))
+            f"Resource constraints Tag is malformatted with error {e}: {tag_value}")
     specs = [config.DEFAULT_RESOURCE_CONSTRAINTS,
              tag_overrides,
              specification_overrides]
@@ -578,8 +569,7 @@ def load_resource_scoring(
                 if "_comment" not in k}
     except ValueError as e:
         raise SchedulingError(
-            "Resource scoring Tag is malformatted with error {}: {}"
-            .format(e, tag_value))
+            f"Resource scoring Tag is malformatted with error {e}: {tag_value}")
 
     specs = [config.DEFAULT_RESOURCE_SCORING,
              tag_overrides,
@@ -676,8 +666,8 @@ def convert_classroom_resources(
             for target in assignments:
                 if target in known_sections:
                     raise SchedulingError(
-                        "Room {} is double-booked and has known section " +
-                        "num {}".format(classroom.name, target))
+                        f"Room {classroom.name} is double-booked and has known section " +
+                        f"num {target}")
         elif len(assignments) == 1:
             target = assignments[0]
             if target not in known_sections:

--- a/esp/esp/program/controllers/autoscheduler/db_interface.py
+++ b/esp/esp/program/controllers/autoscheduler/db_interface.py
@@ -317,7 +317,7 @@ def ensure_section_not_moved(section, as_section):
 def unschedule_section(
         section, ajax_change_log, unscheduled_sections_log=None):
     """Unschedules a ClassSection and records it as needed."""
-    logger.info(f"Unscheduling {section.emailcode()}")
+    logger.info("Unscheduling %s", section.emailcode())
     section.clear_meeting_times()
     section.clearRooms()
     if unscheduled_sections_log is not None:

--- a/esp/esp/program/controllers/autoscheduler/db_interface.py
+++ b/esp/esp/program/controllers/autoscheduler/db_interface.py
@@ -317,7 +317,7 @@ def ensure_section_not_moved(section, as_section):
 def unschedule_section(
         section, ajax_change_log, unscheduled_sections_log=None):
     """Unschedules a ClassSection and records it as needed."""
-    logger.info("Unscheduling %s", section.emailcode())
+    logger.info(f"Unscheduling {section.emailcode()}")
     section.clear_meeting_times()
     section.clearRooms()
     if unscheduled_sections_log is not None:

--- a/esp/esp/program/controllers/autoscheduler/resource_checker.py
+++ b/esp/esp/program/controllers/autoscheduler/resource_checker.py
@@ -76,7 +76,7 @@ class ResourceCriterion(object):
                 resource_request_match.group(1, 2, 4)
             if res_type not in valid_res_types:
                 raise ValueError(
-                    "Resource type {} doesn't exist".format(res_type))
+                    f"Resource type {res_type} doesn't exist")
             if value_regex:
                 matcher = ResourceRequestMatcher(res_type, value_regex)
             else:
@@ -107,7 +107,7 @@ class ResourceCriterion(object):
         if group == "any section":
             return TrivialSectionMatcher()
         raise ValueError(
-            "Clause '{}' doesn't match a valid pattern.".format(group))
+            f"Clause '{group}' doesn't match a valid pattern.")
 
     def check_match(self, section, room):
         """Returns False if the premise holds but the conclusion fails, i.e.
@@ -123,11 +123,9 @@ class ResourceCriterion(object):
         """Returns the specification of this criterion; see
         create_from_specification above."""
         if self.condition_on_section:
-            return "{}: if {} then {}".format(
-                    self.name, self.section_matcher, self.classroom_matcher)
+            return f"{self.name}: if {self.section_matcher} then {self.classroom_matcher}"
         else:
-            return "{}: if {} then {}".format(
-                    self.name, self.classroom_matcher, self.section_matcher)
+            return f"{self.name}: if {self.classroom_matcher} then {self.section_matcher}"
 
 
 class BaseSectionMatcher(object):
@@ -182,9 +180,9 @@ class ResourceRequestMatcher(BaseSectionMatcher):
     def __str__(self):
         """Returns the specification of this criterion; see
         ResourceCriterion.create_from_specification."""
-        string = "section requests {}".format(self.res_type)
+        string = f"section requests {self.res_type}"
         if self.desired_value_regex != ".*":
-            string += " with {}".format(self.desired_value_regex)
+            string += f" with {self.desired_value_regex}"
         return string
 
 
@@ -228,9 +226,9 @@ class ResourceClassroomMatcher(BaseClassroomMatcher):
     def __str__(self):
         """Returns the specification of this criterion; see
         ResourceCriterion.create_from_specification."""
-        string = "classroom has {}".format(self.res_type)
+        string = f"classroom has {self.res_type}"
         if self.attribute_value_regex != ".*":
-            string += " with {}".format(self.attribute_value_regex)
+            string += f" with {self.attribute_value_regex}"
         return string
 
 
@@ -246,7 +244,7 @@ class ClassroomNameMatcher(BaseClassroomMatcher):
     def __str__(self):
         """Returns the specification of this criterion; see
         ResourceCriterion.create_from_specification."""
-        return "classroom matches {}".format(self.name_regex)
+        return f"classroom matches {self.name_regex}"
 
 
 def create_resource_criteria(specification_dicts, valid_res_types,

--- a/esp/esp/program/controllers/autoscheduler/scoring.py
+++ b/esp/esp/program/controllers/autoscheduler/scoring.py
@@ -105,7 +105,7 @@ class CompositeScorer(BaseScorer):
                 if weight is None or weight == 0:
                     continue
                 assert weight >= 0, "Scorer weights should be nonnegative"
-                logger.info("Using scorer {}".format(scorer))
+                logger.info("Using scorer %s", scorer)
                 scorer_obj = available_scorers[scorer](schedule, **kwargs)
                 self.scorers_and_weights.append((scorer_obj, weight))
         self.compute_total_weight()
@@ -128,8 +128,8 @@ class CompositeScorer(BaseScorer):
         for scorer, weight in self.scorers_and_weights:
             score = scorer.score_schedule()
             if self.verbose:
-                logger.info("Scorer {} has score {}".format(
-                        scorer.__class__.__name__, score))
+                logger.info("Scorer %s has score %s",
+                        scorer.__class__.__name__, score)
             total_score += score * weight * scorer.scaling
         return total_score / self.total_weight
 

--- a/esp/esp/program/controllers/autoscheduler/scoring.py
+++ b/esp/esp/program/controllers/autoscheduler/scoring.py
@@ -105,7 +105,7 @@ class CompositeScorer(BaseScorer):
                 if weight is None or weight == 0:
                     continue
                 assert weight >= 0, "Scorer weights should be nonnegative"
-                logger.info("Using scorer %s", scorer)
+                logger.info(f"Using scorer {scorer}")
                 scorer_obj = available_scorers[scorer](schedule, **kwargs)
                 self.scorers_and_weights.append((scorer_obj, weight))
         self.compute_total_weight()
@@ -128,8 +128,7 @@ class CompositeScorer(BaseScorer):
         for scorer, weight in self.scorers_and_weights:
             score = scorer.score_schedule()
             if self.verbose:
-                logger.info("Scorer %s has score %s",
-                        scorer.__class__.__name__, score)
+                logger.info(f"Scorer {scorer.__class__.__name__} has score {score}")
             total_score += score * weight * scorer.scaling
         return total_score / self.total_weight
 

--- a/esp/esp/program/controllers/autoscheduler/test_consistency_checks.py
+++ b/esp/esp/program/controllers/autoscheduler/test_consistency_checks.py
@@ -15,22 +15,19 @@ class ConsistencyCheckerTest(unittest.TestCase):
         try:
             checker.run_all_consistency_checks(sched)
         except ConsistencyError:
-            self.fail("Unexpectedly failed consistency check with error: \n{}"
-                      .format(traceback.format_exc()))
+            self.fail(f"Unexpectedly failed consistency check with error: \n{traceback.format_exc()}")
 
         sched = testutils.create_test_schedule_2()
         try:
             checker.run_all_consistency_checks(sched)
         except ConsistencyError:
-            self.fail("Unexpectedly failed consistency check with error: \n{}"
-                      .format(traceback.format_exc()))
+            self.fail(f"Unexpectedly failed consistency check with error: \n{traceback.format_exc()}")
 
         sched = testutils.create_test_schedule_3()
         try:
             checker.run_all_consistency_checks(sched)
         except ConsistencyError:
-            self.fail("Unexpectedly failed consistency check with error: \n{}"
-                      .format(traceback.format_exc()))
+            self.fail(f"Unexpectedly failed consistency check with error: \n{traceback.format_exc()}")
 
     def test_availability_dict_consistency(self):
         checker = consistency_checks.ConsistencyChecker()
@@ -38,9 +35,9 @@ class ConsistencyCheckerTest(unittest.TestCase):
         try:
             checker.check_availability_dict_consistency(sched)
         except ConsistencyError:
-            self.fail((
+            self.fail(
                 "Unexpectedly failed availability dict consistency "
-                "with error: \n{}").format(traceback.format_exc()))
+                f"with error: \n{traceback.format_exc()}")
 
         room = sched.classrooms["10-250"]
         roomslot = room.availability[0]
@@ -65,9 +62,9 @@ class ConsistencyCheckerTest(unittest.TestCase):
         try:
             checker.check_availability_dict_consistency(sched)
         except ConsistencyError:
-            self.fail((
+            self.fail(
                 "Unexpectedly failed availability dict consistency "
-                "with error: \n{}").format(traceback.format_exc()))
+                f"with error: \n{traceback.format_exc()}")
 
         room.availability.pop()
         with self.assertRaises(ConsistencyError):
@@ -80,9 +77,9 @@ class ConsistencyCheckerTest(unittest.TestCase):
         try:
             checker.check_lunch_consistency(sched)
         except ConsistencyError:
-            self.fail((
+            self.fail(
                 "Unexpectedly failed lunch consistency "
-                "with error: \n{}").format(traceback.format_exc()))
+                f"with error: \n{traceback.format_exc()}")
 
         day = next(iter(sched.lunch_timeslots.keys()))
         sched.lunch_timeslots[day].reverse()
@@ -117,9 +114,9 @@ class ConsistencyCheckerTest(unittest.TestCase):
         try:
             checker.check_resource_dict_consistency(sched)
         except ConsistencyError:
-            self.fail((
+            self.fail(
                 "Unexpectedly failed resource dict consistency "
-                "with error: \n{}").format(traceback.format_exc()))
+                f"with error: \n{traceback.format_exc()}")
 
         requests = sched.class_sections[1].resource_requests
         requests["Foo"] = requests["Projector"]
@@ -141,8 +138,7 @@ class ConsistencyCheckerTest(unittest.TestCase):
             checker.check_roomslots_consistency(sched)
         except ConsistencyError:
             self.fail(
-                "Unexpectedly failed roomslots consistency with error: \n{}"
-                .format(traceback.format_exc()))
+                f"Unexpectedly failed roomslots consistency with error: \n{traceback.format_exc()}")
 
         sched.classrooms["10-250"].availability.insert(
             0, sched.classrooms["26-100"].availability[2])
@@ -177,8 +173,7 @@ class ConsistencyCheckerTest(unittest.TestCase):
             checker.check_roomslots_consistency(sched)
         except ConsistencyError:
             self.fail(
-                "Unexpectedly failed roomslots consistency with error: \n{}"
-                .format(traceback.format_exc()))
+                f"Unexpectedly failed roomslots consistency with error: \n{traceback.format_exc()}")
 
         sched.class_sections[1].assigned_roomslots.append(new_roomslot)
         new_roomslot.assigned_section = sched.class_sections[1]
@@ -234,8 +229,7 @@ class ConsistencyCheckerTest(unittest.TestCase):
             checker.check_roomslots_consistency(sched)
         except ConsistencyError:
             self.fail(
-                "Unexpectedly failed roomslots consistency with error: \n{}"
-                .format(traceback.format_exc()))
+                f"Unexpectedly failed roomslots consistency with error: \n{traceback.format_exc()}")
 
     def test_roomslot_next_and_index_consistency(self):
         checker = consistency_checks.ConsistencyChecker()
@@ -245,10 +239,9 @@ class ConsistencyCheckerTest(unittest.TestCase):
         try:
             checker.check_roomslot_next_and_index_consistency(sched)
         except ConsistencyError:
-            self.fail((
+            self.fail(
                         "Unexpectedly failed roomslot next/index "
-                        "consistency with error: \n{}"
-                    ).format(traceback.format_exc()))
+                        f"consistency with error: \n{traceback.format_exc()}")
 
         room.load_roomslot_caches()
         last_roomslot = room.availability.pop()
@@ -270,10 +263,9 @@ class ConsistencyCheckerTest(unittest.TestCase):
         try:
             checker.check_roomslot_next_and_index_consistency(sched)
         except ConsistencyError:
-            self.fail((
+            self.fail(
                         "Unexpectedly failed roomslot next/index "
-                        "consistency with error: \n{}"
-                    ).format(traceback.format_exc()))
+                        f"consistency with error: \n{traceback.format_exc()}")
 
         room.availability.pop()
         room.flush_roomslot_caches()
@@ -292,8 +284,7 @@ class ConsistencyCheckerTest(unittest.TestCase):
         except ConsistencyError:
             self.fail(
                     "Unexpectedly failed schedule dicts consistency with "
-                    "error: \n{}"
-                    .format(traceback.format_exc()))
+                    f"error: \n{traceback.format_exc()}")
 
         sec = sched.class_sections[1]
         del sched.class_sections[1]
@@ -327,8 +318,7 @@ class ConsistencyCheckerTest(unittest.TestCase):
         except ConsistencyError:
             self.fail(
                     "Unexpectedly failed schedule dicts consistency with "
-                    "error: \n{}"
-                    .format(traceback.format_exc()))
+                    f"error: \n{traceback.format_exc()}")
 
     def test_sorting_consistency(self):
         checker = consistency_checks.ConsistencyChecker()
@@ -337,8 +327,7 @@ class ConsistencyCheckerTest(unittest.TestCase):
             checker.check_sorting_consistency(sched)
         except ConsistencyError:
             self.fail(
-                    "Unexpectedly failed sorting consistency with error: \n{}"
-                    .format(traceback.format_exc()))
+                    f"Unexpectedly failed sorting consistency with error: \n{traceback.format_exc()}")
 
         sched.class_sections[2].assigned_roomslots.reverse()
         with self.assertRaises(ConsistencyError):
@@ -366,8 +355,7 @@ class ConsistencyCheckerTest(unittest.TestCase):
         except ConsistencyError:
             self.fail(
                     "Unexpectedly failed taught sections consistency with "
-                    "error: \n{}"
-                    .format(traceback.format_exc()))
+                    f"error: \n{traceback.format_exc()}")
 
         teacher = sched.teachers[1]
         sec = teacher.taught_sections[1]
@@ -396,8 +384,7 @@ class ConsistencyCheckerTest(unittest.TestCase):
         except ConsistencyError:
             self.fail(
                     "Unexpectedly failed taught sections consistency with "
-                    "error: \n{}"
-                    .format(traceback.format_exc()))
+                    f"error: \n{traceback.format_exc()}")
 
     def test_timeslot_consistency(self):
         checker = consistency_checks.ConsistencyChecker()
@@ -406,8 +393,7 @@ class ConsistencyCheckerTest(unittest.TestCase):
             checker.check_timeslot_consistency(sched)
         except ConsistencyError:
             self.fail(
-                    "Unexpectedly failed timeslot consistency with error: \n{}"
-                    .format(traceback.format_exc()))
+                    f"Unexpectedly failed timeslot consistency with error: \n{traceback.format_exc()}")
 
         sched.timeslots.reverse()
         with self.assertRaises(ConsistencyError):
@@ -437,8 +423,7 @@ class ConsistencyCheckerTest(unittest.TestCase):
         except ConsistencyError:
             self.fail(
                     "Unexpectedly failed timeslot duration consistency "
-                    "with error: \n{}"
-                    .format(traceback.format_exc()))
+                    f"with error: \n{traceback.format_exc()}")
 
         sched.timeslots[0].duration = 0
         with self.assertRaises(ConsistencyError):
@@ -453,8 +438,7 @@ class ConsistencyCheckerTest(unittest.TestCase):
         except ConsistencyError:
             self.fail(
                     "Unexpectedly failed timeslot span consistency "
-                    "with error: \n{}"
-                    .format(traceback.format_exc()))
+                    f"with error: \n{traceback.format_exc()}")
 
         sched.timeslots.append(data_model.AS_Timeslot(
             datetime.datetime(2017, 2, 2, 23, 30),
@@ -472,8 +456,7 @@ class ConsistencyCheckerTest(unittest.TestCase):
         except ConsistencyError:
             self.fail(
                     "Unexpectedly failed timeslot list/dict consistency " +
-                    "with error: \n{}"
-                    .format(traceback.format_exc()))
+                    f"with error: \n{traceback.format_exc()}")
 
         last_timeslot = sched.timeslots[-1]
         timeslot_key = (last_timeslot.start, last_timeslot.end)

--- a/esp/esp/program/controllers/autoscheduler/test_db_interface.py
+++ b/esp/esp/program/controllers/autoscheduler/test_db_interface.py
@@ -172,7 +172,7 @@ class ScheduleLoadAndSaveTest(ProgramFrameworkTest):
         capacity = settings["room_capacity"]
         for i in range(settings["num_rooms"]):
             classrooms.append(data_model.AS_Classroom(
-                "Room {}".format(str(i)), capacity, timeslots[:-1]))
+                f"Room {str(i)}", capacity, timeslots[:-1]))
         restype_id = ResourceType.objects.get(
             name=extra_settings["extra_resource_type_name"]).id
         extra_resource_type = data_model.AS_ResourceType(
@@ -431,8 +431,7 @@ class ScheduleLoadAndSaveTest(ProgramFrameworkTest):
         try:
             db_interface.save(self.schedule)
         except SchedulingError:
-            self.fail("Schedule saving crashed with error: \n{}"
-                      .format(traceback.format_exc()))
+            self.fail(f"Schedule saving crashed with error: \n{traceback.format_exc()}")
         self.assertEqual(len(section_obj.get_meeting_times()), 1,
                          "Section should have been scheduled for 1 timeslot")
         self.assertEqual(section_obj.get_meeting_times()[0].id,
@@ -445,13 +444,11 @@ class ScheduleLoadAndSaveTest(ProgramFrameworkTest):
         try:
             db_interface.save(self.schedule)
         except SchedulingError:
-            self.fail("Schedule saving crashed with error: \n{}"
-                      .format(traceback.format_exc()))
+            self.fail(f"Schedule saving crashed with error: \n{traceback.format_exc()}")
         try:
             db_interface.save(self.schedule)
         except SchedulingError:
-            self.fail("Schedule second save crashed with error: \n{}"
-                      .format(traceback.format_exc()))
+            self.fail(f"Schedule second save crashed with error: \n{traceback.format_exc()}")
 
     def test_load_lunch(self):
         """Make sure that lunch classes cause lunch timeslots to be loaded,
@@ -539,13 +536,12 @@ class ScheduleLoadAndSaveTest(ProgramFrameworkTest):
         try:
             db_interface.save(self.schedule)
         except SchedulingError:
-            self.fail("Schedule saving crashed with error: \n{}"
-                      .format(traceback.format_exc()))
+            self.fail(f"Schedule saving crashed with error: \n{traceback.format_exc()}")
         for r, so in zip(roomslots, section_objs):
             self.assertEqual(
                     len(so.get_meeting_times()), 1,
                     "Section should have been scheduled for 1 timeslot but "
-                    "was scheduled for {}".format(len(so.get_meeting_times())))
+                    f"was scheduled for {len(so.get_meeting_times())}")
             self.assertEqual(so.get_meeting_times()[0].id,
                              r.timeslot.id,
                              "Section was assigned to wrong timeslot")
@@ -558,13 +554,12 @@ class ScheduleLoadAndSaveTest(ProgramFrameworkTest):
         try:
             db_interface.save(self.schedule)
         except SchedulingError:
-            self.fail("Schedule saving crashed with error: \n{}"
-                      .format(traceback.format_exc()))
+            self.fail(f"Schedule saving crashed with error: \n{traceback.format_exc()}")
         for r, so in zip(reversed(roomslots), section_objs):
             self.assertEqual(
                     len(so.get_meeting_times()), 1,
                     "Section should have been scheduled for 1 timeslot but "
-                    "was scheduled for {}".format(len(so.get_meeting_times())))
+                    f"was scheduled for {len(so.get_meeting_times())}")
             self.assertEqual(so.get_meeting_times()[0].id,
                              r.timeslot.id,
                              "Section was assigned to wrong timeslot")
@@ -590,8 +585,7 @@ class ScheduleLoadAndSaveTest(ProgramFrameworkTest):
                 self.assertEqual(
                         len(so.get_meeting_times()), 1,
                         "Section should have been scheduled for 1 timeslot "
-                        "but was scheduled for {}".format(
-                            len(so.get_meeting_times())))
+                        f"but was scheduled for {len(so.get_meeting_times())}")
                 self.assertEqual(so.get_meeting_times()[0].id,
                                  r.timeslot.id,
                                  "Section was assigned to wrong timeslot")


### PR DESCRIPTION

## Description

Convert `.format()` calls to f-strings in `program/controllers/autoscheduler/` — scheduling constraint descriptions, scoring output, room/timeslot formatting, optimizer status messages, and search algorithm logging.

This module heavily used `.format()` with named and positional placeholders in multiline strings. All have been converted to f-strings for consistency.

9 files changed, +134/-226.

## Related Issue

Part of #4555

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced

Closes #4140
