### PR TITLE
Refactor fillslot grade filtering to remove redundancy and fix user_g…

### DIFF
--- a/esp/esp/program/modules/handlers/studentclassregmodule.py
+++ b/esp/esp/program/modules/handlers/studentclassregmodule.py
@@ -499,12 +499,11 @@ class StudentClassRegModule(ProgramModuleObj):
 
         #   Override both grade limits and size limits during onsite registration
         #   Classes are sorted like the catalog
-        if is_onsite and not 'filter' in request.GET:
-            classes = list(ClassSubject.objects.catalog(self.program, ts))
-        else:
-            classes = [c for c in list(ClassSubject.objects.catalog(self.program, ts)) if c.grade_min <= user_grade and c.grade_max >= user_grade]
+        classes = list(ClassSubject.objects.catalog(self.program, ts))
+        should_filter_invalid = (not is_onsite) or ('filter' in request.GET)
+        if should_filter_invalid:
             if user_grade != 0:
-                classes = [c for c in classes if c.grade_min <=user_grade and c.grade_max >= user_grade]
+                classes = [c for c in classes if c.grade_min <= user_grade and c.grade_max >= user_grade]
             classes = [c for c in classes if not c.isRegClosed()]
 
         categories_sort = self.sort_categories(classes, self.program)


### PR DESCRIPTION
## Description

I refactored it to fetch the catalog once up front, then apply the grade and closed-registration filters inside a single conditional that correctly skips them for onsite users. The grade filter now only runs when user_grade != 0, so users with no recorded grade are no longer shown an empty class list.

This also eliminates the duplicated catalog() call that existed in both branches of the original if/else.

## Related Issue

Closes #4736

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## AI Disclosure

Used AI assistance to validate the refactored logic.

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced
