### PR TITLE
feat: show previous-day check-in status on teacher check-in page

### DIFF
--- a/esp/esp/program/modules/handlers/teachercheckinmodule.py
+++ b/esp/esp/program/modules/handlers/teachercheckinmodule.py
@@ -291,12 +291,16 @@ class TeacherCheckinModule(ProgramModuleObj):
         and is used to filter the set of checked-in Records, so that the view
         shows who is not checked in yet for the day.
 
-        Returns the 2-tuple (sections, arrived):
+        Returns the 3-tuple (sections, arrived, previously_checked_in):
             sections: A list of all sections starting at the given time or on
                       the given date which do not have all teachers checked in,
                       with those with no teachers checked in first.
             arrived:  A dict of id -> teacher for all teachers who have already
                       checked in.
+            previously_checked_in: A set of user ids for teachers who checked
+                      in on the previous program day (but have not yet checked
+                      in today).  Useful for prioritising which missing
+                      teachers to call first.
         """
         if when is None:
             when = datetime.now()
@@ -414,7 +418,36 @@ class TeacherCheckinModule(ProgramModuleObj):
             if section.all_arrived
         ]
 
-        return sections, arrived
+        # Find teachers who checked in on the previous program day but have
+        # not yet checked in today.  This helps admins prioritise which
+        # missing teachers to contact first — a teacher who was present
+        # yesterday likely just needs a quick reminder.
+        previously_checked_in = set()
+        check_date = when.date() if date is None else date
+        prog_dates = sorted(prog.dates())
+        if check_date in prog_dates:
+            idx = prog_dates.index(check_date)
+            if idx > 0:
+                prev_date = prog_dates[idx - 1]
+                prev_ids = set(Record.objects.filter(
+                    program=prog,
+                    event__name='teacher_checked_in',
+                    time__year=prev_date.year,
+                    time__month=prev_date.month,
+                    time__day=prev_date.day,
+                ).values_list('user_id', flat=True))
+                # Exclude teachers who have already checked in today.
+                today_ids = set(Record.objects.filter(
+                    program=prog,
+                    event__name='teacher_checked_in',
+                    time__year=check_date.year,
+                    time__month=check_date.month,
+                    time__day=check_date.day,
+                    time__lte=when,
+                ).values_list('user_id', flat=True))
+                previously_checked_in = prev_ids - today_ids
+
+        return sections, arrived, previously_checked_in
 
     def getMissingResources(self, prog, date=None, starttime=None, default_phone = '(missing contact info)'):
         """Return a list of class sections that have ended but have not returned their floating resources.
@@ -515,7 +548,7 @@ class TeacherCheckinModule(ProgramModuleObj):
             when = None
         show_flags = self.program.program_modules.filter(handler='ClassFlagModule').exists()
         context['date'] = date
-        context['sections'], context['arrived'] = self.getMissingTeachers(
+        context['sections'], context['arrived'], context['previously_checked_in'] = self.getMissingTeachers(
             prog, date, starttime, when, show_flags, default_phone)
         context['missing_resources'] = self.getMissingResources(prog, date, getattr(starttime, "start", None))
         if show_flags:

--- a/esp/esp/program/modules/tests/teachercheckinmodule.py
+++ b/esp/esp/program/modules/tests/teachercheckinmodule.py
@@ -35,6 +35,7 @@ Learning Unlimited, Inc.
 import datetime
 import phonenumbers
 
+from esp.cal.models import Event, EventType
 from esp.program.controllers.classreg import ClassCreationController
 from esp.program.modules.base import ProgramModule, ProgramModuleObj
 from esp.program.tests import ProgramFrameworkTest
@@ -142,3 +143,47 @@ class TeacherCheckinModuleTest(ProgramFrameworkTest):
         response = self.client.get('%smissingteachers' % self.program.get_onsite_url())
         phone = phonenumbers.format_number(self.teacher.getLastProfile().contact_user.phone_cell, phonenumbers.PhoneNumberFormat.NATIONAL)
         self.assertIn(phone, str(response.content, encoding='UTF-8'))
+
+    def test_previously_checked_in_returned(self):
+        """Teachers checked in on the previous program day appear in
+        previously_checked_in (and not those already checked in today)."""
+        # Create a second day of timeslots so prog.dates() returns two dates.
+        day2_start = self.settings['start_time'] + datetime.timedelta(days=1)
+        event_type = EventType.get_from_desc('Class Time Block')
+        Event.objects.get_or_create(
+            program=self.program,
+            event_type=event_type,
+            start=day2_start,
+            end=day2_start + datetime.timedelta(minutes=50),
+            short_description='Day2 Slot',
+            description=day2_start.strftime("%H:%M %m/%d/%Y"),
+        )
+
+        day1 = self.settings['start_time'].date()
+        day2 = day2_start.date()
+        self.assertIn(day1, self.program.dates())
+        self.assertIn(day2, self.program.dates())
+
+        # Check in the teacher on day 1.
+        self.checkIn(when=self.settings['start_time'])
+        self.assertTrue(self.isCheckedIn(when=self.settings['start_time']))
+
+        # Query getMissingTeachers for day 2 (teacher has NOT checked in on
+        # day 2, but did check in on day 1).
+        when_day2 = datetime.datetime.combine(day2, self.settings['start_time'].time())
+        _sections, _arrived, prev = self.module.getMissingTeachers(
+            self.program, date=day2, when=when_day2)
+        self.assertIn(self.teacher.id, prev)
+
+        # Now check in the teacher on day 2 as well — they should no longer
+        # appear in previously_checked_in.
+        self.checkIn(when=when_day2)
+        _sections, _arrived, prev = self.module.getMissingTeachers(
+            self.program, date=day2, when=when_day2)
+        self.assertNotIn(self.teacher.id, prev)
+
+    def test_previously_checked_in_empty_on_first_day(self):
+        """On the first program day, previously_checked_in should be empty."""
+        _sections, _arrived, prev = self.module.getMissingTeachers(
+            self.program, date=self.settings['start_time'].date(), when=self.now)
+        self.assertEqual(prev, set())

--- a/esp/public/media/default_styles/missingteachers.css
+++ b/esp/public/media/default_styles/missingteachers.css
@@ -118,3 +118,13 @@ input.not-found {
 #shortcuts-box .message {
     color: red;
 }
+
+.previously-checked-in {
+    font-size: 0.75em;
+    margin-left: 4px;
+    padding: 2px 5px;
+    border-radius: 3px;
+    background-color: #5bc0de;
+    color: #fff;
+    vertical-align: middle;
+}

--- a/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
+++ b/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
@@ -224,6 +224,9 @@
         <td class="not-checked-in">
         {% endif %}
             <a href="/manage/userview?username={{ teacher.username }}&program={{ program.id }}" target="_blank">{{ teacher.name }}</a>
+            {% if teacher.id in previously_checked_in %}
+                <span class="label label-info previously-checked-in" title="Checked in on the previous program day">prev-day</span>
+            {% endif %}
         </td>
         <td class="checkin-column">
             {% if teacher.id not in arrived %}
@@ -263,6 +266,9 @@
             <td class="not-checked-in"{% if forloop.first %} style="border-top:1px solid #ccc;"{% endif %}>
             {% endif %}
                 <a href="/manage/userview?username={{ teacher.username }}&program={{ program.id }}" target="_blank">{{ teacher.name }}</a>
+                {% if teacher.id in previously_checked_in %}
+                    <span class="label label-info previously-checked-in" title="Checked in on the previous program day">prev-day</span>
+                {% endif %}
             </td>
             <td class="checkin-column"{% if forloop.first %} style="border-top:1px solid #ccc;"{% endif %}>
                 {% if teacher.id not in arrived %}


### PR DESCRIPTION
## Summary
Fixes #1540

Teachers who checked in on the previous program day but haven't checked in today are now marked with a **"prev-day"** badge on the missing teachers page. This helps admins prioritize which teachers to contact first:
- A teacher present yesterday likely just needs a quick check-in tap
- A teacher absent yesterday may need directions, room info, etc.

## Changes
- `getMissingTeachers()` now returns a 3-tuple `(sections, arrived, previously_checked_in)` — the new element is a set of user IDs for teachers with a `teacher_checked_in` Record on the previous program day (excluding those already checked in today)
- `missingteachers.html` displays a light-blue "prev-day" label next to qualifying teacher/moderator names
- Added CSS styling for the badge in `missingteachers.css`
- Added 2 unit tests covering the feature

## Test plan
- [x] All 4 existing + new `TeacherCheckinModuleTest` tests pass
- [ ] Manual verification on a multi-day program (badge appears for day-1 teachers on day-2 view)

## Screenshots
_Live UI screenshot to follow in comments._

**AI disclosure:** Partially assisted by AI (Claude). All logic, test design, and code review done by the author.