### PR TITLE
Fix scheduling check false positives for walk-in teacher conflicts

### DIFF
--- a/esp/esp/program/modules/handlers/schedulingcheckmodule.py
+++ b/esp/esp/program/modules/handlers/schedulingcheckmodule.py
@@ -306,7 +306,7 @@ class SchedulingCheckRunner:
             name_heading = "Teacher's Name"
         d = self._timeslot_dict(slot=lambda: {})
         l = []
-        for s in self._all_class_sections():
+        for s in self._all_class_sections(include_walkins=False):
             mt =  s.get_meeting_times()
             for t in mt:
                 for teach in s.teachers:


### PR DESCRIPTION
`teachers_teaching_two_classes_same_time()` was the only scheduling check that included walk-in sections. Walk-ins allow flexible teacher scheduling, so pass `include_walkins=False` to align with all other checks in the same module (`multiple_classes_same_resource_same_time`, `room_capacity_mismatch`, `classes_which_cover_lunch`).

Fixes #1597

## Description

The `teachers_teaching_two_classes_same_time()` check in `schedulingcheckmodule.py` was incorrectly including walk-in sections when scanning for teacher double-booking. This caused false-positive conflicts when a teacher was assigned to consecutive or overlapping walk-in classes at the same timeblock.

Walk-in classes (`ClassCategories` with symbol `W`, category `"Walk-in Activity"`) are special — they are expected to allow teachers to run multiple sessions without triggering scheduling conflicts.

**Change made:** One argument added to one function call:
```diff
- for s in self._all_class_sections():
+ for s in self._all_class_sections(include_walkins=False):
```

This is consistent with every other check in the same file that already uses `include_walkins=False`. No model changes, no migrations, no UI changes required.

## Related Issue

Closes #1597

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

**Manual verification steps:**
1. Created a teacher (`pushkar`) assigned to two walk-in sections (`W21s1`, `W22s1`) at the same timeslot
2. Created the same teacher assigned to two regular sections (`S23s1`, `S24s1`) at the same timeslot
3. Ran `teachers_teaching_two_classes_same_time` check via `/manage/Test/2026/scheduling_checks`
4. Confirmed walk-in sections are excluded from the conflict check — only regular class double-bookings are flagged

## AI Disclosure

AI tools were used to assist in identifying the root cause of the issue and locating the relevant code. The actual code change was reviewed manually multiple times before committing to ensure it behaves exactly as expected. We verified the fix end-to-end — including creating test data, running the scheduling check, and confirming that walk-in conflicts are suppressed while real conflicts on regular classes are still correctly detected.

## Checklist

- [x] Self-reviewed the code
- [x] Updated documentation (if needed)
- [x] No new warnings or errors introduced

<img width="1854" height="1048" alt="image" src="https://github.com/user-attachments/assets/dc7668c2-f1ff-476a-85bb-ba06d46ea7e1" />
