### PR TITLE
fix: Replace naive datetime.now() with timezone-aware timezone.now() (#5006)

### DIFF
--- a/esp/esp/program/controllers/autoscheduler/controller.py
+++ b/esp/esp/program/controllers/autoscheduler/controller.py
@@ -12,6 +12,8 @@ from esp.program.controllers.autoscheduler import \
     search
 from esp.program.controllers.autoscheduler.exceptions import SchedulingError
 
+from django.utils import timezone
+
 logger = logging.getLogger(__name__)
 
 
@@ -125,7 +127,7 @@ class AutoschedulerController(object):
     def compute_assignments(self):
         self.optimizer.optimize_section(
                 self.section, self.depth,
-                datetime.datetime.now() +
+                timezone.now() +
                 datetime.timedelta(seconds=self.timeout))
 
     def get_scheduling_info(self):

--- a/esp/esp/program/controllers/autoscheduler/search.py
+++ b/esp/esp/program/controllers/autoscheduler/search.py
@@ -2,7 +2,7 @@
 
 import datetime
 import esp.program.controllers.autoscheduler.util as util
-
+from django.utils import timezone
 
 class SearchOptimizer:
     def __init__(self, manipulator):
@@ -19,7 +19,7 @@ class SearchOptimizer:
         done."""
         if depth == 0:
             return []
-        if timeout is not None and datetime.datetime.now() > timeout:
+        if timeout is not None and timezone.now() > timeout:
             return []
 
         best_score = self.manipulator.scorer.score_schedule()

--- a/esp/esp/program/models/app_.py
+++ b/esp/esp/program/models/app_.py
@@ -40,6 +40,7 @@ from django import forms
 from django.utils.deconstruct import deconstructible
 
 import datetime
+from django.utils import timezone
 
 __all__ = ['StudentAppQuestion', 'StudentAppResponse', 'StudentAppReview', 'StudentApplication']
 
@@ -110,7 +111,7 @@ class BaseAppElement(object):
         return form
 
     def update(self, form):
-        self.date = datetime.datetime.now()
+        self.date = timezone.now()
         for field_name in self._field_names:
             if field_name in form.cleaned_data:
                 setattr(self, field_name, form.cleaned_data[field_name])

--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -86,6 +86,8 @@ from esp.middleware.threadlocalrequest import get_current_request
 
 from esp.customforms.linkfields import CustomFormsLinkModel
 
+from django.utils import timezone
+
 __all__ = ['ClassSection', 'ClassSubject', 'ClassManager', 'ClassCategories', 'ClassSizeRange']
 
 STATUS_CHOICES = (
@@ -169,7 +171,7 @@ class ClassManager(Manager):
         queries for the category's title (cls.category_txt)
         and the total # of media.
         """
-        now = datetime.datetime.now()
+        now = timezone.now()
 
         enrolled_type = RegistrationType.get_map(include=['Enrolled'], category='student')['Enrolled']
 
@@ -338,7 +340,7 @@ class ClassSection(models.Model):
     @classmethod
     def prefetch_catalog_data(cls, queryset):
         """ Take a queryset of a set of ClassSubject's, and annotate each class in it with the '_count_students' and 'event_ids' fields (used internally when available by many functions to save on queries later) """
-        now = datetime.datetime.now()
+        now = timezone.now()
         enrolled_type = RegistrationType.get_map()['Enrolled']
 
         select = OrderedDict([( '_count_students', 'SELECT COUNT(DISTINCT "program_studentregistration"."user_id") FROM "program_studentregistration" WHERE ("program_studentregistration"."relationship_id" = %s AND "program_studentregistration"."section_id" = "program_classsection"."id" AND ("program_studentregistration"."start_date" IS NULL OR "program_studentregistration"."start_date" <= %s) AND ("program_studentregistration"."end_date" IS NULL OR "program_studentregistration"."end_date" >= %s))')])
@@ -574,7 +576,7 @@ class ClassSection(models.Model):
         start_time = self.start_time()
         if start_time is None:
             return True
-        time_passed = datetime.datetime.now() - start_time.start
+        time_passed = timezone.now() - start_time.start
         if self.parent_class.allow_lateness:
             if time_passed > timedelta(0, 1200):
                 return True
@@ -979,7 +981,7 @@ class ClassSection(models.Model):
          ...
         }
         """
-        now = datetime.datetime.now()
+        now = timezone.now()
 
         rmap = RegistrationType.get_map()
         result = {}
@@ -1128,7 +1130,7 @@ class ClassSection(models.Model):
             self.save()
 
     def clearStudents(self):
-        now = datetime.datetime.now()
+        now = timezone.now()
         qs = StudentRegistration.valid_objects(now).filter(section=self)
         for reg in qs:
             signals.pre_save.send(sender=StudentRegistration, instance=reg)
@@ -1199,7 +1201,7 @@ class ClassSection(models.Model):
             return True
 
         # Get time and tag values to determine what number to base class changes on
-        now = datetime.datetime.now()
+        now = timezone.now()
         switch_time = None
         if Tag.getProgramTag('switch_time_program_attendance', program=self.parent_program):
             try:
@@ -1318,7 +1320,7 @@ class ClassSection(models.Model):
 
         from esp.program.models.app_ import StudentAppQuestion
 
-        now = datetime.datetime.now()
+        now = timezone.now()
 
         #   Stop all active or pending registrations
         if prereg_verbs:

--- a/esp/esp/program/modules/forms/onsite.py
+++ b/esp/esp/program/modules/forms/onsite.py
@@ -3,6 +3,7 @@ from esp.db.forms import AjaxForeignKeyNewformField
 from esp.utils.widgets import DateTimeWidget
 from esp.users.models import K12School, ESPUser
 import datetime
+from django.utils import timezone
 
 class OnSiteRegForm(forms.Form):
     first_name = forms.CharField(max_length=30, widget=forms.TextInput({'size':20, 'class':'required'}))
@@ -33,6 +34,6 @@ class TeacherCheckinForm(forms.Form):
     when = forms.DateTimeField(label='Date/Time', widget=DateTimeWidget, required = False)
 
     def __init__(self, *args, **kwargs):
-        now = datetime.datetime.now()
+        now = timezone.now()
         self.base_fields['when'].initial=datetime.datetime(now.year, now.month, now.day) + datetime.timedelta(days=1, minutes=-1)
         super().__init__(*args, **kwargs)

--- a/esp/esp/program/modules/handlers/bigboardmodule.py
+++ b/esp/esp/program/modules/handlers/bigboardmodule.py
@@ -10,6 +10,7 @@ from esp.program.models import StudentSubjectInterest, StudentRegistration
 from esp.program.modules.base import ProgramModuleObj, needs_admin, main_call
 from esp.users.models import Record
 from esp.utils.web import render_to_response
+from django.utils import timezone
 
 
 class BigBoardModule(ProgramModuleObj):
@@ -130,7 +131,7 @@ class BigBoardModule(ProgramModuleObj):
 
     @cache_function_for(105)
     def num_active_users(self, prog, minutes=10):
-        recent = datetime.datetime.now() - datetime.timedelta(0, minutes * 60)
+        recent = timezone.now() - datetime.timedelta(0, minutes * 60)
         users_with_ssis = set(
             StudentSubjectInterest.objects
             .filter(subject__parent_program=prog)
@@ -198,8 +199,8 @@ class BigBoardModule(ProgramModuleObj):
             ("number of first choices", 'studentregistration',
              sections.filter(studentregistration__relationship__name='Priority/1')),
             ("number of enrollments", "studentregistration",
-             sections.filter((Q(studentregistration__start_date=None) | Q(studentregistration__start_date__lte=datetime.datetime.now())) &
-                 (Q(studentregistration__end_date=None) | Q(studentregistration__end_date__gte=datetime.datetime.now())) &
+             sections.filter((Q(studentregistration__start_date=None) | Q(studentregistration__start_date__lte=timezone.now())) &
+                 (Q(studentregistration__end_date=None) | Q(studentregistration__end_date__gte=timezone.now())) &
                  Q(studentregistration__relationship__name='Enrolled'))),
         ]
         popular_classes = []
@@ -345,7 +346,7 @@ class BigBoardModule(ProgramModuleObj):
             end = max([times[drop_beg:(len(times)-drop_end)][-1][1] for desc, times, cumulative in timess])
             end = end.replace(hour=0, minute=0, second=0, microsecond=0)
             end += datetime.timedelta(1)
-            end = min(end, datetime.datetime.now())
+            end = min(end, timezone.now())
             graph_data = [{"description": desc,
                            "data": BigBoardModule.chunk_times(times, start, end, cumulative = cumulative)}
                           for desc, times, cumulative in timess]

--- a/esp/esp/program/modules/handlers/studentonsite.py
+++ b/esp/esp/program/modules/handlers/studentonsite.py
@@ -34,6 +34,7 @@ Learning Unlimited, Inc.
 import datetime
 
 from django import forms
+from django.utils import timezone
 
 from esp.program.modules.base import ProgramModuleObj, needs_student_in_grade, needs_student_in_grade, meets_deadline, CoreModule, main_call, aux_call, meets_cap
 from esp.program.models  import ClassSubject, ClassSection, StudentRegistration
@@ -100,7 +101,7 @@ class StudentOnsite(ProgramModuleObj, CoreModule):
                     context['has_survey'] = surveys.count() > 0 and surveys[0].questions.filter(per_class = True).exists()
                     first_block = section.firstBlockEvent()
                     if first_block:
-                        context['has_started'] =  first_block.start < datetime.datetime.now()
+                        context['has_started'] =  first_block.start < timezone.now()
                     context['section'] = section
                     return render_to_response(self.baseDir()+'sectioninfo.html', request, context)
         return HttpResponseRedirect(prog.get_learn_url() + 'studentonsite')

--- a/esp/esp/program/modules/handlers/studentregphasezero.py
+++ b/esp/esp/program/modules/handlers/studentregphasezero.py
@@ -47,6 +47,7 @@ from django.template.loader import render_to_string
 from django.db.models.query import Q
 
 import datetime
+from django.utils import timezone
 
 class StudentRegPhaseZero(ProgramModuleObj):
     doc = """Allows students to enter a lottery for admission to the program."""
@@ -240,7 +241,7 @@ class StudentRegPhaseZero(ProgramModuleObj):
         email_from = '%s Registration System <server@%s>' % (self.program.program_type, settings.EMAIL_HOST_SENDER)
         email_context = {'student': student,
                          'program': self.program,
-                         'curtime': datetime.datetime.now(),
+                         'curtime': timezone.now(),
                          'note': note,
                          'DEFAULT_HOST': settings.DEFAULT_HOST}
         email_contents = render_to_string('program/modules/studentregphasezero/confirmation_email.txt', email_context)

--- a/esp/esp/program/modules/handlers/studentregphasezeromanage.py
+++ b/esp/esp/program/modules/handlers/studentregphasezeromanage.py
@@ -44,6 +44,8 @@ from django.db.models.query import Q
 
 import copy, datetime, re
 
+from django.utils import timezone
+
 class StudentRegPhaseZeroManage(ProgramModuleObj):
     doc = """Track registration for the student lottery and/or run the student lottery."""
 
@@ -127,10 +129,10 @@ class StudentRegPhaseZeroManage(ProgramModuleObj):
         if len(messages['error']) == 0:
             # Add users to winners group once we are sure there were no problems
             winners.user_set.add(*students)
-            override_perm = Permission(permission_type='OverridePhaseZero', role=winners, start_date=datetime.datetime.now(), program=prog)
+            override_perm = Permission(permission_type='OverridePhaseZero', role=winners, start_date=timezone.now(), program=prog)
             override_perm.save()
             if 'perms' in post:
-                studentAll_perm = Permission(permission_type='Student/All', role=winners, start_date=datetime.datetime.now(), program=prog)
+                studentAll_perm = Permission(permission_type='Student/All', role=winners, start_date=timezone.now(), program=prog)
                 studentAll_perm.save()
             # Add tag to indicate student lottery has been run
             Tag.setTag('student_lottery_run', target=prog, value='True')

--- a/esp/esp/program/modules/handlers/studentregtwophase.py
+++ b/esp/esp/program/modules/handlers/studentregtwophase.py
@@ -36,6 +36,7 @@ import datetime
 import json
 import logging
 logger = logging.getLogger(__name__)
+from django.utils import timezone
 
 from django.conf import settings
 from django.contrib import messages
@@ -322,7 +323,7 @@ class StudentRegTwoPhase(ProgramModuleObj):
         to_expire = StudentSubjectInterest.objects.filter(
             user=request.user,
             subject__pk__in=json_data['not_interested'])
-        to_expire.update(end_date=datetime.datetime.now())
+        to_expire.update(end_date=timezone.now())
 
         if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
             return HttpResponse()
@@ -549,7 +550,7 @@ class StudentRegTwoPhase(ProgramModuleObj):
             'program': self.program,
             'schedule': schedule,
             'starred_classes': starred_classes,
-            'curtime': datetime.datetime.now(),
+            'curtime': timezone.now(),
             'DEFAULT_HOST': settings.DEFAULT_HOST,
         }
         email_contents = render_to_string(

--- a/esp/esp/program/modules/handlers/studentsurveymodule.py
+++ b/esp/esp/program/modules/handlers/studentsurveymodule.py
@@ -39,6 +39,7 @@ from django.db.models.query   import Q
 from esp.survey.views   import survey_view
 
 import datetime
+from django.utils import timezone
 
 class StudentSurveyModule(ProgramModuleObj):
     doc = """A module for students to take surveys about the program and/or classes."""
@@ -66,7 +67,7 @@ class StudentSurveyModule(ProgramModuleObj):
 
     def isStep(self):
         return (Tag.getBooleanTag('student_survey_isstep', program=self.program) and
-                self.program.getTimeSlots()[0].start < datetime.datetime.now() and
+                self.program.getTimeSlots()[0].start < timezone.now() and
                 self.program.getSurveys().filter(category = "learn").exists())
 
     @main_call

--- a/esp/esp/program/modules/handlers/teacherbigboardmodule.py
+++ b/esp/esp/program/modules/handlers/teacherbigboardmodule.py
@@ -11,6 +11,7 @@ from esp.program.modules.base import ProgramModuleObj, needs_admin, main_call
 from esp.users.models import Record
 from esp.utils.web import render_to_response
 from esp.program.modules.handlers.bigboardmodule import BigBoardModule
+from django.utils import timezone
 
 def get_filter(prog, approved = False, scheduled = False, teachers = None):
     filt = Q(parent_program=prog)
@@ -164,7 +165,7 @@ class TeacherBigBoardModule(ProgramModuleObj):
 
     @cache_function_for(105)
     def num_active_users(self, prog, minutes=10):
-        recent = datetime.datetime.now() - datetime.timedelta(0, minutes * 60)
+        recent = timezone.now() - datetime.timedelta(0, minutes * 60)
         return ClassSubject.objects.filter(parent_program=prog, timestamp__gt=recent
         ).exclude(category__category__iexact="Lunch"
         ).exclude(teachers=None
@@ -172,7 +173,7 @@ class TeacherBigBoardModule(ProgramModuleObj):
 
     @cache_function_for(105)
     def num_checked_in_teachers(self, prog):
-        now = datetime.datetime.now()
+        now = timezone.now()
         return Record.objects.filter(program=prog, event__name='teacher_checked_in',
             time__year=now.year,
             time__month=now.month,

--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -59,6 +59,7 @@ from esp.middleware.threadlocalrequest import get_current_request
 import json
 import re
 import datetime
+from django.utils import timezone
 
 class TeacherClassRegModule(ProgramModuleObj):
     doc = """Allows teachers to register and manage classes and view their enrolled students."""
@@ -90,7 +91,7 @@ class TeacherClassRegModule(ProgramModuleObj):
         context['can_create_open_class'] = self.open_class_reg_is_open()
         context['can_req_cancel'] = self.deadline_met('/Classes/CancelReq')
         context['survey_results'] = (self.program.getSurveys().filter(category = "learn", questions__per_class=True).exists() and
-                                     self.program.getTimeSlots()[0].start < datetime.datetime.now())
+                                     self.program.getTimeSlots()[0].start < timezone.now())
         context['crmi'] = self.crmi
         context['clslist'] = self.clslist(get_current_request().user)
         context['modlist'] = get_current_request().user.getModeratingSectionsFromProgram(self.program)

--- a/esp/esp/program/modules/handlers/teachersurveymodule.py
+++ b/esp/esp/program/modules/handlers/teachersurveymodule.py
@@ -39,6 +39,7 @@ from django.db.models.query   import Q
 from esp.survey.views   import survey_view, survey_review, survey_graphical, survey_review_single
 
 import datetime
+from django.utils import timezone
 
 class TeacherSurveyModule(ProgramModuleObj):
     doc = """Allows teachers to take post-program/class surveys."""
@@ -66,7 +67,7 @@ class TeacherSurveyModule(ProgramModuleObj):
 
     def isStep(self):
         return (Tag.getBooleanTag('teacher_survey_isstep', program=self.program) and
-                self.program.getTimeSlots()[0].start < datetime.datetime.now() and
+                self.program.getTimeSlots()[0].start < timezone.now() and
                 self.program.getSurveys().filter(category__in = ["learn", "teach"]).exists())
 
     @main_call

--- a/esp/esp/program/modules/handlers/unenrollmodule.py
+++ b/esp/esp/program/modules/handlers/unenrollmodule.py
@@ -41,6 +41,7 @@ from esp.program.models import StudentRegistration, RegistrationType
 from esp.users.models import ESPUser
 from esp.utils.decorators import cached_module_view, json_response
 from esp.utils.web import render_to_response
+from django.utils import timezone
 
 logger = logging.getLogger(__name__)
 
@@ -83,7 +84,7 @@ class UnenrollModule(ProgramModuleObj):
                 selected_enrollments = request.POST['selected_enrollments']
                 ids = [int(id) for id in selected_enrollments.split(',')]
                 registrations = StudentRegistration.objects.filter(id__in=ids)
-                registrations.update(end_date=datetime.datetime.now())
+                registrations.update(end_date=timezone.now())
                 logger.info("Expired student registrations: %s", ids)
             # send signal to expire caches
             # XXX: sending all of them is actually kind of
@@ -98,7 +99,7 @@ class UnenrollModule(ProgramModuleObj):
                 self.baseDir()+'result.html', request, context)
 
         timeslots = prog.getTimeSlotList()
-        now = datetime.datetime.now()
+        now = timezone.now()
         hour = datetime.timedelta(minutes=60)
         selections = [{
             'slot': timeslot,

--- a/esp/esp/survey/views.py
+++ b/esp/esp/survey/views.py
@@ -55,6 +55,7 @@ from wsgiref.util import FileWrapper
 from django.contrib.auth.decorators import login_required
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q, Min
+from django.utils import timezone
 
 @login_required
 def survey_view(request, tl, program, instance, template = 'survey/survey.html', context = {}):
@@ -145,7 +146,7 @@ def survey_view(request, tl, program, instance, template = 'survey/survey.html',
 
                 # Set record to mark general survey as completed
                 rt = RecordType.objects.get(name=event)
-                r = Record(user=user, event=rt, program=prog, time=datetime.datetime.now())
+                r = Record(user=user, event=rt, program=prog, time=timezone.now())
                 r.save()
 
                 response.set_answers(request.POST, save=True)
@@ -170,7 +171,7 @@ def survey_view(request, tl, program, instance, template = 'survey/survey.html',
             sections = [sec for sec in sections if sec.meeting_times.count() > 0]
         # Mark sections for whether they've started yet and whether the user has filled out a survey for them yet
         for sec in sections:
-            sec.started = sec.start < datetime.datetime.now()
+            sec.started = sec.start < timezone.now()
             sec.completed = sec in completed_sections
 
         context['general_done'] = Record.user_completed(user, event, prog)

--- a/esp/esp/themes/controllers.py
+++ b/esp/esp/themes/controllers.py
@@ -60,6 +60,7 @@ from esp.tagdict.models import Tag
 from esp.themes import settings as themes_settings
 from esp.varnish import varnish
 from esp.middleware import ESPError
+from django.utils import timezone
 
 THEME_PATH = os.path.join(settings.PROJECT_ROOT, 'esp', 'themes', 'theme_data')
 THEME_COMPILED_WARNING = textwrap.dedent("""\
@@ -119,7 +120,7 @@ class ThemeController(object):
         #   Merge with the existing settings so you don't forget anything
         initial_data = self.get_template_settings()
         initial_data.update(data)
-        now = datetime.datetime.now()
+        now = timezone.now()
         mtime = {'year': now.year, 'month': now.month, 'day': now.day,
                  'hour': now.hour, 'minute': now.minute,
                  'second': now.second, 'microsecond': now.microsecond}

--- a/esp/esp/users/admin.py
+++ b/esp/esp/users/admin.py
@@ -9,6 +9,7 @@ from django.contrib.auth.models import Group
 from django.contrib.auth.admin import UserAdmin, GroupAdmin
 from esp.utils.admin_user_search import default_user_search
 import datetime
+from django.utils import timezone
 
 class UserForwarderAdmin(admin.ModelAdmin):
     list_display = ('source', 'target')
@@ -76,9 +77,9 @@ class ExpiredListFilter(admin.SimpleListFilter):
 
     def queryset(self, request, queryset):
         if self.value() == 'unexpired':
-            return queryset.filter(end_date=None) | queryset.filter(end_date__gt=datetime.datetime.now())
+            return queryset.filter(end_date=None) | queryset.filter(end_date__gt=timezone.now())
         elif self.value() == 'expired':
-            return queryset.filter(end_date__lte=datetime.datetime.now())
+            return queryset.filter(end_date__lte=timezone.now())
 
 class PermissionAdmin(admin.ModelAdmin):
     list_display = ['id', 'user', 'role', 'permission_type', 'program', 'start_date', 'end_date']
@@ -88,7 +89,7 @@ class PermissionAdmin(admin.ModelAdmin):
     actions = [ 'expire', 'renew' ]
 
     def expire(self, request, queryset):
-        rows_updated = queryset.update(end_date=datetime.datetime.now())
+        rows_updated = queryset.update(end_date=timezone.now())
         if rows_updated == 1:
             message_bit = "1 permission was"
         else:
@@ -162,7 +163,7 @@ class GradeChangeRequestAdmin(admin.ModelAdmin):
         if getattr(obj, 'acknowledged_by', None) is None:
             obj.acknowledged_by = request.user
         if getattr(obj, 'acknowledged_time', None) is None and getattr(request.POST, 'approved', None) is True:
-            obj.acknowledged_time = datetime.datetime.now()
+            obj.acknowledged_time = timezone.now()
         obj.save()
 admin_site.register(GradeChangeRequest, GradeChangeRequestAdmin)
 

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -41,6 +41,7 @@ import string
 
 logger = logging.getLogger(__name__)
 import functools
+from django.utils import timezone
 
 from django import forms, dispatch
 from django.conf import settings
@@ -2641,7 +2642,7 @@ class Permission(ExpirableModel):
             `Program` or None
         :param when:
             Check permissions as of this point in time.
-            If None, default to datetime.datetime.now().
+            If None, default to timezone.now().
         :type when:
             `datetime.datetime` or None
         :param program_is_none_implies_all:

--- a/esp/esp/users/tests.py
+++ b/esp/esp/users/tests.py
@@ -8,6 +8,7 @@ from django.test.client import Client, RequestFactory
 from django.http import HttpRequest
 from django.conf import settings
 from django.utils.functional import SimpleLazyObject
+from django.utils import timezone
 
 from esp.middleware import ESPError
 from esp.program.models import RegistrationProfile, Program
@@ -616,9 +617,9 @@ class RecordTest(TestCase):
             # Create Record without time, test that it was created for now,
             # and that the event is complete, both in general and for the
             # current day.
-            before = datetime.datetime.now()
+            before = timezone.now()
             nowRecord = create()
-            after = datetime.datetime.now()
+            after = timezone.now()
             self.assertTrue(before <= nowRecord.time <= after)
             self.assertTrue(user_completed())
             # Below, we must explicitly pass time, instead of relying on

--- a/esp/esp/utils/tests.py
+++ b/esp/esp/utils/tests.py
@@ -21,6 +21,7 @@ import unittest
 from django.db.models.query import Q
 from django.template import loader, Template, Context, TemplateDoesNotExist
 from django.test import TestCase as DjangoTestCase
+from django.utils import timezone
 
 from esp.middleware import ESPError_Log
 from esp.users.models import ESPUser
@@ -204,7 +205,7 @@ class QueryBuilderTest(DjangoTestCase):
         sad_printer = Printer.objects.create(name="Slow")
         nice_user = ESPUser.objects.create(username="nice_user")
         mean_user = ESPUser.objects.create(username="mean_user")
-        now = datetime.datetime.now()
+        now = timezone.now()
         PrintRequest.objects.create(printer=happy_printer, user=nice_user,
                                     time_executed=now)
         PrintRequest.objects.create(printer=happy_printer, user=nice_user,

--- a/esp/esp/web/views/main.py
+++ b/esp/esp/web/views/main.py
@@ -41,6 +41,7 @@ from django.views.generic.base import TemplateView
 from esp.middleware.threadlocalrequest import AutoRequestContext as Context
 
 import datetime
+from django.utils import timezone
 import re
 
 from esp.dbmail.models import MessageRequest
@@ -243,7 +244,7 @@ def registration_redirect(request):
         # then check for which programs they have already registered a class
         for prog in user.getTaughtPrograms():
             # only include the program if it hasn't finished yet
-            if prog not in progs and prog.datetime_range()[1] > datetime.datetime.now():
+            if prog not in progs and prog.datetime_range()[1] > timezone.now():
                 progs.append(prog)
     elif user.isVolunteer():
         userrole['name'] = 'Volunteer'
@@ -265,7 +266,7 @@ def registration_redirect(request):
         # then check for which programs they have already registered for a class
         for prog in user.getLearntPrograms():
             # only include the program if it hasn't finished yet
-            if prog not in progs and prog.datetime_range()[1] > datetime.datetime.now():
+            if prog not in progs and prog.datetime_range()[1] > timezone.now():
                 progs.append(prog)
     else:
         progs = []

--- a/esp/useful_scripts/register_users/generators.py
+++ b/esp/useful_scripts/register_users/generators.py
@@ -4,6 +4,7 @@ import random
 import datetime
 import collections
 from io import open
+from django.utils import timezone
 
 
 base_dir = os.path.dirname(__file__)
@@ -97,7 +98,7 @@ words = [word for word in open('/usr/share/dict/words').read().split()
 
 
 def get_random_dob(grade):
-    current_year = int(datetime.datetime.now().year)
+    current_year = int(timezone.now().year)
     return datetime.date(current_year - grade - 6, 1, 1) + datetime.timedelta(days=random.randint(-182, 182))
 
 


### PR DESCRIPTION
## Summary
This PR replaces all instances of timezone-naive `datetime.datetime.now()` with Django's timezone-aware `django.utils.timezone.now()` across the codebase. 

When `USE_TZ=True` is configured, using naive datetimes causes `RuntimeWarning: DateTimeField received a naive datetime` and can lead to incorrect behavior for ESP chapters operating in non-UTC timezones. 

## Changes Made
* Performed a codebase-wide audit for `datetime.datetime.now()`
* Replaced occurrences with `timezone.now()`
* Added `from django.utils import timezone` imports where missing
* Ran local test suite (`manage.py test`) to ensure no syntax/import errors were introduced

**Fixes #5006**