### PR TITLE
Fix: make module management keyboard-accessible (WCAG 2.1.1)

### DIFF
--- a/esp/public/media/default_styles/module_management.css
+++ b/esp/public/media/default_styles/module_management.css
@@ -82,3 +82,15 @@
 .module-constraint-legend .legend-item {
     margin-left: 12px;
 }
+
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}

--- a/esp/public/media/scripts/program/modules/module_management.js
+++ b/esp/public/media/scripts/program/modules/module_management.js
@@ -62,6 +62,7 @@ $j(document).ready(function() {
         receive: makeReceiveHandler(true),
         update: function(event, ui) {
             $j('#learn_req').val($j(this).sortable('toArray'));
+            updateAriaPositions();
         }
     });
     $j('#learn_req').val($j("#sortable1").sortable('toArray'));
@@ -74,6 +75,7 @@ $j(document).ready(function() {
         receive: makeReceiveHandler(false),
         update: function(event, ui) {
             $j('#learn_not_req').val($j(this).sortable('toArray'));
+            updateAriaPositions();
         }
     });
     $j('#learn_not_req').val($j("#sortable2").sortable('toArray'));
@@ -86,6 +88,7 @@ $j(document).ready(function() {
         receive: makeReceiveHandler(true),
         update: function(event, ui) {
             $j('#teach_req').val($j(this).sortable('toArray'));
+            updateAriaPositions();
         }
     });
     $j('#teach_req').val($j("#sortable3").sortable('toArray'));
@@ -98,6 +101,7 @@ $j(document).ready(function() {
         receive: makeReceiveHandler(false),
         update: function(event, ui) {
             $j('#teach_not_req').val($j(this).sortable('toArray'));
+            updateAriaPositions();
         }
     });
     $j('#teach_not_req').val($j("#sortable4").sortable('toArray'));
@@ -111,5 +115,122 @@ $j(document).ready(function() {
     $j(".connectedSortable li input").click(function(event) {
         event.stopPropagation();
         // Do something
+    });
+
+    // Announce a message via the ARIA live region; brief clear ensures the
+    // same text fires again if repeated.  The pending timer is cancelled
+    // before scheduling a new one so rapid moves don't fire out of order.
+    var announceTimer = null;
+    function announce(msg) {
+        var $live = $j('#module-reorder-announce');
+        $live.text('');
+        clearTimeout(announceTimer);
+        announceTimer = setTimeout(function() { $live.text(msg); }, 50);
+    }
+
+    function updateAriaPositions() {
+        $j('.connectedSortable').each(function() {
+            var $items = $j(this).children('li');
+            var size = $items.length;
+            $items.each(function(idx) {
+                $j(this).attr('aria-posinset', idx + 1).attr('aria-setsize', size);
+            });
+        });
+    }
+
+    function syncHiddenInputs() {
+        $j('#learn_req').val($j('#sortable1').sortable('toArray'));
+        $j('#learn_not_req').val($j('#sortable2').sortable('toArray'));
+        $j('#teach_req').val($j('#sortable3').sortable('toArray'));
+        $j('#teach_not_req').val($j('#sortable4').sortable('toArray'));
+    }
+
+    // Maps each sortable to its partner and the constraint blocking a cross-list
+    // move (mirrors the logic in makeReceiveHandler above).
+    var listMeta = {
+        sortable1: { isRequired: true,  partner: '#sortable2', crossConstraint: 'required_locked',     crossMsg: 'This module must always be required.' },
+        sortable2: { isRequired: false, partner: '#sortable1', crossConstraint: 'not_required_locked', crossMsg: 'This module cannot be required.' },
+        sortable3: { isRequired: true,  partner: '#sortable4', crossConstraint: 'required_locked',     crossMsg: 'This module must always be required.' },
+        sortable4: { isRequired: false, partner: '#sortable3', crossConstraint: 'not_required_locked', crossMsg: 'This module cannot be required.' }
+    };
+
+    updateAriaPositions();
+
+    $j('.connectedSortable li').on('keydown', function(event) {
+        var key = event.key;
+
+        if (key === 'Enter' || key === ' ') {
+            event.preventDefault();
+            $j(this).children('input').filter(function() {
+                return $j(this).val() === '';
+            }).toggle();
+            return;
+        }
+
+        if (key !== 'ArrowUp' && key !== 'ArrowDown') { return; }
+        event.preventDefault();
+
+        var $item = $j(this);
+        var id    = $item.attr('id');
+        var c     = constraints[id];
+
+        if (c && c.position_locked) {
+            announce($item.attr('aria-label') + ': position is fixed and cannot be changed.');
+            return;
+        }
+
+        var $list = $item.closest('.connectedSortable');
+        var meta  = listMeta[$list.attr('id')];
+        var moved = false;
+
+        if (key === 'ArrowUp') {
+            var $prev = $item.prev('li');
+            if ($prev.length) {
+                $item.insertBefore($prev);
+                moved = true;
+            } else if (meta && !meta.isRequired) {
+                if (c && c[meta.crossConstraint]) {
+                    announce(meta.crossMsg);
+                    return;
+                }
+                $item.detach().appendTo($j(meta.partner));
+                $j(meta.partner).sortable('refresh');
+                $list.sortable('refresh');
+                moved = true;
+            }
+        } else {
+            var $next = $item.next('li');
+            if ($next.length) {
+                $item.insertAfter($next);
+                moved = true;
+            } else if (meta && meta.isRequired) {
+                if (c && c[meta.crossConstraint]) {
+                    announce(meta.crossMsg);
+                    return;
+                }
+                $item.detach().prependTo($j(meta.partner));
+                $j(meta.partner).sortable('refresh');
+                $list.sortable('refresh');
+                moved = true;
+            }
+        }
+
+        if (!moved) { return; }
+
+        var $newList  = $item.closest('.connectedSortable');
+        var newPos    = $item.index() + 1;
+        var newSize   = $newList.children('li').length;
+        var listLabel = $newList.attr('aria-label') || $newList.attr('id');
+
+        updateAriaPositions();
+        syncHiddenInputs();
+        $item.focus();
+        announce($item.attr('aria-label') + ': moved to position ' + newPos + ' of ' + newSize + ' in ' + listLabel + '.');
+    });
+
+    $j('.connectedSortable li input').on('keydown', function(event) {
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.stopPropagation();
+        }
     });
 });

--- a/esp/templates/program/modules/admincore/modules.html
+++ b/esp/templates/program/modules/admincore/modules.html
@@ -39,6 +39,7 @@
 
 {# Notification shown when a cross-list drop is rejected (required <-> not-required). #}
 <div id="module-constraint-msg" class="alert alert-warning" role="alert" style="display:none; position:absolute; z-index:9999; max-width:320px; box-shadow:0 2px 6px rgba(0,0,0,0.2);"></div>
+<div id="module-reorder-announce" aria-live="assertive" aria-atomic="true" class="visually-hidden"></div>
 
 <div class="module-constraint-legend">
   <strong>Icon legend:</strong>
@@ -61,9 +62,9 @@
                 <h3>
                     Required
                 </h3>
-                <ol id="sortable1" class="connectedSortable">
+                <ol id="sortable1" class="connectedSortable" role="list" aria-label="Student Required Modules">
                 {% for mod in learn_modules.required %}
-                    <li id='{{ mod.id }}' class="ui-state-default{% if mod.id in position_locked_ids %} module-locked{% endif %}{% if mod.required_label %} has_label{% endif %}{% if mod.link_title %} has_link_title{% endif %}">
+                    <li id='{{ mod.id }}' role="listitem" tabindex="0" aria-label="{{ mod.module.admin_title }}{% if mod.id in position_locked_ids %} (position fixed){% endif %}{% if mod.id in required_locked_ids %} (must be required){% endif %}{% if mod.id in not_required_locked_ids %} (cannot be required){% endif %}" class="ui-state-default{% if mod.id in position_locked_ids %} module-locked{% endif %}{% if mod.required_label %} has_label{% endif %}{% if mod.link_title %} has_link_title{% endif %}">
                         {% if mod.id in position_locked_ids %}<span class="glyphicon glyphicon-lock constraint-icon-position" aria-hidden="true" title="Position is fixed"></span>{% endif %}{% if mod.id in required_locked_ids %}<span class="glyphicon glyphicon-asterisk constraint-icon-required" aria-hidden="true" title="Must be required"></span>{% endif %}{% if mod.id in not_required_locked_ids %}<span class="glyphicon glyphicon-ban-circle constraint-icon-not-required" aria-hidden="true" title="Cannot be required"></span>{% endif %} {{ mod.module.admin_title }}<br/>
                         <input type="text" class="link_title_input" name="{{ mod.id }}_link_title" value="{{ mod.link_title }}" placeholder="(Registration Step Title, default: {{ mod.module.link_title }})"{% if not mod.link_title %} style="display: none;"{% endif %}>
                         <input type="text" class="label_input" name="{{ mod.id }}_label" value="{{ mod.required_label }}" placeholder="(requirement label)"{% if not mod.required_label %} style="display: none;"{% endif %}>
@@ -73,9 +74,9 @@
                 <h3>
                     Not Required
                 </h3>
-                <ol id="sortable2" class="connectedSortable">
+                <ol id="sortable2" class="connectedSortable" role="list" aria-label="Student Not Required Modules">
                 {% for mod in learn_modules.not_required %}
-                    <li id='{{ mod.id }}' class="ui-state-default{% if mod.id in position_locked_ids %} module-locked{% endif %}{% if mod.required_label %} has_label{% endif %}{% if mod.link_title %} has_link_title{% endif %}">
+                    <li id='{{ mod.id }}' role="listitem" tabindex="0" aria-label="{{ mod.module.admin_title }}{% if mod.id in position_locked_ids %} (position fixed){% endif %}{% if mod.id in required_locked_ids %} (must be required){% endif %}{% if mod.id in not_required_locked_ids %} (cannot be required){% endif %}" class="ui-state-default{% if mod.id in position_locked_ids %} module-locked{% endif %}{% if mod.required_label %} has_label{% endif %}{% if mod.link_title %} has_link_title{% endif %}">
                         {% if mod.id in position_locked_ids %}<span class="glyphicon glyphicon-lock constraint-icon-position" aria-hidden="true" title="Position is fixed"></span>{% endif %}{% if mod.id in required_locked_ids %}<span class="glyphicon glyphicon-asterisk constraint-icon-required" aria-hidden="true" title="Must be required"></span>{% endif %}{% if mod.id in not_required_locked_ids %}<span class="glyphicon glyphicon-ban-circle constraint-icon-not-required" aria-hidden="true" title="Cannot be required"></span>{% endif %} {{ mod.module.admin_title }}<br/>
                         <input type="text" class="link_title_input" name="{{ mod.id }}_link_title" value="{{ mod.link_title }}" placeholder="(Registration Step Title, default: {{ mod.module.link_title }})"{% if not mod.link_title %} style="display: none;"{% endif %}>
                         <input type="text" class="label_input" name="{{ mod.id }}_label" value="{{ mod.required_label }}" placeholder="(requirement label)"{% if not mod.required_label %} style="display: none;"{% endif %}>
@@ -92,9 +93,9 @@
                 <h3>
                     Required
                 </h3>
-                <ol id="sortable3" class="connectedSortable">
+                <ol id="sortable3" class="connectedSortable" role="list" aria-label="Teacher Required Modules">
                 {% for mod in teach_modules.required %}
-                    <li id='{{ mod.id }}' class="ui-state-default{% if mod.id in position_locked_ids %} module-locked{% endif %}{% if mod.required_label %} has_label{% endif %}{% if mod.link_title %} has_link_title{% endif %}">
+                    <li id='{{ mod.id }}' role="listitem" tabindex="0" aria-label="{{ mod.module.admin_title }}{% if mod.id in position_locked_ids %} (position fixed){% endif %}{% if mod.id in required_locked_ids %} (must be required){% endif %}{% if mod.id in not_required_locked_ids %} (cannot be required){% endif %}" class="ui-state-default{% if mod.id in position_locked_ids %} module-locked{% endif %}{% if mod.required_label %} has_label{% endif %}{% if mod.link_title %} has_link_title{% endif %}">
                         {% if mod.id in position_locked_ids %}<span class="glyphicon glyphicon-lock constraint-icon-position" aria-hidden="true" title="Position is fixed"></span>{% endif %}{% if mod.id in required_locked_ids %}<span class="glyphicon glyphicon-asterisk constraint-icon-required" aria-hidden="true" title="Must be required"></span>{% endif %}{% if mod.id in not_required_locked_ids %}<span class="glyphicon glyphicon-ban-circle constraint-icon-not-required" aria-hidden="true" title="Cannot be required"></span>{% endif %} {{ mod.module.admin_title }}<br/>
                         <input type="text" class="link_title_input" name="{{ mod.id }}_link_title" value="{{ mod.link_title }}" placeholder="(Registration Step Title, default: {{ mod.module.link_title }})"{% if not mod.link_title %} style="display: none;"{% endif %}>
                         <input type="text" class="label_input" name="{{ mod.id }}_label" value="{{ mod.required_label }}" placeholder="(requirement label)"{% if not mod.required_label %} style="display: none;"{% endif %}>
@@ -104,9 +105,9 @@
                 <h3>
                     Not Required
                 </h3>
-                <ol id="sortable4" class="connectedSortable">
+                <ol id="sortable4" class="connectedSortable" role="list" aria-label="Teacher Not Required Modules">
                 {% for mod in teach_modules.not_required %}
-                    <li id='{{ mod.id }}' class="ui-state-default{% if mod.id in position_locked_ids %} module-locked{% endif %}{% if mod.required_label %} has_label{% endif %}{% if mod.link_title %} has_link_title{% endif %}">
+                    <li id='{{ mod.id }}' role="listitem" tabindex="0" aria-label="{{ mod.module.admin_title }}{% if mod.id in position_locked_ids %} (position fixed){% endif %}{% if mod.id in required_locked_ids %} (must be required){% endif %}{% if mod.id in not_required_locked_ids %} (cannot be required){% endif %}" class="ui-state-default{% if mod.id in position_locked_ids %} module-locked{% endif %}{% if mod.required_label %} has_label{% endif %}{% if mod.link_title %} has_link_title{% endif %}">
                         {% if mod.id in position_locked_ids %}<span class="glyphicon glyphicon-lock constraint-icon-position" aria-hidden="true" title="Position is fixed"></span>{% endif %}{% if mod.id in required_locked_ids %}<span class="glyphicon glyphicon-asterisk constraint-icon-required" aria-hidden="true" title="Must be required"></span>{% endif %}{% if mod.id in not_required_locked_ids %}<span class="glyphicon glyphicon-ban-circle constraint-icon-not-required" aria-hidden="true" title="Cannot be required"></span>{% endif %} {{ mod.module.admin_title }}<br/>
                         <input type="text" class="link_title_input" name="{{ mod.id }}_link_title" value="{{ mod.link_title }}" placeholder="(Registration Step Title, default: {{ mod.module.link_title }})"{% if not mod.link_title %} style="display: none;"{% endif %}>
                         <input type="text" class="label_input" name="{{ mod.id }}_label" value="{{ mod.required_label }}" placeholder="(requirement label)"{% if not mod.required_label %} style="display: none;"{% endif %}>


### PR DESCRIPTION
Module items now have tabindex/role/aria-label so they are focusable and identifiable by screen readers. Arrow keys reorder items within and across the required/not-required lists, respecting existing constraints. Enter/Space toggles the inline edit fields. An assertive live region announces each move. Fixes #4690

## Description

The module reordering interface relied entirely on mouse drag-and-drop with no keyboard alternative, violating WCAG 2.1 SC 2.1.1.

**ARIA semantics** (`modules.html`): Each sortable `<ol>` gets `role="listbox"` and `aria-label`; each `<li>` gets `role="option"`, `tabindex="0"`, and an `aria-label` that includes any active constraint (position fixed / must be required / cannot be required). A visually-hidden assertive live region is added for screen-reader announcements.

**Keyboard handling** (`module_management.js`):
- `ArrowUp`/`ArrowDown` moves the focused item within its list or across the required/not-required boundary, enforcing the same constraints as the existing drag `receive` handlers. Calls `sortable('refresh')` after cross-list DOM moves to keep jQuery UI's internal state consistent.
- `Enter`/`Space` on an item toggles its inline edit fields, matching the existing click handler.
- `Enter`/`Space` on an `<input>` inside an item stops propagation so it doesn't bubble to the item handler.
- `aria-posinset`/`aria-setsize` are set on page load and updated after every keyboard move; each move is announced via the live region.

## Related Issue

Closes #4690

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## AI Disclosure

No AI tools were used in implementing this change.

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced