### PR TITLE
fix: customforms: enforce and test form ownership restrictionsFix security

### DIFF
--- a/esp/esp/customforms/tests.py
+++ b/esp/esp/customforms/tests.py
@@ -34,7 +34,7 @@ Learning Unlimited, Inc.
 
 import json
 
-from esp.customforms.models import Form, Field
+from esp.customforms.models import Form, Field, Page, Section
 from esp.customforms.DynamicModel import DynamicModelHandler
 from esp.customforms.views import hasPerm
 from esp.users.models import ESPUser, AnonymousESPUser
@@ -382,44 +382,54 @@ class ViewResponseTest(TestCase):
         self.student.save()
         self.student.makeRole('Student')
 
-        self.form = Form.objects.create(
-            title='Test Form', created_by=self.admin,
+        self.admin_form = Form.objects.create(
+            title='Admin Form', created_by=self.admin,
             link_type='-1', link_id=-1,
             success_message='OK', success_url='/'
         )
-        # Create dynamic model table so view doesn't crash on query
-        dmh = DynamicModelHandler(self.form)
-        dmh.createTable()
+        self.teacher_form = Form.objects.create(
+            title='Teacher Form', created_by=self.teacher,
+            link_type='-1', link_id=-1,
+            success_message='OK', success_url='/'
+        )
+        # Create dynamic model tables so views don't crash on query
+        DynamicModelHandler(self.admin_form).createTable()
+        DynamicModelHandler(self.teacher_form).createTable()
 
     def tearDown(self):
         for form in Form.objects.all():
-            dmh = DynamicModelHandler(form)
-            dmh.purgeDynModel()
+            DynamicModelHandler(form).purgeDynModel()
 
     def test_admin_can_view_responses(self):
-        """Admin should be able to view responses page."""
+        """Admin should be able to view any form's responses page."""
         self.client.login(username='resp_admin', password='password')
-        response = self.client.get('/customforms/responses/%d/' % self.form.id)
+        response = self.client.get('/customforms/responses/%d/' % self.admin_form.id)
         self.assertEqual(response.status_code, 200)
 
-    def test_teacher_can_view_responses(self):
-        """Teacher should be able to view responses page."""
+    def test_teacher_can_view_own_form_responses(self):
+        """Teacher should be able to view responses for their own form."""
         self.client.login(username='resp_teacher', password='password')
-        response = self.client.get('/customforms/responses/%d/' % self.form.id)
+        response = self.client.get('/customforms/responses/%d/' % self.teacher_form.id)
         self.assertEqual(response.status_code, 200)
+
+    def test_teacher_cannot_view_others_form_responses(self):
+        """Teacher should be blocked from viewing another user's form responses."""
+        self.client.login(username='resp_teacher', password='password')
+        response = self.client.get('/customforms/responses/%d/' % self.admin_form.id)
+        self.assertEqual(response.status_code, 403)
 
     def test_student_cannot_access(self):
         """Student should not be able to view responses."""
         self.client.login(username='resp_student', password='password')
-        response = self.client.get('/customforms/responses/%d/' % self.form.id)
+        response = self.client.get('/customforms/responses/%d/' % self.admin_form.id)
         # Should redirect to home page, which is '/'
         self.assertRedirects(response, '/')
 
     def test_unauthenticated_redirected(self):
         """Unauthenticated user should be redirected to login (by decorator)."""
         self.client.logout()
-        response = self.client.get('/customforms/responses/%d/' % self.form.id)
-        self.assertRedirects(response, '/accounts/login/?next=/customforms/responses/%d/' % self.form.id)
+        response = self.client.get('/customforms/responses/%d/' % self.admin_form.id)
+        self.assertRedirects(response, '/accounts/login/?next=/customforms/responses/%d/' % self.admin_form.id)
 
 
 class FormBuilderViewTest(TestCase):
@@ -706,3 +716,145 @@ class EmptyFormTitleValidationTest(TestCase):
 
         existing_form.refresh_from_db()
         self.assertEqual(existing_form.title, 'A' * max_len)
+
+
+class FormOwnershipAccessTest(TestCase):
+    """Tests that only the form creator, admins, or morphed users can access form response data."""
+
+    def setUp(self):
+        self.admin, _ = ESPUser.objects.get_or_create(username='owner_admin')
+        self.admin.set_password('password')
+        self.admin.save()
+        self.admin.makeRole('Administrator')
+
+        self.teacher_owner, _ = ESPUser.objects.get_or_create(username='owner_teacher')
+        self.teacher_owner.set_password('password')
+        self.teacher_owner.save()
+        self.teacher_owner.makeRole('Teacher')
+
+        self.teacher_other, _ = ESPUser.objects.get_or_create(username='other_teacher')
+        self.teacher_other.set_password('password')
+        self.teacher_other.save()
+        self.teacher_other.makeRole('Teacher')
+
+        self.form = Form.objects.create(
+            title='Ownership Test Form', description='Test',
+            created_by=self.teacher_owner,
+            link_type='-1', link_id=-1, anonymous=False, perms='',
+            success_message='OK', success_url='/'
+        )
+        page = Page.objects.create(form=self.form, seq=1)
+        section = Section.objects.create(page=page, title='Section 1', seq=1)
+        self.field = Field.objects.create(
+            form=self.form, section=section,
+            field_type='textField', seq=0, label='Q1', required=False
+        )
+        self.question_name = f'question_{self.field.id}'
+        dmh = DynamicModelHandler(self.form)
+        dmh.createTable()
+
+    def tearDown(self):
+        for form in Form.objects.all():
+            dmh = DynamicModelHandler(form)
+            dmh.purgeDynModel()
+
+    def test_owner_can_view_responses(self):
+        self.client.login(username='owner_teacher', password='password')
+        response = self.client.get(f'/customforms/responses/{self.form.id}/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_nonowner_teacher_cannot_view_responses(self):
+        self.client.login(username='other_teacher', password='password')
+        response = self.client.get(f'/customforms/responses/{self.form.id}/')
+        self.assertEqual(response.status_code, 403)
+
+    def test_admin_can_view_any_responses(self):
+        self.client.login(username='owner_admin', password='password')
+        response = self.client.get(f'/customforms/responses/{self.form.id}/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_viewresponse_nonexistent_form_returns_404(self):
+        self.client.login(username='owner_teacher', password='password')
+        response = self.client.get('/customforms/responses/999999/')
+        self.assertEqual(response.status_code, 404)
+
+    def test_owner_can_get_excel(self):
+        self.client.login(username='owner_teacher', password='password')
+        response = self.client.get(f'/customforms/exceldata/{self.form.id}/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_nonowner_teacher_cannot_get_excel(self):
+        self.client.login(username='other_teacher', password='password')
+        response = self.client.get(f'/customforms/exceldata/{self.form.id}/')
+        self.assertEqual(response.status_code, 403)
+
+    def test_admin_can_get_any_excel(self):
+        self.client.login(username='owner_admin', password='password')
+        response = self.client.get(f'/customforms/exceldata/{self.form.id}/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_exceldata_nonexistent_form_returns_404(self):
+        self.client.login(username='owner_teacher', password='password')
+        response = self.client.get('/customforms/exceldata/999999/')
+        self.assertEqual(response.status_code, 404)
+
+    def test_owner_can_get_data(self):
+        self.client.login(username='owner_teacher', password='password')
+        response = self.client.get(
+            '/customforms/getData/',
+            {'form_id': self.form.id},
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_nonowner_teacher_cannot_get_data(self):
+        self.client.login(username='other_teacher', password='password')
+        response = self.client.get(
+            '/customforms/getData/',
+            {'form_id': self.form.id},
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_admin_can_get_any_data(self):
+        self.client.login(username='owner_admin', password='password')
+        response = self.client.get(
+            '/customforms/getData/',
+            {'form_id': self.form.id},
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_getdata_nonexistent_form_returns_404(self):
+        self.client.login(username='owner_teacher', password='password')
+        response = self.client.get(
+            '/customforms/getData/',
+            {'form_id': 999999},
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_nonowner_teacher_cannot_bulk_download(self):
+        self.client.login(username='other_teacher', password='password')
+        response = self.client.get(
+            '/customforms/bulkdownloadfiles/',
+            {'form_id': self.form.id, 'question_name': self.question_name},
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_admin_can_bulk_download_any(self):
+        self.client.login(username='owner_admin', password='password')
+        response = self.client.get(
+            '/customforms/bulkdownloadfiles/',
+            {'form_id': self.form.id, 'question_name': self.question_name},
+        )
+        # No responses exist so the zip will be empty, but access should be granted
+        self.assertEqual(response.status_code, 200)
+
+    def test_bulkdownload_nonexistent_form_returns_404(self):
+        self.client.login(username='owner_teacher', password='password')
+        response = self.client.get(
+            '/customforms/bulkdownloadfiles/',
+            {'form_id': 999999, 'question_name': self.question_name},
+        )
+        self.assertEqual(response.status_code, 404)

--- a/esp/esp/customforms/views.py
+++ b/esp/esp/customforms/views.py
@@ -3,7 +3,7 @@ import json
 
 from django.db import transaction
 from django.shortcuts import redirect
-from django.http import Http404, HttpResponse, HttpResponseRedirect, JsonResponse
+from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.urls import reverse
 from django.db import connection
 from django.core.exceptions import ObjectDoesNotExist
@@ -19,8 +19,8 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth.decorators import user_passes_test, login_required
 
 from esp.users.models import ESPUser
-from esp.middleware import ESPError
-from esp.utils.web import render_to_response, zip_download
+from esp.middleware import ESPError, Http403
+from esp.utils.web import render_to_response, zip_download, error404
 
 def test_func(user):
     return user.is_authenticated and (user.is_morphed() or user.isTeacher() or user.isAdministrator())
@@ -338,7 +338,7 @@ def viewForm(request, form_id):
         form_id = int(form_id)
         form = Form.objects.get(pk=form_id)
     except (ValueError, Form.DoesNotExist):
-        raise Http404
+        return error404(request)
 
     perm, error_text = hasPerm(request.user, form)
     if not perm:
@@ -354,7 +354,7 @@ def success(request, form_id):
     try:
         form_id = int(form_id)
     except ValueError:
-        raise Http404
+        return error404(request)
 
     form = Form.objects.get(pk=form_id)
     return render_to_response('customforms/success.html', request, {'success_message': form.success_message,
@@ -365,15 +365,16 @@ def viewResponse(request, form_id):
     """
     Viewing response data
     """
-    # Only teachers and admins can view responses; others are redirected to home
-    if not (request.user.isTeacher() or request.user.isAdministrator()):
+    if not (request.user.isTeacher() or request.user.isAdministrator() or request.user.is_morphed(request)):
         return HttpResponseRedirect(reverse('home'))
 
     try:
         form_id = int(form_id)
-    except ValueError:
-        raise Http404
-    form = Form.objects.get(id=form_id)
+        form = Form.objects.get(pk=form_id)
+    except (ValueError, Form.DoesNotExist):
+        return error404(request)
+    if not request.user.isAdministrator() and not request.user.is_morphed(request) and form.created_by_id != request.user.id:
+        raise Http403('You do not have permission to view responses for this form.')
     return render_to_response('customforms/view_results.html', request, {'form': form})
 
 @user_passes_test(test_func)
@@ -384,10 +385,11 @@ def getExcelData(request, form_id):
 
     try:
         form_id = int(form_id)
-    except ValueError:
-        return HttpResponse(status=400)
-
-    form = Form.objects.get(pk=form_id)
+        form = Form.objects.get(pk=form_id)
+    except (ValueError, Form.DoesNotExist):
+        return error404(request)
+    if not request.user.isAdministrator() and not request.user.is_morphed(request) and form.created_by_id != request.user.id:
+        raise Http403('You do not have permission to download responses for this form.')
     fh = FormHandler(form=form, request=request)
     wbk = fh.getResponseExcel()
     response = HttpResponse(wbk.getvalue(), content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
@@ -403,9 +405,11 @@ def getData(request):
         if request.method == 'GET':
             try:
                 form_id = int(request.GET['form_id'])
-            except ValueError:
-                return HttpResponse(status=400)
-            form = Form.objects.get(pk=form_id)
+                form = Form.objects.get(pk=form_id)
+            except (KeyError, ValueError, Form.DoesNotExist):
+                return error404(request)
+            if not request.user.isAdministrator() and not request.user.is_morphed(request) and form.created_by_id != request.user.id:
+                raise Http403('You do not have permission to view responses for this form.')
             fh = FormHandler(form=form, request=request)
             resp_data = json.dumps(fh.getResponseData(form), cls=DjangoJSONEncoder)
             return HttpResponse(resp_data)
@@ -422,7 +426,12 @@ def bulkDownloadFiles(request):
             question_name = request.GET['question_name']
         except (ValueError, KeyError):
             return HttpResponse(status=400)
-        form = Form.objects.get(pk=form_id)
+        try:
+            form = Form.objects.get(pk=form_id)
+        except Form.DoesNotExist:
+            return error404(request)
+        if not request.user.isAdministrator() and not request.user.is_morphed(request) and form.created_by_id != request.user.id:
+            raise Http403('You do not have permission to download files for this form.')
         dmh = DMH(form=form)
         dyn = dmh.createDynModel()
         filenames = [resp[question_name] for resp in dyn.objects.all().values()]


### PR DESCRIPTION
## Description
This PR enforces ownership restrictions on custom form response data views and adds tests to verify that only the form creator (teacher) or an admin can access response data, Excel exports, and file downloads. Non-owner teachers are now correctly denied access to other teachers' form data.

## Related Issue
Closes #4527 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [x] New tests added (if applicable)
- [ ] Manually verified


## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced
