### PR TITLE
Fix #1837: standardize grade 0 handling across the system

### DIFF
--- a/esp/esp/program/controllers/lottery.py
+++ b/esp/esp/program/controllers/lottery.py
@@ -386,9 +386,12 @@ class LotteryAssignmentController(object):
         possible_students = numpy.copy(signup[:, si])
 
         #   Filter students by the section's grade limits
+        #   Grade 0 means "unknown/unset" – treat as any grade (allow through).
         if self.options['check_grade'] and not (priority == self.effective_priority_limit and self.grade_range_exceptions):
-            possible_students *= (self.student_grades >= self.section_grade_min[si])
-            possible_students *= (self.student_grades <= self.section_grade_max[si])
+            grade_ok = ((self.student_grades == 0) |
+                        ((self.student_grades >= self.section_grade_min[si]) &
+                         (self.student_grades <= self.section_grade_max[si])))
+            possible_students *= grade_ok
 
         if self.options['use_student_apps']:
             possible_students *= (self.ranks[:, si] == rank)

--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -1821,8 +1821,8 @@ class ClassSubject(models.Model, CustomFormsLinkModel):
             scrmi = self.parent_program.studentclassregmoduleinfo
             return scrmi.temporarily_full_text
 
-        if user.getGrade(self.parent_program) < self.grade_min or \
-               user.getGrade(self.parent_program) > self.grade_max:
+        user_grade = user.getGrade(self.parent_program)
+        if not ESPUser.grade_in_range(user_grade, self.grade_min, self.grade_max):
             if not Permission.user_has_perm(user, "GradeOverride", self.parent_program):
                 return 'You are not in the requested grade range for this class.'
 

--- a/esp/esp/program/modules/handlers/classchangerequestmodule.py
+++ b/esp/esp/program/modules/handlers/classchangerequestmodule.py
@@ -93,7 +93,8 @@ class ClassChangeRequestModule(ProgramModuleObj):
             context['success'] = False
 
         if request.user.isStudent():
-            sections_by_slot = dict([(timeslot, [(section, 1 == StudentRegistration.valid_objects().filter(user=context['user'], section=section, relationship__name="Request").count()) for section in sections if section.get_meeting_times()[0] == timeslot and section.parent_class.grade_min <= request.user.getGrade(prog) <= section.parent_class.grade_max and section.parent_class not in list(enrollments.values()) and ESPUser.getRankInClass(request.user, section.parent_class) in (5, 10)]) for timeslot in timeslots])
+            _student_grade = request.user.getGrade(prog)
+            sections_by_slot = dict([(timeslot, [(section, 1 == StudentRegistration.valid_objects().filter(user=context['user'], section=section, relationship__name="Request").count()) for section in sections if section.get_meeting_times()[0] == timeslot and ESPUser.grade_in_range(_student_grade, section.parent_class.grade_min, section.parent_class.grade_max) and section.parent_class not in list(enrollments.values()) and ESPUser.getRankInClass(request.user, section.parent_class) in (5, 10)]) for timeslot in timeslots])
         else:
             sections_by_slot = dict([(timeslot, [(section, False) for section in sections if section.get_meeting_times()[0] == timeslot]) for timeslot in timeslots])
 

--- a/esp/esp/program/modules/handlers/classchangerequestmodule.py
+++ b/esp/esp/program/modules/handlers/classchangerequestmodule.py
@@ -93,8 +93,14 @@ class ClassChangeRequestModule(ProgramModuleObj):
             context['success'] = False
 
         if request.user.isStudent():
-            _student_grade = request.user.getGrade(prog)
-            sections_by_slot = dict([(timeslot, [(section, 1 == StudentRegistration.valid_objects().filter(user=context['user'], section=section, relationship__name="Request").count()) for section in sections if section.get_meeting_times()[0] == timeslot and ESPUser.grade_in_range(_student_grade, section.parent_class.grade_min, section.parent_class.grade_max) and section.parent_class not in list(enrollments.values()) and ESPUser.getRankInClass(request.user, section.parent_class) in (5, 10)]) for timeslot in timeslots])
+            student_grade = request.user.getGrade(prog)
+            requested_section_ids = set(StudentRegistration.valid_objects().filter(
+                user=context['user'],
+                section__in=sections,
+                relationship__name="Request"
+            ).values_list('section_id', flat=True))
+            enrolled_class_ids = set([c.id for c in enrollments.values() if c is not None])
+            sections_by_slot = dict([(timeslot, [(section, section.id in requested_section_ids) for section in sections if section.get_meeting_times()[0] == timeslot and ESPUser.grade_in_range(student_grade, section.parent_class.grade_min, section.parent_class.grade_max) and section.parent_class.id not in enrolled_class_ids and ESPUser.getRankInClass(request.user, section.parent_class) in (5, 10)]) for timeslot in timeslots])
         else:
             sections_by_slot = dict([(timeslot, [(section, False) for section in sections if section.get_meeting_times()[0] == timeslot]) for timeslot in timeslots])
 

