### PR TITLE
Fixes the #shortcuts-box on the Missing Teachers page

### DIFF
--- a/esp/esp/themes/theme_data/droplets/less/main.less
+++ b/esp/esp/themes/theme_data/droplets/less/main.less
@@ -317,10 +317,7 @@ select {
     width: auto;
 }
 
-/* Fix #shortcuts-box overlapping with fixed navbar (Issue #3926).
-   Default style sets top: 10px, which renders behind the fixed navbar
-   (z-index 1030 > 100). Push it below navbar on desktop; on narrow
-   screens move it to bottom-right above the fixed footer. */
+
 #shortcuts-box {
     top: 50px;
 }


### PR DESCRIPTION
## Description
Fixes issue #3926 where the `#shortcuts-box` on the Missing Teachers page was being obscured or cut off by the fixed navigation bars in the Droplets theme.
* **Desktop layout**: Moved the shortcuts box from `top: 10px` to `top: 50px`. This successfully clears the ~40px fixed top navbar so the top of the box is no longer cut off.
* **Responsive layout (≤979px)**: Repositioned the shortcuts box to `bottom: 60px; right: 10px;`. On narrower screens where the navbar wraps and takes up more vertical space, the box is now anchored at the bottom right corner, successfully avoiding both the wrapping top navbar and the bottom footer.
* **Minor CSS fix**: Corrected a syntactical typo changing `webkit-box-shadow` to `-webkit-box-shadow`.
## Related Issue
Closes #3926