### PR TITLE
Migrate deprecated url() to path()/re_path() across all urls.py files(closes #4544)

### DIFF
--- a/esp/esp/accounting/urls.py
+++ b/esp/esp/accounting/urls.py
@@ -33,13 +33,13 @@ Learning Unlimited, Inc.
   Email: web-team@learningu.org
 """
 
-from django.conf.urls import url
+from django.urls import path, re_path
 from esp.accounting.views import summary, user_summary
 from esp.accounting.refund_views import refund, process_refund
 
 urlpatterns = [
-    url(r'^$', summary),
-    url(r'^user$', user_summary),
-    url(r'^refund/?$', refund, name='accounting_refund'),
-    url(r'^refund/process/?$', process_refund, name='accounting_refund_process'),
+    path('', summary),
+    path('user', user_summary),
+    re_path(r'^refund/?$', refund, name='accounting_refund'),
+    re_path(r'^refund/process/?$', process_refund, name='accounting_refund_process'),
 ]

--- a/esp/esp/customforms/urls.py
+++ b/esp/esp/customforms/urls.py
@@ -1,21 +1,21 @@
-from django.conf.urls import url
+from django.urls import path, re_path
 
 from esp.customforms import views
 
 urlpatterns = [
-    url(r'^/?$', views.landing),
-    url(r'^/create/?$', views.formBuilder),
-    url(r'^/submit/$', views.onSubmit),
-    url(r'^/modify/$', views.onModify),
-    url(r'^/view/(?P<form_id>\d{1,6})/$', views.viewForm),
-    url(r'^/success/(?P<form_id>\d{1,6})/$', views.success),
-    url(r'^/responses/(?P<form_id>\d{1,6})/$', views.viewResponse),
-    url(r'^/getData/$', views.getData),
-    url(r'^/metadata/$', views.getRebuildData),
-    url(r'^/getperms/$', views.getPerms),
-    url(r'^/getlinks/$', views.get_links),
-    url(r'^/getmodules/$', views.get_modules),
-    url(r'^/builddata/$', views.formBuilderData),
-    url(r'^/exceldata/(?P<form_id>\d{1,6})/$', views.getExcelData),
-    url(r'^/bulkdownloadfiles/?', views.bulkDownloadFiles)
+    re_path(r'^/?$', views.landing),
+    re_path(r'^/create/?$', views.formBuilder),
+    path('/submit/', views.onSubmit),
+    path('/modify/', views.onModify),
+    re_path(r'^/view/(?P<form_id>\d{1,6})/$', views.viewForm),
+    re_path(r'^/success/(?P<form_id>\d{1,6})/$', views.success),
+    re_path(r'^/responses/(?P<form_id>\d{1,6})/$', views.viewResponse),
+    path('/getData/', views.getData),
+    path('/metadata/', views.getRebuildData),
+    path('/getperms/', views.getPerms),
+    path('/getlinks/', views.get_links),
+    path('/getmodules/', views.get_modules),
+    path('/builddata/', views.formBuilderData),
+    re_path(r'^/exceldata/(?P<form_id>\d{1,6})/$', views.getExcelData),
+    re_path(r'^/bulkdownloadfiles/?', views.bulkDownloadFiles)
 ]

--- a/esp/esp/formstack/urls.py
+++ b/esp/esp/formstack/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import url
+from django.urls import path, re_path
 
 from esp.formstack import views
 
 urlpatterns = [
-    url(r'^medicalsyncapi$', views.medicalsyncapi),
-    url(r'^formstack_webhook/?$', views.formstack_webhook)
+    path('medicalsyncapi', views.medicalsyncapi),
+    re_path(r'^formstack_webhook/?$', views.formstack_webhook)
 ]

--- a/esp/esp/program/urls.py
+++ b/esp/esp/program/urls.py
@@ -1,27 +1,27 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from esp.program import views
 import esp.users.views.merge
 
 urlpatterns = [
     # manage stuff
-    url(r'^manage/programs/?$', views.manage_programs),
-    url(r'^manage/newprogram/?$', views.newprogram),
-    url(r'^manage/submit_transaction/?$', views.submit_transaction),
-    url(r'^manage/pages/?$', views.manage_pages),
-    url(r'^manage/userview/?$', views.userview),
-    url(r'^manage/deactivate_user/?$', views.deactivate_user),
-    url(r'^manage/activate_user/?$', views.activate_user),
-    url(r'^manage/unenroll_student/?$', views.unenroll_student),
-    url(r'^manage/usersearch/?$', views.usersearch),
-    url(r'^manage/flushcache/?$', views.flushcache),
-    url(r'^manage/emails/?$', views.emails),
-    url(r'^manage/catsflagsrecs/?(?P<section>[^/]*)/?$', views.catsflagsrecs),
-    url(r'^manage/tags/?(?P<section>[^/]*)/?$', views.tags),
-    url(r'^manage/redirects/?(?P<section>[^/]*)/?$', views.redirects),
-    url(r'^manage/statistics/?$', views.statistics),
-    url(r'^manage/preview/?$', views.template_preview),
-    url(r'^manage/docs/?$', views.manage_docs),
-    url(r'^manage/docs/(?P<doc_path>.+)/?$', views.manage_docs),
-    url(r'^manage/mergeaccounts/?$', esp.users.views.merge.merge_accounts),
+    re_path(r'^manage/programs/?$', views.manage_programs),
+    re_path(r'^manage/newprogram/?$', views.newprogram),
+    re_path(r'^manage/submit_transaction/?$', views.submit_transaction),
+    re_path(r'^manage/pages/?$', views.manage_pages),
+    re_path(r'^manage/userview/?$', views.userview),
+    re_path(r'^manage/deactivate_user/?$', views.deactivate_user),
+    re_path(r'^manage/activate_user/?$', views.activate_user),
+    re_path(r'^manage/unenroll_student/?$', views.unenroll_student),
+    re_path(r'^manage/usersearch/?$', views.usersearch),
+    re_path(r'^manage/flushcache/?$', views.flushcache),
+    re_path(r'^manage/emails/?$', views.emails),
+    re_path(r'^manage/catsflagsrecs/?(?P<section>[^/]*)/?$', views.catsflagsrecs),
+    re_path(r'^manage/tags/?(?P<section>[^/]*)/?$', views.tags),
+    re_path(r'^manage/redirects/?(?P<section>[^/]*)/?$', views.redirects),
+    re_path(r'^manage/statistics/?$', views.statistics),
+    re_path(r'^manage/preview/?$', views.template_preview),
+    re_path(r'^manage/docs/?$', views.manage_docs),
+    re_path(r'^manage/docs/(?P<doc_path>.+)/?$', views.manage_docs),
+    re_path(r'^manage/mergeaccounts/?$', esp.users.views.merge.merge_accounts),
 ]

--- a/esp/esp/qsdmedia/urls.py
+++ b/esp/esp/qsdmedia/urls.py
@@ -1,7 +1,7 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from esp.qsdmedia import views
 
 urlpatterns = [
-    url(r'^\/([^/]+)/?$', views.qsdmedia2),
-    url(r'^\/([^/]+)\/([^/]+)/?$', views.qsdmedia2)]
+    re_path(r'^\/([^/]+)/?$', views.qsdmedia2),
+    re_path(r'^\/([^/]+)\/([^/]+)/?$', views.qsdmedia2)]

--- a/esp/esp/random/urls.py
+++ b/esp/esp/random/urls.py
@@ -1,7 +1,7 @@
-from django.conf.urls import url
+from django.urls import path, re_path
 from esp.random import views
 
 urlpatterns = [
-    url(r'^/?$', views.main),
-    url(r'^/ajax$', views.ajax),
+    re_path(r'^/?$', views.main),
+    path('/ajax', views.ajax),
 ]

--- a/esp/esp/survey/urls.py
+++ b/esp/esp/survey/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import url
+from django.urls import re_path
 from esp.survey.views import survey_view
 
 
 urlpatterns = [
     # Program stuff
-    url(r'^(onsite|manage|teach|learn)/(.*?)/(.*?)/program.survey$', survey_view),
+    re_path(r'^(onsite|manage|teach|learn)/(.*?)/(.*?)/program.survey$', survey_view),
 ]

--- a/esp/esp/tests/urls.py
+++ b/esp/esp/tests/urls.py
@@ -1,5 +1,5 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from esp.tests import views
 
-urlpatterns = [url('^/?$', views.javascript_tests)]
+urlpatterns = [re_path(r'^/?$', views.javascript_tests)]

--- a/esp/esp/themes/urls.py
+++ b/esp/esp/themes/urls.py
@@ -1,14 +1,14 @@
 
 from esp.themes.views import editor, selector, configure, confirm_overwrite, landing, recompile, logos
 
-from django.conf.urls import url
+from django.urls import path, re_path
 
 urlpatterns = [
-    url(r'^/?$', landing),
-    url(r'^/select', selector),
-    url(r'^/setup', configure),
-    url(r'^/confirm_overwrite', confirm_overwrite),
-    url(r'^/logos', logos),
-    url(r'^/customize', editor),
-    url(r'^/recompile', recompile),
+    re_path(r'^/?$', landing),
+    path('/select', selector),
+    path('/setup', configure),
+    path('/confirm_overwrite', confirm_overwrite),
+    path('/logos', logos),
+    path('/customize', editor),
+    path('/recompile', recompile),
 ]

--- a/esp/esp/urls.py
+++ b/esp/esp/urls.py
@@ -32,7 +32,7 @@ Learning Unlimited, Inc.
   Email: web-team@learningu.org
 """
 
-from django.conf.urls import include, handler500, handler404, url
+from django.urls import path, re_path, include
 from django.contrib import admin
 from esp.admin import admin_site, autodiscover
 from django.conf import settings
@@ -75,63 +75,63 @@ urlpatterns = static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT) + st
 
 # Robots.txt
 urlpatterns += [
-    url('robots.txt', TemplateView.as_view(template_name="robots.txt", content_type="text/plain"))
+    path('robots.txt', TemplateView.as_view(template_name="robots.txt", content_type="text/plain"))
 ]
 
 # Admin stuff
 urlpatterns += [
-    url(r'^admin_tools/', include('admin_tools.urls')),
-    url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
-    url(r'^admin/ajax_qsd/?$', esp.qsd.views.ajax_qsd),
-    url(r'^admin/ajax_qsd_preview/?$', esp.qsd.views.ajax_qsd_preview),
-    url(r'^admin/ajax_qsd_image_upload/?$', esp.qsd.views.ajax_qsd_image_upload),
-    url(r'^admin/ajax_autocomplete/?', esp.db.views.ajax_autocomplete),
-    url(r'^admin/filebrowser/', filebrowser_site.urls),
-    url(r'^admin/', admin_site.urls),
-    url(r'^accounts/login/$', esp.users.views.CustomLoginView.as_view()),
-    url(r'^(?P<subsection>(learn|teach|program|help|manage|onsite))/?$', RedirectView.as_view(url='/%(subsection)s/index.html', permanent=True)),
+    path('admin_tools/', include('admin_tools.urls')),
+    path('admin/doc/', include('django.contrib.admindocs.urls')),
+    re_path(r'^admin/ajax_qsd/?$', esp.qsd.views.ajax_qsd),
+    re_path(r'^admin/ajax_qsd_preview/?$', esp.qsd.views.ajax_qsd_preview),
+    re_path(r'^admin/ajax_qsd_image_upload/?$', esp.qsd.views.ajax_qsd_image_upload),
+    re_path(r'^admin/ajax_autocomplete/?', esp.db.views.ajax_autocomplete),
+    path('admin/filebrowser/', filebrowser_site.urls),
+    path('admin/', admin_site.urls),
+    path('accounts/login/', esp.users.views.CustomLoginView.as_view()),
+    re_path(r'^(?P<subsection>(learn|teach|program|help|manage|onsite))/?$', RedirectView.as_view(url='/%(subsection)s/index.html', permanent=True)),
 ]
 
 # Adds missing trailing slash to any admin urls that haven't been matched yet.
 urlpatterns += [
-    url(r'^(?P<url>admin($|(.*[^/]$)))', RedirectView.as_view(url='/%(url)s/', permanent=True))]
+    re_path(r'^(?P<url>admin($|(.*[^/]$)))', RedirectView.as_view(url='/%(url)s/', permanent=True))]
 
 # generic stuff
 urlpatterns += [
-    url(r'^$', main.home), # index
-    url(r'^set_csrf_token', main.set_csrf_token), # tiny view used to set csrf token
+    path('', main.home), # index
+    path('set_csrf_token', main.set_csrf_token), # tiny view used to set csrf token
 ]
 
 # main list of apps (please consolidate more things into this!)
 urlpatterns += [
-    url(r'^cache/', include(argcache.urls)),
-    url(r'^__debug__/', include(debug_toolbar.urls)),
-    url(r'^accounting/', include(esp.accounting.urls)),
-    url(r'^customforms', include(esp.customforms.urls)),
-    url(r'^random', include(esp.random.urls)),
-    url(r'^', include(esp.formstack.urls)),
-    url(r'^',  include(esp.program.urls)),
-    url(r'^download', include(esp.qsdmedia.urls)),
-    url(r'^',  include(esp.survey.urls)),
-    url('^javascript_tests', include(esp.tests.urls)),
-    url(r'^themes', include(esp.themes.urls)),
-    url(r'^myesp/', include(esp.users.urls)),
-    url(r'^varnish/', include(esp.varnish.urls)),
+    path('cache/', include(argcache.urls)),
+    path('__debug__/', include(debug_toolbar.urls)),
+    path('accounting/', include(esp.accounting.urls)),
+    path('customforms', include(esp.customforms.urls)),
+    path('random', include(esp.random.urls)),
+    path('', include(esp.formstack.urls)),
+    path('',  include(esp.program.urls)),
+    path('download', include(esp.qsdmedia.urls)),
+    path('',  include(esp.survey.urls)),
+    path('javascript_tests', include(esp.tests.urls)),
+    path('themes', include(esp.themes.urls)),
+    path('myesp/', include(esp.users.urls)),
+    path('varnish/', include(esp.varnish.urls)),
 ]
 
 urlpatterns += [
     # bios
-    url(r'^(?P<tl>teach|learn)/teachers/', include('esp.web.urls')),
+    re_path(r'^(?P<tl>teach|learn)/teachers/', include('esp.web.urls')),
 ]
 
 # Specific .html pages that have defaults
 urlpatterns += [
-    url(r'^(faq|faq\.html)$', main.FAQView.as_view(), name='FAQ'),
-    url(r'^(contact|contact\.html)$', main.ContactUsView.as_view(), name='Contact Us'),
+    re_path(r'^(faq|faq\.html)$', main.FAQView.as_view(), name='FAQ'),
+    re_path(r'^(contact|contact\.html)$', main.ContactUsView.as_view(), name='Contact Us'),
 ]
 
 urlpatterns += [
-    url(r'^(?P<url>.*)\.html$', esp.qsd.views.qsd),
+    re_path(r'^(?P<url>.*)\.html$', esp.qsd.views.qsd),
 ]
 
 # QSD Media
@@ -139,26 +139,26 @@ urlpatterns += [
 urlpatterns += [
     # aseering - Is it worth consolidating these?  Two entries for the single "contact us! widget
     # Contact Us! pages
-    url(r'^contact/contact/?$', main.contact),
-    url(r'^contact/contact/(?P<section>[^/]+)/?$', main.contact),
+    re_path(r'^contact/contact/?$', main.contact),
+    re_path(r'^contact/contact/(?P<section>[^/]+)/?$', main.contact),
 
     # Program stuff
-    url(r'^(onsite|manage|teach|learn|volunteer|json)/([-A-Za-z0-9_ ]+)/([-A-Za-z0-9_ ]+)/([-A-Za-z0-9_ ]+)/([-A-Za-z0-9_ ]+)/?$', main.program),
-    url(r'^(onsite|manage|teach|learn|volunteer|json)/([-A-Za-z0-9_ ]+)/([-A-Za-z0-9_ ]+)/([-A-Za-z0-9_ ]+)/?$', main.program),
+    re_path(r'^(onsite|manage|teach|learn|volunteer|json)/([-A-Za-z0-9_ ]+)/([-A-Za-z0-9_ ]+)/([-A-Za-z0-9_ ]+)/([-A-Za-z0-9_ ]+)/?$', main.program),
+    re_path(r'^(onsite|manage|teach|learn|volunteer|json)/([-A-Za-z0-9_ ]+)/([-A-Za-z0-9_ ]+)/([-A-Za-z0-9_ ]+)/?$', main.program),
 
     # all the archives
-    url(r'^archives/([-A-Za-z0-9_ ]+)/?$', main.archives),
-    url(r'^archives/([-A-Za-z0-9_ ]+)/([-A-Za-z0-9_ ]+)/?$', main.archives),
-    url(r'^archives/([-A-Za-z0-9_ ]+)/([-A-Za-z0-9_ ]+)/([-A-Za-z0-9_ ]+)/?$', main.archives),
+    re_path(r'^archives/([-A-Za-z0-9_ ]+)/?$', main.archives),
+    re_path(r'^archives/([-A-Za-z0-9_ ]+)/([-A-Za-z0-9_ ]+)/?$', main.archives),
+    re_path(r'^archives/([-A-Za-z0-9_ ]+)/([-A-Za-z0-9_ ]+)/([-A-Za-z0-9_ ]+)/?$', main.archives),
 
-    url(r'^email/([0-9]+)/?$', main.public_email),
+    re_path(r'^email/([0-9]+)/?$', main.public_email),
 ]
 
 urlpatterns += [
-url(r'^(?P<subsection>onsite|manage|teach|learn|volunteer)/(?P<program>[-A-Za-z0-9_ ]+)/?$', RedirectView.as_view(url='/%(subsection)s/%(program)s/index.html', permanent=True))]
+re_path(r'^(?P<subsection>onsite|manage|teach|learn|volunteer)/(?P<program>[-A-Za-z0-9_ ]+)/?$', RedirectView.as_view(url='/%(subsection)s/%(program)s/index.html', permanent=True))]
 
 
 urlpatterns += [
-    url(r'^manage/templateoverride/(?P<template_id>[0-9]+)',
+    re_path(r'^manage/templateoverride/(?P<template_id>[0-9]+)',
         esp.utils.views.diff_templateoverride),
 ]

--- a/esp/esp/users/urls.py
+++ b/esp/esp/users/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import re_path, path
 
 from esp.users import views
 from esp.users.views.registration import GradeChangeRequestView
@@ -7,46 +7,46 @@ from esp.web.views import main
 from esp.web.views import myesp
 
 urlpatterns = [
-    url(r'^register/?$', views.user_registration_phase1,
+    re_path(r'^register/?$', views.user_registration_phase1,
         name='esp.users.views.user_registration_phase1'),
-    url(r'^register/information/?$', views.user_registration_phase2,
+    re_path(r'^register/information/?$', views.user_registration_phase2,
         name='esp.users.views.user_registration_phase2'),
-    url(r'^activate/?$', views.registration.activate_account),
-    url(r'^passwdrecover/(success)?/?$', views.initial_passwd_request),
-    url(r'^passwdrecover/?$', views.initial_passwd_request),
-    url(r'^recoveremail/(success)?/?$', views.email_passwd_followup),
-    url(r'^recoveremail/?$', views.email_passwd_followup),
-    url(r'^cancelrecover/?$', views.email_passwd_cancel),
-    url(r'^resend/?$', views.resend_activation_view,
+    re_path(r'^activate/?$', views.registration.activate_account),
+    re_path(r'^passwdrecover/(success)?/?$', views.initial_passwd_request),
+    re_path(r'^passwdrecover/?$', views.initial_passwd_request),
+    re_path(r'^recoveremail/(success)?/?$', views.email_passwd_followup),
+    re_path(r'^recoveremail/?$', views.email_passwd_followup),
+    re_path(r'^cancelrecover/?$', views.email_passwd_cancel),
+    re_path(r'^resend/?$', views.resend_activation_view,
         name='esp.users.views.resend_activation_view'),
-    url(r'^signout/?$', views.signout),
-    url(r'^signedout/?$', views.signed_out_message),
-    url(r'^login/?$', views.CustomLoginView.as_view(), name="login"),
-    url(r'^disableaccount/?$', views.disable_account),
-    url(r'^grade_change_request/?$', GradeChangeRequestView.as_view(),
+    re_path(r'^signout/?$', views.signout),
+    re_path(r'^signedout/?$', views.signed_out_message),
+    re_path(r'^login/?$', views.CustomLoginView.as_view(), name="login"),
+    re_path(r'^disableaccount/?$', views.disable_account),
+    re_path(r'^grade_change_request/?$', GradeChangeRequestView.as_view(),
         name='grade_change_request'),
-    url(r'^makeadmin/?$', views.make_admin),
-    url(r'^loginhelp', views.LoginHelpView.as_view(), name='Login Help'),
-    url(r'^morph/?$', views.morph_into_user),
-    url(r'^unsubscribe/(?P<username>[^/]+)/(?P<token>[\w.:\-_=]+)/$',
+    re_path(r'^makeadmin/?$', views.make_admin),
+    path('loginhelp', views.LoginHelpView.as_view(), name='Login Help'),
+    re_path(r'^morph/?$', views.morph_into_user),
+    re_path(r'^unsubscribe/(?P<username>[^/]+)/(?P<token>[\w.:\-_=]+)/$',
         views.unsubscribe, name="unsubscribe"),
-    url(r'^unsubscribe_oneclick/(?P<username>[^/]+)/(?P<token>[\w.:\-_=]+)/$',
+    re_path(r'^unsubscribe_oneclick/(?P<username>[^/]+)/(?P<token>[\w.:\-_=]+)/$',
         views.unsubscribe_oneclick, name="unsubscribe_oneclick"),
 ]
 
 urlpatterns += [
-    url(r'^redirect/?$', main.registration_redirect),
+    re_path(r'^redirect/?$', main.registration_redirect),
 ]
 
 urlpatterns += [
-    url(r'^switchback/?$', myesp.myesp_switchback),
-    url(r'^stop_testing/?$', myesp.myesp_stop_testing),
-    url(r'^onsite/?$', myesp.myesp_onsite),
-    url(r'^passwd/?$', myesp.myesp_passwd),
-    url(r'^accountmanage/?$', myesp.myesp_accountmanage),
-    url(r'^profile/?$', myesp.edit_profile),
+    re_path(r'^switchback/?$', myesp.myesp_switchback),
+    re_path(r'^stop_testing/?$', myesp.myesp_stop_testing),
+    re_path(r'^onsite/?$', myesp.myesp_onsite),
+    re_path(r'^passwd/?$', myesp.myesp_passwd),
+    re_path(r'^accountmanage/?$', myesp.myesp_accountmanage),
+    re_path(r'^profile/?$', myesp.edit_profile),
 ]
 
 urlpatterns += [
-    url(r'^teacherbio/?$', bio.bio_edit)
+    re_path(r'^teacherbio/?$', bio.bio_edit)
 ]

--- a/esp/esp/varnish/urls.py
+++ b/esp/esp/varnish/urls.py
@@ -1,7 +1,7 @@
-from django.conf.urls import url
+from django.urls import path
 
 from esp.varnish import views
 
 urlpatterns = [
-    url(r'^purge_page$', views.varnish_purge),
+    path('purge_page', views.varnish_purge),
 ]

--- a/esp/esp/web/urls.py
+++ b/esp/esp/web/urls.py
@@ -1,12 +1,12 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from esp.web.views import bio
 
 urlpatterns = [
     # bios (/learn URLs are deprecated)
-    url(r'^(?P<username>[^/]+)/bio\.html$', bio.bio),
-    url(r'^(?P<username>[^/]+)/bio\.edit\.html/?(.*)$', bio.bio_edit),
+    re_path(r'^(?P<username>[^/]+)/bio\.html$', bio.bio),
+    re_path(r'^(?P<username>[^/]+)/bio\.edit\.html/?(.*)$', bio.bio_edit),
     # more deprecated URLs for bios
-    url(r'^(?P<last>[-A-Za-z0-9_ \.]+)/(?P<first>[-A-Za-z_ \.]+)(?P<usernum>[0-9]*)/bio\.html$', bio.bio),
-    url(r'^(?P<last>[-A-Za-z0-9_ ]+)/(?P<first>[-A-Za-z_ ]+)(?P<usernum>[0-9]*)/bio\.edit\.html/?(.*)$', bio.bio_edit),
+    re_path(r'^(?P<last>[-A-Za-z0-9_ \.]+)/(?P<first>[-A-Za-z_ \.]+)(?P<usernum>[0-9]*)/bio\.html$', bio.bio),
+    re_path(r'^(?P<last>[-A-Za-z0-9_ ]+)/(?P<first>[-A-Za-z_ ]+)(?P<usernum>[0-9]*)/bio\.edit\.html/?(.*)$', bio.bio_edit),
 ]


### PR DESCRIPTION
## Description

Migrates all deprecated `url()` calls to `path()` or `re_path()` across all 13 `urls.py` files in the codebase.

`url()` was deprecated in Django 3.1 and is scheduled for removal in Django 4.0. This is a purely mechanical change with no behaviour change patterns that required full regex were converted to `re_path()`, and simple patterns that needed no regex were converted to `path()`. Imports were updated accordingly in each file.

Files changed:
- `esp/esp/urls.py` (38 calls)
- `esp/esp/users/urls.py` (26 calls)
- `esp/esp/program/urls.py` (17 calls)
- `esp/esp/customforms/urls.py` (15 calls)
- `esp/esp/themes/urls.py` (7 calls)
- `esp/esp/accounting/urls.py` (4 calls)
- `esp/esp/web/urls.py` (4 calls)
- `esp/esp/qsdmedia/urls.py` (2 calls)
- `esp/esp/formstack/urls.py` (2 calls)
- `esp/esp/random/urls.py` (2 calls)
- `esp/esp/varnish/urls.py` (1 call)
- `esp/esp/survey/urls.py` (1 call)
- `esp/esp/tests/urls.py` (1 call)

## Related Issue

Closes #4544 
Related to Django Upgrade(#3964 )

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## AI Disclosure

No tool was used

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced