### PR TITLE
Fix case-insensitive username lookup in resend_activation_view

### DIFF
--- a/esp/esp/users/views/registration.py
+++ b/esp/esp/users/views/registration.py
@@ -197,7 +197,10 @@ def resend_activation_view(request):
         if not form.is_valid():
             return render_to_response('registration/resend.html', request,
                                       {'form':form, 'site': Site.objects.get_current()})
-        user=ESPUser.objects.get(username=form.cleaned_data['username'])
+        user = ESPUser.objects.filter( username__iexact=form.cleaned_data['username']).first()
+        if not user:
+            return render_to_response('registration/resend.html', request,
+                                       {'form': form, 'site': Site.objects.get_current()})
         userkey=user.password[user.password.rfind("_")+1:]
         send_activation_email(user, userkey)
         return render_to_response('registration/resend_done.html', request,


### PR DESCRIPTION
## Description

Fixes a bug where `resend_activation_view` performed a case-sensitive username lookup.

Previously the code used:

    ESPUser.objects.get(username=form.cleaned_data['username'])

This could raise `ESPUser.DoesNotExist` if the username was entered with different casing (e.g. `JohnDoe` vs `johndoe`), causing a 500 error.

This change replaces the lookup with a case-insensitive query:

    ESPUser.objects.filter(username__iexact=form.cleaned_data['username']).first()

and safely handles the case where no user is found.

## Result

Users can now request a resend of their activation email even if the username casing differs from the stored username.

## Testing

- Started local dev server with Docker
- Created a test user (`johndoe`)
- Submitted resend request with `JohnDoe`
- Verified the request no longer crashes and is handled correctly.

## AI Disclosure

I used AI assistance to better understand the repository structure and approach the fix. The final code changes were implemented and reviewed manually by me.

## Checklist

- [✅] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [✅] No new warnings or errors introduced
