### PR TITLE
Perf: Move RecordType query outside loop in checkout module

### DIFF
--- a/esp/esp/program/modules/handlers/onsitecheckoutmodule.py
+++ b/esp/esp/program/modules/handlers/onsitecheckoutmodule.py
@@ -62,8 +62,8 @@ class OnSiteCheckoutModule(ProgramModuleObj):
 
         if "checkoutall" in request.POST and "confirm" in request.POST:
             students = prog.currentlyCheckedInStudents()
+            rt = RecordType.objects.get(name="checked_out")
             for student in students:
-                rt = RecordType.objects.get(name="checked_out")
                 Record.objects.create(user=student, event=rt, program=prog)
             context['checkout_all_message'] = "Successfully checked out %s students" % (students.count())
 


### PR DESCRIPTION
## Description

In the "Check Out All Students" feature, `RecordType.objects.get(name="checked_out")` was being called inside the for-loop. Since the RecordType doesn't change between students, this results in the same query hitting the database once per student. For a Splash event with 200 students, thats 199 wasted queries.
Moved the query above the loop so it runs once and the result is reused.

## Related Issue

Closes #4778 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [X] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [X] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manually verified


## Checklist

- [X] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [X] No new warnings or errors introduced
