### PR TITLE
Add CI test to validate tag registration

### DIFF
--- a/esp/esp/tagdict/tests.py
+++ b/esp/esp/tagdict/tests.py
@@ -311,7 +311,7 @@ class TagRegistrationTest(SimpleTestCase):
     """
     Statically scan the codebase for Tag.getTag(), Tag.getProgramTag(), and
     Tag.getBooleanTag() calls and verify that every string-literal tag key
-    is registered in all_global_tags or all_program_tags (issue #2481).
+    is registered in all_global_tags or all_program_tags.
     """
 
     # Paths (relative to the esp/ root) to skip when scanning, because they


### PR DESCRIPTION
## Description

Adds a CI test (`TagRegistrationTest`) that statically scans the `esp/` codebase for usage of:

- `Tag.getTag(...)`

- `Tag.getProgramTag(...)`

- `Tag.getBooleanTag(...)`

The test verifies that every string-literal tag key used in Python files and Django templates is registered in `all_global_tags` or `all_program_tags` in `esp/tagdict/__init__.py`.

If an undefined tag is detected, the test fails and reports the file path and line number.

This prevents accidental usage of unregistered tags from reaching production and addresses the long-standing request in Issue 

## Related Issue

Closes #2481

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [x] CI/CD or build change

## Testing

- [x] Existing tests pass
- [x] New tests added (if applicable)
- [x] Manually verified

Verified by:

- Running python manage.py test esp.tagdict.tests.TagRegistrationTest
- Temporarily introducing a fake tag to confirm the test fails correctly

## AI Disclosure

AI tools were used to assist with implementation structure and review. All logic was reviewed, validated, and tested manually before submission.

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced
