### PR TITLE
use getProgramTag instead of getTag

### DIFF
--- a/esp/esp/program/modules/handlers/creditcardmodule_cybersource.py
+++ b/esp/esp/program/modules/handlers/creditcardmodule_cybersource.py
@@ -78,7 +78,7 @@ class CreditCardModule_Cybersource(ProgramModuleObj):
     def _extracost_requires_payment(self):
         """Check if the student selected extra cost items that require CC payment."""
         from esp.accounting.models import Transfer
-        tag_value = Tag.getTag('creditcard_required_for_extracosts', self.program, default='')
+        tag_value = Tag.getProgramTag('creditcard_required_for_extracosts', program=self.program, default='')
         if not tag_value:
             return False
         request = get_current_request()

--- a/esp/esp/program/modules/handlers/creditcardmodule_stripe.py
+++ b/esp/esp/program/modules/handlers/creditcardmodule_stripe.py
@@ -115,7 +115,7 @@ class CreditCardModule_Stripe(ProgramModuleObj):
     def _extracost_requires_payment(self):
         """Check if the student selected extra cost items that require CC payment."""
         from esp.accounting.models import Transfer
-        tag_value = Tag.getTag('creditcard_required_for_extracosts', self.program, default='')
+        tag_value = Tag.getProgramTag('creditcard_required_for_extracosts', program=self.program, default='')
         if not tag_value:
             return False
         request = get_current_request()


### PR DESCRIPTION
## Description

Use `getProgramTag` instead of `getTag` on `creditcard_required_for_extracosts` to remove these warnings:

```
web-1  | [2026-03-08 15:53:23,247 esp.tagdict.models:48] WARNING: Tag creditcard_required_for_extracosts not in list of global tags
web-1  | [2026-03-08 15:53:23,247 esp.tagdict.models:54] WARNING: getTag() called for key creditcard_required_for_extracosts with specific target; consider using getProgramTag()
```

## Related Issue

The tag was added in #4576 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [X] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [ X Existing tests pass
- [ ] New tests added (if applicable)
- [X] Manually verified

## AI Disclosure

<!-- If you used AI tools for any part of this pull request, please disclose this here -->

## Checklist

- [X] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [X] No new warnings or errors introduced
