### PR TITLE
refactor: convert string formatting to f-strings in program modules

### DIFF
--- a/esp/esp/program/modules/base.py
+++ b/esp/esp/program/modules/base.py
@@ -60,8 +60,7 @@ from esp.middleware.threadlocalrequest import get_current_request
 
 def _login_redirect(request):
     return HttpResponseRedirect(
-        '%s?%s=%s' % (settings.LOGIN_URL, REDIRECT_FIELD_NAME,
-                      quote(request.get_full_path())))
+        f'{settings.LOGIN_URL}?{REDIRECT_FIELD_NAME}={quote(request.get_full_path())}')
 
 class CoreModule(object):
     """
@@ -84,7 +83,7 @@ class ProgramModuleObj(models.Model):
         return self.module.link_title
 
     def __str__(self):
-        return '"%s" for "%s"' % (self.module.admin_title, str(self.program))
+        return f'"{self.module.admin_title}" for "{self.program}"'
 
     def _get_views_by_call_tag(self, tags):
         """ We define decorators below (aux_call, main_call, etc.) which allow
@@ -271,8 +270,7 @@ class ProgramModuleObj(models.Model):
     # important functions for hooks...
     @cache_function
     def get_full_path(self):
-        return '/%s/%s/%s' % (
-            self.module.module_type, self.program.url, self.main_view)
+        return f'/{self.module.module_type}/{self.program.url}/{self.main_view}'
     get_full_path.depend_on_row('modules.ProgramModuleObj', 'self')
     get_full_path.depend_on_model('program.Program')
 
@@ -308,15 +306,15 @@ class ProgramModuleObj(models.Model):
     def makeSetupLink(self):
         title = self.get_setup_title()
         link = self.get_setup_path()
-        return mark_safe('<a href="%s" title="%s">%s</a>' % (link, title, title))
+        return mark_safe(f'<a href="{link}" title="{title}">{title}</a>')
 
     def makeButtonLink(self):
         if not self.module.module_type == 'manage':
-            link = """<div class="module_button">\
-                                <a href="%s"><button type="button" class="module_link_large">
-                                    <div class="module_link_main">%s</div>
+            link = f"""<div class="module_button">\
+                                <a href="{self.get_full_path()}"><button type="button" class="module_link_large">
+                                    <div class="module_link_main">{self.module.link_title}</div>
                                 </button></a>
-                            </div>""" % (self.get_full_path(), self.module.link_title)
+                            </div>"""
         else:
             link = '<a href="%s" onmouseover="updateDocs(\'<p>%s</p>\');"></a><button type="button" class="module_link_large btn btn-default btn-lg"> <div class="module_link_main">%s%s</div></button></a>' % \
                (self.get_full_path(), self.docs().replace("'", "\\'").replace('\n', '<br />\\n').replace('\r', ''), self.module.link_title, self.module.handler)
@@ -364,7 +362,7 @@ class ProgramModuleObj(models.Model):
 
     def getTemplate(self):
         if self.module.inline_template:
-            return 'program/modules/%s/%s' % (self.__class__.__name__.lower(), self.module.inline_template)
+            return f'program/modules/{self.__class__.__name__.lower()}/{self.module.inline_template}'
         return None
 
     def teacherDesc(self):
@@ -473,7 +471,7 @@ class ProgramModuleObj(models.Model):
                 props["seq"] = 200
             if not "choosable" in props:
                 props["choosable"] = 0
-                raise AttributeError("Module `{}` doesn't have choosable property.".format(cls.__name__))
+                raise AttributeError(f"Module `{cls.__name__}` doesn't have choosable property.")
 
         if isinstance(props, dict):
             props = [ props ]

--- a/esp/esp/program/modules/forms/admincore.py
+++ b/esp/esp/program/modules/forms/admincore.py
@@ -19,7 +19,7 @@ def get_rt_choices():
     choices = [("All", "All")]
     for rt in RegistrationType.objects.all().order_by('name'):
         if rt.displayName:
-            choices.append((rt.name, '%s (displayed as "%s")' % (rt.name, rt.displayName)))
+            choices.append((rt.name, f'{rt.name} (displayed as "{rt.displayName}")'))
         else:
             choices.append((rt.name, rt.name))
     return choices
@@ -92,7 +92,8 @@ class ProgramSettingsForm(ProgramCreationForm):
             'flag_types': forms.CheckboxSelectMultiple(),
         }
         model = Program
-ProgramSettingsForm.base_fields['director_email'].widget = forms.EmailInput(attrs={'pattern': r'(^.+@{0}$)|(^.+@(\w+\.)?learningu\.org$)'.format(settings.SITE_INFO[1].replace('.', r'\.'))})
+_ESCAPED_SITE_DOMAIN = settings.SITE_INFO[1].replace('.', r'\.')
+ProgramSettingsForm.base_fields["director_email"].widget = forms.EmailInput(attrs={"pattern": rf"(^.+@{_ESCAPED_SITE_DOMAIN}$)|(^.+@(\w+\.)?learningu\.org$)"})
 
 class TeacherRegSettingsForm(BetterModelForm):
     """ Form for changing teacher class registration settings. """

--- a/esp/esp/program/modules/forms/management.py
+++ b/esp/esp/program/modules/forms/management.py
@@ -171,7 +171,7 @@ class SectionManageForm(ManagementForm):
             for ts in sec.meeting_times.all():
                 avails = [res for res in sec.parent_program.getFloatingResources(timeslot=ts, queryset=True).filter(name=r) if res.is_available()]
                 if len(avails)== 0:
-                    raise ESPError('No floating resource "%s" available for timeslot %s.' % (r, ts), log=True)
+                    raise ESPError(f'No floating resource "{r}" available for timeslot {ts}.', log=True)
                 else:
                     res_list.append(avails[0])
             #if we made it this far, the resources are available, so we can assign them
@@ -200,7 +200,7 @@ class ClassCancellationForm(forms.Form):
 class SectionMultipleChoiceField(forms.ModelMultipleChoiceField):
     """ Custom field to customize the section labels """
     def label_from_instance(self, sec):
-        return '%s: %s (%s)' % (sec.emailcode(), sec.title(), ', '.join(sec.friendly_times(include_date = True)))
+        return f'{sec.emailcode()}: {sec.title()} ({", ".join(sec.friendly_times(include_date = True))})'
 
 class SectionCancellationForm(forms.Form):
     target = SectionMultipleChoiceField(label = "Section(s)", queryset=ClassSection.objects.all(), widget = forms.CheckboxSelectMultiple(), required=False)

--- a/esp/esp/program/modules/forms/moderate.py
+++ b/esp/esp/program/modules/forms/moderate.py
@@ -51,11 +51,11 @@ class ModeratorForm(forms.ModelForm):
         self.fields['num_slots'].widget.choices = choices
 
         #set default labels that need custom title
-        self.fields['will_moderate'].label = 'Will you serve as a %s?' % (self.program.getModeratorTitle().lower())
+        self.fields['will_moderate'].label = f'Will you serve as a {self.program.getModeratorTitle().lower()}?'
 
         # set default help texts that need custom title
-        self.fields['will_moderate'].help_text = "Would you like to serve as a %s for other teachers' classes?" % (self.program.getModeratorTitle().lower())
-        self.fields['num_slots'].help_text = 'For how many timeslots can you serve as a %s (we will use your teacher availability)?' % (self.program.getModeratorTitle().lower())
+        self.fields['will_moderate'].help_text = f"Would you like to serve as a {self.program.getModeratorTitle().lower()} for other teachers' classes?"
+        self.fields['num_slots'].help_text = f'For how many timeslots can you serve as a {self.program.getModeratorTitle().lower()} (we will use your teacher availability)?'
 
         # override help text/labels with tags
         for field in self.fields.keys():

--- a/esp/esp/program/modules/forms/volunteer.py
+++ b/esp/esp/program/modules/forms/volunteer.py
@@ -121,7 +121,7 @@ class VolunteerOfferForm(forms.Form):
 
         super().__init__(*args, **kwargs)
         vrs = self.program.getVolunteerRequests()
-        self.fields['requests'].choices = [(v.id, '%s: %s (%s more needed)' % (v.timeslot.pretty_time(), v.timeslot.description, positive_or_no(v.num_volunteers - v.num_offers()))) for v in vrs]
+        self.fields['requests'].choices = [(v.id, f'{v.timeslot.pretty_time()}: {v.timeslot.description} ({positive_or_no(v.num_volunteers - v.num_offers())} more needed)') for v in vrs]
         self.fields['shirt_size'].choices = [('', '')]+[(x.strip(), x.strip()) for x in Tag.getTag('volunteer_shirt_sizes').split(',')]
         self.fields['shirt_type'].choices = [('', '')]+[(x.strip(), x.strip()) for x in Tag.getTag('shirt_types').split(',')]
 

--- a/esp/esp/program/modules/handlers/adminclass.py
+++ b/esp/esp/program/modules/handlers/adminclass.py
@@ -179,9 +179,9 @@ class AdminClass(ProgramModuleObj):
                 try:
                     s = ClassSection.objects.get(id=int(request.GET['sec_id']))
                     s.delete()
-                    return HttpResponseRedirect('/manage/%s/%s/manageclass/%s' % (one, two, extra))
+                    return HttpResponseRedirect(f'/manage/{one}/{two}/manageclass/{extra}')
                 except (ValueError, ClassSection.DoesNotExist):
-                    raise ESPError('Unable to delete a section.  The section requested was: %s' % request.GET['sec_id'], log=False)
+                    raise ESPError(f'Unable to delete a section.  The section requested was: {request.GET["sec_id"]}', log=False)
         else:
             section_id = int(request.GET['sec_id'])
             section = ClassSection.objects.get(id=section_id)
@@ -196,7 +196,7 @@ class AdminClass(ProgramModuleObj):
         cls = self.getClass(request, extra)
         cls.add_section()
 
-        return HttpResponseRedirect('/manage/%s/%s/manageclass/%s' % (one, two, extra))
+        return HttpResponseRedirect(f'/manage/{one}/{two}/manageclass/{extra}')
 
     @aux_call
     @needs_admin

--- a/esp/esp/program/modules/handlers/admincore.py
+++ b/esp/esp/program/modules/handlers/admincore.py
@@ -159,7 +159,7 @@ class AdminCore(ProgramModuleObj, CoreModule):
 
         #   Populate context with variables to show which program module views are available
         for (tl, view_name) in prog.getModuleViews():
-            context['%s_%s' % (tl, view_name)] = True
+            context[f'{tl}_{view_name}'] = True
 
         # Metadata for admin search across dashboard sections and other views.
         # Pass list of dicts; template uses json_script for safe embedding (no XSS).
@@ -201,7 +201,7 @@ class AdminCore(ProgramModuleObj, CoreModule):
                         new_prog.save()
                         #If the url for the program is now different, redirect to the new settings page
                         if new_prog.url is not old_url:
-                            return HttpResponseRedirect( '/manage/%s/settings/program' % (new_prog.url))
+                            return HttpResponseRedirect( f'/manage/{new_prog.url}/settings/program')
                     else:
                         forms['program'] = form
                     context['open_section'] = "program"
@@ -370,15 +370,15 @@ class AdminCore(ProgramModuleObj, CoreModule):
                     perms[0].unexpire()
                 else:
                     Permission.objects.create(role = group, permission_type = request.GET['perm'], start_date = datetime.now(), program = prog)
-                message_good = 'Deadline opened for %ss: %s.' % (group, Permission.nice_name_lookup(request.GET['perm']))
+                message_good = f'Deadline opened for {group}s: {Permission.nice_name_lookup(request.GET["perm"])}.'
             elif 'perm_id' in request.GET:
                 perms = Permission.objects.filter(id=request.GET['perm_id'])
                 if perms.count() == 1:
                     perm = perms[0]
                     perm.unexpire()
-                    message_good = 'Permission opened for %s: %s.' % (perm.user, perm.nice_name())
+                    message_good = f'Permission opened for {perm.user}: {perm.nice_name()}.'
                 else:
-                    message_bad = 'No permission with ID %s.' % (request.GET['perm_id'])
+                    message_bad = f'No permission with ID {request.GET["perm_id"]}.'
 
         elif extra == 'close':
             #   If there are open permission(s) for this type, close them all
@@ -386,15 +386,15 @@ class AdminCore(ProgramModuleObj, CoreModule):
                 group = Group.objects.get(id = request.GET['group'])
                 perms = Permission.valid_objects().filter(permission_type = request.GET['perm'], program = prog, role = group)
                 perms.update(end_date = datetime.now())
-                message_good = 'Deadline closed for %ss: %s.' % (group, Permission.nice_name_lookup(request.GET['perm']))
+                message_good = f'Deadline closed for {group}s: {Permission.nice_name_lookup(request.GET["perm"])}.'
             if 'perm_id' in request.GET:
                 perms = Permission.objects.filter(id=request.GET['perm_id'])
                 if perms.count() == 1:
                     perm = perms[0]
                     perm.expire()
-                    message_good = 'Permission closed for %s: %s.' % (perm.user, perm.nice_name())
+                    message_good = f'Permission closed for {perm.user}: {perm.nice_name()}.'
                 else:
-                    message_bad = 'No permission with ID %s.' % (request.GET['perm_id'])
+                    message_bad = f'No permission with ID {request.GET["perm_id"]}.'
 
         elif extra == 'delete' and 'perm_id' in request.GET:
             #   Delete the specified permission if it exists
@@ -402,9 +402,9 @@ class AdminCore(ProgramModuleObj, CoreModule):
             if perms.count() == 1:
                 perm = perms[0]
                 if 'deadline' in request.GET:
-                    message_good = 'Deadline deleted for %ss: %s.' % (perm.role, perm.nice_name())
+                    message_good = f'Deadline deleted for {perm.role}s: {perm.nice_name()}.'
                 else:
-                    message_good = 'Permission deleted for %s: %s.' % (perm.user, perm.nice_name())
+                    message_good = f'Permission deleted for {perm.user}: {perm.nice_name()}.'
                 perm.delete()
             else:
                 if 'deadline' in request.GET:
@@ -420,7 +420,7 @@ class AdminCore(ProgramModuleObj, CoreModule):
                     perm = Permission.objects.create(user=None, permission_type=create_form.cleaned_data['deadline_type'],
                                                      role=Group.objects.get(name=create_form.cleaned_data['role']), program=prog,
                                                      start_date = create_form.cleaned_data['start_date'], end_date = create_form.cleaned_data['end_date'])
-                    message_good = 'Deadline created for %ss: %s.' % (create_form.cleaned_data['role'], perm.nice_name())
+                    message_good = f'Deadline created for {create_form.cleaned_data["role"]}s: {perm.nice_name()}.'
                     create_form = NewDeadlineForm()
                 else:
                     message_bad = 'Error(s) while creating deadline (see below)'
@@ -429,7 +429,7 @@ class AdminCore(ProgramModuleObj, CoreModule):
                 if perm_form.is_valid():
                     perm = Permission.objects.create(user=perm_form.cleaned_data['user'], permission_type=perm_form.cleaned_data['permission_type'], program=prog,
                                                      start_date = perm_form.cleaned_data['perm_start_date'], end_date = perm_form.cleaned_data['perm_end_date'])
-                    message_good = 'Permission created for %s: %s.' % (perm_form.cleaned_data['user'], perm.nice_name())
+                    message_good = f'Permission created for {perm_form.cleaned_data["user"]}: {perm.nice_name()}.'
                     perm_form = NewPermissionForm()
                 else:
                     message_bad = 'Error(s) while creating permission (see below)'

--- a/esp/esp/program/modules/handlers/adminreviewapps.py
+++ b/esp/esp/program/modules/handlers/adminreviewapps.py
@@ -198,10 +198,10 @@ class AdminReviewApps(ProgramModuleObj):
     @staticmethod
     def getSchedule(program, student):
 
-        schedule = """
-Student schedule for %s:
+        schedule = f"""
+Student schedule for {student.name()}:
 
- Time               | Class                   | Room""" % student.name()
+ Time               | Class                   | Room"""
 
         regs = StudentRegistration.valid_objects().filter(user=student, section__parent_class__parent_program=program, relationship__name='Accepted')
         classes = sorted([x.section.parent_class for x in regs])
@@ -215,10 +215,8 @@ Student schedule for %s:
             else:
                 rooms = ", ".join(rooms)
 
-            schedule += """
-%s|%s|%s""" % (",".join(cls.friendly_times()).ljust(20),
-               cls.title.ljust(25),
-               rooms)
+            schedule += f"""
+{",".join(cls.friendly_times()).ljust(20)}|{cls.title.ljust(25)}|{rooms}"""
 
         return schedule
 

--- a/esp/esp/program/modules/handlers/admissionsdashboard.py
+++ b/esp/esp/program/modules/handlers/admissionsdashboard.py
@@ -108,10 +108,10 @@ class AdmissionsDashboard(ProgramModuleObj):
                 decision_status_lines = []
                 cls = classapp.app.admitted_to_class()
                 if cls is not None:
-                    line = 'Admitted: {0}'.format(cls.title)
+                    line = f'Admitted: {cls.title}'
                     decision_status_lines.append(line)
                 for cls in classapp.app.waitlisted_to_class():
-                    line = 'Waitlisted: {0}'.format(cls.title)
+                    line = f'Waitlisted: {cls.title}'
                     decision_status_lines.append(line)
                 result['decision_status'] = '\n'.join(decision_status_lines)
             results.append(result)

--- a/esp/esp/program/modules/handlers/ajaxschedulingmodule.py
+++ b/esp/esp/program/modules/handlers/ajaxschedulingmodule.py
@@ -295,7 +295,7 @@ class AJAXSchedulingModule(ProgramModuleObj):
         if action == 'removemod':
             sec.moderators.remove(mod)
             self.get_change_log(prog).appendModerator(mod_id, sec_id, False, request.user)
-            return self.makeret(prog, ret=True, msg="Moderator '%s' removed from Class Section '%s'" % (mod.name(), sec.emailcode()))
+            return self.makeret(prog, ret=True, msg=f"Moderator '{mod.name()}' removed from Class Section '{sec.emailcode()}'")
         elif action == 'assignmod':
             override = request.POST['override'] == "true"
             if not override:
@@ -303,10 +303,10 @@ class AJAXSchedulingModule(ProgramModuleObj):
                 avail_times = [time.id for time in mod.getAvailableTimes(prog)]
                 for time in sec.meeting_times.all():
                     if time.id not in avail_times:
-                        return self.makeret(prog, ret=False, msg="Moderator '%s' is not available to moderate Class Section '%s'" % (mod.name(), sec.emailcode()))
+                        return self.makeret(prog, ret=False, msg=f"Moderator '{mod.name()}' is not available to moderate Class Section '{sec.emailcode()}'")
             sec.moderators.add(mod)
             self.get_change_log(prog).appendModerator(mod_id, sec_id, True, request.user)
-            return self.makeret(prog, ret=True, msg="Moderator '%s' assigned to Class Section '%s'" % (mod.name(), sec.emailcode()))
+            return self.makeret(prog, ret=True, msg=f"Moderator '{mod.name()}' assigned to Class Section '{sec.emailcode()}'")
         else:
             return self.makeret(prog, ret=False, msg="Unrecognized command: '%s'" % action)
 
@@ -394,7 +394,7 @@ class AJAXSchedulingModule(ProgramModuleObj):
 
         if request.method == 'POST':
             num_affected_sections = self.clear_schedule_logic(prog, lock_level)
-            data = {'message': 'Cleared schedule assignments for %d sections.' % (num_affected_sections)}
+            data = {'message': f'Cleared schedule assignments for {num_affected_sections} sections.'}
             response = HttpResponse(content_type="application/json")
             json.dump(data, response)
         else:

--- a/esp/esp/program/modules/handlers/availabilitymodule.py
+++ b/esp/esp/program/modules/handlers/availabilitymodule.py
@@ -115,7 +115,7 @@ class AvailabilityModule(ProgramModuleObj):
 
         if tl == "manage":
             # They probably want to check or edit someone's availability instead
-            return HttpResponseRedirect( '/manage/%s/%s/edit_availability' % (one, two) )
+            return HttpResponseRedirect( f'/manage/{one}/{two}/edit_availability' )
         else:
             return self.availabilityForm(request, tl, one, two, prog, request.user, False)
 
@@ -195,7 +195,7 @@ class AvailabilityModule(ProgramModuleObj):
 
                 if isAdmin:
                     #   Return to the relevant edit_availability page
-                    return HttpResponseRedirect( '/manage/%s/%s/edit_availability?user=%s' % (one, two, teacher.id) )
+                    return HttpResponseRedirect( f'/manage/{one}/{two}/edit_availability?user={teacher.id}' )
                 else:
                     #   Return to the main registration page
                     return self.goToCore(tl)

--- a/esp/esp/program/modules/handlers/bulkcreateaccountmodule.py
+++ b/esp/esp/program/modules/handlers/bulkcreateaccountmodule.py
@@ -175,7 +175,7 @@ def get_group(group):
         except Group.DoesNotExist:
             return None
     else:
-        raise ESPError('{} is not a Group or Group name'.format(str(group)))
+        raise ESPError(f'{group} is not a Group or Group name')
 
 
 def create_user_with_profile(username, password, program, groups):

--- a/esp/esp/program/modules/handlers/commmodule.py
+++ b/esp/esp/program/modules/handlers/commmodule.py
@@ -162,7 +162,7 @@ class CommModule(ProgramModuleObj):
         # Set From address
         if request.POST.get('from', '').strip():
             fromemail = request.POST['from']
-            if not re.match(r'(^.+@{0}$)|(^.+<.+@{0}>$)|(^.+@(\w+\.)?learningu\.org$)|(^.+<.+@(\w+\.)?learningu\.org>$)'.format(settings.SITE_INFO[1].replace('.', r'\.')), fromemail):
+            if not re.match(rf'(^.+@{re.escape(settings.SITE_INFO[1])}$)|(^.+<.+@{re.escape(settings.SITE_INFO[1])}>$)|(^.+@(\w+\.)?learningu\.org$)|(^.+<.+@(\w+\.)?learningu\.org>$)', fromemail):
                 raise ESPError("Invalid 'From' email address. The 'From' email address must " +
                                "end in @" + settings.SITE_INFO[1] + " (your website), " +
                                "@learningu.org, or a valid subdomain of learningu.org " +
@@ -172,8 +172,7 @@ class CommModule(ProgramModuleObj):
             prs = PlainRedirect.objects.filter(original = "info")
             if not prs.exists():
                 redirect = PlainRedirect.objects.create(original = "info", destination = settings.DEFAULT_EMAIL_ADDRESSES['default'])
-            fromemail = '%s <%s@%s>' % (Tag.getTag('full_group_name') or '%s %s' % (settings.INSTITUTION_NAME, settings.ORGANIZATION_SHORT_NAME),
-                                        "info", settings.SITE_INFO[1])
+            fromemail = f'{Tag.getTag("full_group_name") or f"{settings.INSTITUTION_NAME} {settings.ORGANIZATION_SHORT_NAME}"} <info@{settings.SITE_INFO[1]}>'
 
         # Set Reply-To address
         if request.POST.get('replyto', '').strip():
@@ -204,7 +203,7 @@ class CommModule(ProgramModuleObj):
 
         # Use whichever template the user selected or the default (just an unsubscribe slug) if 'None'
         template = request.POST.get('template', 'default')
-        rendered_text = render_to_string('email/{}_email.html'.format(template),
+        rendered_text = render_to_string(f'email/{template}_email.html',
                                         {'msgbody': body})
         # Render the text for the first user
         contextdict = {'user'   : ActionHandler(firstuser, firstuser),
@@ -280,7 +279,7 @@ class CommModule(ProgramModuleObj):
             current_program_url
         )
         if other_program_urls and not request.POST.get('confirm_send_with_other_program_links'):
-            rendered_text = render_to_string('email/{}_email.html'.format(template),
+            rendered_text = render_to_string(f'email/{template}_email.html',
                                              {'msgbody': body})
             listcount = request.POST.get('listcount', '')
             selected = request.POST.get('selected', '')
@@ -302,7 +301,7 @@ class CommModule(ProgramModuleObj):
             })
 
         # Use whichever template the user selected or the default (just an unsubscribe slug) if 'None'
-        rendered_text = render_to_string('email/{}_email.html'.format(template),
+        rendered_text = render_to_string(f'email/{template}_email.html',
                                         {'msgbody': body})
 
         try:
@@ -352,8 +351,7 @@ class CommModule(ProgramModuleObj):
         context['sendto_fn_name'] = request.POST.get('sendto_fn_name', MessageRequest.SEND_TO_SELF_REAL)
         context['sendto_fn'] = MessageRequest.assert_is_valid_sendto_fn_or_ESPError(context['sendto_fn_name'])
 
-        context['default_from'] = '%s <%s@%s>' % (Tag.getTag('full_group_name') or '%s %s' % (settings.INSTITUTION_NAME, settings.ORGANIZATION_SHORT_NAME),
-                                              "info", settings.SITE_INFO[1])
+        context['default_from'] = f'{Tag.getTag("full_group_name") or f"{settings.INSTITUTION_NAME} {settings.ORGANIZATION_SHORT_NAME}"} <info@{settings.SITE_INFO[1]}>'
         context['from'] = context['default_from']
 
         context['listcount'] = self.approx_num_of_recipients(filterObj, context['sendto_fn'])
@@ -382,8 +380,7 @@ class CommModule(ProgramModuleObj):
         if request.method == 'POST':
             #   Turn multi-valued QueryDict into standard dictionary
             data = ListGenModule.processPost(request)
-            context['default_from'] = '%s <%s@%s>' % (Tag.getTag('full_group_name') or '%s %s' % (settings.INSTITUTION_NAME, settings.ORGANIZATION_SHORT_NAME),
-                                                      "info", settings.SITE_INFO[1])
+            context['default_from'] = f'{Tag.getTag("full_group_name") or f"{settings.INSTITUTION_NAME} {settings.ORGANIZATION_SHORT_NAME}"} <info@{settings.SITE_INFO[1]}>'
             ##  Handle normal list selecting submissions
             if ('base_list' in data and 'recipient_type' in data) or ('combo_base_list' in data):
 

--- a/esp/esp/program/modules/handlers/creditcardmodule_stripe.py
+++ b/esp/esp/program/modules/handlers/creditcardmodule_stripe.py
@@ -250,7 +250,7 @@ class CreditCardModule_Stripe(ProgramModuleObj):
         context['postdata'] = request.POST.copy()
         domain_name = Site.objects.get_current().domain
         msg_content = render_to_string(self.baseDir() + 'error_email.txt', context)
-        msg_subject = '[ ESP CC ] Credit card error on %s: %d %s' % (domain_name, request.user.id, request.user.name())
+        msg_subject = f'[ ESP CC ] Credit card error on {domain_name}: {request.user.id} {request.user.name()}'
         # This message could contain sensitive information.  Send to the
         # confidential messages address, and don't bcc the archive list.
         send_mail(msg_subject, msg_content, settings.SERVER_EMAIL, [self.program.getDirectorConfidentialEmail()], bcc=None)
@@ -264,7 +264,7 @@ class CreditCardModule_Stripe(ProgramModuleObj):
 
         context = {'postdata': request.POST.copy()}
 
-        group_name = Tag.getTag('full_group_name') or '%s %s' % (settings.INSTITUTION_NAME, settings.ORGANIZATION_SHORT_NAME)
+        group_name = Tag.getTag('full_group_name') or f'{settings.INSTITUTION_NAME} {settings.ORGANIZATION_SHORT_NAME}'
 
         iac = IndividualAccountingController(self.program, request.user)
 
@@ -333,7 +333,7 @@ class CreditCardModule_Stripe(ProgramModuleObj):
                         amount=amount_cents_post,
                         currency="usd",
                         card=request.POST['stripeToken'],
-                        description="Payment for %s %s - %s" % (group_name, prog.niceName(), request.user.name()),
+                        description=f"Payment for {group_name} {prog.niceName()} - {request.user.name()}",
                         statement_descriptor=group_name[0:22], #stripe limits statement descriptors to 22 characters
                         metadata={
                             'ponumber': request.POST['ponumber'],

--- a/esp/esp/program/modules/handlers/financialaidappmodule.py
+++ b/esp/esp/program/modules/handlers/financialaidappmodule.py
@@ -126,45 +126,30 @@ class FinancialAidAppModule(ProgramModuleObj):
 
                 # Send an email announcing the application
                 date_str = str(datetime.now())
-                subj_str = '%s %s applied for Financial Aid for %s' % (request.user.first_name, request.user.last_name, prog.niceName())
-                msg_str = "\n%s %s applied for Financial Aid for %s on %s."
+                subj_str = f'{request.user.first_name} {request.user.last_name} applied for Financial Aid for {prog.niceName()}'
+                msg_str = f"\n{request.user.first_name} {request.user.last_name} applied for Financial Aid for {prog.niceName()} on {date_str}."
                 send_mail(subj_str, (msg_str +
-                """
+                f"""
 
 Here is their form data:
 
 ========================================
-Program:  %s
-User:  %s %s <%s>
-Approved:  %s
-Has Reduced Lunch:  %s
-Household Income:  $%s
-Form Was Filled Out by Non-Student:  %s
+Program:  {app.program}
+User:  {request.user.first_name} {request.user.last_name} <{app.user}>
+Approved:  {date_str}
+Has Reduced Lunch:  {app.reduced_lunch}
+Household Income:  ${app.household_income}
+Form Was Filled Out by Non-Student:  {app.student_prepare}
 Extra Explanation:
-%s
+{app.extra_explaination}
 
 ========================================
 
 This request can be (re)viewed at:
-<%s://%s/admin/program/financialaidrequest/%s/>
+<{'http' if settings.DEBUG else 'https'}://{settings.DEFAULT_HOST}/admin/program/financialaidrequest/{app.id}/>
 
 
-""") % (request.user.first_name,
-    request.user.last_name,
-    prog.niceName(),
-    date_str,
-    str(app.program),
-    request.user.first_name,
-    request.user.last_name,
-    str(app.user),
-    date_str,
-    str(app.reduced_lunch),
-    str(app.household_income),
-    str(app.student_prepare),
-    app.extra_explaination,
-    'http' if settings.DEBUG else 'https',
-    settings.DEFAULT_HOST, # server hostname
-    str(app.id)),
+"""),
                             settings.SERVER_EMAIL,
                             [ prog.getDirectorConfidentialEmail() ] )
                 # Automatically accept apps for people with subsidized lunches

--- a/esp/esp/program/modules/handlers/listgenmodule.py
+++ b/esp/esp/program/modules/handlers/listgenmodule.py
@@ -224,7 +224,7 @@ class UserAttributeGetter(object):
         if self.profile.student_info:
             dob = self.profile.student_info.dob
             if dob:
-                return '{:%Y-%m-%d}'.format(dob)
+                return f'{dob:%Y-%m-%d}'
 
     def get_gender(self):
         if self.profile.student_info:

--- a/esp/esp/program/modules/handlers/nametagmodule.py
+++ b/esp/esp/program/modules/handlers/nametagmodule.py
@@ -106,7 +106,7 @@ class NameTagModule(ProgramModuleObj):
             else:
                 pronoun = None
             user_dict = {'title': title,
-                         'name' : '%s %s' % (user.first_name, user.last_name),
+                         'name' : f'{user.first_name} {user.last_name}',
                          'id'   : user.id,
                          'username': user.username,
                          'pronoun': pronoun}
@@ -240,7 +240,7 @@ class NameTagModule(ProgramModuleObj):
 
         context['barcodes'] = True if 'barcodes' in request.POST else False
         context['users_and_backs'] = users_and_backs
-        context['group_name'] = Tag.getTag('full_group_name') or '%s %s' % (settings.INSTITUTION_NAME, settings.ORGANIZATION_SHORT_NAME)
+        context['group_name'] = Tag.getTag('full_group_name') or f'{settings.INSTITUTION_NAME} {settings.ORGANIZATION_SHORT_NAME}'
         context['phone_number'] = Tag.getTag('group_phone_number')
         current_logo_version = Tag.getTag('current_logo_version')
         context['current_logo_version'] = current_logo_version if current_logo_version is not None else ''

--- a/esp/esp/program/modules/handlers/onsitecheckinmodule.py
+++ b/esp/esp/program/modules/handlers/onsitecheckinmodule.py
@@ -242,11 +242,11 @@ class OnSiteCheckinModule(ProgramModuleObj):
                         rt = RecordType.objects.get(name="attended")
                         rec = Record(user=student, event=rt, program=prog)
                         rec.save()
-                    context['message'] = '%s %s marked as attended.' % (student.first_name, student.last_name)
+                    context['message'] = f'{student.first_name} {student.last_name} marked as attended.'
                     if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
                         return self.ajax_status(request, tl, one, two, module, extra, prog, context)
                 else:
-                    context['message'] = '%s %s is not a student and has not been checked in' % (student.first_name, student.last_name)
+                    context['message'] = f'{student.first_name} {student.last_name} is not a student and has not been checked in'
                     if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
                         return self.ajax_status(request, tl, one, two, module, extra, prog, context)
                 form = StudentSearchForm(initial={'target_user': student.id})
@@ -345,7 +345,7 @@ class OnSiteCheckinModule(ProgramModuleObj):
                                     messages.append('%s is now checked in!' % info_string)
                             else:
                                 self.create_record(key)
-                                messages.append('%s record set for %s' % (key, info_string))
+                                messages.append(f'{key} record set for {info_string}')
                     json_data['message'] = "\n".join(messages)
                 else:
                     json_data['message'] = '%s is not a student!' % info_string

--- a/esp/esp/program/modules/handlers/onsitecheckoutmodule.py
+++ b/esp/esp/program/modules/handlers/onsitecheckoutmodule.py
@@ -65,7 +65,7 @@ class OnSiteCheckoutModule(ProgramModuleObj):
             rt = RecordType.objects.get(name="checked_out")
             for student in students:
                 Record.objects.create(user=student, event=rt, program=prog)
-            context['checkout_all_message'] = "Successfully checked out %s students" % (students.count())
+            context['checkout_all_message'] = f"Successfully checked out {students.count()} students"
 
         target_id = None
         student = None
@@ -93,7 +93,7 @@ class OnSiteCheckoutModule(ProgramModuleObj):
 
             # Get most recent check-in record
             if not prog.isCheckedIn(student):
-                context['checkout_message_warning'] = "Caution: %s (%s) is not currently checked in for this program!" % (student.name(), student.username)
+                context['checkout_message_warning'] = f"Caution: {student.name()} ({student.username}) is not currently checked in for this program!"
 
             if 'checkout_student' in request.POST:
                 # Make checked_out record
@@ -104,7 +104,7 @@ class OnSiteCheckoutModule(ProgramModuleObj):
                 verbs = RTC.getVisibleRegistrationTypeNames(prog)
                 for sec in ClassSection.objects.filter(id__in=[_f for _f in request.POST.getlist('unenroll') if _f]).distinct():
                     sec.unpreregister_student(student, verbs)
-                context['checkout_message_success'] = "Successfully checked out %s (%s)" % (student.name(), student.username)
+                context['checkout_message_success'] = f"Successfully checked out {student.name()} ({student.username})"
 
             context.update(StudentClassRegModule.prepare_static(student, prog))
         else:

--- a/esp/esp/program/modules/handlers/onsiteclasslist.py
+++ b/esp/esp/program/modules/handlers/onsiteclasslist.py
@@ -258,7 +258,7 @@ class OnSiteClassList(ProgramModuleObj):
         try:
             desired_sections = json.loads(request.GET['sections'])
         except (KeyError, ValueError, TypeError):
-            result['messages'].append('Error: could not parse requested sections %s' % request.GET.get('sections', None))
+            result['messages'].append(f'Error: could not parse requested sections {request.GET.get("sections", None)}')
             desired_sections = None
 
         #   Check in student if not currently checked in, since if they're using this view they must be onsite
@@ -277,7 +277,7 @@ class OnSiteClassList(ProgramModuleObj):
             failed_add_sections = []
             for sec in sections_to_add:
                 if sec.isFull(webapp=True) and not override_full:
-                    result['messages'].append('Failed to add %s (%s) to %s: %s (%s).  Error was: %s' % (user.name(), user.id, sec.emailcode(), sec.title(), sec.id, 'Class is currently full.'))
+                    result['messages'].append(f'Failed to add {user.name()} ({user.id}) to {sec.emailcode()}: {sec.title()} ({sec.id}).  Error was: Class is currently full.')
                     failed_add_sections.append(sec.id)
 
             if len(failed_add_sections) == 0:
@@ -285,7 +285,7 @@ class OnSiteClassList(ProgramModuleObj):
                 #   Remove sections the student wants out of
                 for sec in sections_to_remove:
                     sec.unpreregister_student(user, verbs)
-                    result['messages'].append('Removed %s (%s) from %s: %s (%s)' % (user.name(), user.id, sec.emailcode(), sec.title(), sec.id))
+                    result['messages'].append(f'Removed {user.name()} ({user.id}) from {sec.emailcode()}: {sec.title()} ({sec.id})')
 
                 #   Remove sections that conflict with those the student wants into
                 sec_times = sections_to_add.select_related('meeting_times__id').values_list('id', 'meeting_times__id').order_by('meeting_times__id').distinct()
@@ -299,7 +299,7 @@ class OnSiteClassList(ProgramModuleObj):
                         for sm_sec in sm.map[ts]:
                             if sm_sec.id not in sections_to_add_ids:
                                 sm_sec.unpreregister_student(user, verbs)
-                                result['messages'].append('Removed %s (%s) from %s: %s (%s)' % (user.name(), user.id, sm_sec.emailcode(), sm_sec.title(), sm_sec.id))
+                                result['messages'].append(f'Removed {user.name()} ({user.id}) from {sm_sec.emailcode()}: {sm_sec.title()} ({sm_sec.id})')
                             else:
                                 existing_sections.append(sm_sec)
 
@@ -314,9 +314,9 @@ class OnSiteClassList(ProgramModuleObj):
                         else:
                             reg_result = False
                         if reg_result:
-                            result['messages'].append('Added %s (%s) to %s: %s (%s)' % (user.name(), user.id, sec.emailcode(), sec.title(), sec.id))
+                            result['messages'].append(f'Added {user.name()} ({user.id}) to {sec.emailcode()}: {sec.title()} ({sec.id})')
                         else:
-                            result['messages'].append('Failed to add %s (%s) to %s: %s (%s).  Error was: %s' % (user.name(), user.id, sec.emailcode(), sec.title(), sec.id, error))
+                            result['messages'].append(f'Failed to add {user.name()} ({user.id}) to {sec.emailcode()}: {sec.title()} ({sec.id}).  Error was: {error}')
 
             result['user'] = user.id
             result['sections'] = list(ClassSection.objects.filter(nest_Q(StudentRegistration.is_valid_qobject(), 'studentregistration'), status__gt=0, parent_class__status__gt=0, parent_class__parent_program=prog, studentregistration__relationship__name='Enrolled', studentregistration__user__id=result['user']).values_list('id', flat=True).distinct())
@@ -337,7 +337,7 @@ class OnSiteClassList(ProgramModuleObj):
             user_obj = ESPUser.objects.get(id=user)
         except (ValueError, TypeError, KeyError, ESPUser.DoesNotExist):
             resp.status_code = 400
-            result['message'] = "Could not find user %s." % request.GET.get('user', None)
+            result['message'] = f"Could not find user {request.GET.get('user', None)}."
             json.dump(result, resp)
             return resp
 
@@ -346,7 +346,7 @@ class OnSiteClassList(ProgramModuleObj):
             printer = Printer.objects.get(name=printer)
 
         req = PrintRequest.objects.create(user=user_obj, printer=printer)
-        result['message'] = "Submitted %s's schedule for printing (print request #%s)." % (user_obj.name(), req.id)
+        result['message'] = f"Submitted {user_obj.name()}'s schedule for printing (print request #{req.id})."
 
         json.dump(result, resp)
         return resp
@@ -486,17 +486,16 @@ class OnSiteClassList(ProgramModuleObj):
 
     def makeLink(self):
         calls = [("classchange_grid", "Grid-based Class Changes Interface"), ("classList", "Scrolling Class List"), (self.get_main_view(), self.module.link_title)]
-        strings = ['<a href="%s" title="%s" class="vModuleLink" >%s</a>' % \
-                ('/' + self.module.module_type + '/' + self.program.url + '/' + call[0], call[1], call[1]) for call in calls]
+        strings = [f'<a href="/{self.module.module_type}/{self.program.url}/{call[0]}" title="{call[1]}" class="vModuleLink" >{call[1]}</a>' for call in calls]
         return "</li><li>".join(strings)
 
     def makeButtonLink(self):
         calls = [("classchange_grid", "Grid-based Class Changes Interface"), ("classList", "Scrolling Class List"), (self.get_main_view(), self.module.link_title)]
-        strings = ["""<div class="module_button">\
-                                <a href="%s"><button type="button" class="module_link_large">
-                                    <div class="module_link_main">%s</div>
+        strings = [f"""<div class="module_button">\
+                                <a href="/{self.module.module_type}/{self.program.url}/{call[0]}"><button type="button" class="module_link_large">
+                                    <div class="module_link_main">{call[1]}</div>
                                 </button></a>
-                            </div>""" % ('/' + self.module.module_type + '/' + self.program.url + '/' + call[0], call[1]) for call in calls]
+                            </div>""" for call in calls]
         return "".join(strings)
 
     class Meta:

--- a/esp/esp/program/modules/handlers/onsiteprintschedules.py
+++ b/esp/esp/program/modules/handlers/onsiteprintschedules.py
@@ -78,7 +78,7 @@ class OnsitePrintSchedules(ProgramModuleObj):
             response = ProgramPrintables.get_student_schedules(request, [req.user], prog, onsite=True)
             if request.GET['gen_img'] == 'json':
                 import base64
-                src = "data:image/png;base64,{}".format(base64.b64encode(response.content))
+                src = f"data:image/png;base64,{base64.b64encode(response.content)}"
                 data = {
                     'src': src,
                     'id': req.id,

--- a/esp/esp/program/modules/handlers/onsiteregister.py
+++ b/esp/esp/program/modules/handlers/onsiteregister.py
@@ -120,7 +120,7 @@ class OnSiteRegister(ProgramModuleObj):
 
                 return render_to_response(self.baseDir()+'reg_success.html', request, {
                     'student': new_user,
-                    'retUrl': '/onsite/%s/classchange_grid?student_id=%s' % (self.program.getUrlBase(), new_user.id)
+                    'retUrl': f'/onsite/{self.program.getUrlBase()}/classchange_grid?student_id={new_user.id}'
                     })
 
         else:

--- a/esp/esp/program/modules/handlers/programprintables.py
+++ b/esp/esp/program/modules/handlers/programprintables.py
@@ -334,7 +334,7 @@ class ProgramPrintables(ProgramModuleObj):
 
         group_name = Tag.getTag('full_group_name')
         if not group_name:
-            group_name = '%s %s' % (settings.INSTITUTION_NAME, settings.ORGANIZATION_SHORT_NAME)
+            group_name = f'{settings.INSTITUTION_NAME} {settings.ORGANIZATION_SHORT_NAME}'
         context['group_name'] = group_name
 
         #   Hack for timeblock sorting (sorting by category is the default)
@@ -718,13 +718,13 @@ class ProgramPrintables(ProgramModuleObj):
     @needs_admin
     def teachermoderatorlist(self, request, tl, one, two, module, extra, prog):
         """ default list of teachers; function left in for compatibility """
-        return self.teachersbyFOO(request, tl, one, two, module, extra, prog, teaching=True, moderating=True, display_name = 'Teacher and %s List' % (prog.getModeratorTitle()))
+        return self.teachersbyFOO(request, tl, one, two, module, extra, prog, teaching=True, moderating=True, display_name = f'Teacher and {prog.getModeratorTitle()} List')
 
     @aux_call
     @needs_admin
     def moderatorlist(self, request, tl, one, two, module, extra, prog):
         """ default list of teachers; function left in for compatibility """
-        return self.teachersbyFOO(request, tl, one, two, module, extra, prog, teaching=False, moderating=True, display_name = '%s List' % (prog.getModeratorTitle()))
+        return self.teachersbyFOO(request, tl, one, two, module, extra, prog, teaching=False, moderating=True, display_name = f'{prog.getModeratorTitle()} List')
 
     @staticmethod
     def cmpsorttime(one, other):
@@ -754,12 +754,12 @@ class ProgramPrintables(ProgramModuleObj):
     @aux_call
     @needs_admin
     def teachermoderatorsbytime(self, request, tl, one, two, module, extra, prog):
-        return self.teachersbyFOO(request, tl, one, two, module, extra, prog, self.cmpsorttime, teaching = True, moderating = True, display_name = 'Teacher and %s List by Time' % (prog.getModeratorTitle()))
+        return self.teachersbyFOO(request, tl, one, two, module, extra, prog, self.cmpsorttime, teaching = True, moderating = True, display_name = f'Teacher and {prog.getModeratorTitle()} List by Time')
 
     @aux_call
     @needs_admin
     def moderatorsbytime(self, request, tl, one, two, module, extra, prog):
-        return self.teachersbyFOO(request, tl, one, two, module, extra, prog, self.cmpsorttime, teaching = False, moderating = True, display_name = '%s List by Time' % (prog.getModeratorTitle()))
+        return self.teachersbyFOO(request, tl, one, two, module, extra, prog, self.cmpsorttime, teaching = False, moderating = True, display_name = f'{prog.getModeratorTitle()} List by Time')
 
     @staticmethod
     def cmpsortname(one, other):
@@ -780,12 +780,12 @@ class ProgramPrintables(ProgramModuleObj):
     @aux_call
     @needs_admin
     def teachermoderatorsbyname(self, request, tl, one, two, module, extra, prog):
-        return self.teachersbyFOO(request, tl, one, two, module, extra, prog, self.cmpsortname, teaching = True, moderating = True, display_name = 'Teacher and %s List by Name' % (prog.getModeratorTitle()))
+        return self.teachersbyFOO(request, tl, one, two, module, extra, prog, self.cmpsortname, teaching = True, moderating = True, display_name = f'Teacher and {prog.getModeratorTitle()} List by Name')
 
     @aux_call
     @needs_admin
     def moderatorsbyname(self, request, tl, one, two, module, extra, prog):
-        return self.teachersbyFOO(request, tl, one, two, module, extra, prog, self.cmpsortname, teaching = False, moderating = True, display_name = '%s List by Name' % (prog.getModeratorTitle()))
+        return self.teachersbyFOO(request, tl, one, two, module, extra, prog, self.cmpsortname, teaching = False, moderating = True, display_name = f'{prog.getModeratorTitle()} List by Name')
 
     @needs_admin
     def roomsbyFOO(self, request, tl, one, two, module, extra, prog, sort_exp = lambda x, y: cmp(x, y), filt_exp = lambda x: True, template_file = 'roomlist.html', extra_func = lambda x: {}):
@@ -864,7 +864,7 @@ class ProgramPrintables(ProgramModuleObj):
     def teachermoderatorschedules(self, request, tl, one, two, module, extra, prog):
         """ generate teacher/moderator schedules """
 
-        filterObj, found = UserSearchController().create_filter(request, self.program, add_to_context = {'module': 'Teacher and %s Schedules' % (prog.getModeratorTitle())})
+        filterObj, found = UserSearchController().create_filter(request, self.program, add_to_context = {'module': f'Teacher and {prog.getModeratorTitle()} Schedules'})
         if not found:
             return filterObj
 
@@ -933,7 +933,7 @@ class ProgramPrintables(ProgramModuleObj):
     def moderatorschedules(self, request, tl, one, two, module, extra, prog):
         """ generate moderator schedules """
 
-        filterObj, found = UserSearchController().create_filter(request, self.program, add_to_context = {'module': '%s Schedules' % (prog.getModeratorTitle())})
+        filterObj, found = UserSearchController().create_filter(request, self.program, add_to_context = {'module': f'{prog.getModeratorTitle()} Schedules'})
         if not found:
             return filterObj
 
@@ -1576,7 +1576,7 @@ class ProgramPrintables(ProgramModuleObj):
     def classrostersbymoderator(self, request, tl, one, two, module, extra, prog):
         """ generate class rosters by moderator"""
 
-        filterObj, found = UserSearchController().create_filter(request, self.program, add_to_context = {'module': 'Class Rosters by %s' % (prog.getModeratorTitle())})
+        filterObj, found = UserSearchController().create_filter(request, self.program, add_to_context = {'module': f'Class Rosters by {prog.getModeratorTitle()}'})
         if not found:
             return filterObj
 
@@ -1796,10 +1796,10 @@ class ProgramPrintables(ProgramModuleObj):
                                [smart_str(section.parent_class.pretty_teachers())] + \
                                [needs_resource('LCD Projector', section)] + \
                                [needs_resource('Computer Lab', section)] + \
-                               [', '.join(['%s: %s' % (r.res_type.name, r.desired_value) for r in section.getResourceRequests()])] + \
+                               [', '.join([f'{r.res_type.name}: {r.desired_value}' for r in section.getResourceRequests()])] + \
                                [section.parent_class.class_size_optimal] + \
                                [section.parent_class.class_size_max] + \
-                               ['%d--%d' %(section.parent_class.grade_min, section.parent_class.grade_max)] +\
+                               [f'{section.parent_class.grade_min}--{section.parent_class.grade_max}'] +\
                                [smart_str(section.parent_class.message_for_directors)] + \
                                [", ".join(section.friendly_times())] + [", ".join(section.prettyrooms())] + \
                                time_values)
@@ -2007,7 +2007,7 @@ class AllClassesFieldConverter(object):
         elif hasattr(class_subject, fieldname):
             fieldvalue = getattr(class_subject, fieldname)
         else:
-            raise ValueError('Invalid fieldname supplied {0}'.format(fieldname))
+            raise ValueError(f'Invalid fieldname supplied {fieldname}')
         return fieldvalue
 
 class AllClassesSelectionForm(forms.Form):

--- a/esp/esp/program/modules/handlers/studentclassregmodule.py
+++ b/esp/esp/program/modules/handlers/studentclassregmodule.py
@@ -563,17 +563,17 @@ class StudentClassRegModule(ProgramModuleObj):
 
         category_list_href = "#top"
         if separate_catalog:
-            category_list_href = "/learn/%s/catalog" % prog.getUrlBase()
+            category_list_href = f"/learn/{prog.getUrlBase()}/catalog"
 
         category_header_str = """
-    <div class="cat_wrapper" data-category="%d">
+    <div class="cat_wrapper" data-category="{cat_id}">
       <hr size="1"/>
-      <a name="cat%d"></a>
+      <a name="cat{cat_id}"></a>
         <p style="font-size: 1.2em;" class="category">
-           %s
+           {cat_name}
         </p>
         <p class="linktop">
-           <a href="%s">[ Return to Category List ]</a>
+           <a href="{category_list_href}">[ Return to Category List ]</a>
         </p>
 """
 
@@ -583,7 +583,7 @@ class StudentClassRegModule(ProgramModuleObj):
                 class_category_id = cls.category.id
                 if (class_category_id != None):
                     class_blobs.append('</div>')
-                class_blobs.append(category_header_str % (class_category_id, class_category_id, cls.category.category, category_list_href))
+                class_blobs.append(category_header_str.format(cat_id=class_category_id, cat_name=cls.category.category, category_list_href=category_list_href))
             class_blobs.append(render_class_direct(cls))
             class_blobs.append('<br />')
         context['class_descs'] = ''.join(class_blobs)

--- a/esp/esp/program/modules/handlers/studentcustomformmodule.py
+++ b/esp/esp/program/modules/handlers/studentcustomformmodule.py
@@ -106,7 +106,7 @@ class StudentCustomFormModule(ProgramModuleObj):
             cf = Form.objects.get(id=int(custom_form_id))
         else:
             if request.user.isAdmin():
-                error = 'Cannot find an appropriate form for this module. You should <a href="/customforms" target="_blank">create one</a> and link it to the "Student Custom Form" module of the %s program.' % (self.program)
+                error = f'Cannot find an appropriate form for this module. You should <a href="/customforms" target="_blank">create one</a> and link it to the "Student Custom Form" module of the {self.program} program.'
             else:
                 error = 'Cannot find an appropriate form for this module. Please ask your administrator to create a form and link it to the "Student Custom Form" module.'
             raise ESPError(error, log=False)

--- a/esp/esp/program/modules/handlers/studentextracosts.py
+++ b/esp/esp/program/modules/handlers/studentextracosts.py
@@ -101,11 +101,11 @@ class StudentExtraCosts(ProgramModuleObj):
         student_desc = {}
         pac = ProgramAccountingController(self.program)
         for line_item_type in pac.get_lineitemtypes(include_donations=False):
-            student_desc['extracosts_%d' % line_item_type.id] = """Students who have opted for '%s'""" % line_item_type.text
+            student_desc[f'extracosts_{line_item_type.id}'] = f"""Students who have opted for '{line_item_type.text}'"""
             for option in line_item_type.options:
                 (option_id, option_amount, option_description, has_custom_amt) = option
-                key = 'extracosts_%d_%d' % (line_item_type.id, option_id)
-                student_desc[key] = """Students who have opted for '%s' for '%s' ($%s)""" % (option_description, line_item_type.text, option_amount or line_item_type.amount_dec)
+                key = f'extracosts_{line_item_type.id}_{option_id}'
+                student_desc[key] = f"""Students who have opted for '{option_description}' for '{line_item_type.text}' (${option_amount or line_item_type.amount_dec})"""
         if self.program.sibling_discount:
             student_desc['sibling_discount'] = """Students who have opted for a sibling discount"""
 
@@ -122,12 +122,12 @@ class StudentExtraCosts(ProgramModuleObj):
             q_object = pac.all_transfers_Q(lineitemtype_id=i.id)
             students_q = nest_Q(q_object, 'transfer')
             if QObject:
-                student_lists['extracosts_%d' % i.id] = students_q
+                student_lists[f'extracosts_{i.id}'] = students_q
             else:
                 students = ESPUser.objects.filter(students_q).distinct()
-                student_lists['extracosts_%d' % i.id] = students
+                student_lists[f'extracosts_{i.id}'] = students
             for option in i.options:
-                key = 'extracosts_%d_%d' % (i.id, option[0])
+                key = f'extracosts_{i.id}_{option[0]}'
                 filter_qobject = Q(transfer__option=option[0])
                 if QObject:
                     student_lists[key] = students_q & filter_qobject

--- a/esp/esp/program/modules/handlers/studentregphasezero.py
+++ b/esp/esp/program/modules/handlers/studentregphasezero.py
@@ -184,7 +184,7 @@ class StudentRegPhaseZero(ProgramModuleObj):
                         if not old_group.user.exists():
                             old_group.delete()
                 else:
-                    join_error = 'Error - This group already contains the maximum number of students (%s).' % (num_allowed_users)
+                    join_error = f'Error - This group already contains the maximum number of students ({num_allowed_users}).'
 
         context['join_error'] = join_error
         if join_error and not in_lottery:
@@ -233,8 +233,8 @@ class StudentRegPhaseZero(ProgramModuleObj):
         return JsonResponse(obj_list, safe=False)
 
     def send_confirmation_email(self, student, note=None):
-        email_title = 'Student Lottery Confirmation for %s: %s' % (self.program.niceName(), student.name())
-        email_from = '%s Registration System <server@%s>' % (self.program.program_type, settings.EMAIL_HOST_SENDER)
+        email_title = f'Student Lottery Confirmation for {self.program.niceName()}: {student.name()}'
+        email_from = f'{self.program.program_type} Registration System <server@{settings.EMAIL_HOST_SENDER}>'
         email_context = {'student': student,
                          'program': self.program,
                          'curtime': datetime.datetime.now(),

--- a/esp/esp/program/modules/handlers/studentregphasezeromanage.py
+++ b/esp/esp/program/modules/handlers/studentregphasezeromanage.py
@@ -82,10 +82,10 @@ class StudentRegPhaseZeroManage(ProgramModuleObj):
                         if len(grade_keys) == 1:
                             newcounts[grade_keys[0]] += 1
                         elif len(grade_keys) == 0:
-                            messages['error'].append("The <i>program_size_by_grade</i> <a href='/manage/" + prog.getUrlBase() + "/tags/learn'>tag</a> does not include grade %i. Lottery not run." % (grade))
+                            messages['error'].append(f"The <i>program_size_by_grade</i> <a href='/manage/{prog.getUrlBase()}/tags/learn'>tag</a> does not include grade {grade}. Lottery not run.")
                             break
                         else:
-                            messages['error'].append("The <i>program_size_by_grade</i> <a href='/manage/" + prog.getUrlBase() + "/tags/learn'>tag</a> includes grade %i multiple times. Lottery not run." % (grade))
+                            messages['error'].append(f"The <i>program_size_by_grade</i> <a href='/manage/{prog.getUrlBase()}/tags/learn'>tag</a> includes grade {grade} multiple times. Lottery not run.")
                             break
 
                     cpass = not any(newcounts[c] > grade_caps[c] for c in counts)
@@ -94,7 +94,7 @@ class StudentRegPhaseZeroManage(ProgramModuleObj):
                         students.extend(sibs)
                         counts = newcounts
             else:
-                messages['error'].append("<i>program_size_by_grade</i> <a href='/manage/" + prog.getUrlBase() + "/tags'>tag</a> is not set. Lottery not run.")
+                messages['error'].append(f"<i>program_size_by_grade</i> <a href='/manage/{prog.getUrlBase()}/tags'>tag</a> is not set. Lottery not run.")
 
         elif post.get('mode') == 'manual':
             usernames = [_f for _f in re.split(r'[;,\s]\s*', post.get('usernames')) if _f]
@@ -151,19 +151,19 @@ class StudentRegPhaseZeroManage(ProgramModuleObj):
                 add_user = ESPUser.objects.get(id=request.POST['student_selected1'])
                 in_lottery = PhaseZeroRecord.objects.filter(user=add_user, program=prog).exists()
                 if in_lottery:
-                    context['error'] = 'Error - %s is already in the lottery.' % (add_user.name())
+                    context['error'] = f'Error - {add_user.name()} is already in the lottery.'
                 else:
                     rec = PhaseZeroRecord(program=prog)
                     rec.save()
                     rec.user.add(add_user)
-                    context['success'] = "%s has been added to the lottery." % (add_user.name())
+                    context['success'] = f"{add_user.name()} has been added to the lottery."
             elif request.POST.get('mode') == 'addtoexisting':
                 add_user = ESPUser.objects.get(id=request.POST['student_selected2'])
                 join_user = ESPUser.objects.get(id=request.POST['student_selected3'])
                 try:
                     rec = PhaseZeroRecord.objects.get(user=join_user, program=prog)
                 except PhaseZeroRecord.DoesNotExist:
-                    context['error'] = 'Error - %s is not in an existing lottery group.' % (join_user.name())
+                    context['error'] = f'Error - {join_user.name()} is not in an existing lottery group.'
                 else:
                     in_lottery = PhaseZeroRecord.objects.filter(user=add_user, program=prog).exists()
                     if in_lottery:
@@ -176,21 +176,21 @@ class StudentRegPhaseZeroManage(ProgramModuleObj):
                             old_rec.user.remove(add_user)
                             if not old_rec.user.exists():
                                 old_rec.delete()
-                            context['success'] = "%s has been moved to a different lottery group." % (add_user.name())
-                        context['success'] = "%s has been added to the lottery group." % (add_user.name())
+                            context['success'] = f"{add_user.name()} has been moved to a different lottery group."
+                        context['success'] = f"{add_user.name()} has been added to the lottery group."
                     else:
-                        context['error'] = 'Error - This group already contains the maximum number of students (%s).' % (num_allowed_users)
+                        context['error'] = f'Error - This group already contains the maximum number of students ({num_allowed_users}).'
             elif request.POST.get('mode') == 'remove':
                 remove_user = ESPUser.objects.get(id=request.POST['student_selected4'])
                 try:
                     rec = PhaseZeroRecord.objects.get(user=remove_user, program=prog)
                 except PhaseZeroRecord.DoesNotExist:
-                    context['error'] = 'Error - %s is not in the lottery.' % (remove_user.name())
+                    context['error'] = f'Error - {remove_user.name()} is not in the lottery.'
                 else:
                     rec.user.remove(remove_user)
                     if not rec.user.exists():
                         rec.delete()
-                    context['success'] = "%s has been removed from the lottery." % (remove_user.name())
+                    context['success'] = f"{remove_user.name()} has been removed from the lottery."
             elif Tag.getBooleanTag('student_lottery_run', prog):
                 if request.POST.get('mode') == 'undo':
                     if "confirm" in request.POST:

--- a/esp/esp/program/modules/handlers/teacheracknowledgementmodule.py
+++ b/esp/esp/program/modules/handlers/teacheracknowledgementmodule.py
@@ -16,9 +16,9 @@ def teacheracknowledgementform_factory(prog):
         teach_text = "teacher"
 
     if date_range is None:
-        label = "I have read the above and commit to serving as a %s for my %s class(es)." % (teach_text, prog.program_type)
+        label = f"I have read the above and commit to serving as a {teach_text} for my {prog.program_type} class(es)."
     else:
-        label = "I have read the above and commit to serving as a %s for my %s class(es) on %s." % (teach_text, prog.program_type, date_range)
+        label = f"I have read the above and commit to serving as a {teach_text} for my {prog.program_type} class(es) on {date_range}."
 
     d = dict(acknowledgement=forms.BooleanField(required=True, label=label))
     return type(name, bases, d)

--- a/esp/esp/program/modules/handlers/teachercheckinmodule.py
+++ b/esp/esp/program/modules/handlers/teachercheckinmodule.py
@@ -97,14 +97,14 @@ class TeacherCheckinModule(ProgramModuleObj):
             if not checked_in_already:
                 rt = RecordType.objects.get(name="teacher_checked_in")
                 Record.objects.create(user=teacher, event=rt, program=prog, time=when)
-                return '%s is checked in until %s.' % (teacher.name(), str(endtime))
+                return f'{teacher.name()} is checked in until {endtime}.'
             else:
-                return '%s has already been checked in until %s.' % (teacher.name(), str(endtime))
+                return f'{teacher.name()} has already been checked in until {endtime}.'
         else:
             if prog.hasModule("TeacherModeratorModule"):
-                return '%s is not a teacher or %s for %s.' % (teacher.name(), prog.getModeratorTitle().lower(), prog.niceName())
+                return f'{teacher.name()} is not a teacher or {prog.getModeratorTitle().lower()} for {prog.niceName()}.'
             else:
-                return '%s is not a teacher for %s.' % (teacher.name(), prog.niceName())
+                return f'{teacher.name()} is not a teacher for {prog.niceName()}.'
 
 
     def undoCheckIn(self, teacher, prog, when=None):
@@ -116,7 +116,7 @@ class TeacherCheckinModule(ProgramModuleObj):
             records.delete()
             return '%s is no longer checked in.' % teacher.name()
         else:
-            return '%s was not checked in for %s.' % (teacher.name(), prog.niceName())
+            return f'{teacher.name()} was not checked in for {prog.niceName()}.'
 
     @main_call
     @needs_onsite

--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -138,8 +138,8 @@ class TeacherClassRegModule(ProgramModuleObj):
             possible_values = res_type.resourcerequest_set.values_list('desired_value', flat=True).distinct()
             for i in range(len(possible_values)):
                 val = possible_values[i]
-                label = 'teacher_res_%d_%d' % (res_type.id, i)
-                full_description = 'Teachers who requested "%s" for their %s' % (val, res_type.name)
+                label = f'teacher_res_{res_type.id}_{i}'
+                full_description = f'Teachers who requested "{val}" for their {res_type.name}'
                 query = Q(classsubject__sections__resourcerequest__res_type=res_type, classsubject__sections__resourcerequest__desired_value=val, classsubject__sections__parent_class__parent_program=self.program)
                 items.append((label, full_description, query))
         return items
@@ -210,7 +210,7 @@ class TeacherClassRegModule(ProgramModuleObj):
             'class_proposed': """Teachers teaching an unreviewed class""",
             'class_rejected': """Teachers teaching a rejected class""",
             'class_full': """Teachers teaching a completely full class""",
-            'class_nearly_full': """Teachers teaching a nearly-full class (>%d%% of capacity)""" % (100 * capacity_factor),
+            'class_nearly_full': f"""Teachers teaching a nearly-full class (>{int(100 * capacity_factor)}% of capacity)""",
             'taught_before': """Teachers who have taught for a previous program""",
         }
         for item in self.get_resource_pairs():
@@ -452,8 +452,8 @@ class TeacherClassRegModule(ProgramModuleObj):
             reason = request.POST['reason']
             request_teacher = request.user
 
-            email_title = '[%s] Class Cancellation Request for %s: %s' % (self.program.niceName(), cls.emailcode(), cls.title)
-            email_from = '%s Registration System <server@%s>' % (self.program.program_type, settings.EMAIL_HOST_SENDER)
+            email_title = f'[{self.program.niceName()}] Class Cancellation Request for {cls.emailcode()}: {cls.title}'
+            email_from = f'{self.program.program_type} Registration System <server@{settings.EMAIL_HOST_SENDER}>'
             email_context = {'request_teacher': request_teacher,
                              'program': self.program,
                              'cls': cls,
@@ -533,7 +533,7 @@ class TeacherClassRegModule(ProgramModuleObj):
                     ufile = form.cleaned_data['uploadedfile']
 
                     #	Append the class code on the filename
-                    desired_filename = '%s_%s' % (target_class.emailcode(), ufile.name)
+                    desired_filename = f'{target_class.emailcode()}_{ufile.name}'
                     media.handle_file(ufile, desired_filename)
 
                     media.format = ''
@@ -629,7 +629,7 @@ class TeacherClassRegModule(ProgramModuleObj):
             coteachers = [ x for x in coteachers if x != '' ]
             coteachers = [ ESPUser.objects.get(id=userid)
                            for userid in coteachers                ]
-            add_list_members("%s_%s-teachers" % (prog.program_type, prog.program_instance), coteachers)
+            add_list_members(f"{prog.program_type}_{prog.program_instance}-teachers", coteachers)
 
         op = ''
         if 'op' in request.POST:
@@ -819,11 +819,11 @@ class TeacherClassRegModule(ProgramModuleObj):
         try:
             int(extra)
         except (ValueError, TypeError):
-            raise ESPError("Invalid integer for class ID! Got `{}`".format(extra), log=False)
+            raise ESPError(f"Invalid integer for class ID! Got `{extra}`", log=False)
 
         classes = ClassSubject.objects.filter(id = extra)
         if len(classes) == 0:
-            raise ESPError("No class found matching this ID (ID={})!".format(extra), log=False)
+            raise ESPError(f"No class found matching this ID (ID={extra})!", log=False)
 
         if len(classes) != 1 or not request.user.canEdit(classes[0]):
             return render_to_response(self.baseDir()+'cannoteditclass.html', request, {})
@@ -934,7 +934,7 @@ class TeacherClassRegModule(ProgramModuleObj):
                     if request.POST['manage_submit'] == 'reload':
                         return HttpResponseRedirect(request.get_full_path()+'?manage=manage')
                     elif request.POST['manage_submit'] == 'manageclass':
-                        return HttpResponseRedirect('/manage/%s/manageclass/%s' % (self.program.getUrlBase(), extra))
+                        return HttpResponseRedirect(f'/manage/{self.program.getUrlBase()}/manageclass/{extra}')
                     elif request.POST['manage_submit'] == 'dashboard':
                         return HttpResponseRedirect('/manage/%s/dashboard' % self.program.getUrlBase())
                     elif request.POST['manage_submit'] == 'main':
@@ -1144,7 +1144,7 @@ class TeacherClassRegModule(ProgramModuleObj):
             users = list(user_dict.values())
 
             # Construct combo-box items
-            obj_list = [{'name': "%s, %s" % (user.last_name, user.first_name), 'username': user.username, 'id': user.id} for user in users]
+            obj_list = [{'name': f"{user.last_name}, {user.first_name}", 'username': user.username, 'id': user.id} for user in users]
         else:
             obj_list = []
 

--- a/esp/esp/program/modules/handlers/teachercustomformmodule.py
+++ b/esp/esp/program/modules/handlers/teachercustomformmodule.py
@@ -130,7 +130,7 @@ class TeacherCustomFormModule(ProgramModuleObj):
             cf = Form.objects.get(id=int(custom_form_id))
         else:
             if request.user.isAdmin():
-                error = 'Cannot find an appropriate form for this module. You should <a href="/customforms" target="_blank">create one</a> and link it to the "Teacher Custom Form" module of the %s program.' % (self.program)
+                error = f'Cannot find an appropriate form for this module. You should <a href="/customforms" target="_blank">create one</a> and link it to the "Teacher Custom Form" module of the {self.program} program.'
             else:
                 error = 'Cannot find an appropriate form for this module. Please ask your administrator to create a form and link it to the "Teacher Custom Form" module.'
             raise ESPError(error, log=False)

--- a/esp/esp/program/modules/handlers/teachereventsmodule.py
+++ b/esp/esp/program/modules/handlers/teachereventsmodule.py
@@ -124,7 +124,7 @@ class TeacherEventsModule(ProgramModuleObj):
                 event_types = EventType.objects.filter(is_teacher_type=True)
                 UserAvailability.objects.filter(user=request.user, event__event_type__in=event_types).delete()
                 for event_type in event_types:
-                    field_name = 'event_type_%d' % event_type.id
+                    field_name = f'event_type_{event_type.id}'
                     event = data.get(field_name)
                     if event:
                         ua, created = UserAvailability.objects.get_or_create( user=request.user, event=event, role=self.availability_role())
@@ -132,9 +132,8 @@ class TeacherEventsModule(ProgramModuleObj):
                         if self.program.director_email and created and 'interview' in event_type.description.lower():
                             event_name = event.description
                             send_mail('['+self.program.niceName()+'] Teacher Interview for ' + request.user.first_name + ' ' + request.user.last_name + ': ' + event_name, \
-                                  """Teacher Interview Registration Notification\n--------------------------------- \n\nTeacher: %s %s\n\nTime: %s\n\n""" % \
-                                  (request.user.first_name, request.user.last_name, event_name), \
-                                  '%s Registration System <server@%s>' % (self.program.program_type, settings.EMAIL_HOST_SENDER), \
+                                  f"""Teacher Interview Registration Notification\n--------------------------------- \n\nTeacher: {request.user.first_name} {request.user.last_name}\n\nTime: {event_name}\n\n""", \
+                                  f'{self.program.program_type} Registration System <server@{settings.EMAIL_HOST_SENDER}>', \
                                   [self.program.getDirectorCCEmail()], True, extra_headers = {'Reply-To': request.user.get_email_sendto_address()})
                 return self.goToCore(tl)
         else:
@@ -143,7 +142,7 @@ class TeacherEventsModule(ProgramModuleObj):
             for event_type in EventType.objects.filter(is_teacher_type=True):
                 desc = event_type.description
                 if entries[desc].count() > 0:
-                    data['event_type_%d' % event_type.id] = entries[desc][0].event.id
+                    data[f'event_type_{event_type.id}'] = entries[desc][0].event.id
             form = TeacherEventSignupForm(self, initial=data)
         return render_to_response( self.baseDir()+'event_signup.html', request, {'prog':prog, 'form': form} )
 

--- a/esp/esp/program/modules/handlers/teachermoderatormodule.py
+++ b/esp/esp/program/modules/handlers/teachermoderatormodule.py
@@ -123,7 +123,7 @@ class TeacherModeratorModule(ProgramModuleObj):
             users = list(user_dict.values())
 
             # Construct combo-box items
-            obj_list = [{'name': "%s, %s" % (user.last_name, user.first_name), 'username': user.username, 'id': user.id} for user in users]
+            obj_list = [{'name': f"{user.last_name}, {user.first_name}", 'username': user.username, 'id': user.id} for user in users]
         else:
             obj_list = []
 

--- a/esp/esp/program/modules/handlers/teacherquizmodule.py
+++ b/esp/esp/program/modules/handlers/teacherquizmodule.py
@@ -112,7 +112,7 @@ class TeacherQuizModule(ProgramModuleObj):
             cf = Form.objects.get(id=int(custom_form_id))
         else:
             if request.user.isAdmin():
-                error = 'Cannot find an appropriate form for this module. You should <a href="/customforms" target="_blank">create one</a> and link it to the "Teacher Logistics Quiz" module of the %s program.' % (self.program)
+                error = f'Cannot find an appropriate form for this module. You should <a href="/customforms" target="_blank">create one</a> and link it to the "Teacher Logistics Quiz" module of the {self.program} program.'
             else:
                 error = 'Cannot find an appropriate form for this module. Please ask your administrator to create a form and link it to the "Teacher Logistics Quiz" module.'
             raise ESPError(error, log=False)

--- a/esp/esp/program/modules/handlers/teacherreviewapps.py
+++ b/esp/esp/program/modules/handlers/teacherreviewapps.py
@@ -65,10 +65,10 @@ class TeacherReviewApps(ProgramModuleObj):
         try:
             cls = ClassSubject.objects.get(id = extra)
         except ClassSubject.DoesNotExist:
-            raise ESPError('Cannot find class with ID {}).'.format(extra), log=False)
+            raise ESPError(f'Cannot find class with ID {extra}.', log=False)
 
         if not request.user.canEdit(cls):
-            raise ESPError('You cannot edit class "%s"' % cls, log=False)
+            raise ESPError(f'You cannot edit class "{cls}"', log=False)
 
         #   Fetch any student even remotely related to the class.
         students_dict = cls.students_dict()
@@ -112,7 +112,7 @@ class TeacherReviewApps(ProgramModuleObj):
             for current in students[1:]:
                 if prev.id == prev_id and current.app_completed:
                     from django.shortcuts import redirect
-                    url = "/%s/%s/%s/review_student/%s/?student=%s" % (tl, one, two, extra, current.id)
+                    url = f"/{tl}/{one}/{two}/review_student/{extra}/?student={current.id}"
                     return redirect(url)
                 if prev.id != prev_id:
                     prev = current
@@ -192,7 +192,7 @@ class TeacherReviewApps(ProgramModuleObj):
             raise ESPError('Cannot find class.', log=False)
 
         if not request.user.canEdit(cls):
-            raise ESPError('You cannot edit class "%s"' % cls, log=False)
+            raise ESPError(f'You cannot edit class "{cls}"', log=False)
 
         student = request.GET.get('student', None)
         if not student:
@@ -201,7 +201,7 @@ class TeacherReviewApps(ProgramModuleObj):
         try:
             student = ESPUser.objects.get(id = int(student))
         except ESPUser.DoesNotExist:
-            raise ESPError('Cannot find student, %s' % student, log=False)
+            raise ESPError(f'Cannot find student, {student}', log=False)
 
         not_registered = not StudentRegistration.valid_objects().filter(section__parent_class = cls, user = student).exists()
         if not_registered:
@@ -228,9 +228,9 @@ class TeacherReviewApps(ProgramModuleObj):
             if form.is_valid():
                 form.target.update(form)
                 if 'submit_next' in request.POST or 'submit_return' in request.POST:
-                    url = '/%s/%s/%s/review_students/%s/' % (tl, one, two, extra)
+                    url = f'/{tl}/{one}/{two}/review_students/{extra}/'
                     if 'submit_next' in request.POST:
-                        url += '?prev=%s' % student.id
+                        url += f'?prev={student.id}'
                     from django.shortcuts import redirect
                     return redirect(url) # self.review_students(request, tl, one, two, module, extra, prog)
 

--- a/esp/esp/program/modules/handlers/usergroupmodule.py
+++ b/esp/esp/program/modules/handlers/usergroupmodule.py
@@ -119,11 +119,11 @@ class UserGroupModule(ProgramModuleObj):
 
         message = ""
         if created:
-            message += "User group '%s' has been created. " % (group.name)
+            message += f"User group '{group.name}' has been created. "
         if not created and clean:
-            message += "%i users were removed from user group '%s'. " % (diff2, group.name)
+            message += f"{diff2} users were removed from user group '{group.name}'. "
 
-        message += "%i new users have been added to user group '%s'. User group '%s' now has %i users." % (diff1, group.name, group.name, group.user_set.count())
+        message += f"{diff1} new users have been added to user group '{group.name}'. User group '{group.name}' now has {group.user_set.count()} users."
 
         return message
 

--- a/esp/esp/program/modules/handlers/volunteermanage.py
+++ b/esp/esp/program/modules/handlers/volunteermanage.py
@@ -208,7 +208,7 @@ class VolunteerManage(ProgramModuleObj):
             target_id = request.POST['user']
         else:
             context = {}
-            return HttpResponseRedirect( '/manage/%s/%s/volunteering' % (one, two) )
+            return HttpResponseRedirect( f'/manage/{one}/{two}/volunteering' )
 
         try:
             volunteer = ESPUser.objects.get(id=target_id)

--- a/esp/esp/program/modules/module_ext.py
+++ b/esp/esp/program/modules/module_ext.py
@@ -61,7 +61,7 @@ class DBReceipt(models.Model):
     receipt = models.TextField()
 
     def __str__(self):
-        return 'Registration (%s) receipt for %s' % (self.action, self.program)
+        return f'Registration ({self.action}) receipt for {self.program}'
 
 class StudentClassRegModuleInfo(models.Model):
     """ Define what happens when students add classes to their schedule at registration. """
@@ -131,7 +131,7 @@ class StudentClassRegModuleInfo(models.Model):
 
         if self.use_priority:
             for i in range(0, self.priority_limit):
-                name = 'Priority/%d' % (i + 1)
+                name = f'Priority/{i + 1}'
                 verb_list.append(RegistrationType.get_map(include=[name], category='student')[name])
 
         #   Require that the /Applied bit is in the list, since students cannot enroll

--- a/esp/esp/program/modules/tests/ajaxschedulingmodule.py
+++ b/esp/esp/program/modules/tests/ajaxschedulingmodule.py
@@ -56,9 +56,9 @@ class AJAXSchedulingModuleTestBase(ProgramFrameworkTest):
             sec.save()
 
         #some useful urls
-        self.ajax_url_base = '/manage/%s/' % self.program.getUrlBase()
+        self.ajax_url_base = f'/manage/{self.program.getUrlBase()}/'
         self.changelog_url = self.ajax_url_base + 'ajax_change_log'
-        self.schedule_class_url = '/manage/%s/' % self.program.getUrlBase() + 'ajax_schedule_class'
+        self.schedule_class_url = f'/manage/{self.program.getUrlBase()}/ajax_schedule_class'
 
 
     def loginAdmin(self):
@@ -129,13 +129,13 @@ class AJAXSchedulingModuleTest(AJAXSchedulingModuleTestBase):
         # Fetch two consecutive vacancies in two different rooms
         rooms = self.rooms[0].identical_resources().filter(event__in=self.timeslots).order_by('event__start')
         self.assertTrue(rooms.count() >= 2, "Not enough timeslots to run this test.")
-        a1 = '\n'.join(['%s,%s' % (r.event.id, r.identical_id()) for r in rooms[0:2]])
+        a1 = '\n'.join([f'{r.event.id},{r.identical_id()}' for r in rooms[0:2]])
         rooms = self.rooms.exclude(name=rooms[0].name)[0].identical_resources().filter(event__in=self.timeslots).order_by('event__start')
         self.assertTrue(rooms.count() >= 2, "Not enough timeslots to run this test.")
-        a2 = '\n'.join(['%s,%s' % (r.event.id, r.identical_id()) for r in rooms[0:2]])
+        a2 = '\n'.join([f'{r.event.id},{r.identical_id()}' for r in rooms[0:2]])
 
         # Schedule one class.
-        ajax_url = '/manage/%s/ajax_schedule_class' % self.program.getUrlBase()
+        ajax_url = f'/manage/{self.program.getUrlBase()}/ajax_schedule_class'
         s1, s2 = t.getTaughtSections(self.program)[:2]
         timeslots = self.program.getTimeSlots().order_by('start')
         self.client.post(ajax_url, {'action': 'deletereg', 'cls': s1.id})

--- a/esp/esp/program/modules/tests/ajaxstudentreg.py
+++ b/esp/esp/program/modules/tests/ajaxstudentreg.py
@@ -65,7 +65,7 @@ class AjaxStudentRegTest(ProgramFrameworkTest):
         resp_data = json.loads(str(response.content, encoding='UTF-8'))
         self.assertTrue('student_schedule_html' in resp_data)
         search_str = 'Your schedule for %s is empty.  Please add classes below!' % self.program.niceName()
-        self.assertTrue(search_str in resp_data['student_schedule_html'], 'Could not find empty fragment "%s" in response "%s"' % (search_str, resp_data['student_schedule_html']))
+        self.assertTrue(search_str in resp_data['student_schedule_html'], f'Could not find empty fragment "{search_str}" in response "{resp_data["student_schedule_html"]}"')
 
     def expect_sections_in_schedule(self, response, sections=[]):
         resp_data = json.loads(str(response.content, encoding='UTF-8'))
@@ -86,7 +86,7 @@ class AjaxStudentRegTest(ProgramFrameworkTest):
         self.assertTrue(int(resp_data['status']) == 200)
         error_msg = resp_data['error']
 
-        self.assertTrue(error_msg == error_str, 'Unexpected Ajax error: "%s", expected "%s"' % (error_msg, error_str))
+        self.assertTrue(error_msg == error_str, f'Unexpected Ajax error: "{error_msg}", expected "{error_str}"')
 
     def test_ajax_schedule(self):
         program = self.program
@@ -190,9 +190,9 @@ class AjaxStudentRegTest(ProgramFrameworkTest):
         self.expect_sections_in_schedule(response, [sec1, sec2])
 
         #   Clear 1 timeslot and check that only the desired class remains
-        response = self.client.get('/learn/%s/ajax_clearslot/%d' % (program.getUrlBase(), sec1.meeting_times.all()[0].id), HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        response = self.client.get(f'/learn/{program.getUrlBase()}/ajax_clearslot/{sec1.meeting_times.all()[0].id}', HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         self.expect_sections_in_schedule(response, [sec2])
 
         #   Clear other timeslot and check that the schedule is empty
-        response = self.client.get('/learn/%s/ajax_clearslot/%d' % (program.getUrlBase(), sec2.meeting_times.all()[0].id), HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        response = self.client.get(f'/learn/{program.getUrlBase()}/ajax_clearslot/{sec2.meeting_times.all()[0].id}', HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         self.expect_empty_schedule(response)

--- a/esp/esp/program/modules/tests/auth.py
+++ b/esp/esp/program/modules/tests/auth.py
@@ -308,10 +308,7 @@ class ProgramModuleAuthTest(ProgramFrameworkTest):
             for view_name in view_names:
                 view = getattr(module, view_name)
                 self.assertTrue(getattr(view, 'has_auth_check', None), \
-                    'Module "{}" is missing an auth check for view "{}"'.format(
-                        module,
-                        view_name
-                    ))
+                    f'Module "{module}" is missing an auth check for view "{view_name}"')
 
     def testViewDecoratorOrder(self):
         """Check that module view decorators are ordered as expected.
@@ -381,88 +378,55 @@ class ProgramModuleAuthTest(ProgramFrameworkTest):
                         if name in self.CACHE_DECORATORS
                     ]
 
-                    method_name = '{}.{}'.format(class_node.name, func_node.name)
-                    decorator_list = ', '.join('@{}'.format(name) for name in decorator_names if name)
+                    method_name = f'{class_node.name}.{func_node.name}'
+                    decorator_list = ', '.join(f'@{name}' for name in decorator_names if name)
 
                     if call_pos != 0:
                         failures.append(
-                            '{}:{} {} should have @main_call/@aux_call as the outermost decorator. '
-                            'Found: {}'.format(
-                                handler_file.as_posix(),
-                                func_node.lineno,
-                                method_name,
-                                decorator_list,
-                            )
+                            f'{handler_file.as_posix()}:{func_node.lineno} {method_name} should have @main_call/@aux_call as the outermost decorator. '
+                            f'Found: {decorator_list}'
                         )
 
                     if auth_positions and grade_positions and min(auth_positions) > min(grade_positions):
                         failures.append(
-                            '{}:{} {} has @meets_grade outside auth decorators. Found: {}'.format(
-                                handler_file.as_posix(),
-                                func_node.lineno,
-                                method_name,
-                                decorator_list,
-                            )
+                            f'{handler_file.as_posix()}:{func_node.lineno} {method_name} has @meets_grade outside auth decorators. '
+                            f'Found: {decorator_list}'
                         )
 
                     if auth_positions and deadline_positions and min(auth_positions) > min(deadline_positions):
                         failures.append(
-                            '{}:{} {} has deadline decorators outside auth decorators. Found: {}'.format(
-                                handler_file.as_posix(),
-                                func_node.lineno,
-                                method_name,
-                                decorator_list,
-                            )
+                            f'{handler_file.as_posix()}:{func_node.lineno} {method_name} has deadline decorators outside auth decorators. '
+                            f'Found: {decorator_list}'
                         )
 
                     if grade_positions and deadline_positions and min(grade_positions) > min(deadline_positions):
                         failures.append(
-                            '{}:{} {} has deadline decorators outside @meets_grade. Found: {}'.format(
-                                handler_file.as_posix(),
-                                func_node.lineno,
-                                method_name,
-                                decorator_list,
-                            )
+                            f'{handler_file.as_posix()}:{func_node.lineno} {method_name} has deadline decorators outside @meets_grade. '
+                            f'Found: {decorator_list}'
                         )
 
                     if auth_positions and cap_positions and min(auth_positions) > min(cap_positions):
                         failures.append(
-                            '{}:{} {} has @meets_cap outside auth decorators. Found: {}'.format(
-                                handler_file.as_posix(),
-                                func_node.lineno,
-                                method_name,
-                                decorator_list,
-                            )
+                            f'{handler_file.as_posix()}:{func_node.lineno} {method_name} has @meets_cap outside auth decorators. '
+                            f'Found: {decorator_list}'
                         )
 
                     if grade_positions and cap_positions and min(grade_positions) > min(cap_positions):
                         failures.append(
-                            '{}:{} {} has @meets_cap outside @meets_grade. Found: {}'.format(
-                                handler_file.as_posix(),
-                                func_node.lineno,
-                                method_name,
-                                decorator_list,
-                            )
+                            f'{handler_file.as_posix()}:{func_node.lineno} {method_name} has @meets_cap outside @meets_grade. '
+                            f'Found: {decorator_list}'
                         )
 
                     if deadline_positions and cap_positions and min(deadline_positions) > min(cap_positions):
                         failures.append(
-                            '{}:{} {} has @meets_cap outside deadline decorators. Found: {}'.format(
-                                handler_file.as_posix(),
-                                func_node.lineno,
-                                method_name,
-                                decorator_list,
-                            )
+                            f'{handler_file.as_posix()}:{func_node.lineno} {method_name} has @meets_cap outside deadline decorators. '
+                            f'Found: {decorator_list}'
                         )
 
                     if no_auth_positions and cache_positions and min(no_auth_positions) > min(cache_positions):
                         failures.append(
-                            '{}:{} {} has cache decorators outside @no_auth. Found: {}'.format(
-                                handler_file.as_posix(),
-                                func_node.lineno,
-                                method_name,
-                                decorator_list,
-                            )
+                            f'{handler_file.as_posix()}:{func_node.lineno} {method_name} has cache decorators outside @no_auth. '
+                            f'Found: {decorator_list}'
                         )
 
         self.assertEqual([], failures, '\n'.join(failures))

--- a/esp/esp/program/modules/tests/commpanel.py
+++ b/esp/esp/program/modules/tests/commpanel.py
@@ -84,7 +84,7 @@ class CommunicationsPanelTest(ProgramFrameworkTest):
             'finalsent': 'Test List',
             'submitform': 'I have my list, go on!',
         }
-        response = self.client.post('/manage/%s/%s' % (self.program.getUrlBase(), 'commpanel_old'), post_data)
+        response = self.client.post(f'/manage/{self.program.getUrlBase()}/commpanel_old', post_data)
         self.assertEqual(response.status_code, 200)
 
         #   Extract filter ID from response
@@ -101,7 +101,7 @@ class CommunicationsPanelTest(ProgramFrameworkTest):
             'replyto': 'replyto@testserver.learningu.org',
             'filterid': filterid,
         }
-        response = self.client.post('/manage/%s/%s' % (self.program.getUrlBase(), 'commfinal'), post_data)
+        response = self.client.post(f'/manage/{self.program.getUrlBase()}/commfinal', post_data)
         self.assertEqual(response.status_code, 200)
 
         #   Check that a MessageRequest has been created

--- a/esp/esp/program/modules/tests/existence.py
+++ b/esp/esp/program/modules/tests/existence.py
@@ -85,7 +85,7 @@ class ModuleExistenceTest(ProgramFrameworkTest):
             are consistent with those associated with the program. """
 
         #   Fetch the registration page and the lists of desired/actual modules
-        response = self.client.get('/%s/%s/%s' % (tl, self.program.getUrlBase(), core_url))
+        response = self.client.get(f'/{tl}/{self.program.getUrlBase()}/{core_url}')
         self.assertEqual(response.status_code, 200)
         actual_modules = self.observed_module_list(tl, str(response.content, encoding='UTF-8'))
         target_modules = self.target_module_list(tl)

--- a/esp/esp/program/modules/tests/jsondatamodule.py
+++ b/esp/esp/program/modules/tests/jsondatamodule.py
@@ -67,38 +67,26 @@ class JSONDataModuleTest(ProgramFrameworkTest):
         # Ensure endpoints returned successfully before attempting to parse JSON.
         self.assertEqual(
             self.stats_response.status_code, 200,
-            "Expected 200 from /json/%s/stats, got %d. Body snippet: %r"
-            % (self.program.getUrlBase(),
-               self.stats_response.status_code,
-               self.stats_response.content[:200]),
+            f"Expected 200 from /json/{self.program.getUrlBase()}/stats, got {self.stats_response.status_code}. Body snippet: {self.stats_response.content[:200]!r}"
         )
         self.assertEqual(
             self.classes_response.status_code, 200,
-            "Expected 200 from /json/%s/class_subjects, got %d. Body snippet: %r"
-            % (self.program.getUrlBase(),
-               self.classes_response.status_code,
-               self.classes_response.content[:200]),
+            f"Expected 200 from /json/{self.program.getUrlBase()}/class_subjects, got {self.classes_response.status_code}. Body snippet: {self.classes_response.content[:200]!r}"
         )
         # Cache parsed payloads so individual tests don't re-parse repeatedly.
         try:
             self.stats_data = self.stats_response.json()
         except ValueError:
             self.fail(
-                "Failed to parse JSON from /json/%s/stats (status %d). "
-                "Body snippet: %r"
-                % (self.program.getUrlBase(),
-                   self.stats_response.status_code,
-                   self.stats_response.content[:200])
+                f"Failed to parse JSON from /json/{self.program.getUrlBase()}/stats (status {self.stats_response.status_code}). "
+                f"Body snippet: {self.stats_response.content[:200]!r}"
             )
         try:
             self.classes_data = self.classes_response.json()
         except ValueError:
             self.fail(
-                "Failed to parse JSON from /json/%s/class_subjects (status %d). "
-                "Body snippet: %r"
-                % (self.program.getUrlBase(),
-                   self.classes_response.status_code,
-                   self.classes_response.content[:200])
+                f"Failed to parse JSON from /json/{self.program.getUrlBase()}/class_subjects (status {self.classes_response.status_code}). "
+                f"Body snippet: {self.classes_response.content[:200]!r}"
             )
     def testStudentStats(self):
         ## Student statistics
@@ -113,7 +101,7 @@ class JSONDataModuleTest(ProgramFrameworkTest):
 
         for query_label, query in student_display_dict.items():
             value = query.count()
-            json_str = "[\"%s\", %d]" % (query_label, value)
+            json_str = f'["{query_label}", {value}]'
             self.assertContains(self.stats_response, json_str)
 
     def testTeacherStats(self):
@@ -129,7 +117,7 @@ class JSONDataModuleTest(ProgramFrameworkTest):
 
         for query_label, query in teacher_display_dict.items():
             value = query.count()
-            json_str = "[\"%s\", %d]" % (query_label, value)
+            json_str = f'["{query_label}", {value}]'
             self.assertContains(self.stats_response, json_str)
 
     def testGradesStats(self):
@@ -236,8 +224,7 @@ class JSONDataModuleTest(ProgramFrameworkTest):
         _label, total_count = class_num_pairs[0]
         expected = self.program.classes().distinct().count()
         self.assertEqual(total_count, expected,
-                         "vitals classnum total mismatch: got %d, expected %d"
-                         % (total_count, expected))
+                         f"vitals classnum total mismatch: got {total_count}, expected {expected}")
 
     def testCategoriesSection(self):
         """The 'categories' section has per-category data with required fields."""
@@ -298,7 +285,7 @@ class JSONDataModuleTest(ProgramFrameworkTest):
                                       "section id should be an int, got %r" % sec_id)
             # No duplicate section IDs within a class.
             self.assertEqual(len(sections), len(set(sections)),
-                             "Duplicate section IDs for class id=%s: %r" % (cid, sections))
+                             f"Duplicate section IDs for class id={cid}: {sections!r}")
 
     def testClassSubjectsTeachersAreListed(self):
         """The 'teachers' field in each class_subjects entry is a list of ints."""
@@ -309,8 +296,7 @@ class JSONDataModuleTest(ProgramFrameworkTest):
                                   "teachers should be a list for class id=%s" % cid)
             for t_id in teachers:
                 self.assertIsInstance(t_id, int,
-                                      "teacher id should be an int, got %r (class id=%s)"
-                                      % (t_id, cid))
+                                      f"teacher id should be an int, got {t_id!r} (class id={cid})")
 
     def testClassSubjectsTeachersBlock(self):
         """The top-level 'teachers' block in class_subjects has correct fields."""

--- a/esp/esp/program/modules/tests/programprintables.py
+++ b/esp/esp/program/modules/tests/programprintables.py
@@ -56,7 +56,7 @@ class ProgramPrintablesModuleTest(ProgramFrameworkTest):
 
         self.factory = RequestFactory()
 
-        self.all_classes_csv_url = '/manage/%s/%s' % (self.program.getUrlBase(), 'all_classes_spreadsheet')
+        self.all_classes_csv_url = f'/manage/{self.program.getUrlBase()}/all_classes_spreadsheet'
 
     def _login_admin(self):
         """
@@ -71,14 +71,14 @@ class ProgramPrintablesModuleTest(ProgramFrameworkTest):
         self.assertTrue(self.client.login(username=self.admins[0].username, password='password'), "Failed to log in admin user.")
 
         #   Select users to fetch
-        response = self.client.get('/manage/%s/%s' % (self.program.getUrlBase(), view_name))
+        response = self.client.get(f'/manage/{self.program.getUrlBase()}/{view_name}')
         self.assertEqual(response.status_code, 200)
         post_data = {
             'recipient_type': user_type,
             'base_list': list_name,
             'use_checklist': 0,
         }
-        response = self.client.post('/manage/%s/%s' % (self.program.getUrlBase(), view_name), post_data)
+        response = self.client.post(f'/manage/{self.program.getUrlBase()}/{view_name}', post_data)
         self.assertEqual(response.status_code, 200)
         return response
 

--- a/esp/esp/program/modules/tests/studentreg.py
+++ b/esp/esp/program/modules/tests/studentreg.py
@@ -73,7 +73,7 @@ class StudentRegTest(ProgramFrameworkTest):
         return [x.name for x in response.templates]
 
     def expect_template(self, response, template):
-        self.assertTrue(template in self.get_template_names(response), 'Wrong template for profile: got %s, expected %s' % (self.get_template_names(response), template))
+        self.assertTrue(template in self.get_template_names(response), f'Wrong template for profile: got {self.get_template_names(response)}, expected {template}')
 
     def test_confirm(self):
         program = self.program
@@ -106,22 +106,22 @@ class StudentRegTest(ProgramFrameworkTest):
 
                 #   Check title
                 title = cls_info['title'].strip()
-                expected_title = '%s: %s' % (cls.emailcode(), cls.title)
-                self.assertTrue(title == expected_title, 'Incorrect class title in catalog: got "%s", expected "%s"' % (title, expected_title))
+                expected_title = f'{cls.emailcode()}: {cls.title}'
+                self.assertTrue(title == expected_title, f'Incorrect class title in catalog: got "{title}", expected "{expected_title}"')
 
                 #   Check description
                 description = cls_info['description'].replace('<br />', '').strip()
-                self.assertTrue(description == cls.class_info.strip(), 'Incorrect class description in catalog: got "%s", expected "%s"' % (description, cls.class_info.strip()))
+                self.assertTrue(description == cls.class_info.strip(), f'Incorrect class description in catalog: got "{description}", expected "{cls.class_info.strip()}"')
 
                 #   Check enrollments
                 enrollments = [x.replace('<br />', '').strip() for x in cls_info['enrollment'].split('Section')[1:]]
                 class_sections = cls.sections.order_by('id')
                 self.assertTrue(len(enrollments) == len(list(class_sections)),
-                                'Recovered {} enrollments from catalog but expecting {}. Listed below\n\tRecovered: {}\n\tExpecting: {}'.format(len(enrollments), len(list(class_sections)), enrollments, list(class_sections)))
+                                f'Recovered {len(enrollments)} enrollments from catalog but expecting {len(list(class_sections))}. Listed below\n\tRecovered: {enrollments}\n\tExpecting: {list(class_sections)}')
                 for sec in class_sections:
                     i = sec.index() - 1
-                    expected_str = '%s: %s (max %s)' % (sec.index(), sec.num_students(), sec.capacity)
-                    self.assertTrue(enrollments[i] == expected_str, 'Incorrect enrollment for %s in catalog: got "%s", expected "%s"' % (sec.emailcode(), enrollments[i], expected_str))
+                    expected_str = f'{sec.index()}: {sec.num_students()} (max {sec.capacity})'
+                    self.assertTrue(enrollments[i] == expected_str, f'Incorrect enrollment for {sec.emailcode()} in catalog: got "{enrollments[i]}", expected "{expected_str}"')
 
         program = self.program
 

--- a/esp/esp/program/modules/tests/support/program_manager.py
+++ b/esp/esp/program/modules/tests/support/program_manager.py
@@ -31,7 +31,7 @@ class ProgramManagerTestHelper():
         (section, timeslots, rooms) = self.getClassToSchedule(section=section, teacher=teacher, timeslots=timeslots, rooms=rooms)
 
         #schedule the class
-        blocks = '\n'.join(['%s,%s' % (r.event.id, r.identical_id()) for r in rooms[0:2]])
+        blocks = '\n'.join([f'{r.event.id},{r.identical_id()}' for r in rooms[0:2]])
         response = self.client.post(self.schedule_class_url, {'action': 'assignreg', 'cls': section.id, 'block_room_assignments': blocks, 'override': 'false'})
         assert response.status_code == 200
 

--- a/esp/esp/program/modules/tests/survey.py
+++ b/esp/esp/program/modules/tests/survey.py
@@ -89,7 +89,7 @@ class SurveyTest(ProgramFrameworkTest):
         self.assertEqual(response.status_code, 200)
         self.assertIn('Question1', str(response.content, encoding='UTF-8'))
         #   Check the section-specific survey
-        response = self.client.get('/learn/%s/survey?sec=%s' % (self.program.url, sec.id))
+        response = self.client.get(f'/learn/{self.program.url}/survey?sec={sec.id}')
         self.assertEqual(response.status_code, 200)
         self.assertIn('Question2', str(response.content, encoding='UTF-8'))
         self.assertIn('Question3', str(response.content, encoding='UTF-8'))
@@ -99,8 +99,8 @@ class SurveyTest(ProgramFrameworkTest):
         form_settings = {
             'attendance_%d' % sec_timeslot.id: '%s' % sec.id,
             'question_%d' % question_base.id: 'Yes',
-            'question_%d_%d' % (question_perclass.id, sec_timeslot.id): 'No',
-            'question_%d_%d' % (question_number.id, sec_timeslot.id): '3',
+            f'question_{question_perclass.id}_{sec_timeslot.id}': 'No',
+            f'question_{question_number.id}_{sec_timeslot.id}': '3',
         }
 
         #   Submit the survey

--- a/esp/esp/program/modules/tests/teacherclassregmodule.py
+++ b/esp/esp/program/modules/tests/teacherclassregmodule.py
@@ -121,7 +121,7 @@ class TeacherClassRegTest(ProgramFrameworkTest):
 
         # Add free_teacher1
         response = self.apply_coteacher_op({'op': 'add', 'clsid': self.cls.id, 'teacher_selected': self.free_teacher1.id, 'coteachers': ",".join([str(coteacher) for coteacher in cur_coteachers])})
-        self.assertContains(response, "({})".format(self.free_teacher1.username), status_code=200)
+        self.assertContains(response, f"({self.free_teacher1.username})", status_code=200)
         cur_coteachers.append(self.free_teacher1.id)
 
         # Error on adding the same coteacher again
@@ -130,29 +130,29 @@ class TeacherClassRegTest(ProgramFrameworkTest):
 
         # Add free_teacher2
         response = self.apply_coteacher_op({'op': 'add', 'clsid': self.cls.id, 'teacher_selected': self.free_teacher2.id, 'coteachers': ",".join([str(coteacher) for coteacher in cur_coteachers])})
-        self.assertContains(response, "({})".format(self.free_teacher2.username), status_code=200)
+        self.assertContains(response, f"({self.free_teacher2.username})", status_code=200)
         cur_coteachers.append(self.free_teacher2.id)
 
         # Delete free_teacher 1
         response = self.apply_coteacher_op({'op': 'del', 'clsid': self.cls.id, 'delete_coteachers': self.free_teacher1.id, 'coteachers': ",".join([str(coteacher) for coteacher in cur_coteachers])})
-        self.assertNotContains(response, "({})".format(self.free_teacher1.username), status_code=200)
+        self.assertNotContains(response, f"({self.free_teacher1.username})", status_code=200)
         cur_coteachers.remove(self.free_teacher1.id)
 
         # Add free_teacher 1
         response = self.apply_coteacher_op({'op': 'add', 'clsid': self.cls.id, 'teacher_selected': self.free_teacher1.id, 'coteachers': ",".join([str(coteacher) for coteacher in cur_coteachers])})
-        self.assertContains(response, "({})".format(self.free_teacher1.username), status_code=200)
+        self.assertContains(response, f"({self.free_teacher1.username})", status_code=200)
         cur_coteachers.append(self.free_teacher1.id)
 
         # Delete both free_teacher1 and free_teacher2
         response = self.apply_coteacher_op({'op': 'del', 'clsid': self.cls.id, 'delete_coteachers': [self.free_teacher1.id, self.free_teacher2.id], 'coteachers': ",".join([str(coteacher) for coteacher in cur_coteachers])})
-        self.assertNotContains(response, "({})".format(self.free_teacher1.username), status_code=200)
-        self.assertNotContains(response, "({})".format(self.free_teacher2.username), status_code=200)
+        self.assertNotContains(response, f"({self.free_teacher1.username})", status_code=200)
+        self.assertNotContains(response, f"({self.free_teacher2.username})", status_code=200)
         cur_coteachers.remove(self.free_teacher1.id)
         cur_coteachers.remove(self.free_teacher2.id)
 
         # Add free_teacher 1
         response = self.apply_coteacher_op({'op': 'add', 'clsid': self.cls.id, 'teacher_selected': self.free_teacher1.id, 'coteachers': ",".join([str(coteacher) for coteacher in cur_coteachers])})
-        self.assertContains(response, "({})".format(self.free_teacher1.username), status_code=200)
+        self.assertContains(response, f"({self.free_teacher1.username})", status_code=200)
         cur_coteachers.append(self.free_teacher1.id)
 
         # Save the coteachers
@@ -172,7 +172,7 @@ class TeacherClassRegTest(ProgramFrameworkTest):
         ResourceRequest.objects.filter(target = sec, res_type = res_type).delete()
 
     def has_resource_pair_with_teacher(self, res_type, val_index, teacher):
-        label = 'teacher_res_%d_%d' % (res_type.id, val_index)
+        label = f'teacher_res_{res_type.id}_{val_index}'
         label_list = [resource_pair[0] for resource_pair in self.moduleobj.get_resource_pairs()]
         if not label in label_list:
             return False


### PR DESCRIPTION
## Description

Convert `%` formatting and `.format()` calls to f-strings across `program/modules/`:

- **34 handler files** — `programprintables`, `admincore`, `teacherclassregmodule`, `financialaidappmodule`, `creditcardmodule_stripe`, `onsitecheckinmodule`, `commmodule`, `studentclassregmodule`, and 26 others
- **`base.py`** and **`module_ext.py`**
- **4 form files** — `moderate.py`, `management.py`, `admincore.py`, `volunteer.py`
- **12 test files**

Intentionally kept as `.format()`:

- Migration file (auto-generated)
- Template-based `.format()` in `bulkcreateaccountmodule.py` (user-provided format strings)
- Named `.format()` in `studentclassregmodule.py` (HTML template with named placeholders)

51 files changed, +209/-250.

## Related Issue

Part of #4555

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced

Closes #4140