### PR TITLE
Add skip link and landmark regions for accessibility

### DIFF
--- a/esp/esp/web/tests.py
+++ b/esp/esp/web/tests.py
@@ -75,8 +75,11 @@ class PageTest(TestCase):
         self.assertEqual(response.status_code, 200)
 
         # Make sure that we've gotten an HTML document, and not a Django error
-        self.assertStringContains(str(response.content, encoding='UTF-8'), "<html")
-        self.assertNotStringContains(str(response.content, encoding='UTF-8'), "You're seeing this error because you have <code>DEBUG = True</code>")
+        content = str(response.content, encoding='UTF-8')
+        self.assertStringContains(content, "<html")
+        self.assertNotStringContains(content, "You're seeing this error because you have <code>DEBUG = True</code>")
+        self.assertStringContains(content, '<a class="skip-link" href="#main-content">Skip to main content</a>')
+        self.assertStringContains(content, '<div id="main-content" role="main" tabindex="-1">')
 
 class NavbarTest(TestCase):
 
@@ -307,5 +310,4 @@ class JavascriptSyntaxTest(TestCase):
                 logger.info(line)
 
             self.assertEqual(num_errors, 0, 'Closure compiler detected Javascript syntax errors')
-
 

--- a/esp/templates/elements/html
+++ b/esp/templates/elements/html
@@ -25,6 +25,22 @@
     <link href="{{ settings.CDN_ADDRESS }}/bootstrap/docs/assets/js/google-code-prettify/prettify.css" rel="stylesheet"/>
 
     <link rel="stylesheet" type="text/css" href="/media/styles/user_visibility.css" media="all" />
+    <style type="text/css">
+      .skip-link {
+        position: absolute;
+        left: -9999px;
+        top: 0;
+        z-index: 10000;
+        padding: 8px 12px;
+        background: #112E51;
+        color: #fff;
+        text-decoration: none;
+      }
+      .skip-link:focus {
+        left: 10px;
+        top: 10px;
+      }
+    </style>
     {% block jquery_ui_stylesheet_version %}
     <link href="https://ajax.aspnetcdn.com/ajax/jquery.ui/{{ settings.JQUERY_UI_VERSION }}/themes/base/jquery-ui.css" rel="stylesheet" type="text/css"/>
     {% endblock jquery_ui_stylesheet_version %}
@@ -147,7 +163,10 @@
   </head>
   
   <body>
-    {% block body %}{% endblock %}
+    <a class="skip-link" href="#main-content">Skip to main content</a>
+    <div id="main-content" role="main" tabindex="-1">
+      {% block body %}{% endblock %}
+    </div>
 
     {% block counter %}{% endblock %}
 

--- a/esp/templates/inclusion/web/navbar.html
+++ b/esp/templates/inclusion/web/navbar.html
@@ -4,6 +4,7 @@
 <link rel="stylesheet" href="/media/styles/myesp2.css" type="text/css" media="screen" />
 {% endif %}
 
+<div role="navigation" aria-label="Primary navigation">
 {% if page_setup.navlinks %}
 {% for navlink in page_setup.navlinks %}
 <div id="divnav{{forloop.counter0}}">
@@ -87,6 +88,7 @@
 </div>
 {% endif %}
 {% endif %}
+</div>
 
 <!-- section name -->
 <div id="divsectionname">

--- a/esp/templates/inclusion/web/navbar_left.html
+++ b/esp/templates/inclusion/web/navbar_left.html
@@ -1,5 +1,6 @@
 {% if navbar_list.entries %}
   <!-- secondary nav -->
+  <div role="navigation" aria-label="Secondary navigation">
   <ul id="submenu">
   {% for nav_entry in navbar_list.entries %}
     <li class="divsecondarynavlink {% if nav_entry.entry.indent %}indent{% endif %}">
@@ -24,4 +25,5 @@
   {% endwith %}
   {% endif %}
   </ul>
+  </div>
 {% endif %}


### PR DESCRIPTION
## Problem
Pages lack a consistent skip navigation mechanism and explicit landmark regions, which makes keyboard and assistive-technology navigation harder.

## What This PR Changes
- adds a global skip link (`Skip to main content`) in `esp/templates/elements/html`
- adds a shared main landmark container with `id="main-content"` and `role="main"`
- adds primary/secondary navigation landmarks in shared navbar include templates
- adds homepage regression assertions in `esp/esp/web/tests.py` to verify skip link and main landmark are present

## Verification
- `docker compose exec web python esp/manage.py test esp.web.tests.PageTest esp.web.tests.NavbarTest`

## Scope
- accessibility semantics and keyboard navigation improvements only
- no business logic changes