### PR TITLE
Fix: swap assignment order in ESPError() so log parameter is preserved

### DIFF
--- a/esp/esp/middleware/esperrormiddleware.py
+++ b/esp/esp/middleware/esperrormiddleware.py
@@ -79,8 +79,8 @@ def ESPError(message=None, log=True):
     if isinstance(message, bool):
         # trying to pass a bool argument: assume they meant log rather than message
         # this should become deprecated -lua 2013-02-15
-        message = None
         log = message
+        message = None
 
     if log:
         cls = ESPError_Log


### PR DESCRIPTION
## Description

In `esperrormiddleware.py`, the legacy bool-handling branch of `ESPError()` had the assignment lines in the wrong order:

```python
if isinstance(message, bool):
    message = None
    log = message    # log is always None — original bool is lost
```

Setting `message = None` before `log = message` meant `log` was always `None` regardless of the bool passed in. So `ESPError(True)` incorrectly returned `ESPError_NoLog` instead of `ESPError_Log`.

The fix swaps the two lines so the bool value is captured before being cleared.

## Related Issue

Closes #4874

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## AI Disclosure

Used AI for researching code. Bug identification done while research. Fix implemented with help of AI.

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced