### PR TITLE
docs(dev): add quick reference map to directory_structure.rst per #4122

### DIFF
--- a/docs/dev/directory_structure.rst
+++ b/docs/dev/directory_structure.rst
@@ -1,7 +1,7 @@
 Directory Structure
 ===================
 
-This is not intended to be an exhaustive list, just a summary with some comments, to help new devs find things. 
+This is not intended to be an exhaustive list, just a summary with some comments, to help new devs find things.
 
 Quick Reference: Where to Start
 -------------------------------

--- a/docs/dev/directory_structure.rst
+++ b/docs/dev/directory_structure.rst
@@ -1,7 +1,20 @@
 Directory Structure
 ===================
 
-This is not intended to be an exhaustive list, just a summary with some comments, to help new devs find things.  Starting in the root of the repository:
+This is not intended to be an exhaustive list, just a summary with some comments, to help new devs find things. 
+
+Quick Reference: Where to Start
+-------------------------------
+If you are a new contributor looking to make common changes, here are the highest-impact locations:
+
+* **Routing / URLs**: ``esp/esp/urls.py`` is the master entrypoint for routing.
+* **HTML Templates**: ``esp/templates/`` contains the frontend UI templates.
+* **Static Files (CSS/JS)**: ``esp/public/media/`` contains stylesheets, JavaScript, and images.
+* **Core Logic**: ``esp/esp/program/`` contains the bulk of the business logic.
+
+Full Directory Tree
+-------------------
+Starting in the root of the repository:
 
 * ``docs``: Fairly new and therefore very incomplete; add to it!
 


### PR DESCRIPTION
## Description
Added a "Quick Reference: Where to Start" map to the top of `directory_structure.rst`. This provides new contributors with immediate, high-visibility pointers to the most important locations (Routing, HTML Templates, Static Files, and Core Logic) without having to read through the entire exhaustive directory tree, as requested in the issue.

## Related Issue
Closes #4122

## Type of Change
[ ] Bug fix
[ ] New feature
[ ] Breaking change
[x] Documentation update
[ ] Refactor/cleanup
[ ] CI/CD or build change

## Testing
[ ] Existing tests pass
[ ] New tests added (if applicable)
[x] Manually verified (Documentation only)

## AI Disclosure
No Use of AI