### PR TITLE
Fix accidental number input value changes on mouse wheel scroll (Closes #4714)

### DIFF
--- a/esp/public/media/scripts/common.js
+++ b/esp/public/media/scripts/common.js
@@ -12,8 +12,12 @@ $j.ajax({
 });
 };
 
-$j(function() {
-        $j(document).on('wheel mousewheel DOMMouseScroll', 'input[type=number]:focus', function() {
+$(document).on('focusin', 'input[type=number]', function() {
+        $(this).on('wheel mousewheel DOMMouseScroll.numberInputBlur', function() {
                 this.blur();
         });
+});
+
+$(document).on('focusout', 'input[type=number]', function() {
+        $(this).off('wheel.numberInputBlur mousewheel.numberInputBlur DOMMouseScroll.numberInputBlur');
 });


### PR DESCRIPTION
## Description
Fixes an issue where scrolling the page with the mouse wheel could unintentionally increment/decrement focused `input[type="number"]` fields in admin/program forms.

Added a global wheel-event handler in `esp/public/media/scripts/common.js` that blurs focused number inputs on wheel scroll to prevent accidental value changes while preserving normal form behavior.

## Related Issue
Closes #4714

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing
- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## AI Disclosure
N/A

## Checklist
- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced