### PR TITLE
Fix PlainRedirect exposing all recipient addresses in To: header (#2393)

### DIFF
--- a/esp/esp/dbmail/receivers/plainlist.py
+++ b/esp/esp/dbmail/receivers/plainlist.py
@@ -12,7 +12,12 @@ class PlainList(BaseHandler):
         if len(redirects.values('id')[:1]) == 0:
             return
 
-        self.recipients = [redirect.destination for redirect in redirects]
+        self.recipients = []
+        for redirect in redirects:
+            for addr in redirect.destination.split(','):
+                addr = addr.strip()
+                if addr:
+                    self.recipients.append(addr)
 
         self.send = True
 

--- a/esp/esp/dbmail/receivers/plainlist.py
+++ b/esp/esp/dbmail/receivers/plainlist.py
@@ -5,12 +5,18 @@ from esp.dbmail.models import PlainRedirect
 
 class PlainList(BaseHandler):
 
+    # Hide real recipient addresses from the sender by using SMTP envelope
+    # routing instead of exposing them in the To: header.
+    hide_recipients = True
+
     def process(self, user, user_match):
 
         redirects = PlainRedirect.objects.filter(original__iexact = user)
 
         if len(redirects.values('id')[:1]) == 0:
             return
+
+        self.original_address = user
 
         self.recipients = []
         for redirect in redirects:

--- a/esp/esp/dbmail/tests.py
+++ b/esp/esp/dbmail/tests.py
@@ -488,3 +488,28 @@ class PlainListRecipientPrivacyTest(TestCase):
         handler = self._make_handler()
         handler.process('nonexistent', 'nonexistent')
         self.assertFalse(handler.send)
+
+    def test_hide_recipients_flag_set(self):
+        """PlainList should set hide_recipients=True so the mailgate uses
+        envelope routing instead of exposing real addresses in To: header."""
+        PlainRedirect.objects.create(original='board', destination='alice@example.com')
+        handler = self._make_handler()
+        handler.process('board', 'board')
+        self.assertTrue(handler.hide_recipients)
+
+    def test_original_address_stored(self):
+        """PlainList should store the original alias address so the mailgate
+        can use it in the To: header instead of the real recipient."""
+        PlainRedirect.objects.create(original='board', destination='alice@example.com')
+        handler = self._make_handler()
+        handler.process('board', 'board')
+        self.assertEqual(handler.original_address, 'board')
+
+    def test_case_insensitive_match_preserves_original(self):
+        """The original_address should store the user input (for the To: header),
+        even when it differs in case from the stored redirect."""
+        PlainRedirect.objects.create(original='Board', destination='alice@example.com')
+        handler = self._make_handler()
+        handler.process('BOARD', 'BOARD')
+        self.assertEqual(handler.original_address, 'BOARD')
+        self.assertTrue(handler.send)

--- a/esp/esp/dbmail/tests.py
+++ b/esp/esp/dbmail/tests.py
@@ -418,3 +418,73 @@ class MessageRequestAdminTest(TestCase):
         mr = MessageRequest.objects.filter(subject='Test subject').first()
         self.assertIsNotNone(mr)
         self.assertIsNone(mr.processed_by)
+
+
+class PlainListRecipientPrivacyTest(TestCase):
+    """Test that PlainList splits comma-separated destinations into individual
+    recipients so that each person receives their own email (protecting
+    recipient privacy).  Fixes #2393."""
+
+    def _make_handler(self):
+        """Return a PlainList instance with a minimal stub handler/message."""
+        from esp.dbmail.receivers.plainlist import PlainList
+        from esp.dbmail.base import BaseHandler
+
+        class _StubHandler:
+            cc_all = False
+        return PlainList(_StubHandler(), None)
+
+    def test_single_address_destination(self):
+        """A redirect with a single destination should produce one recipient."""
+        from esp.dbmail.receivers.plainlist import PlainList
+        PlainRedirect.objects.create(original='directors', destination='alice@example.com')
+        handler = self._make_handler()
+        handler.process('directors', 'directors')
+        self.assertEqual(handler.recipients, ['alice@example.com'])
+
+    def test_multi_address_destination_splits(self):
+        """A redirect whose destination contains multiple comma-separated
+        addresses must be split into individual recipients so that each
+        person's email is not exposed to the others (#2393)."""
+        from esp.dbmail.receivers.plainlist import PlainList
+        PlainRedirect.objects.create(
+            original='board',
+            destination='alice@example.com, bob@example.com, carol@example.com',
+        )
+        handler = self._make_handler()
+        handler.process('board', 'board')
+        self.assertEqual(handler.recipients, [
+            'alice@example.com',
+            'bob@example.com',
+            'carol@example.com',
+        ])
+
+    def test_multi_redirect_objects_combined(self):
+        """Multiple PlainRedirect rows for the same original should have all
+        their individual addresses collected."""
+        from esp.dbmail.receivers.plainlist import PlainList
+        PlainRedirect.objects.create(original='staff', destination='alice@example.com, bob@example.com')
+        PlainRedirect.objects.create(original='staff', destination='carol@example.com')
+        handler = self._make_handler()
+        handler.process('staff', 'staff')
+        self.assertIn('alice@example.com', handler.recipients)
+        self.assertIn('bob@example.com', handler.recipients)
+        self.assertIn('carol@example.com', handler.recipients)
+        self.assertEqual(len(handler.recipients), 3)
+
+    def test_whitespace_in_destinations_trimmed(self):
+        """Extra whitespace around addresses should be stripped."""
+        from esp.dbmail.receivers.plainlist import PlainList
+        PlainRedirect.objects.create(
+            original='test',
+            destination='  alice@example.com ,  bob@example.com  ',
+        )
+        handler = self._make_handler()
+        handler.process('test', 'test')
+        self.assertEqual(handler.recipients, ['alice@example.com', 'bob@example.com'])
+
+    def test_no_matching_redirect_does_not_send(self):
+        """If no PlainRedirect matches, send should remain False."""
+        handler = self._make_handler()
+        handler.process('nonexistent', 'nonexistent')
+        self.assertFalse(handler.send)

--- a/esp/mailgates/mailgate.py
+++ b/esp/mailgates/mailgate.py
@@ -3,7 +3,7 @@
 # Main mailgate
 # Handles incoming messages etc.
 
-import sys, os, email, re, smtplib, socket, hashlib, random
+import sys, os, email, re, smtplib, socket, hashlib, random, subprocess
 from io import open
 new_path = '/'.join(sys.path[0].split('/')[:-1])
 sys.path += [new_path]
@@ -51,9 +51,17 @@ DEBUG=False
 
 user = "UNKNOWN USER"
 
-def send_mail(message):
-    p = os.popen("%s -i -t" % MAIL_PATH, 'w')
-    p.write(message)
+def send_mail(message, envelope_recipient=None):
+    if envelope_recipient:
+        # Deliver to explicit envelope recipient, ignoring To: header for routing.
+        # This lets us hide the real recipient address from the message headers.
+        p = subprocess.Popen([MAIL_PATH, '-i', envelope_recipient],
+                             stdin=subprocess.PIPE)
+        p.communicate(message.encode('utf-8') if isinstance(message, str) else message)
+    else:
+        # Default: extract recipients from To: header
+        p = os.popen("%s -i -t" % MAIL_PATH, 'w')
+        p.write(message)
 
 try:
     user = os.environ['LOCAL_PART']
@@ -106,7 +114,8 @@ try:
                                                  host)
 
         # Common path for ALL handlers — iterate recipients
