### PR TITLE
Fix: correct upcoming timeslot pre-check logic in unenrollmodule

### DIFF
--- a/esp/esp/program/modules/handlers/unenrollmodule.py
+++ b/esp/esp/program/modules/handlers/unenrollmodule.py
@@ -104,7 +104,7 @@ class UnenrollModule(ProgramModuleObj):
             'slot': timeslot,
             'seq': seq,
             'passed': timeslot.start < now - hour,
-            'upcoming': timeslot.start < now + hour,
+            'upcoming': timeslot.start > now - hour,
         } for seq, timeslot in enumerate(timeslots)]
         context = {}
         context['selections'] = selections


### PR DESCRIPTION
Closes #4971



## Issue
The 'upcoming' flag in 'unenrollmodule.py' was incorrectly defined, 
causing past timeslots to be pre-checked in the right column of the 
unenroll page.

## Root Cause
The condition 'timeslot.start < now + hour' evaluates to 'True' for 
ALL past timeslots, not just upcoming ones. For example, if it is 
2:00 PM, slots from 10:00 AM, 11:00 AM, and 12:00 PM would all be 
incorrectly pre-checked.

## Fix
Changed the condition to 'timeslot.start > now - hour' so that only 
slots that started within the last hour or haven't started yet are 
pre-checked in the right column.

## Before
'''python
'upcoming': timeslot.start < now + hour,
'''

## After
'''python
'upcoming': timeslot.start > now - hour,
'''