### PR TITLE
Fix medicalsyncapi missing field validation (#4636)

### DIFF
--- a/esp/esp/formstack/views.py
+++ b/esp/esp/formstack/views.py
@@ -18,7 +18,7 @@ def formstack_webhook(request):
 
 from django.contrib.auth import authenticate
 from django.http import HttpResponse, Http404, HttpResponseServerError, \
-    HttpResponseForbidden, HttpResponseNotFound
+    HttpResponseForbidden, HttpResponseNotFound, HttpResponseBadRequest
 from django.dispatch import receiver
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_exempt
@@ -45,16 +45,24 @@ def medicalsyncapi(request):
     if not request.is_secure():
         return HttpResponseServerError("HTTPS is required when accessing this view")
 
+    # Validate required fields
+    username = request.POST.get('username')
+    password = request.POST.get('password')
+    program = request.POST.get('program')
+
+    if not username or not password:
+        return HttpResponseBadRequest("Missing credentials")
+    if not program:
+        return HttpResponseBadRequest("Missing program")
+
     # Authenticate
-    username = request.POST['username']
-    password = request.POST['password']
 
     user = authenticate(username=username, password=password)
     if user is None or not user.isAdministrator():
         return HttpResponseForbidden("Authentication failed")
 
     # Find Program
-    chunks = request.POST['program'].split(' ')
+    chunks = program.split(' ')
     if len(chunks) == 2:
         url = chunks[0] + '/' + chunks[1]
     elif len(chunks) == 3:


### PR DESCRIPTION
## Description

This fixes a server error in medicalsyncapi when required POST parameters are missing.

Previously, the endpoint directly accessed request.POST['username'], request.POST['password'], and request.POST['program']. If any field was absent, Django raised MultiValueDictKeyError, causing a 500 response.

This change adds input validation before authentication and program parsing:
- Reads username, password, and program via .get()
- Returns 400 Bad Request with clear messages for missing required inputs:
  - Missing credentials (missing username/password)
  - Missing program (missing program)
- Keeps existing auth and program lookup behavior unchanged for valid requests

## Before

- Missing required POST fields caused unhandled exception
- Response: 500 Internal Server Error
- Error observed: MultiValueDictKeyError ('username' / 'password' / 'program')

### Screenshot (Before)
<img width="947" height="776" alt="Screenshot 2026-03-03 191132" src="https://github.com/user-attachments/assets/f8defe5f-be1d-44c5-b07a-cdd85af3c6ad" />


## After

- Required POST fields are validated first
- Missing username/password returns: 400 Bad Request ("Missing credentials")
- Missing program returns: 400 Bad Request ("Missing program")
- No unhandled KeyError path for malformed POST payloads

### Screenshot (After)
<img width="887" height="76" alt="Screenshot 2026-03-03 190816" src="https://github.com/user-attachments/assets/0fd2b886-2429-43d8-8684-28accada65a5" />


## Related Issue

Closes #4636

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

Manual verification:
- Ran lint using project CI rules (deploy/lint) and confirmed no lint failures for this change
- Confirmed missing required POST fields now return 400 responses instead of unhandled 500 errors

## AI Disclosure

Used GPT-5.3-Codex to assist with drafting PR description.

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced