### PR TITLE
Fix fruitsalad: use side tab color when top tab and side tab match sa…

### DIFF
--- a/esp/esp/web/templatetags/main.py
+++ b/esp/esp/web/templatetags/main.py
@@ -78,7 +78,14 @@ def extract_theme(url):
         num_chars_matched = count_matching_chars(url, category['header_link'])
         if num_chars_matched > max_chars_matched:
             max_chars_matched = num_chars_matched
-            tab_index = 0
+            # If the header_link is fully consumed by the match (URL is within this
+            # section), default to the first sub-tab color instead of tabcolor0.
+            # This fixes the case where a top tab and a side tab point to the same
+            # URL — the side tab color now takes priority over tabcolor0.
+            if num_chars_matched >= len(category['header_link']) and category['links']:
+                tab_index = 1
+            else:
+                tab_index = 0
         i = 1
         for item in category['links']:
             num_chars_matched = count_matching_chars(url, item['link'])


### PR DESCRIPTION
When a top tab's header_link and a side tab's link point to the same URL, tabcolor0 was incorrectly taking priority over the section's sub-tab color.
Fix: in extract_theme(), when the header_link match fully consumes the URL meaning the URL belongs to this section), default to tab_index=1 (first sub-tab color) instead of tab_index=0 (logo color). A deeper sub-link match
later in the loop still overrides correctly via the existing strict-greater comparison.

Before: /learn/ -> tabcolor0 (logo green, wrong)
After:  /learn/ -> tabcolor1 (section color, correct)

Fixes #2165

## Description

When clicking the first sub tab (e.g. "Learn"), the page body was not changing to the expected section color. Instead it stayed at tabcolor0 (the default logo color), making it appear as if the tab had not been clicked. Other tabs like "Teach" and "Volunteer" were working correctly.

Root cause: in `extract_theme()` inside `esp/web/templatetags/main.py`, the URL matching logic always assigned `tab_index = 0` when a top tab's `header_link` matched the current URL. Since the top tab match was processed before the sub-link loop, and the first sub-link typically matched with equal prefix length (not strictly greater), it never overrode `tabcolor0`.

Fix: when the `header_link` is fully consumed by the URL match (i.e. the URL belongs to that section), we now default to `tab_index = 1` (first sub-tab color) instead of `tab_index = 0`. If a deeper sub-link later matches more characters, it still overrides correctly via the existing strict-greater comparison in the sub-link loop.

## Related Issue

Closes #2165

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified


## AI Disclosure

We took suggestions from an AI tool to help identify the root cause and the appropriate location of the fix. However, the actual code change was typed manually, the logic was understood and reviewed by us independently,
and the fix was manually verified in the Django shell before committing.

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced