### PR TITLE
Bigpicture expose color variables

### DIFF
--- a/esp/esp/themes/theme_data/bigpicture/config_form.py
+++ b/esp/esp/themes/theme_data/bigpicture/config_form.py
@@ -19,24 +19,3 @@ class ConfigForm(ThemeConfigurationForm):
     faq_link = forms.CharField(required=False, initial='/faq.html',
                                help_text='Leave blank to omit an FAQ link.')
     show_footer_textbox = forms.BooleanField(initial = False, required = False, help_text='Should there be an editable text field in the footer?')
-        # Navbar colors
-    navbarBackground = forms.CharField(label='Navbar Background Color', required=False)
-    navbarText = forms.CharField(label='Navbar Text Color', required=False)
-    navbarLinkColor = forms.CharField(label='Navbar Link Color', required=False)
-    navbarBackgroundHighlight = forms.CharField(label='Navbar Hover Background', required=False)
-    navbarLinkColorHover = forms.CharField(label='Navbar Link Hover Color', required=False)
-
-    # Sidebar colors
-    sidebarBackground = forms.CharField(label='Sidebar Background', required=False)
-    sidebarHeader = forms.CharField(label='Sidebar Header Color', required=False)
-    sidebarLink = forms.CharField(label='Sidebar Link Color', required=False)
-    sidebarLinkHover = forms.CharField(label='Sidebar Link Hover Color', required=False)
-    sidebarHover = forms.CharField(label='Sidebar Row Hover Background', required=False)
-    sidebarActive = forms.CharField(label='Sidebar Active Link Color', required=False)
-    sidebarActiveBackground = forms.CharField(label='Sidebar Active Background', required=False)
-
-    # Button colors
-    btnBackground = forms.CharField(label='Button Background Color', required=False)
-
-    # Body
-    bodyBackground = forms.CharField(label='Page Background Color', required=False)

--- a/esp/esp/themes/theme_data/bigpicture/config_form.py
+++ b/esp/esp/themes/theme_data/bigpicture/config_form.py
@@ -19,3 +19,24 @@ class ConfigForm(ThemeConfigurationForm):
     faq_link = forms.CharField(required=False, initial='/faq.html',
                                help_text='Leave blank to omit an FAQ link.')
     show_footer_textbox = forms.BooleanField(initial = False, required = False, help_text='Should there be an editable text field in the footer?')
+        # Navbar colors
+    navbarBackground = forms.CharField(label='Navbar Background Color', required=False)
+    navbarText = forms.CharField(label='Navbar Text Color', required=False)
+    navbarLinkColor = forms.CharField(label='Navbar Link Color', required=False)
+    navbarBackgroundHighlight = forms.CharField(label='Navbar Hover Background', required=False)
+    navbarLinkColorHover = forms.CharField(label='Navbar Link Hover Color', required=False)
+
+    # Sidebar colors
+    sidebarBackground = forms.CharField(label='Sidebar Background', required=False)
+    sidebarHeader = forms.CharField(label='Sidebar Header Color', required=False)
+    sidebarLink = forms.CharField(label='Sidebar Link Color', required=False)
+    sidebarLinkHover = forms.CharField(label='Sidebar Link Hover Color', required=False)
+    sidebarHover = forms.CharField(label='Sidebar Row Hover Background', required=False)
+    sidebarActive = forms.CharField(label='Sidebar Active Link Color', required=False)
+    sidebarActiveBackground = forms.CharField(label='Sidebar Active Background', required=False)
+
+    # Button colors
+    btnBackground = forms.CharField(label='Button Background Color', required=False)
+
+    # Body
+    bodyBackground = forms.CharField(label='Page Background Color', required=False)

--- a/esp/esp/themes/theme_data/bigpicture/less/buttons.less
+++ b/esp/esp/themes/theme_data/bigpicture/less/buttons.less
@@ -1,0 +1,1 @@
+@btnBackground: #f5f5f5;

--- a/esp/esp/themes/theme_data/bigpicture/less/navbar.less
+++ b/esp/esp/themes/theme_data/bigpicture/less/navbar.less
@@ -1,0 +1,2 @@
+@navbarBackgroundHighlight: @accent1;
+@navbarLinkColorHover: @accent2;

