### PR TITLE
fix(lottery): cast priority index to int in get_computed_schedule

### DIFF
--- a/esp/esp/program/controllers/lottery.py
+++ b/esp/esp/program/controllers/lottery.py
@@ -690,7 +690,7 @@ class LotteryAssignmentController(object):
             assignments = numpy.nonzero(self.priority[1][self.student_indices[student_id],:])[0]
         else:
             import re
-            p = re.search('(?<=priority_)\d*', mode).group(0)
+            p = re.search(r'(?<=priority_)\d*', mode).group(0)
             if p:
                 assignments = numpy.nonzero(self.priority[int(p)][self.student_indices[student_id],:])[0]
         result = []


### PR DESCRIPTION
Fixes #4759

## Description

Fixes a TypeError in get_computed_schedule() where the priority level extracted from the mode string ("priority_N") was used as a string when indexing self.priority, which is a list. Python requires list indices to be integers, causing a runtime crash.

##Problem

The method supports a mode parameter in the form:

`priority_N`

For example:

```
priority_1
priority_2
priority_3
```

The priority value N is extracted using a regex:

`p = re.search('(?<=priority_)\d*', mode).group(0)`

However, p is returned as a string (e.g., "2").
Later it is used to index into self.priority, which is a list:

`self.priority[p]`

Since list indices must be integers, this raises:

`TypeError: list indices must be integers or slices, not str`

This causes get_computed_schedule() to fail whenever a "priority_N" mode is used.


##Solution

Convert the extracted priority value to an integer before indexing the list.

Before

`assignments = numpy.nonzero(self.priority[p][self.student_indices[student_id],:])[0]`

After

`assignments = numpy.nonzero(self.priority[int(p)][self.student_indices[student_id],:])[0]`

This ensures the correct integer index is used.
