### PR TITLE
feat: add SendGrid Event Webhook for email delivery tracking

### DIFF
--- a/esp/esp/dbmail/admin.py
+++ b/esp/esp/dbmail/admin.py
@@ -35,7 +35,7 @@ Learning Unlimited, Inc.
 from django.contrib import admin
 from esp.admin import admin_site
 
-from esp.dbmail.models import MessageVars, EmailList, PlainRedirect, MessageRequest, TextOfEmail
+from esp.dbmail.models import MessageVars, EmailList, PlainRedirect, MessageRequest, TextOfEmail, SendGridEvent
 from esp.utils.admin_user_search import default_user_search
 
 class MessageVarsAdmin(admin.ModelAdmin):
@@ -66,3 +66,11 @@ class TextOfEmailAdmin(admin.ModelAdmin):
     date_hierarchy = 'sent'
     list_filter = ('send_from',)
 admin_site.register(TextOfEmail, TextOfEmailAdmin)
+
+class SendGridEventAdmin(admin.ModelAdmin):
+    list_display = ('email', 'event_type', 'timestamp', 'textofemail', 'sg_message_id')
+    list_filter = ('event_type',)
+    search_fields = ('email', 'sg_message_id', 'sg_event_id')
+    date_hierarchy = 'timestamp'
+    raw_id_fields = ('textofemail',)
+admin_site.register(SendGridEvent, SendGridEventAdmin)

--- a/esp/esp/dbmail/models.py
+++ b/esp/esp/dbmail/models.py
@@ -449,6 +449,13 @@ class TextOfEmail(models.Model):
         else:
             extra_headers = {}
 
+        # Inject SendGrid unique_args so webhook events can be linked
+        # back to this TextOfEmail. SendGrid strips the X-SMTPAPI header
+        # and passes unique_args in Event Webhook callbacks.
+        extra_headers['X-SMTPAPI'] = json.dumps({
+            'unique_args': {'textofemail_id': str(self.id)}
+        })
+
         now = datetime.now()
 
         try:
@@ -565,6 +572,50 @@ class MessageVars(models.Model):
 
     class Meta:
         verbose_name_plural = 'Message variables'
+
+class SendGridEvent(models.Model):
+    """Stores delivery events received from SendGrid's Event Webhook."""
+
+    EVENT_TYPES = (
+        ('processed', 'Processed'),
+        ('dropped', 'Dropped'),
+        ('delivered', 'Delivered'),
+        ('deferred', 'Deferred'),
+        ('bounce', 'Bounce'),
+        ('open', 'Open'),
+        ('click', 'Click'),
+        ('spamreport', 'Spam Report'),
+        ('unsubscribe', 'Unsubscribe'),
+    )
+
+    textofemail = models.ForeignKey(
+        TextOfEmail, null=True, blank=True,
+        on_delete=models.SET_NULL,
+        related_name='sendgrid_events',
+    )
+    email = models.EmailField(db_index=True)
+    event_type = models.CharField(max_length=32, choices=EVENT_TYPES, db_index=True)
+    timestamp = models.DateTimeField(db_index=True)
+    sg_event_id = models.CharField(
+        max_length=255, unique=True,
+        help_text="SendGrid's unique event ID for deduplication",
+    )
+    sg_message_id = models.CharField(max_length=255, blank=True, default='')
+    reason = models.TextField(blank=True, default='')
+    response = models.TextField(blank=True, default='')
+    raw_event = models.TextField(
+        blank=True, default='{}',
+        help_text="Full raw event JSON from SendGrid for debugging")
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ['-timestamp']
+        verbose_name = 'SendGrid event'
+        verbose_name_plural = 'SendGrid events'
+
+    def __str__(self):
+        return '%s for %s at %s' % (self.event_type, self.email, self.timestamp)
+
 
 class EmailRequest(models.Model):
     """ Each email is sent to all users in a category.  This a one-to-many that binds a message to the users that it will be sent to. """

--- a/esp/esp/dbmail/tests.py
+++ b/esp/esp/dbmail/tests.py
@@ -347,3 +347,205 @@ class PlainRedirectValidationTest(TestCase):
 
         self.assertIn('destination', error.exception.message_dict)
         self.assertIn('<empty>', error.exception.message_dict['destination'][0])
+
+
+# ---------------------------------------------------------------------------
+# Tests for SendGrid Event Webhook
+# ---------------------------------------------------------------------------
+import base64
+import json
+import time
+
+from django.test import override_settings, RequestFactory
+
+from esp.dbmail.models import SendGridEvent, TextOfEmail
+
+
+WEBHOOK_AUTH_SETTINGS = {
+    'SENDGRID_WEBHOOK_USERNAME': 'testuser',
+    'SENDGRID_WEBHOOK_PASSWORD': 'testpass',
+}
+
+
+def _basic_auth_header(username, password):
+    credentials = base64.b64encode(
+        ('%s:%s' % (username, password)).encode('utf-8')
+    ).decode('utf-8')
+    return 'Basic %s' % credentials
+
+
+class SendGridEventModelTest(TestCase):
+    def test_create_event(self):
+        event = SendGridEvent.objects.create(
+            email='user@example.com',
+            event_type='delivered',
+            timestamp='2026-03-08T12:00:00Z',
+            sg_event_id='unique-id-123',
+        )
+        self.assertEqual(event.event_type, 'delivered')
+        self.assertEqual(event.email, 'user@example.com')
+
+    def test_sg_event_id_uniqueness(self):
+        SendGridEvent.objects.create(
+            email='user@example.com',
+            event_type='delivered',
+            timestamp='2026-03-08T12:00:00Z',
+            sg_event_id='duplicate-id',
+        )
+        from django.db import IntegrityError
+        with self.assertRaises(IntegrityError):
+            SendGridEvent.objects.create(
+                email='other@example.com',
+                event_type='bounce',
+                timestamp='2026-03-08T12:01:00Z',
+                sg_event_id='duplicate-id',
+            )
+
+    def test_textofemail_link(self):
+        toe = TextOfEmail.objects.create(
+            send_to='user@example.com',
+            send_from='from@learningu.org',
+            subject='Test',
+            msgtext='Body',
+        )
+        event = SendGridEvent.objects.create(
+            textofemail=toe,
+            email='user@example.com',
+            event_type='delivered',
+            timestamp='2026-03-08T12:00:00Z',
+            sg_event_id='linked-event-1',
+        )
+        self.assertEqual(event.textofemail, toe)
+        self.assertEqual(toe.sendgrid_events.count(), 1)
+
+
+@override_settings(**WEBHOOK_AUTH_SETTINGS)
+class SendGridWebhookViewTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        _setup_roles()
+        self.url = '/webhooks/sendgrid/'
+        self.auth_header = _basic_auth_header('testuser', 'testpass')
+
+    def test_valid_webhook_returns_200(self):
+        events = [
+            {
+                'event': 'delivered',
+                'email': 'user@example.com',
+                'timestamp': int(time.time()),
+                'sg_event_id': 'evt-001',
+                'sg_message_id': 'msg-001',
+            },
+        ]
+        response = self.client.post(
+            self.url,
+            data=json.dumps(events),
+            content_type='application/json',
+            HTTP_AUTHORIZATION=self.auth_header,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(SendGridEvent.objects.count(), 1)
+        event = SendGridEvent.objects.first()
+        self.assertEqual(event.event_type, 'delivered')
+        self.assertEqual(event.email, 'user@example.com')
+
+    def test_missing_auth_returns_403(self):
+        events = [{'event': 'delivered', 'email': 'x@x.com',
+                    'timestamp': 0, 'sg_event_id': 'e1'}]
+        response = self.client.post(
+            self.url,
+            data=json.dumps(events),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(SendGridEvent.objects.count(), 0)
+
+    def test_wrong_auth_returns_403(self):
+        events = [{'event': 'delivered', 'email': 'x@x.com',
+                    'timestamp': 0, 'sg_event_id': 'e2'}]
+        response = self.client.post(
+            self.url,
+            data=json.dumps(events),
+            content_type='application/json',
+            HTTP_AUTHORIZATION=_basic_auth_header('wrong', 'creds'),
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_idempotent_processing(self):
+        events = [
+            {
+                'event': 'delivered',
+                'email': 'user@example.com',
+                'timestamp': int(time.time()),
+                'sg_event_id': 'idempotent-001',
+            },
+        ]
+        payload = json.dumps(events)
+        for _ in range(3):
+            self.client.post(
+                self.url, data=payload,
+                content_type='application/json',
+                HTTP_AUTHORIZATION=self.auth_header,
+            )
+        self.assertEqual(SendGridEvent.objects.count(), 1)
+
+    def test_links_textofemail_via_unique_args(self):
+        toe = TextOfEmail.objects.create(
+            send_to='user@example.com',
+            send_from='from@learningu.org',
+            subject='Test',
+            msgtext='Body',
+        )
+        events = [
+            {
+                'event': 'delivered',
+                'email': 'user@example.com',
+                'timestamp': int(time.time()),
+                'sg_event_id': 'linked-evt-001',
+                'textofemail_id': str(toe.id),
+            },
+        ]
+        self.client.post(
+            self.url,
+            data=json.dumps(events),
+            content_type='application/json',
+            HTTP_AUTHORIZATION=self.auth_header,
+        )
+        event = SendGridEvent.objects.first()
+        self.assertEqual(event.textofemail, toe)
+
+    def test_event_without_textofemail_id_stored_with_null(self):
+        events = [
+            {
+                'event': 'bounce',
+                'email': 'bounce@example.com',
+                'timestamp': int(time.time()),
+                'sg_event_id': 'no-link-001',
+                'reason': 'mailbox full',
+            },
+        ]
+        self.client.post(
+            self.url,
+            data=json.dumps(events),
+            content_type='application/json',
+            HTTP_AUTHORIZATION=self.auth_header,
+        )
+        event = SendGridEvent.objects.first()
+        self.assertIsNone(event.textofemail)
+        self.assertEqual(event.reason, 'mailbox full')
+
+    def test_invalid_json_returns_400(self):
+        response = self.client.post(
+            self.url,
+            data='not json',
+            content_type='application/json',
+            HTTP_AUTHORIZATION=self.auth_header,
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_get_method_not_allowed(self):
+        response = self.client.get(
+            self.url,
+            HTTP_AUTHORIZATION=self.auth_header,
+        )
+        self.assertEqual(response.status_code, 405)

--- a/esp/esp/dbmail/urls.py
+++ b/esp/esp/dbmail/urls.py
@@ -1,0 +1,7 @@
+from django.conf.urls import url
+
+from esp.dbmail import views
+
+urlpatterns = [
+    url(r'^webhooks/sendgrid/?$', views.sendgrid_webhook),
+]

--- a/esp/esp/dbmail/views.py
+++ b/esp/esp/dbmail/views.py
@@ -34,3 +34,100 @@ Learning Unlimited, Inc.
 """
 # Create your views here.
 
+import base64
+import json
+import logging
+
+from datetime import datetime, timezone
+
+from django.conf import settings
+from django.http import HttpResponse, HttpResponseForbidden
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
+
+from esp.dbmail.models import SendGridEvent, TextOfEmail
+
+logger = logging.getLogger(__name__)
+
+
+def _check_basic_auth(request):
+    """Verify HTTP Basic Auth against SendGrid webhook credentials."""
+    expected_user = getattr(settings, 'SENDGRID_WEBHOOK_USERNAME', '')
+    expected_pass = getattr(settings, 'SENDGRID_WEBHOOK_PASSWORD', '')
+    if not expected_user or not expected_pass:
+        return False
+
+    auth_header = request.META.get('HTTP_AUTHORIZATION', '')
+    if not auth_header.startswith('Basic '):
+        return False
+
+    try:
+        decoded = base64.b64decode(auth_header[6:]).decode('utf-8')
+        username, password = decoded.split(':', 1)
+        return username == expected_user and password == expected_pass
+    except Exception:
+        return False
+
+
+@csrf_exempt
+@require_POST
+def sendgrid_webhook(request):
+    """Receive and store SendGrid Event Webhook POST data.
+
+    SendGrid sends batches of events as a JSON array in the request body.
+    Authentication is via HTTP Basic Auth, configured in local_settings.py
+    as SENDGRID_WEBHOOK_USERNAME and SENDGRID_WEBHOOK_PASSWORD.
+    """
+    if not _check_basic_auth(request):
+        return HttpResponseForbidden('Invalid credentials')
+
+    try:
+        events = json.loads(request.body)
+    except (ValueError, TypeError):
+        logger.warning('SendGrid webhook: invalid JSON in request body')
+        return HttpResponse(status=400)
+
+    if not isinstance(events, list):
+        events = [events]
+
+    for event_data in events:
+        try:
+            sg_event_id = event_data.get('sg_event_id')
+            if not sg_event_id:
+                continue
+
+            # Link back to TextOfEmail via unique_args injected in send()
+            textofemail_id = event_data.get('textofemail_id')
+            textofemail = None
+            if textofemail_id:
+                try:
+                    textofemail = TextOfEmail.objects.get(id=int(textofemail_id))
+                except (TextOfEmail.DoesNotExist, ValueError):
+                    pass
+
+            timestamp = datetime.fromtimestamp(
+                event_data.get('timestamp', 0),
+                tz=timezone.utc,
+            )
+
+            SendGridEvent.objects.get_or_create(
+                sg_event_id=sg_event_id,
+                defaults={
+                    'textofemail': textofemail,
+                    'email': event_data.get('email', ''),
+                    'event_type': event_data.get('event', ''),
+                    'timestamp': timestamp,
+                    'sg_message_id': event_data.get('sg_message_id', ''),
+                    'reason': event_data.get('reason', ''),
+                    'response': event_data.get('response', ''),
+                    'raw_event': json.dumps(event_data),
+                },
+            )
+        except Exception:
+            logger.exception(
+                'SendGrid webhook: error processing event %s',
+                event_data.get('sg_event_id', 'unknown')
+            )
+
+    return HttpResponse(status=200)
+

--- a/esp/esp/django_settings.py
+++ b/esp/esp/django_settings.py
@@ -143,6 +143,10 @@ ORGANIZATION_SHORT_NAME = 'Splash'
 # The host for ESP site-supported email lists.
 EMAIL_HOST = 'localhost'
 
+# SendGrid Event Webhook credentials (override in local_settings.py)
+SENDGRID_WEBHOOK_USERNAME = ''
+SENDGRID_WEBHOOK_PASSWORD = ''
+
 #################################
 # Default localization settings #
 #################################

--- a/esp/esp/program/views.py
+++ b/esp/esp/program/views.py
@@ -55,7 +55,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.redirects.models import Redirect
 from django.contrib.sites.models import Site
 from django.db.models.query import Q
-from django.db.models import Min
+from django.db.models import Count, Min
 from django.db import transaction
 from django.core.mail import mail_admins
 from django.core.cache import cache
@@ -955,6 +955,14 @@ def get_email_data(start_date):
                 req.finished_at = "(Not finished)"
         else:
             req.finished_at = "(Not finished)"
+
+        # Aggregate SendGrid delivery events for this message request
+        from esp.dbmail.models import SendGridEvent
+        event_counts = SendGridEvent.objects.filter(
+            textofemail__in=toes
+        ).values('event_type').annotate(count=Count('id'))
+        req.delivery_stats = {item['event_type']: item['count'] for item in event_counts}
+
         requests_list.append(req)
     return requests_list
 get_email_data.depend_on_model(MessageRequest)

--- a/esp/esp/urls.py
+++ b/esp/esp/urls.py
@@ -109,6 +109,7 @@ urlpatterns += [
     url(r'^accounting/', include(esp.accounting.urls)),
     url(r'^customforms', include(esp.customforms.urls)),
     url(r'^random', include(esp.random.urls)),
+    url(r'^', include(esp.dbmail.urls)),
     url(r'^', include(esp.formstack.urls)),
     url(r'^',  include(esp.program.urls)),
     url(r'^download', include(esp.qsdmedia.urls)),

--- a/esp/templates/admin/emails.html
+++ b/esp/templates/admin/emails.html
@@ -61,10 +61,13 @@ tr.email-details {
 <table class="emails-table">
     <tr>
         <th style="width:5%;"></th>
-        <th style="width:50%;">Subject</th>
+        <th style="width:35%;">Subject</th>
         <th>Request Processed</th>
         <th># Recipients</th>
         <th># Emails Sent</th>
+        <th>Delivered</th>
+        <th>Bounced</th>
+        <th>Opened</th>
     </tr>
     {% for req in requests %}
         <tr class="email-header">
@@ -73,16 +76,26 @@ tr.email-details {
             <td style="text-align:center;">{% if req.processed %}&#10003;{% else %}&#10005;{% endif %}</td>
             <td style="text-align:center;">{{ req.num_rec }}</td>
             <td style="text-align:center;">{{ req.num_sent }}</td>
+            <td style="text-align:center;">{{ req.delivery_stats.delivered|default:"—" }}</td>
+            <td style="text-align:center;">{% if req.delivery_stats.bounce %}<span style="color:red;">{{ req.delivery_stats.bounce }}</span>{% else %}—{% endif %}</td>
+            <td style="text-align:center;">{{ req.delivery_stats.open|default:"—" }}</td>
         </tr>
         <tr class="email-details">
-            <td colspan="3" style="vertical-align:top;">
+            <td colspan="4" style="vertical-align:top;">
                 <iframe srcdoc="{{ req.msgtext|join:""|escape }}" style="width: 100%; max-height: 600px;"></iframe>
             </td>
-            <td colspan="2" style="vertical-align:top;padding:0;"><table>
+            <td colspan="4" style="vertical-align:top;padding:0;"><table>
                 <tr><td><i>Sent by:</i><br /><a href="/manage/userview?username={{ req.creator|urlencode }}">{{ req.creator }}</a></td></tr>
                 <tr><td><i>Sending address:</i><br />{{ req.sender }}</td></tr>
                 <tr><td><i>Created at:</i><br />{{ req.created_at }}</td></tr>
                 <tr><td><i>Finished at:</i><br />{{ req.finished_at }}</td></tr>
+                {% if req.delivery_stats %}
+                <tr><td><i>Delivery details:</i><br />
+                    {% for event_type, count in req.delivery_stats.items %}
+                        {{ event_type }}: <b>{{ count }}</b>&nbsp;&nbsp;
+                    {% endfor %}
+                </td></tr>
+                {% endif %}
                 {% if req.public %}
                 <tr><td><i><a href="/email/{{ req.id }}" target="_blank">Public here</a></i><br /></td></tr>
                 {% endif %}


### PR DESCRIPTION
Closes #4910

## Summary
Adds a webhook endpoint to receive SendGrid delivery events (delivered, bounced, opened, etc.) and displays them on the existing Email Status page at `/manage/emails`.

Currently, the email pipeline ends at the SMTP relay: `CommModule.commfinal()` → `MessageRequest` → cron `process_messages()` → `TextOfEmail.send()` → `send_mail()` → `CustomSMTPBackend` → SMTP. Admins can see whether emails were *sent*, but have no visibility into whether they were actually *delivered*, bounced, or opened. This PR closes that gap.

## Changes
- **New `SendGridEvent` model** (`esp/esp/dbmail/models.py`) — stores webhook events with `sg_event_id` uniqueness for idempotent processing
- **Webhook endpoint** at `/webhooks/sendgrid/` (`esp/esp/dbmail/views.py`) — `@csrf_exempt @require_POST` with HTTP Basic Auth, parses SendGrid event JSON
- **X-SMTPAPI header injection** in `TextOfEmail.send()` — adds `unique_args` with `textofemail_id` so webhook events link back to specific emails
- **Email Status page columns** (`esp/templates/admin/emails.html`) — shows Delivered, Bounced, Opened counts per message request
- **Admin registration** for `SendGridEvent` with search/filter
- **8 tests** covering auth, idempotency, event linking, and edge cases

## Test Plan
- [x] `SendGridEvent` model creation and uniqueness constraint
- [x] Webhook returns 200 on valid JSON, 403 on bad auth, 400 on invalid JSON
- [x] Idempotent processing (same `sg_event_id` twice = 1 record)
- [x] `textofemail_id` linking works via `unique_args`
- [x] Events without `textofemail_id` stored with null FK
- [x] Email Status page renders delivery columns