### PR TITLE
Make Docker builds more resilient and remove broken admin font refs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,17 @@ WORKDIR /app
 
 # Install system dependencies from packages_base.txt to avoid duplication.
 COPY esp/packages_base.txt /tmp/packages_base.txt
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    $(cat /tmp/packages_base.txt | grep -v '^python' | grep -v '^#' | tr '\n' ' ') \
-    && rm -rf /var/lib/apt/lists/*
+RUN set -eux; \
+    pkgs="$(cat /tmp/packages_base.txt | grep -v '^python' | grep -v '^#' | tr '\n' ' ')"; \
+    for i in 1 2 3 4 5; do \
+      apt-get update && \
+      apt-get install -y --no-install-recommends -o Acquire::Retries=5 $pkgs && \
+      break; \
+      echo "apt attempt ${i} failed; retrying in 10s..."; \
+      sleep 10; \
+      rm -rf /var/lib/apt/lists/*; \
+    done; \
+    rm -rf /var/lib/apt/lists/*
 
 # Install LESS via npm (from packages_base_manual_install.sh)
 RUN npm install --prefix /usr less@1.7.5 -g

--- a/esp/public/media/default_styles/admin_theme.css
+++ b/esp/public/media/default_styles/admin_theme.css
@@ -58,26 +58,6 @@ div.breadcrumbs a {
     text-transform: uppercase;
 
 }
-@font-face {
-  font-family: 'Roboto';
-  src: url('../fonts/Roboto-Bold-webfont.woff');
-  font-weight: 700;
-  font-style: normal;
-}
-
-@font-face {
-  font-family: 'Roboto';
-  src: url('../fonts/Roboto-Regular-webfont.woff');
-  font-weight: 400;
-  font-style: normal;
-}
-
-@font-face {
-  font-family: 'Roboto';
-  src: url('../fonts/Roboto-Light-webfont.woff');
-  font-weight: 300;
-  font-style: normal;
-}
 .dashboard-module-content a {
 	color: #205493;
 }
@@ -165,4 +145,3 @@ body.login {
 div.breadcrumbs a:link, div.breadcrumbs a:visited {
 	color: white;
 }
-


### PR DESCRIPTION
## Problem
Docker image builds can fail due to transient apt mirror/DNS issues. Also, admin pages emit repeated 404 warnings for missing Roboto webfont files referenced by the admin theme CSS.

## What This PR Changes
- Updates `Dockerfile` apt install step to include retry/backoff behavior for transient network failures
- Removes broken `@font-face` declarations in `esp/public/media/default_styles/admin_theme.css` that point to non-existent font files

## Verification
- Rebuilt image with `docker compose up --build`
- Confirmed app starts successfully
- Confirmed missing Roboto font 404 warnings no longer appear from these CSS references

## Scope
- Build reliability improvement and frontend asset cleanup
- No functional application logic changes