### PR TITLE
Fix LESS 3.x compilation failure by enabling --math=always

### DIFF
--- a/esp/esp/themes/controllers.py
+++ b/esp/esp/themes/controllers.py
@@ -240,7 +240,7 @@ class ThemeController(object):
         logger.debug('LESS search path is "%s"', less_search_path)
 
         #   Compile to CSS
-        lessc_args = ['lessc', '--include-path=%s' % less_search_path, '-']
+        lessc_args = ['lessc','--math=always','--include-path=%s' % less_search_path, '-']
         lessc_process = subprocess.Popen(lessc_args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         css_data = lessc_process.communicate(less_data.encode())[0]
 


### PR DESCRIPTION
## Description

Fixes LESS compilation failure when using LESS 3.x.

LESS 3.x changed its default math behavior, which can cause compilation errors for expressions used in the project’s theme styles. This resulted in failures when compiling LESS during theme processing.

This change adds the `--math=always` flag to the `lessc` invocation so that legacy math evaluation behavior is enabled, restoring compatibility with the existing styles and allowing LESS compilation to succeed.

## Related Issue

Closes #4819

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation update
* [ ] Refactor / cleanup
* [ ] CI/CD or build change

## Testing

* [x] Existing tests pass
* [ ] New tests added (if applicable)
* [x] Manually verified

## AI Disclosure

AI assistance was used to help reason about the LESS compiler behavior change and verify the appropriate fix.

## Checklist

* [x] Self-reviewed the code
* [ ] Updated documentation (not required)
* [x] No new warnings or errors introduced