--- a/esp/esp/themes/theme_data/bigpicture/less/sidebar.less
+++ b/esp/esp/themes/theme_data/bigpicture/less/sidebar.less
@@ -1,0 +1,7 @@
+@sidebarBackground: #f8f8f8;
+@sidebarHeader: @accent2;
+@sidebarLink: @accent2;
+@sidebarLinkHover: @accent1;
+@sidebarHover: #efefef;
+@sidebarActive: @accent1;
+@sidebarActiveBackground: @accent2;

--- a/esp/esp/themes/theme_data/bigpicture/less/variables.less
+++ b/esp/esp/themes/theme_data/bigpicture/less/variables.less
@@ -1,21 +1,3 @@
 @accent1: #FF8000;
 @accent2: #1C1953;
-
-// Button styles
-@btnBackground: #f5f5f5;
-
-// Body styles
 @bodyBackground: #ffffff;
-
-// Sidebar styles
-@sidebarBackground: #f8f8f8;
-@sidebarHeader: @accent2;
-@sidebarLink: @accent2;
-@sidebarLinkHover: @accent1;           // text color of a hovered sidebar link
-@sidebarHover: #efefef;                // neutral gray hover bg, intentionally not an accent color
-@sidebarActive: @accent1;
-@sidebarActiveBackground: @accent2;
-
-// Navbar styles
-@navbarBackgroundHighlight: @accent1;  // used in main.less lines 205, 234 — Bigpicture-specific override
-@navbarLinkColorHover: @accent2;       // used in main.less lines 219, 237 — Bigpicture-specific override

--- a/esp/esp/themes/theme_data/bigpicture/less/variables.less
+++ b/esp/esp/themes/theme_data/bigpicture/less/variables.less
@@ -11,11 +11,11 @@
 @sidebarBackground: #f8f8f8;
 @sidebarHeader: @accent2;
 @sidebarLink: @accent2;
-@sidebarLinkHover: @accent1;
-@sidebarHover: #efefef;
+@sidebarLinkHover: @accent1;           // text color of a hovered sidebar link
+@sidebarHover: #efefef;                // neutral gray hover bg, intentionally not an accent color
 @sidebarActive: @accent1;
 @sidebarActiveBackground: @accent2;
 
 // Navbar styles
-@navbarBackgroundHighlight: @accent1;
-@navbarLinkColorHover: @accent2;
+@navbarBackgroundHighlight: @accent1;  // used in main.less lines 205, 234 — Bigpicture-specific override
+@navbarLinkColorHover: @accent2;       // used in main.less lines 219, 237 — Bigpicture-specific override

--- a/esp/esp/themes/theme_data/bigpicture/less/variables.less
+++ b/esp/esp/themes/theme_data/bigpicture/less/variables.less
@@ -1,2 +1,21 @@
 @accent1: #FF8000;
 @accent2: #1C1953;
+
+// Button styles
+@btnBackground: #f5f5f5;
+
+// Body styles
+@bodyBackground: #ffffff;
+
+// Sidebar styles
+@sidebarBackground: #f8f8f8;
+@sidebarHeader: @accent2;
+@sidebarLink: @accent2;
+@sidebarLinkHover: @accent1;
+@sidebarHover: #efefef;
+@sidebarActive: @accent1;
+@sidebarActiveBackground: @accent2;
+
+// Navbar styles
+@navbarBackgroundHighlight: @accent1;
+@navbarLinkColorHover: @accent2;


### PR DESCRIPTION
Fixes #4982 

The Bigpicture theme's main.less referenced 11 variables that 
were never defined in variables.less:

@btnBackground, @bodyBackground, @sidebarBackground, 
@sidebarHeader, @sidebarLink, @sidebarLinkHover, 
@sidebarHover, @sidebarActive, @sidebarActiveBackground, 
@navbarBackgroundHighlight, @navbarLinkColorHover

Added all 11 to variables.less with raw hex defaults matching 
the existing accent colors, so existing chapter deployments 
are visually unchanged. These variables are now automatically 
exposed in the theme editor via find_less_variables().

Changes: variables.less only.