-        if handler.cc_all:
+        hide = getattr(instance, 'hide_recipients', False)
+        if handler.cc_all and not hide:
             # send one mass-email
             del(message['To'])
             message['To'] = ', '.join(instance.recipients)
@@ -115,8 +124,14 @@ try:
             # send an email for each recipient
             for recipient in instance.recipients:
                 del(message['To'])
-                message['To'] = recipient
-                send_mail(str(message))
+                if hide:
+                    # Keep the alias in the To: header so real addresses
+                    # are never exposed to the sender or other recipients.
+                    message['To'] = '%s@%s' % (instance.original_address, host)
+                    send_mail(str(message), envelope_recipient=recipient)
+                else:
+                    message['To'] = recipient
+                    send_mail(str(message))
 
         sys.exit(0)
 


### PR DESCRIPTION
## Problem

When an email is sent to a forwarding address (e.g., `directors@site.com`), the `PlainList` handler exposes **all destination addresses** in the To: header to every recipient. This is a privacy concern — recipients can see each other's personal email addresses, even if the original alias was BCC'd.

As @milescalabresi noted in #2393, this also leaks redirect destinations in Mailer Daemon bounce messages when case mismatches occur.

## Root Cause

In `plainlist.py`, `self.recipients` was set to a comma-separated destination string, so all addresses ended up in a single To: header — exposing everyone's address.

## Fix (Two-Part)

### 1. Split comma-separated destinations (`plainlist.py`)
Each `PlainRedirect.destination` field is now properly split into individual addresses:

```python
self.recipients = []
for redirect in redirects:
    for addr in redirect.destination.split(','):
        addr = addr.strip()
        if addr:
            self.recipients.append(addr)
```

### 2. SMTP envelope routing for full privacy (`mailgate.py`)
Per @milescalabresi's feedback, recipients should not see each other's addresses at all — not even their own real address in the To: header. The fix uses **SMTP envelope routing**:

- The `To:` header shows the **alias address** (e.g., `directors@site.com`), preserving the appearance of a normal mailing list
- The actual recipient is passed via the **SMTP envelope** using `sendmail -i <recipient>` (no `-t` flag), so the MTA delivers to the real address without it appearing in headers
- Uses `subprocess.Popen` instead of `os.popen` to pass arguments as a list (avoids shell injection)

```python
# When hide_recipients is True:
message['To'] = 'alias@site.com'         # What the recipient sees
send_mail(str(message), envelope_recipient=real@example.com)  # Where it actually goes
```

This is the same approach used by Mailman and other mailing list software.

## Testing

Added `PlainListRecipientPrivacyTest` with tests covering:
- `hide_recipients` flag is set on PlainList handler
- Original alias address is stored for To: header substitution
- Case-insensitive matching preserves original address casing
- Single and multi-address destination splitting
- Multiple PlainRedirect objects for the same alias
- Whitespace trimming
- No-match scenario

All tests pass. @SuyashJain17 confirmed the fix works locally.

**Test output:**

<img width="997" height="552" alt="image" src="https://github.com/user-attachments/assets/ced230c3-70e6-4099-b86c-3f702c66bff3" />
<img width="1609" height="860" alt="image" src="https://github.com/user-attachments/assets/849fc41e-03a4-400e-acfb-857433df651c" />

## AI Disclosure

AI assistant used for code suggestions and test scaffolding. Root cause analysis, architectural decisions, and all testing performed by contributor.

Closes #2393