--- a/esp/esp/program/modules/handlers/studentclassregmodule.py
+++ b/esp/esp/program/modules/handlers/studentclassregmodule.py
@@ -485,9 +485,9 @@ class StudentClassRegModule(ProgramModuleObj):
         if is_onsite and not 'filter' in request.GET:
             classes = list(ClassSubject.objects.catalog(self.program, ts))
         else:
-            classes = [c for c in list(ClassSubject.objects.catalog(self.program, ts)) if c.grade_min <= user_grade and c.grade_max >= user_grade]
-            if user_grade != 0:
-                classes = [c for c in classes if c.grade_min <=user_grade and c.grade_max >= user_grade]
+            # grade 0 means unknown/unset — treat as any grade and skip the filter
+            classes = [c for c in list(ClassSubject.objects.catalog(self.program, ts))
+                       if ESPUser.grade_in_range(user_grade, c.grade_min, c.grade_max)]
             classes = [c for c in classes if not c.isRegClosed()]
 
         categories_sort = self.sort_categories(classes, self.program)

--- a/esp/esp/program/modules/handlers/studentonsite.py
+++ b/esp/esp/program/modules/handlers/studentonsite.py
@@ -134,7 +134,8 @@ class StudentOnsite(ProgramModuleObj, CoreModule):
                 raise ESPError('Please use the links on the schedule page.', log=False)
             context['timeslot'] = ts
             classes = list(ClassSubject.objects.catalog(prog, ts))
-            classes = [c for c in classes if c.grade_min <=user_grade and c.grade_max >= user_grade]
+            # user_grade == 0 means the grade is unknown/unset; show all classes
+            classes = [c for c in classes if user_grade == 0 or (c.grade_min <= user_grade <= c.grade_max)]
             context['checked_in'] = Record.objects.filter(program=prog, event__name='attended', user=user).exists()
 
         else:

--- a/esp/esp/program/modules/handlers/studentonsite.py
+++ b/esp/esp/program/modules/handlers/studentonsite.py
@@ -134,8 +134,8 @@ class StudentOnsite(ProgramModuleObj, CoreModule):
                 raise ESPError('Please use the links on the schedule page.', log=False)
             context['timeslot'] = ts
             classes = list(ClassSubject.objects.catalog(prog, ts))
-            # user_grade == 0 means the grade is unknown/unset; show all classes
-            classes = [c for c in classes if user_grade == 0 or (c.grade_min <= user_grade <= c.grade_max)]
+            # grade_in_range() treats grade 0 as unknown/unset and allows all grades.
+            classes = [c for c in classes if ESPUser.grade_in_range(user_grade, c.grade_min, c.grade_max)]
             context['checked_in'] = Record.objects.filter(program=prog, event__name='attended', user=user).exists()
 
         else:

--- a/esp/esp/program/modules/handlers/studentonsite.py
+++ b/esp/esp/program/modules/handlers/studentonsite.py
@@ -39,7 +39,7 @@ from esp.program.modules.base import ProgramModuleObj, needs_student_in_grade, n
 from esp.program.models  import ClassSubject, ClassSection, StudentRegistration
 from esp.accounting.controllers import IndividualAccountingController
 from esp.utils.web import render_to_response
-from esp.users.models    import Record, RecordType, Permission
+from esp.users.models    import Record, RecordType, Permission, ESPUser
 from esp.cal.models import Event
 from esp.middleware   import ESPError
 from esp.survey.views   import survey_view

--- a/esp/esp/program/modules/handlers/studentregtwophase.py
+++ b/esp/esp/program/modules/handlers/studentregtwophase.py
@@ -296,12 +296,19 @@ class StudentRegTwoPhase(ProgramModuleObj):
             return HttpResponseBadRequest('JSON data mis-formatted.')
 
         # Determine which of the given class ids are valid
+        student_grade = request.user.getGrade(prog)
+        grade_filter = {}
+        if student_grade != 0:
+            # grade 0 means "unknown / any grade"; skip grade filtering for those students
+            grade_filter = {
+                'grade_min__lte': student_grade,
+                'grade_max__gte': student_grade,
+            }
         valid_classes = ClassSubject.objects.filter(
             pk__in=json_data['interested'],
             parent_program=prog,
             status__gte=0,
-            grade_min__lte=request.user.getGrade(prog),
-            grade_max__gte=request.user.getGrade(prog))
+            **grade_filter)
         # Unexpire any matching SSIs that exist already (to avoid
         # creating duplicate objects).
         to_unexpire = StudentSubjectInterest.objects.filter(
@@ -419,8 +426,10 @@ class StudentRegTwoPhase(ProgramModuleObj):
             if (not sec.status > 0 or not sec.parent_class.status > 0):
                 logger.warning("Class '%s' was not approved.  Not letting "
                                "user '%s' register.", sec, request.user)
-            if (not sec.parent_class.grade_min <= request.user.getGrade(prog)
-                or not sec.parent_class.grade_max >= request.user.getGrade(prog)):
+            student_grade = request.user.getGrade(prog)
+            if not ESPUser.grade_in_range(student_grade,
+                                          sec.parent_class.grade_min,
+                                          sec.parent_class.grade_max):
                 logger.warning("User '%s' not in class grade range; not "
                                "letting them register.", request.user)
                 continue

--- a/esp/esp/program/modules/handlers/studentregtwophase.py
+++ b/esp/esp/program/modules/handlers/studentregtwophase.py
@@ -391,6 +391,7 @@ class StudentRegTwoPhase(ProgramModuleObj):
 
         timeslot = Event.objects.get(pk=timeslot_id)
         priorities = json_data[timeslot_id]
+        student_grade = request.user.getGrade(prog)
         for rel_index, cls_id in priorities.items():
             rel_name = 'Priority/%s' % rel_index
             rel = RegistrationType.objects.get(name=rel_name, category='student')
@@ -426,7 +427,6 @@ class StudentRegTwoPhase(ProgramModuleObj):
             if (not sec.status > 0 or not sec.parent_class.status > 0):
                 logger.warning("Class '%s' was not approved.  Not letting "
                                "user '%s' register.", sec, request.user)
-            student_grade = request.user.getGrade(prog)
             if not ESPUser.grade_in_range(student_grade,
                                           sec.parent_class.grade_min,
                                           sec.parent_class.grade_max):

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -1135,6 +1135,19 @@ class BaseESPUser(object):
         return schoolyear + 12 - yog
 
     @staticmethod
+    def grade_in_range(grade, grade_min, grade_max):
+        """Return True if grade satisfies [grade_min, grade_max].
+
+        Grade 0 is the sentinel value returned by getGrade() when a student
+        has no graduation year on their profile.  It means "unknown / unset"
+        and should be treated as "any grade" rather than literal grade 0, so
+        we allow such students through every grade-range check.
+        """
+        if grade == 0:
+            return True
+        return grade_min <= grade <= grade_max
+
+    @staticmethod
     def YOGFromGrade(grade, schoolyear=None):
         if schoolyear is None:
             schoolyear = ESPUser.current_schoolyear()


### PR DESCRIPTION
Grade 0 is the sentinel value returned by `getGrade()` when a student has no graduation year on their profile. It means "unknown / unset" and should behave as "any grade", but several codepaths were treating it as a literal grade value,
silently blocking students.

## Description

`ESPUser.getGrade()` returns `0` when a student has no graduation year set on their profile. The intended meaning of grade 0 is "unknown / any grade", and the access-control decorators (`meets_grade`, `needs_student_in_grade`) already
handle it correctly by letting grade-0 students through. However, several downstream codepaths were missing this guard and treated grade 0 as a real grade, causing silent failures:

- `ClassSubject.cannotAdd` returned "not in grade range" for grade-0 students.
- `save_interests` in two-phase registration silently discarded all interests for grade-0 students because `grade_min__lte=0` matched no real classes.
- `save_priorities` silently skipped every section for grade-0 students.
- The lottery numpy filter excluded grade-0 students from every section with `grade_min >= 1`, blocking them from the lottery entirely.
- `onsitecatalog` showed an empty class list to grade-0 students.
- The class-change request module and `fillslot` view filtered out all section  for grade-0 students.

**Fix:** Added a single `ESPUser.grade_in_range(grade, grade_min, grade_max)` static helper that returns `True` unconditionally when `grade == 0`, and `grade_min <= grade <= grade_max` otherwise. All affected codepaths now use
this helper, establishing one consistent rule across the system.

## Related Issue

Closes #1837
Related to #1836

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

Manual verification steps performed:
1. Confirmed that a student with no graduation year (grade 0) can reach the two-phase registration page without hitting a "wrong grade" error.
2. Confirmed that `save_interests` accepts class IDs for a grade-0 student  instead of silently discarding them.
3. Confirmed that `save_priorities` registers sections correctly for a grade-0  student instead of logging "not in grade range" and continuing.
4. Confirmed that `cannotAdd` returns `None` (no error) for grade-0 students on classes with `grade_min >= 1`.
5. Verified the numpy lottery filter logic in isolation — grade-0 students are now included in every section's eligible pool while normal grade enforcement  is unchanged.
6. Confirmed `onsitecatalog` shows the full class list for grade-0 students.

## AI Disclosure

GitHub Copilot was used to assist with locating affected code areas and suggesting the initial structure of the `grade_in_range` helper. However, every changed file was manually reviewed in detail before and after the edit. The
fix logic, the identification of all 8 affected call sites (including the double-filter bug in `studentclassregmodule.py`), and the final correctness were verified manually multiple times. No AI-generated code was accepted without thorough human review.

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced