### PR TITLE
 fix: user search controller combination queries (#956)

### DIFF
--- a/esp/esp/users/controllers/tests/test_usersearch.py
+++ b/esp/esp/users/controllers/tests/test_usersearch.py
@@ -80,7 +80,7 @@ class TestUserSearchController(ProgramFrameworkTest):
         post_data['checkbox_and_confirmed'] = '1'
 
         # Create test user
-        test_user = self.user  # Use existing test user from ProgramFrameworkTest
+        test_user = self.students[0]  # Use existing test student from ProgramFrameworkTest
 
         # Setup RecordTypes
         rt_attended, _ = RecordType.objects.get_or_create(name='attended', defaults={'description': 'Attended'})
@@ -92,7 +92,9 @@ class TestUserSearchController(ProgramFrameworkTest):
 
         # Create another user with only ONE record to ensure exclusion
         other_user = ESPUser.objects.create_user(username='otheruser', email='other@example.com', password='password')
-        RegistrationProfile.objects.create(user=other_user)
+        other_user.makeRole("Student")
+        student_info = StudentInfo.objects.create(user=other_user, graduation_year=ESPUser.program_schoolyear(self.program)+2)
+        RegistrationProfile.objects.create(user=other_user, program=self.program, student_info=student_info, most_recent_profile=True)
         Record.objects.create(user=other_user, event=rt_attended, program=self.program)
 
         query = self.controller.query_from_postdata(self.program, post_data)

--- a/esp/esp/users/controllers/tests/test_usersearch.py
+++ b/esp/esp/users/controllers/tests/test_usersearch.py
@@ -3,10 +3,10 @@ from esp.program.tests import ProgramFrameworkTest
 from esp.tagdict.models import Tag
 from esp.tests.util import user_role_setup
 from esp.users.forms.user_reg import ValidHostEmailField
-from esp.users.models import User, ESPUser, UserForwarder, StudentInfo, Permission
+from esp.users.models import User, ESPUser, UserForwarder, StudentInfo, Permission, Record, RecordType
 from django.test import TestCase
 import esp.users.views as views
-from esp.program.models import Program
+from esp.program.models import Program, RegistrationProfile
 
 import random
 import string
@@ -65,3 +65,41 @@ class TestUserSearchController(ProgramFrameworkTest):
         result = ESPUser.objects.filter(query)
         self.assertEqual(result.model, ESPUser)
         self.assertGreater(result.count(), 0)
+
+    def test_overlap_bug(self):
+        """
+        Verify that combining mutually exclusive checklist filters (e.g., 'attended' AND
+        'confirmed') using the combo_base_list intersection strategy does not result in a
+        single row failing the AND condition, and instead properly intersects the subsets.
+        Issue #956
+        """
+        # Base list: Student Profile
+        post_data = self._get_combination_post_data('Student', 'student_profile')
+        # Add AND filters for both 'attended' and 'confirmed'
+        post_data['checkbox_and_attended'] = '1'
+        post_data['checkbox_and_confirmed'] = '1'
+
+        # Create test user
+        test_user = self.user  # Use existing test user from ProgramFrameworkTest
+
+        # Setup RecordTypes
+        rt_attended, _ = RecordType.objects.get_or_create(name='attended', defaults={'description': 'Attended'})
+        rt_confirmed, _ = RecordType.objects.get_or_create(name='reg_confirmed', defaults={'description': 'Registration Confirmed'})
+
+        # Create records for the same user
+        Record.objects.create(user=test_user, event=rt_attended, program=self.program)
+        Record.objects.create(user=test_user, event=rt_confirmed, program=self.program)
+
+        # Create another user with only ONE record to ensure exclusion
+        other_user = ESPUser.objects.create_user(username='otheruser', email='other@example.com', password='password')
+        RegistrationProfile.objects.create(user=other_user)
+        Record.objects.create(user=other_user, event=rt_attended, program=self.program)
+
+        query = self.controller.query_from_postdata(self.program, post_data)
+        results = ESPUser.objects.filter(query).distinct()
+
+        # The test_user should be found because they have BOTH records
+        self.assertIn(test_user, results)
+        # The other_user should NOT be found because they only have ONE of the records (AND logic)
+        self.assertNotIn(other_user, results)
+        self.assertEqual(results.count(), 1)

--- a/esp/esp/users/controllers/usersearch.py
+++ b/esp/esp/users/controllers/usersearch.py
@@ -307,65 +307,27 @@ class UserSearchController(object):
             and_keys = [x[4:] for x in [x for x in checkbox_keys if x.startswith('and_')]]
             or_keys = [x[3:] for x in [x for x in checkbox_keys if x.startswith('or_')]]
             not_keys = [x[4:] for x in [x for x in checkbox_keys if x.startswith('not_')]]
-            #if any keys concern the same field, we will place them into
-            #a subquery and count occurrences
-
-            #for the purpose of experimentation simply fix this to the record__event
-            #as this could very well have different implications for other fields
-
-            subqry_fieldmap = {'record__event':[]}
-
             for and_list_name in and_keys:
                 user_type = get_recipient_type(and_list_name)
-
                 if user_type:
-
                     qobject = getattr(program, user_type)(QObjects=True)[and_list_name]
+                    subquery_qs = ESPUser.objects.filter(qobject).values_list('pk', flat=True).distinct()
 
                     if and_list_name in not_keys:
-                        q_program = q_program & ~qobject
+                        q_program = q_program & ~Q(pk__in=subquery_qs)
                     else:
-                        needs_subquery = False
-                        if len(qobject.children) > 1:
-                            qobject_child = qobject.children[1]
-
-                            if isinstance(qobject_child, (list, tuple)):
-                                field_name, field_value = qobject.children[1]
-                                needs_subquery = field_name in subqry_fieldmap
-
-                                if needs_subquery:
-                                    subqry_fieldmap[field_name].append(field_value)
-                        if not needs_subquery:
-                            q_program = q_program & qobject
-
-            event_fields = subqry_fieldmap['record__event']
-
-            if event_fields:
-                #annotation is needed to initiate group by
-                #except that it causes the query to return two columns
-                #so we call values at the end of the chain, however,
-                #that results in multiple group by fields(causing the query to fail)
-                #so, we assign a group by field, to force grouping by user_id
-                subquery = (
-                              Record
-                              .objects
-                              .filter(program=program, event__name__in=event_fields)
-                              .annotate(numusers=Count('user__id'))
-                              .filter(numusers=len(event_fields))
-                              .values_list('user_id', flat=True)
-                            )
-
-                subquery.query.group_by = []#leave empty to strip out duplicate group by
-                subquery = Q(pk__in=subquery)
+                        q_program = q_program & Q(pk__in=subquery_qs)
 
             for or_list_name in or_keys:
                 user_type = get_recipient_type(or_list_name)
                 if user_type:
                     qobject = getattr(program, user_type)(QObjects=True)[or_list_name]
+                    subquery_qs = ESPUser.objects.filter(qobject).values_list('pk', flat=True).distinct()
+
                     if or_list_name not in not_keys:
-                        q_program = q_program | qobject
+                        q_program = q_program | Q(pk__in=subquery_qs)
                     else:
-                        q_program = q_program | ~qobject
+                        q_program = q_program | ~Q(pk__in=subquery_qs)
 
             #   Get the user-specific part of the query (e.g. ID, name, school)
             q_extra = self.query_from_criteria(recipient_type, data, program)


### PR DESCRIPTION
## Description

This PR fixes a long-standing architectural bug in the `UserSearchController` that handles "Combination lists" in the communications panel. 

Previously, when joining multiple intersecting criteria (e.g., combining Event "Attended" AND Event "Confirm Pre-Registration"), the controller incorrectly chained these conditions using the `&` operator across the same related `Q` object fields. Due to Django's handling of multi-valued relationships, this would attempt to match both contradictory conditions on a single joined row, resulting in 0 users being returned.

This fix shifts the filtering architecture from monolithic `Q` object chaining to querying intersections based on evaluating `Q(pk__in=...)` subsets. This isolates each condition correctly and resolves the empty result sets for overlapping requirements.

## Related Issue

Closes #956
Closes #1718

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [x] New tests added (if applicable)
- [x] Manually verified

## AI Disclosure

AI was just used for suggestion.

## Checklist

- [x] Self-reviewed the code
- [x] Updated documentation (if needed)
- [x] No new warnings or errors introduced

