### PR TITLE
Remove Python 2 compatibility code

### DIFF
--- a/deploy/config_templates/local_settings.py
+++ b/deploy/config_templates/local_settings.py
@@ -1,6 +1,5 @@
 """ Local system-specific settings. """
 
-from __future__ import absolute_import
 import os
 
 SITE_INFO = (1, 'devsite.learningu.org', 'LU Dev Site')

--- a/esp/esp/accounting/forms.py
+++ b/esp/esp/accounting/forms.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from django import forms
 from esp.program.models import Program
 from esp.db.forms import AjaxForeignKeyNewformField

--- a/esp/esp/accounting/refund_views.py
+++ b/esp/esp/accounting/refund_views.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"

--- a/esp/esp/django_settings.py
+++ b/esp/esp/django_settings.py
@@ -1,5 +1,4 @@
 """ Django settings for ESP website. """
-from __future__ import absolute_import
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"

--- a/esp/esp/program/controllers/testingutils.py
+++ b/esp/esp/program/controllers/testingutils.py
@@ -1,6 +1,4 @@
 
-from __future__ import absolute_import
-
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"

--- a/esp/esp/program/modules/handlers/admintestingmodule.py
+++ b/esp/esp/program/modules/handlers/admintestingmodule.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import logging
 
 from django.http import HttpResponseRedirect

--- a/esp/esp/program/modules/handlers/schedulingcheckmodule.py
+++ b/esp/esp/program/modules/handlers/schedulingcheckmodule.py
@@ -363,7 +363,7 @@ class SchedulingCheckRunner:
                     if open_class_cat.id not in [c.category.id for c in classes]:
                         #converts the list of class section objects to a single string
                         str1 = ', '
-                        classes = str1.join([unicode(c) for c in classes])
+                        classes = str1.join([str(c) for c in classes])
                         bads.append({
                             'Username': t,
                             'Teacher Name': t.name(),

--- a/esp/esp/program/modules/migrations/0047_add_admintestingmodule.py
+++ b/esp/esp/program/modules/migrations/0047_add_admintestingmodule.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from __future__ import absolute_import
 
 from django.db import migrations
 

--- a/esp/esp/program/modules/tests/admincore.py
+++ b/esp/esp/program/modules/tests/admincore.py
@@ -78,7 +78,7 @@ class ModuleManagementConstraintsTest(ProgramFrameworkTest):
         modules.append(ProgramModule.objects.get(handler='AvailabilityModule'))
         modules.append(ProgramModule.objects.get(handler='StudentRegConfirm'))
 
-        super(ModuleManagementConstraintsTest, self).setUp(modules=modules)
+        super().setUp(modules=modules)
 
         self.adminUser, created = ESPUser.objects.get_or_create(username='admin_constraints')
         self.adminUser.set_password('password')
@@ -219,7 +219,7 @@ class ModuleManagementLinkTitleTest(ProgramFrameworkTest):
         modules.append(ProgramModule.objects.get(handler='TeacherClassRegModule'))
         modules.append(ProgramModule.objects.get(handler='AdminCore'))
 
-        super(ModuleManagementLinkTitleTest, self).setUp(modules=modules)
+        super().setUp(modules=modules)
 
         # Force lazy creation of ProgramModuleObj rows so they exist
         # before individual tests query for them.

--- a/esp/esp/program/modules/tests/admintestingmodule.py
+++ b/esp/esp/program/modules/tests/admintestingmodule.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from esp.program.models import ProgramModule, RegistrationProfile, StudentRegistration
 from esp.program.modules.base import ProgramModuleObj
 from esp.program.tests import ProgramFrameworkTest
@@ -13,7 +11,7 @@ class AdminTestingModuleTest(ProgramFrameworkTest):
     def setUp(self, *args, **kwargs):
         kwargs.update({'num_students': 5, 'num_timeslots': 2, 'timeslot_length': 50,
                        'timeslot_gap': 10})
-        super(AdminTestingModuleTest, self).setUp(*args, **kwargs)
+        super().setUp(*args, **kwargs)
 
         pm = ProgramModule.objects.get(handler='AdminTestingModule')
         self.module = ProgramModuleObj.getFromProgModule(self.program, pm)

--- a/esp/esp/program/tests_testingutils.py
+++ b/esp/esp/program/tests_testingutils.py
@@ -6,7 +6,6 @@ These tests verify:
 2. That it does NOT delete objects belonging to other users in the same program.
 3. That it does NOT delete objects from other programs.
 """
-from __future__ import absolute_import
 
 from esp.program.controllers.testingutils import TestDataCleanupController
 from esp.program.models import (

--- a/esp/esp/survey/migrations/0005_answer_migration.py
+++ b/esp/esp/survey/migrations/0005_answer_migration.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 
 from django.db import migrations, models
 


### PR DESCRIPTION
Date : 3 March 2026
Developer Name : Dhirender Choudhary

## Description
Remove Python 2 compatibility code from the codebase. Now that ESP-Website uses Django 2.2+ and Python 3, these legacy compatibility patterns are no longer needed.

## Related Issue

<!-- Link the relevant issue. Use "Closes #123" to auto-close on merge. -->

Closes #3958 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified


## Checklist

- [x] Self-reviewed the code
- [x] Updated documentation (if needed)
- [x] No new warnings or errors introduced
