### PR TITLE
Fix #4636: Handle missing POST fields gracefully in medicalsyncapi

### DIFF
--- a/esp/esp/formstack/views.py
+++ b/esp/esp/formstack/views.py
@@ -18,7 +18,7 @@ def formstack_webhook(request):
 
 from django.contrib.auth import authenticate
 from django.http import HttpResponse, Http404, HttpResponseServerError, \
-    HttpResponseForbidden, HttpResponseNotFound
+    HttpResponseForbidden, HttpResponseNotFound, HttpResponseBadRequest
 from django.dispatch import receiver
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_exempt
@@ -46,15 +46,21 @@ def medicalsyncapi(request):
         return HttpResponseServerError("HTTPS is required when accessing this view")
 
     # Authenticate
-    username = request.POST['username']
-    password = request.POST['password']
+    username = request.POST.get('username')
+    password = request.POST.get('password')
+    program = request.POST.get('program')
+
+    if not username or not password:
+        return HttpResponseBadRequest("Missing credentials")
+    if not program:
+        return HttpResponseBadRequest("Missing program")
 
     user = authenticate(username=username, password=password)
     if user is None or not user.isAdministrator():
         return HttpResponseForbidden("Authentication failed")
 
     # Find Program
-    chunks = request.POST['program'].split(' ')
+    chunks = program.split(' ')
     if len(chunks) == 2:
         url = chunks[0] + '/' + chunks[1]
     elif len(chunks) == 3:


### PR DESCRIPTION
Fixes #4636.

Updates `medicalsyncapi` in `esp/esp/formstack/views.py` to use `.get()` instead of direct dictionary access for `username`, `password`, and `program` POST data to prevent `KeyError` 500 crashes. It now explicitly returns `HttpResponseBadRequest` (400) if required information is missing.