### PR TITLE
Fix inconsistent vertical spacing in authentication forms

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -4,3 +4,5 @@ This directory contains documentation for the ESP Website.
 
 - The `<dev/>`_ directory is for developer documentation.
 
+- For a guide to all the ways you can customize the site, see `<customizing.rst>`_.
+

--- a/docs/admin/program_modules.rst
+++ b/docs/admin/program_modules.rst
@@ -31,7 +31,7 @@ You will also see references to other data structures that store configuration s
 
 * [Teacher] module control (ClassRegModuleInfo): http://[hostname]/admin/modules/classregmoduleinfo/
 * Student module control (StudentClassRegModuleInfo): http://[hostname]/admin/modules/studentclassregmoduleinfo/
-* Tags: http://[hostname]/admin/tagdict/tag/ - Very powerful, but more advanced; see [[Customize behavior with Tags]] for more information.
+* Tags: http://[hostname]/admin/tagdict/tag/ - Very powerful, but more advanced; see `Customizing with Tags <tags.rst>`_ for more information.
 
 Below we provide a more detailed explanation of what each program module is for and which settings can be used to adjust it.
 

--- a/docs/admin/tags.rst
+++ b/docs/admin/tags.rst
@@ -1,0 +1,82 @@
+=======================
+Customizing with Tags
+=======================
+
+.. contents:: :local:
+
+Tags are the primary mechanism for enabling, disabling, or fine-tuning
+optional behaviour on an ESP site — without any code changes.  This page is
+the admin-facing guide.  For the developer-facing guide (declaring new tags in
+code), see `dev/tags.rst <../dev/tags.rst>`_.
+
+What Is a Tag?
+==============
+
+A **tag** is a named key–value pair stored in the database.  Think of it as a
+configuration switch you can flip from the admin panel.  For example:
+
+* Setting the tag ``volunteer_tshirt_options`` to ``True`` adds a T-shirt size
+  field to the volunteer sign-up form.
+* Setting ``group_phone_number`` to ``617-555-0100`` prints that number on
+  nametags and room rosters.
+
+Tags come in two flavors:
+
+* **Global tags** — apply site-wide, across all programs.
+  Navigate to ``https://[yoursite].learningu.org/manage/tags/`` for global
+  tag settings.
+* **Program tags** — apply to one specific program only.
+  Navigate to ``https://[yoursite].learningu.org/manage/<program>/tags/``
+  for a specific program. The program-level value takes precedence over the
+  global default for that program only.
+
+Both pages show all tags that are marked as user-facing settings, grouped
+by category, with help text for each one.
+
+How to Set a Tag
+================
+
+1. Go to the Tag Settings page.
+2. Find the tag you want — each entry shows a description.
+3. Enter the desired value and save.
+
+Tag Categories
+==============
+
+Tags are grouped into the following categories on the Tag Settings page:
+
+* **teach** — settings that affect teacher registration and class creation.
+* **class** — settings that affect individual classes (e.g., scheduling and
+  display).
+* **learn** — settings that affect student registration and the course catalog.
+* **manage** — site-management settings (names, contact info, etc.).
+* **onsite** — settings relevant during the day of the event.
+* **volunteer** — settings for the volunteer sign-up form.
+* **moderate** — settings related to moderating or approving content and
+  activity.
+* **theme** — settings related to the visual theme.
+
+
+
+ClassRegModuleInfo (CRMI) and StudentClassRegModuleInfo (SCRMI)
+===============================================================
+
+For settings that control the registration module behaviour (grade limits,
+lottery mode, teacher deadlines, etc.) see the dedicated admin forms:
+
+* **CRMI** (teacher-facing class registration):
+  ``/admin/modules/classregmoduleinfo/``
+* **SCRMI** (student-facing class registration):
+  ``/admin/modules/studentclassregmoduleinfo/``
+
+A full description of every field for both forms is in
+`admin/program_modules.rst <program_modules.rst>`_.
+
+See Also
+========
+
+* Developer guide to declaring and reading tags in code:
+  `dev/tags.rst <../dev/tags.rst>`_
+* Program modules and SCRMI/CRMI fields reference:
+  `admin/program_modules.rst <program_modules.rst>`_
+* Customization index: `customizing.rst <../customizing.rst>`_

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -1,0 +1,94 @@
+============================
+Customizing the ESP Website
+============================
+
+.. contents:: :local:
+
+This page is a **starting point** for anyone who wants to change how the ESP
+website looks or behaves.  It lists every major customization mechanism, gives
+a short description of each, and links to the relevant detailed documentation.
+Pick the section that matches what you want to do.
+
+QSD — Inline Text Blocks
+=========================
+
+QSD ("Quasi-Static Data") lets admins edit pieces of text or images that are
+embedded directly inside existing pages — without touching any code.  For
+example, the introductory paragraph on a program splash page is typically a
+QSD block.  Any page that contains a ``render_inline_qsd`` or
+``inline_qsd_block`` template tag exposes an editable region to admins.
+
+* Developer reference (template tags ``render_inline_qsd``,
+  ``inline_qsd_block``, and their program-scoped variants):
+  `dev/utils.rst <dev/utils.rst>`_
+
+QSD — Standalone Pages
+=======================
+
+Admins can also create entirely new content pages served at
+``<page-name>.html``.  These pages are managed through the admin toolbar
+("Edit this page") on the live site, or via the Django admin interface.
+
+* Developer reference (same rendering machinery): `dev/utils.rst <dev/utils.rst>`_
+
+Tags and (S)CRMI
+================
+
+**Tags** are key–value settings (global or per-program) that control optional
+site behaviour — for example, enabling a custom registration workflow or
+setting a program-specific reply-to e-mail address.  Tags are visible to
+chapter admins on the tag settings page under the admin toolbar.
+
+**StudentClassRegModuleInfo (SCRMI)** and **ClassRegModuleInfo (CRMI)** are
+database objects that expose per-program configuration knobs for the class
+registration modules (e.g. grade limits, lottery behaviour, teacher deadlines).
+
+* Admin guide (how to set tags from the admin panel): `admin/tags.rst <admin/tags.rst>`_
+* How to declare and use Tags (developer guide): `dev/tags.rst <dev/tags.rst>`_
+* SCRMI / CRMI fields reference: `admin/program_modules.rst <admin/program_modules.rst>`_
+
+Themes and Visual Customizations
+================================
+
+The ``/themes/`` app lets admins pick a pre-built layout, fill in
+site-specific information (title, contact details, navigation links), and
+adjust the colour palette and logo — all through a web form, with no code
+changes required.  There are three steps: *Select* a theme, *Set up* the
+theme, and *Customize* the theme.
+
+* Admin guide (select → set up → customize): `admin/themes.rst <admin/themes.rst>`_
+* Catalogue of available themes with screenshots:
+  `admin/available_themes.rst <admin/available_themes.rst>`_
+
+Template Overrides
+==================
+
+Any Django template can be overridden for a specific site by saving a new
+version to the database via the ``TemplateOverride`` model.  The themes app
+uses this mechanism internally; it is also useful for customising printables
+and other one-off pages.
+
+* Model description and usage: `dev/utils.rst <dev/utils.rst>`_
+* Manual theming workflow (without the app): `admin/themes.rst <admin/themes.rst>`_
+  — see the *Manual Theming* section.
+
+Custom Themes / Adding a New Theme
+====================================
+
+To contribute a fully custom front-end design for other chapters to use,
+package it as a theme inside ``esp/themes/theme_data/``.  The themes app
+compiles LESS → CSS with user-supplied parameters at runtime.  A theme
+consists of pre-defined template overrides, images, and LESS stylesheets.
+
+* Full developer guide (architecture, file layout, LESS pipeline, adding a
+  theme): `dev/themes.rst <dev/themes.rst>`_
+
+Contributing to the Codebase
+==============================
+
+For changes that go beyond configuration — new features, bug fixes, or
+structural improvements — follow the standard development workflow: fork the
+repository, work on a feature branch, write tests, open a pull request, and
+go through code review.
+
+* Git workflow and PR process: `dev/contributing.rst <dev/contributing.rst>`_


### PR DESCRIPTION
Closes #4581

Fixes inconsistent vertical spacing between form fields
in login and registration templates by adjusting
`.form-horizontal .control-group` margins.

This is a visual-only change. No functional behavior was modified.