### PR TITLE
Fix case-insensitive username lookup in resend_activation_view

### DIFF
--- a/esp/esp/users/views/registration.py
+++ b/esp/esp/users/views/registration.py
@@ -197,7 +197,10 @@ def resend_activation_view(request):
         if not form.is_valid():
             return render_to_response('registration/resend.html', request,
                                       {'form':form, 'site': Site.objects.get_current()})
-        user=ESPUser.objects.get(username=form.cleaned_data['username'])
+        user = ESPUser.objects.filter( username__iexact=form.cleaned_data['username']).first()
+        if not user:
+            return render_to_response('registration/resend.html', request,
+                                       {'form': form, 'site': Site.objects.get_current()})
         userkey=user.password[user.password.rfind("_")+1:]
         send_activation_email(user, userkey)
         return render_to_response('registration/resend_done.html', request,


### PR DESCRIPTION
## Description

Fixes a bug where `resend_activation_view` performed a case-sensitive username lookup.

Previously the code used:
`ESPUser.objects.get(username=form.cleaned_data['username'])`

If the user entered the username with different casing (for example `JohnDoe` instead of `johndoe`), the lookup could fail and raise `ESPUser.DoesNotExist`, which could lead to an error.

This change replaces the lookup with a case-insensitive query:

`ESPUser.objects.filter(username__iexact=form.cleaned_data['username']).first()`

It also safely handles the case where no matching user is found.

## Related Issue

Closes #4798

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation update
* [ ] Refactor / cleanup
* [ ] CI/CD or build change

## Testing

* [x] Existing tests pass
* [ ] New tests added (if applicable)
* [x] Manually verified

Testing steps:

* Ran the project locally using Docker.
* Created a test user with username `johndoe`.
* Submitted a resend activation request using `JohnDoe`.
* Verified that the request works correctly and no error occurs.

## AI Disclosure

AI tools were used for guidance in understanding the repository structure and workflow. The code changes were reviewed and implemented by me manually.

## Checklist

* [x] Self-reviewed the code
* [ ] Updated documentation (if needed)
* [x] No new warnings or errors introduced