### PR TITLE
Fix incorrect response index in get_class_application_2 and get_class_application_3

### DIFF
--- a/esp/esp/program/modules/handlers/listgenmodule.py
+++ b/esp/esp/program/modules/handlers/listgenmodule.py
@@ -263,13 +263,13 @@ class UserAttributeGetter(object):
     def get_class_application_2(self):
         responses = self.user.listAppResponses(self.program)
         if len(responses) > 1:
-            return str(responses[1].question.subject) + ':  ' + str(responses[0])
+            return str(responses[1].question.subject) + ':  ' + str(responses[1])
         else:
             return None
     def get_class_application_3(self):
         responses = self.user.listAppResponses(self.program)
         if len(responses) > 2:
-            return str(responses[2].question.subject) + ':  ' + str(responses[0])
+            return str(responses[2].question.subject) + ':  ' + str(responses[2])
         else:
             return None
 


### PR DESCRIPTION
## Description

While reviewing `listgenmodule.py`, I noticed that `get_class_application_2()` and `get_class_application_3()` were returning the wrong response text.

Both methods correctly use `responses[1]` and `responses[2]` to fetch the question subject, but the response text itself was still being taken from `responses[0]`. As a result, the first response's text was always displayed even when the second or third application field was selected.

This PR updates the index used for the response text so that each method returns the correct response corresponding to its question.

## Related Issue

Closes #4709

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Manually verified

Verified by reviewing the logic to ensure each method now references the correct response index.

## AI Disclosure

No AI tools were used to generate the final code changes.

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (not required for this change)
- [x] No new warnings or errors introduced