### PR TITLE
Fix IDOR vulnerability in AdminClass endpoints by verifying program ownership

### DIFF
--- a/esp/esp/program/modules/handlers/adminclass.py
+++ b/esp/esp/program/modules/handlers/adminclass.py
@@ -149,11 +149,9 @@ class AdminClass(ProgramModuleObj):
 
             class_id = request.POST['class_id']
             try:
-                class_subject = ClassSubject.objects.get(pk=class_id)
-            except ClassSubject.MultipleObjectsReturned:
-                raise ESPError("Error: multiple classes selected")
-            except ClassSubject.DoesNotExist:
-                raise ESPError("Error: no classes found with id "+str(class_id))
+                class_subject = self.getClassFromId(request, class_id)
+            except ESPError:
+                raise
 
             review_status = request.POST['review_status']
 
@@ -177,14 +175,16 @@ class AdminClass(ProgramModuleObj):
         if request.method == 'POST':
             if request.POST.get('sure') == 'True':
                 try:
-                    s = ClassSection.objects.get(id=int(request.GET['sec_id']))
+                    s = ClassSection.objects.get(id=int(request.GET['sec_id']),
+                    parent_class__parent_program=self.program)
                     s.delete()
                     return HttpResponseRedirect('/manage/%s/%s/manageclass/%s' % (one, two, extra))
                 except (ValueError, ClassSection.DoesNotExist):
                     raise ESPError('Unable to delete a section.  The section requested was: %s' % request.GET['sec_id'], log=False)
         else:
             section_id = int(request.GET['sec_id'])
-            section = ClassSection.objects.get(id=section_id)
+            section = ClassSection.objects.get(id=section_id,
+                parent_class__parent_program=self.program)
             context = {'sec': section, 'module': self}
 
             return render_to_response(self.baseDir()+'delete_confirm.html', request, context)
@@ -245,7 +245,8 @@ class AdminClass(ProgramModuleObj):
                         sf.data = request.POST
                         sf.is_bound = True
                         if sf.is_valid():
-                            sec = ClassSection.objects.get(id=sf.cleaned_data['secid'])
+                            sec = ClassSection.objects.get(id=sf.cleaned_data['secid'],
+                                parent_class__parent_program=self.program)
                             orig_sec_status = sec.status
                             sf.save_data(sec)
                             verbs = RTC.getVisibleRegistrationTypeNames(prog)


### PR DESCRIPTION
## Description

Fixes an Insecure Direct Object Reference (IDOR) vulnerability in AdminClass endpoints.

Previously, several handlers retrieved `ClassSection` objects using only the section ID:

ClassSection.objects.get(id=...)

This allowed administrators of one program to modify or delete sections belonging to another program by supplying a section ID from a different program.

This change ensures that `ClassSection` objects are always fetched with program ownership verification:

ClassSection.objects.get(
    id=section_id,
    parent_class__parent_program=self.program
)

By enforcing this constraint, administrators can only modify or delete sections that belong to the program they manage.

---

## Related Issue

Closes #4799

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

---

## Testing

- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

Tested locally using Docker.

Verified that:
- Admins can modify and delete sections belonging to their program.
- Requests using section IDs from other programs are rejected.
- Normal section management functionality continues to work.

---

## AI Disclosure

AI assistance was used to help understand the repository structure and identify vulnerable query patterns. The code modifications and validation of the fix were implemented manually.

---

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced