### PR TITLE
Refactor: Replace manual list comprehension with list() in search_for_user

### DIFF
--- a/esp/esp/users/views/usersearch.py
+++ b/esp/esp/users/views/usersearch.py
@@ -268,7 +268,7 @@ def search_for_user(request, user_type='Any', extra='', returnList = False, add_
     if not usc.updated:
         users = None
     else:
-        users = [ user for user in QSUsers ]
+        users = list(QSUsers)
 
     if users is not None and len(users) == 0:
         error = True


### PR DESCRIPTION
Fixes #4987

Problem
In search_for_user(), the QuerySet QSUsers was converted to a list using a manual list comprehension:

users = [user for user in QSUsers]

Since Django QuerySets are iterable, Python’s built-in list() function can directly convert them into a list.

Solution
Replaced the manual list comprehension with:

users = list(QSUsers)

Benefits
- Cleaner and more idiomatic Python
- Improved readability
- No functional changes

Testing
Tested locally and confirmed that the user search functionality works as expected.