### PR TITLE
fix: use case-insensitive username lookup in resend_activation_view

### DIFF
--- a/esp/esp/users/views/registration.py
+++ b/esp/esp/users/views/registration.py
@@ -197,7 +197,13 @@ def resend_activation_view(request):
         if not form.is_valid():
             return render_to_response('registration/resend.html', request,
                                       {'form':form, 'site': Site.objects.get_current()})
-        user=ESPUser.objects.get(username=form.cleaned_data['username'])
+        user = ESPUser.objects.filter(
+            username__iexact=form.cleaned_data['username'],
+            is_active=False,
+            password__regex=r'\$(.*)_'
+        ).exclude(password='emailuser').first()
+        if user is None:
+            raise ESPError("User not found or already activated.", log=False)
         userkey=user.password[user.password.rfind("_")+1:]
         send_activation_email(user, userkey)
         return render_to_response('registration/resend_done.html', request,


### PR DESCRIPTION
## Fix case-insensitive username lookup in resend activation view

Fixes #4798

### Problem
The `resend_activation_view` performs a case-sensitive `ESPUser.objects.get(username=...)` lookup, but the form validation (`AwaitingActivationEmailForm`) checks usernames case-insensitively. When a user enters their username with different casing (e.g. `JOHNDOE` vs `johndoe`), the lookup raises `ESPUser.DoesNotExist` and returns a 500 server error.

### Fix
- Replace `ESPUser.objects.get(username=...)` with `ESPUser.objects.filter(username__iexact=...).first()`  
- Add `is_active=False` and `password__regex` filters to match only accounts awaiting activation (consistent with the pattern used in `AwaitingActivationEmailForm`)  
- Exclude email-only users (`password='emailuser'`)  
- Handle the `None` case gracefully by raising `ESPError` instead of crashing

### Changes
- `esp/esp/users/views/registration.py` — 1 file, 7 insertions, 1 deletion
- No new dependencies