### PR TITLE
Fix: sanitize_walkin() only expires last section's registrations

### DIFF
--- a/esp/esp/program/controllers/studentregsanity.py
+++ b/esp/esp/program/controllers/studentregsanity.py
@@ -79,10 +79,10 @@ class StudentRegSanityController(object):
                 srs = sec.getRegistrations()
                 report.append((sec, srs.count()))
 
-        for sr in srs:
-            if not fake:
-                if csvlog: csvwriter.writerow([w.title().encode('ascii', 'ignore'), ', '.join(sec.friendly_times()), sr.user.name().encode('ascii', 'ignore'), sr.relationship.__str__().encode('ascii', 'ignore')])
-                sr.expire()
+                for sr in srs:
+                    if not fake:
+                        if csvlog: csvwriter.writerow([w.title().encode('ascii', 'ignore'), ', '.join(sec.friendly_times()), sr.user.name().encode('ascii', 'ignore'), sr.relationship.__str__().encode('ascii', 'ignore')])
+                        sr.expire()
         logger.debug(report)
         if closeatend: csvfile.close()
         logger.info("Walkins checked")


### PR DESCRIPTION
## Description

In `studentregsanity.py`, the `for sr in srs:` loop that expires student registrations was outside both `for` loops, so it only processed registrations from the last section of the last walk-in class. All other sections were silently skipped.

```python
# Before (broken):
for w in walkins:
    for sec in w.get_sections():
        srs = sec.getRegistrations()        # srs reassigned each iteration
        report.append((sec, srs.count()))

for sr in srs:    # outside both loops — only last section's srs
    if not fake:
        sr.expire()
```

The fix moves `for sr in srs:` inside the inner loop so all sections' registrations are processed.

Additionally, if `walkins` was empty, `srs` was never defined, which would cause a `NameError`.

Note: this is separate from #4437 which covers the csv.writer binary mode issue in the same file.

## Related Issue

Closes #4873

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## AI Disclosure

Used AI for researching code. Bug identification done while research. Fix implemented with help of AI.

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced