### PR TITLE
feat: add auto-refresh and summary stats to teacher check-in page

### DIFF
--- a/esp/esp/program/modules/handlers/teachercheckinmodule.py
+++ b/esp/esp/program/modules/handlers/teachercheckinmodule.py
@@ -493,6 +493,22 @@ class TeacherCheckinModule(ProgramModuleObj):
         context['date'] = date
         context['sections'], context['arrived'] = self.getMissingTeachers(
             prog, date, starttime, when, show_flags, default_phone)
+
+        # Compute summary statistics for the stats bar
+        all_teacher_ids = set()
+        arrived_teacher_ids = set()
+        all_arrived_count = 0
+        for section in context['sections']:
+            teacher_ids = {t.id for t in section.teachers_list}
+            all_teacher_ids.update(teacher_ids)
+            arrived_teacher_ids.update(teacher_ids & set(context['arrived'].keys()))
+            if section.all_arrived:
+                all_arrived_count += 1
+        context['total_teachers'] = len(all_teacher_ids)
+        context['arrived_teachers'] = len(arrived_teacher_ids)
+        context['total_sections'] = len(context['sections'])
+        context['all_arrived_sections'] = all_arrived_count
+
         context['missing_resources'] = self.getMissingResources(prog, date, getattr(starttime, "start", None))
         if show_flags:
             context['show_flags'] = True
@@ -503,6 +519,79 @@ class TeacherCheckinModule(ProgramModuleObj):
         context['previous'] = previous
         return render_to_response(self.baseDir()+'missingteachers.html',
                                   request, context)
+
+    @aux_call
+    @needs_onsite
+    def ajaxmissingstats(self, request, tl, one, two, module, extra, prog):
+        """AJAX endpoint returning current check-in statistics as JSON.
+
+        Used for auto-refreshing the missing teachers page without a
+        full page reload. Returns arrived teacher IDs and per-timeslot
+        summary statistics.
+        """
+        starttime = date = None
+        if 'start' in request.GET:
+            starttime = Event.objects.get(id=request.GET['start'])
+            date = starttime.start.date()
+        elif 'date' in request.GET:
+            date = datetime.strptime(request.GET['date'], "%m/%d/%Y").date()
+
+        form = TeacherCheckinForm(request.GET)
+        when = None
+        if form.is_valid():
+            when = form.cleaned_data['when']
+
+        sections, arrived = self.getMissingTeachers(
+            prog, date, starttime, when, show_flags=False)
+
+        # Compute per-timeslot statistics
+        all_teacher_ids = set()
+        arrived_teacher_ids = set()
+        all_arrived_count = 0
+        timeslot_data = {}
+
+        for section in sections:
+            teacher_ids = {t.id for t in section.teachers_list}
+            all_teacher_ids.update(teacher_ids)
+            section_arrived = teacher_ids & set(arrived.keys())
+            arrived_teacher_ids.update(section_arrived)
+            if section.all_arrived:
+                all_arrived_count += 1
+
+            ts_key = str(section.begin_time)
+            if ts_key not in timeslot_data:
+                timeslot_data[ts_key] = {
+                    'timeslot': str(section.begin_time),
+                    'total': set(),
+                    'arrived': set(),
+                }
+            timeslot_data[ts_key]['total'].update(teacher_ids)
+            timeslot_data[ts_key]['arrived'].update(section_arrived)
+
+        by_timeslot = []
+        for ts_key in sorted(timeslot_data.keys()):
+            ts = timeslot_data[ts_key]
+            total = len(ts['total'])
+            arrived_count = len(ts['arrived'])
+            by_timeslot.append({
+                'timeslot': ts['timeslot'],
+                'total': total,
+                'arrived': arrived_count,
+                'pct': round(100 * arrived_count / total) if total > 0 else 100,
+            })
+
+        data = {
+            'arrived_ids': list(arrived.keys()),
+            'stats': {
+                'total_sections': len(sections),
+                'all_arrived_sections': all_arrived_count,
+                'total_teachers': len(all_teacher_ids),
+                'arrived_teachers': len(arrived_teacher_ids),
+                'by_timeslot': by_timeslot,
+            },
+            'timestamp': datetime.now().strftime('%H:%M:%S'),
+        }
+        return HttpResponse(json.dumps(data), content_type='application/json')
 
     class Meta:
         proxy = True

--- a/esp/public/media/default_styles/missingteachers.css
+++ b/esp/public/media/default_styles/missingteachers.css
@@ -118,3 +118,23 @@ input.not-found {
 #shortcuts-box .message {
     color: red;
 }
+
+#checkin-stats-bar {
+    background-color: #f5f5f5;
+    padding: 10px;
+    margin: 10px 0 5px 0;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    font-size: 0.95em;
+    line-height: 1.6;
+}
+
+#auto-refresh-controls {
+    text-align: right;
+    margin-bottom: 10px;
+    font-size: 0.85em;
+}
+
+#auto-refresh-controls label {
+    cursor: pointer;
+}

--- a/esp/public/media/scripts/onsite/teacher_checkin.js
+++ b/esp/public/media/scripts/onsite/teacher_checkin.js
@@ -388,6 +388,66 @@ $j(function(){
         lastLength = input.val().length;
     });
 
+    // ----- Auto-refresh for check-in statistics -----
+    var autoRefreshInterval = 30000;
+    var autoRefreshTimer = null;
+    var autoRefreshEnabled = true;
+
+    function buildRefreshUrl() {
+        var params = [];
+        var urlParams = new URLSearchParams(window.location.search);
+        if (urlParams.has('start')) params.push('start=' + urlParams.get('start'));
+        if (urlParams.has('date')) params.push('date=' + urlParams.get('date'));
+        if (urlParams.has('when')) params.push('when=' + urlParams.get('when'));
+        return 'ajaxmissingstats' + (params.length ? '?' + params.join('&') : '');
+    }
+
+    function refreshCheckinStatus() {
+        if (!autoRefreshEnabled) return;
+        $j.getJSON(buildRefreshUrl(), function(data) {
+            if (data.stats) {
+                updateStatsBar(data.stats);
+            }
+            $j('#last-refresh-time').text('Updated ' + data.timestamp);
+        }).always(function() {
+            if (autoRefreshEnabled) {
+                autoRefreshTimer = setTimeout(refreshCheckinStatus, autoRefreshInterval);
+            }
+        });
+    }
+
+    function updateStatsBar(stats) {
+        var html = '<strong>' + stats.arrived_teachers + '/' + stats.total_teachers + '</strong> teachers checked in';
+        html += ' &nbsp;|&nbsp; <strong>' + stats.all_arrived_sections + '/' + stats.total_sections + '</strong> sections fully staffed';
+        if (stats.by_timeslot && stats.by_timeslot.length > 0) {
+            html += '<br/>';
+            for (var i = 0; i < stats.by_timeslot.length; i++) {
+                var ts = stats.by_timeslot[i];
+                var color = ts.pct >= 90 ? '#5cb85c' : ts.pct >= 50 ? '#f0ad4e' : '#d9534f';
+                html += '<span style="margin-right:10px;">' + ts.timeslot + ': ';
+                html += '<span style="color:' + color + ';font-weight:bold;">' + ts.pct + '%</span>';
+                html += ' (' + ts.arrived + '/' + ts.total + ')</span>';
+            }
+        }
+        html += '<span id="last-refresh-time" style="float:right; color:#888;">' +
+                $j('#last-refresh-time').text() + '</span>';
+        $j('#checkin-stats-bar').html(html);
+    }
+
+    $j('#auto-refresh-toggle').on('change', function() {
+        autoRefreshEnabled = this.checked;
+        if (autoRefreshEnabled) {
+            refreshCheckinStatus();
+        } else if (autoRefreshTimer) {
+            clearTimeout(autoRefreshTimer);
+        }
+    });
+
+    // Start auto-refresh only for live views (not historical)
+    if (!new URLSearchParams(window.location.search).has('when')) {
+        autoRefreshTimer = setTimeout(refreshCheckinStatus, autoRefreshInterval);
+    }
+
     var lastResult = '';
     Quagga.onDetected(function(result) {
         var code = result.codeResult.code;

--- a/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
+++ b/esp/templates/program/modules/teachercheckinmodule/missingteachers.html
@@ -57,7 +57,24 @@
 </div>
 {% endif %}
 <div style="clear: both;"></div>
-<br>
+
+<!-- Check-in summary statistics bar -->
+<div id="checkin-stats-bar">
+    <strong>{{ arrived_teachers }}/{{ total_teachers }}</strong> teachers checked in
+    &nbsp;|&nbsp;
+    <strong>{{ all_arrived_sections }}/{{ total_sections }}</strong> sections fully staffed
+    <span id="last-refresh-time" style="float:right; color:#888;"></span>
+</div>
+
+<!-- Auto-refresh controls -->
+<div id="auto-refresh-controls">
+    <label>
+        <input type="checkbox" id="auto-refresh-toggle" checked
+               {% if when %}disabled{% endif %} />
+        Auto-refresh every 30s
+    </label>
+    {% if when %}<span style="color:#888; margin-left:5px;">(disabled for historical view)</span>{% endif %}
+</div>
 
 <div style="text-align:right; float: right; width: 225px; padding-bottom: 10px;">
 <input class="button text-all-teachers" type="button" value="Text All Unchecked-In Teachers"


### PR DESCRIPTION
Closes #4911

## Summary
Adds AJAX auto-refresh (30s polling) and per-timeslot summary statistics to the missing teachers page, giving admins real-time situational awareness during events without requiring manual page reloads.

## Changes
- **New `ajaxmissingstats` endpoint** (`teachercheckinmodule.py`) — `@aux_call @needs_onsite` method returning JSON with arrived teacher IDs, per-timeslot stats, and timestamp
- **Summary stats bar** (`missingteachers.html`) — shows "X/Y teachers checked in | Z/W sections fully staffed" with per-timeslot breakdown and color-coded percentages
- **Auto-refresh polling** (`teacher_checkin.js`) — 30s jQuery `setTimeout`-based polling that updates the stats bar DOM; automatically disabled for historical views (`?when=` parameter)
- **Toggle control** — checkbox to enable/disable auto-refresh with last-refresh timestamp display
- **CSS styling** (`missingteachers.css`) — stats bar and auto-refresh control styling

## Test Plan
- [x] Stats bar renders with initial server-side data
- [x] `ajaxmissingstats` returns valid JSON with correct structure
- [x] Auto-refresh updates stats bar every 30s
- [x] Toggle checkbox enables/disables polling
- [x] Auto-refresh disabled for historical views (`?when=` parameter)
- [x] Graceful failure handling (reschedules poll on error)