### PR TITLE
Fix Jodit alignment buttons to work on selected text only

### DIFF
--- a/esp/templates/inclusion/qsd/render_qsd.html
+++ b/esp/templates/inclusion/qsd/render_qsd.html
@@ -48,7 +48,7 @@ $j(document).ready(function() {
 
 (function() {
 var editor = new Jodit("#qsd_content_{{ qsdrec.edit_id }}", {
-  "enter": "BR",
+  "enter": "P",
   "buttons": "source,|,bold,strikethrough,underline,italic,|,superscript,subscript,|,ul,ol,outdent,indent,align,|,font,fontsize,brush,paragraph,|,image,video,table,link,hr,|,undo,redo,cut,eraser,copyformat,|,symbol,fullsize,selectall",
   "toolbarAdaptive": false,
   "saveModeInStorage": true,

--- a/esp/templates/program/modules/commmodule/step2.html
+++ b/esp/templates/program/modules/commmodule/step2.html
@@ -88,7 +88,7 @@ Both email address fields also support named "mailboxes", such as "{{ default_fr
 
 <script type="text/javascript">
 var editor = new Jodit("#emailbody", {
-  "enter": "BR",
+  "enter": "P",
   "buttons": "source,|,bold,strikethrough,underline,italic,|,superscript,subscript,|,ul,ol,outdent,indent,align,|,font,fontsize,brush,paragraph,|,image,video,table,link,hr,|,undo,redo,cut,eraser,copyformat,|,symbol,fullsize,selectall,|",
   "toolbarAdaptive": false,
   "saveModeInStorage": true,

--- a/esp/templates/qsd/qsd_edit.html
+++ b/esp/templates/qsd/qsd_edit.html
@@ -67,7 +67,7 @@ var tinyMDE = new TinyMDE.Editor({ textarea: "qsd_content" });
 var commandBar = new TinyMDE.CommandBar({element: 'tinymde_commandbar', editor: tinyMDE});
 {% else %}
 var editor = new Jodit("#qsd_content", {
-  "enter": "BR",
+  "enter": "P",
   "buttons": "source,|,bold,strikethrough,underline,italic,|,superscript,subscript,|,ul,ol,outdent,indent,align,|,font,fontsize,brush,paragraph,|,image,video,table,link,hr,|,undo,redo,cut,eraser,copyformat,|,symbol,fullsize,selectall",
   "toolbarAdaptive": false,
   "saveModeInStorage": true,


### PR DESCRIPTION
## Description

Fixed the alignment buttons in Jodit rich text editors to apply formatting only to selected text instead of the entire content. Changed the Jodit `enter` configuration from `"BR"` (line break mode) to `"P"` (paragraph mode) in three template files. This allows block-level operations like text alignment to work correctly on selected text blocks.

### Before
<img width="1233" height="424" alt="Before - alignment button aligns entire QSD" src="https://github.com/user-attachments/assets/94ca3ce8-01ec-447b-bfc5-3bcdb68572a6" />

### After  
<img width="1219" height="480" alt="After - alignment button aligns only selected text" src="https://github.com/user-attachments/assets/59e05b3c-0460-40ec-9fa4-89481e11b2ec" />

## Related Issue

Closes #2888

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified (alignment buttons now work on selected text only)

## AI Disclosure

Copilot was used to write PR description; all other changes were done manually.

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced

## Changes Made

Modified 3 files with minimal changes (single line per file):
- `esp/templates/qsd/qsd_edit.html` (line 70)
- `esp/templates/inclusion/qsd/render_qsd.html` (line 51)
- `esp/templates/program/modules/commmodule/step2.html` (line 91)

Each change: `"enter": "BR"` → `"enter": "P"`

This ensures that alignment buttons apply formatting to selected text blocks rather than the entire editor content.