### PR TITLE
Fix #4599: Add website documentation link to droplets theme admin bar

### DIFF
--- a/esp/esp/themes/theme_data/droplets/scripts/admin_bar.js
+++ b/esp/esp/themes/theme_data/droplets/scripts/admin_bar.js
@@ -87,7 +87,8 @@ ESP.registerAdminModule({
                   '<a href="/manage/pages">Manage static pages</a><br />' +
                   (debug ? '<a href="/admin/">Administration pages</a><br />' : '') +
                   '<a href="/admin/filebrowser/browse/">Manage media files</a><br />' +
-                  '<a href="/themes/">Manage theme settings</a>' +
+                  '<a href="/themes/">Manage theme settings</a><br />' +
+                  '<a href="/manage/docs/">Website Documentation</a>' +
                   '</div>',
     name: 'Other',
     displayName: 'Other Important Links'


### PR DESCRIPTION
Hi @willgearty,

I’ve tried to address the issue by updating the droplets theme admin bar so that the website documentation link now appears there as well. I tested it locally and it seems to be working as expected.

However, since this involves theme-specific frontend behavior, I just wanted to request a careful review from your side. If there’s anything that could be improved — structurally, stylistically, or architecturally — I would really appreciate your specific guidance so I can refine it properly.

Thank you very much for your time and feedback!

Fixes #4599