### PR TITLE
Fix/theme recompile settings

### DIFF
--- a/esp/esp/themes/controllers.py
+++ b/esp/esp/themes/controllers.py
@@ -321,7 +321,7 @@ class ThemeController(object):
 
         # Save current parameters and palette before they are cleared
         current_vars = self.get_current_params()
-        current_palette = self.get_palette()['custom']
+        current_palette = json.loads(Tag.getTag('current_theme_palette', default='[]'))
 
         backup_info = self.clear_theme(keep_files=keep_files)
         self.load_theme(theme_name, backup_info=backup_info)
@@ -332,17 +332,11 @@ class ThemeController(object):
 
         if customization_name is not None and customization_name != "None":
             try:
-                (loaded_vars, loaded_palette) = self.load_customizations(customization_name)
-                # Merge the loaded file back with the user's active database customizations
-                merged_vars = dict(loaded_vars)
-                merged_vars.update(current_vars)
-                vars = merged_vars
-
-                merged_palette = list(set(current_palette) | set(loaded_palette))
-                palette = merged_palette
+                (vars, palette) = self.load_customizations(customization_name)
             except FileNotFoundError:
-                logger.warning("Customization file for %s missing. Using parameters from database.", customization_name)
-                self.unset_current_customization()
+                logger.warning("Customization file for %s missing. Initializing with parameters from database.", customization_name)
+                self.save_customizations(customization_name, theme_name=theme_name, vars=current_vars, palette=current_palette)
+                (vars, palette) = self.load_customizations(customization_name)
 
         if vars:
             self.customize_theme(vars)

--- a/esp/esp/themes/tests.py
+++ b/esp/esp/themes/tests.py
@@ -232,3 +232,33 @@ class ThemesTest(TestCase):
 
         #   We're done.  Log out.
         self.client.logout()
+
+    def testRecompileThemeCreatesMissingCustomization(self):
+        """ Check that recompile_theme does not crash and leaves the system in a consistent state
+            by creating the customization file if it is missing. """
+        import tempfile
+        import uuid
+
+        tc = ThemeController()
+        tc.clear_theme()
+        tc.load_theme('barebones')
+
+        # Use a temporary directory + unique filename to avoid dirtying the working tree
+        original_themes_dir = themes_settings.themes_dir
+        themes_settings.themes_dir = tempfile.mkdtemp()
+        fake_customization_name = f'test_missing_{uuid.uuid4().hex}'
+        customization_file = os.path.join(themes_settings.themes_dir, f'{fake_customization_name}.less')
+
+        tc.set_current_customization(fake_customization_name)
+
+        try:
+            # This shouldn't raise FileNotFoundError; it should catch it and create the file
+            tc.recompile_theme(customization_name=fake_customization_name)
+
+            # The file should be created now
+            self.assertTrue(os.path.exists(customization_file))
+        finally:
+            # Cleanup tag and temporary files
+            tc.unset_current_customization()
+            shutil.rmtree(themes_settings.themes_dir, ignore_errors=True)
+            themes_settings.themes_dir = original_themes_dir


### PR DESCRIPTION
Fix error when recompiling theme for the first time.

When a developer sets up the project with a database dump and recompiles the theme from the /themes/ directory, an IOError appears the first time.

This happens because the theme settings file does not exist yet, but the system tries to read it during recompilation. Because of this, the first run shows an error, even though the theme still recompiles.

If the command is run again, it works correctly because the settings file has already been created.

Proposed Fix
- Check if the settings file exists before reading it
- If it doesn't exist, create it with default settings
- Otherwise continue the normal recompilation process

Closes #1429