### PR TITLE
Refactor/f strings esp users

### DIFF
--- a/esp/esp/users/admin.py
+++ b/esp/esp/users/admin.py
@@ -92,8 +92,8 @@ class PermissionAdmin(admin.ModelAdmin):
         if rows_updated == 1:
             message_bit = "1 permission was"
         else:
-            message_bit = "%s permissions were" % rows_updated
-        self.message_user(request, "%s successfully expired." % message_bit)
+            message_bit = f"{rows_updated} permissions were"
+        self.message_user(request, f"{message_bit} successfully expired.")
     expire.short_description = "Expire permissions"
 
     def renew(self, request, queryset):
@@ -101,8 +101,8 @@ class PermissionAdmin(admin.ModelAdmin):
         if rows_updated == 1:
             message_bit = "1 permission was"
         else:
-            message_bit = "%s permissions were" % rows_updated
-        self.message_user(request, "%s successfully expired." % message_bit)
+            message_bit = f"{rows_updated} permissions were"
+        self.message_user(request, f"{message_bit} successfully expired.")
     renew.short_description = "Renew permissions"
 
 admin_site.register(Permission, PermissionAdmin)
@@ -146,7 +146,7 @@ class K12SchoolAdmin(admin.ModelAdmin):
     list_filter = ['school_type']
     def contact_name(self, obj):
         if obj.contact:
-            return "%s %s" % (obj.contact.first_name, obj.contact.last_name)
+            return f"{obj.contact.first_name} {obj.contact.last_name}"
         return None
     contact_name.short_description = 'Contact name'
 

--- a/esp/esp/users/controllers/tests/test_usersearch.py
+++ b/esp/esp/users/controllers/tests/test_usersearch.py
@@ -34,7 +34,7 @@ class TestUserSearchController(ProgramFrameworkTest):
             'gradyear_max': '',
             'userid': '',
             'zipcode': '',
-            'combo_base_list': '%s:%s' % (list_a, list_b),
+            'combo_base_list': f'{list_a}:{list_b}',
             'email': '',
             'states': '',
             'zipdistance': '',

--- a/esp/esp/users/controllers/usersearch.py
+++ b/esp/esp/users/controllers/usersearch.py
@@ -66,7 +66,7 @@ class UserSearchController(object):
             Q_base = Q()
         else:
             if user_type not in ESPUser.getTypes():
-                raise ESPError('user_type must be one of '+str(ESPUser.getTypes()))
+                raise ESPError(f"user_type must be one of {ESPUser.getTypes()!s}")
             Q_base = ESPUser.getAllOfType(user_type, True)
 
         Q_include = Q()
@@ -144,9 +144,9 @@ class UserSearchController(object):
                     try:
                         rc = re.compile(criteria[field])
                     except re.error:
-                        raise ESPError('Invalid search expression, please check your syntax: %s' % criteria[field], log=False)
-                    filter_dict = {'%s__iregex' % field: criteria[field]}
-                    if '%s__not' % field in criteria:
+                        raise ESPError(f'Invalid search expression, please check your syntax: {criteria[field]}', log=False)
+                    filter_dict = {f'{field}__iregex': criteria[field]}
+                    if f'{field}__not' in criteria:
                         Q_exclude |= Q(**filter_dict)
                     else:
                         Q_include &= Q(**filter_dict)
@@ -157,7 +157,7 @@ class UserSearchController(object):
                 try:
                     zipc = ZipCode.objects.get(zip_code = criteria['zipcode'])
                 except ZipCode.DoesNotExist:
-                    raise ESPError('Zip code not found.  This may be because you didn\'t enter a valid US zipcode.  Tried: "%s"' % criteria['zipcode'], log=False)
+                    raise ESPError(f"Zip code not found.  This may be because you didn't enter a valid US zipcode.  Tried: \"{criteria['zipcode']}\"", log=False)
                 zipcodes = zipc.close_zipcodes(criteria['zipdistance'])
                 # Excludes zipcodes within a certain radius, giving an annulus; can fail to exclude people who used to live outside the radius.
                 # This may have something to do with the Q_include line below taking more than just the most recent profile. -ageng, 2008-01-15
@@ -281,7 +281,7 @@ class UserSearchController(object):
                     q_program = Q()
                     recipient_type = data['recipient_type']
                 else:
-                    program_lists = getattr(program, data['recipient_type'].lower()+'s')(QObjects=True)
+                    program_lists = getattr(program, f"{data['recipient_type'].lower()}s")(QObjects=True)
                     q_program = program_lists[data['base_list']]
                     """ Some program queries rely on UserBits, and since user types are also stored in
                         UserBits we cannot store both of these in a single Q object.  To compensate, we
@@ -298,7 +298,7 @@ class UserSearchController(object):
             if list_name.startswith('all'):
                 q_program = Q()
             else:
-                q_program = getattr(program, recipient_type.lower()+'s')(QObjects=True)[list_name]
+                q_program = getattr(program, f"{recipient_type.lower()}s")(QObjects=True)[list_name]
 
             #   Apply Boolean filters
             #   Base list will be intersected with any lists marked 'AND', and then unioned
@@ -398,7 +398,7 @@ class UserSearchController(object):
         filterObj = PersistentQueryFilter.create_from_Q(ESPUser, query)
 
         if 'base_list' in data and 'recipient_type' in data:
-            filterObj.useful_name = 'Program list: %s' % data['base_list']
+            filterObj.useful_name = f"Program list: {data['base_list']}"
         elif 'combo_base_list' in data:
             filterObj.useful_name = 'Custom user list'
         filterObj.save()
@@ -414,7 +414,7 @@ class UserSearchController(object):
             if not sendtos:
                 sendtos.append('self')
             sendtos.sort(key=['self', 'guardian', 'emergency'].index)
-            return 'send_to_' + '_and_'.join(sendtos)
+            return f"send_to_{'_and_'.join(sendtos)}"
         else:
             return MessageRequest.SEND_TO_SELF_REAL
 
@@ -438,10 +438,10 @@ class UserSearchController(object):
 
         #   Add in global lists for each user type
         for user_type in ESPUser.getTypes():
-            key = user_type.lower() + 's'
+            key = f"{user_type.lower()}s"
             if user_type not in category_lists:
                 category_lists[user_type] = []
-            category_lists[user_type].insert(0, {'name': 'all_%s' % user_type, 'list': ESPUser.getAllOfType(user_type), 'description': 'All %s in the database' % key, 'preferred': True, 'all_flag': True})
+            category_lists[user_type].insert(0, {'name': f'all_{user_type}', 'list': ESPUser.getAllOfType(user_type), 'description': f'All {key} in the database', 'preferred': True, 'all_flag': True})
 
         #   Add in mailing list accounts
         category_lists['emaillist'] = [{'name': 'all_emaillist', 'list': Q(password = 'emailuser'), 'description': 'Everyone signed up for the mailing list', 'preferred': True}]
@@ -453,7 +453,7 @@ class UserSearchController(object):
                 context['all_list_names'].append(item['name'])
 
         if target_path is None:
-            target_path = '/manage/%s/commpanel' % program.getUrlBase()
+            target_path = f'/manage/{program.getUrlBase()}/commpanel'
         context['action_path'] = target_path
         context['groups'] = Group.objects.all()
         context['regtypes'] = RegistrationType.objects.all().order_by("name")

--- a/esp/esp/users/forms/password_reset.py
+++ b/esp/esp/users/forms/password_reset.py
@@ -27,7 +27,7 @@ class PasswordResetForm(forms.Form):
         try:
             user = ESPUser.objects.get(username=self.cleaned_data['username'])
         except ESPUser.DoesNotExist:
-            raise forms.ValidationError("User '%s' does not exist." % self.cleaned_data['username'])
+            raise forms.ValidationError(f"User '{self.cleaned_data['username']}' does not exist.")
 
         return self.cleaned_data['username'].strip()
 
@@ -38,7 +38,7 @@ class PasswordResetForm(forms.Form):
         if len(ESPUser.objects.filter(email__iexact=self.cleaned_data['email']).values('id')[:1])>0:
             return self.cleaned_data['email'].strip()
 
-        raise forms.ValidationError('No user has email %s' % self.cleaned_data['email'])
+        raise forms.ValidationError(f"No user has email {self.cleaned_data['email']}")
 
 class UserPasswdForm(FormWithRequiredCss):
     password = SizedCharField(length=12, max_length=32, widget=forms.PasswordInput())

--- a/esp/esp/users/forms/user_profile.py
+++ b/esp/esp/users/forms/user_profile.py
@@ -225,7 +225,7 @@ class StudentInfoForm(FormUnrestrictedOtherUser):
             new_choices = []
             for x in self.fields['graduation_year'].choices:
                 if len(x[0]) > 0:
-                    new_choices.append((str(x[0]), "%s (%sth grade)" % (x[0], x[1])))
+                    new_choices.append((str(x[0]), f"{x[0]} ({x[1]}th grade)"))
                 else:
                     new_choices.append(x)
             self.fields['graduation_year'].choices = new_choices
@@ -346,7 +346,7 @@ class TeacherInfoForm(FormWithRequiredCss):
 
     pronoun = forms.CharField(max_length=50, required=False)
     graduation_year = SizedCharField(length=4, max_length=4, required=False)
-    affiliation = DropdownOtherField(required=False, widget=DropdownOtherWidget(choices=AFFILIATION_CHOICES), label ='What is your affiliation with %s?' % settings.INSTITUTION_NAME)
+    affiliation = DropdownOtherField(required=False, widget=DropdownOtherWidget(choices=AFFILIATION_CHOICES), label =f'What is your affiliation with {settings.INSTITUTION_NAME}?')
     major = SizedCharField(length=30, max_length=32, required=False)
     shirt_size = forms.ChoiceField(choices=[], required=False)
     shirt_type = forms.ChoiceField(choices=[], required=False)
@@ -374,15 +374,15 @@ class TeacherInfoForm(FormWithRequiredCss):
             affiliation_field = self.fields['affiliation']
             affiliation, school = affiliation_field.widget.decompress(cleaned_data.get('affiliation'))
             if affiliation == '':
-                msg = 'Please select your affiliation with %s.' % settings.INSTITUTION_NAME
+                msg = f'Please select your affiliation with {settings.INSTITUTION_NAME}.'
                 self.add_error('affiliation', msg)
             elif affiliation in (AFFILIATION_UNDERGRAD, AFFILIATION_GRAD, AFFILIATION_POSTDOC):
                 cleaned_data['affiliation'] = affiliation_field.compress([affiliation, '']) # ignore the box
             else: # OTHER or NONE -- Make sure they entered something into the other box
                 if school.strip() == '':
-                    msg = 'Please select your affiliation with %s.' % settings.INSTITUTION_NAME
+                    msg = f'Please select your affiliation with {settings.INSTITUTION_NAME}.'
                     if affiliation == AFFILIATION_OTHER:
-                        msg = 'Please enter your affiliation with %s.' % settings.INSTITUTION_NAME
+                        msg = f'Please enter your affiliation with {settings.INSTITUTION_NAME}.'
                     elif affiliation == AFFILIATION_NONE:
                         msg = 'Please enter your school or employer.'
                     self.add_error('affiliation', msg)

--- a/esp/esp/users/forms/user_reg.py
+++ b/esp/esp/users/forms/user_reg.py
@@ -23,7 +23,7 @@ class ValidHostEmailField(forms.EmailField):
             try:
                 DNS.DiscoverNameServers()
                 if len(DNS.Request(qtype='a').req(email_host).answers) == 0 and len(DNS.Request(qtype='mx').req(email_host).answers) == 0:
-                    raise forms.ValidationError('"%s" is not a valid email host' % email_host)
+                    raise forms.ValidationError(f'"{email_host}" is not a valid email host')
             except (IOError, DNS.DNSError): # (no resolv.conf, no nameservers)
                 pass
         except ImportError: # no PyDNS

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -103,7 +103,7 @@ def admin_required(func):
     @functools.wraps(func)
     def wrapped(request, *args, **kwargs):
         if not request.user or not request.user.is_authenticated:
-            return HttpResponseRedirect('%s?%s=%s' % (settings.LOGIN_URL, REDIRECT_FIELD_NAME, quote(request.get_full_path())))
+            return HttpResponseRedirect(f'{settings.LOGIN_URL}?{REDIRECT_FIELD_NAME}={quote(request.get_full_path())}')
         elif not request.user.isAdministrator():
             raise PermissionDenied
         return func(request, *args, **kwargs)
@@ -121,7 +121,7 @@ class UserAvailability(models.Model):
         verbose_name_plural = 'User availabilities'
 
     def __str__(self):
-        return '%s available as %s at %s' % (self.user.username, self.role.name, str(self.event))
+        return f'{self.user.username} available as {self.role.name} at {self.event!s}'
 
     def save(self, *args, **kwargs):
         #   Assign default role if not set.
@@ -136,7 +136,7 @@ class UserAvailability(models.Model):
         return self.objects.filter(event=event)
 
     def get_absolute_url(self):
-        return self.event.program.get_manage_url()+"edit_availability?user="+str(self.user.id)
+        return f"{self.event.program.get_manage_url()}edit_availability?user={self.user.id!s}"
 
 
 class ESPUserManager(UserManager):
@@ -173,9 +173,9 @@ class BaseESPUser(object):
                 # override. Start by defining all the membership methods for
                 # the default types as returning False, and then overwrite them
                 # as necessary.
-                setattr(cls, 'is%s' % user_type, lambda user: False)
+                setattr(cls, f'is{user_type}', lambda user: False)
             for user_type in cls.getTypes() + ['Officer']:
-                setattr(cls, 'is%s' % user_type, cls.create_membership_method(user_type))
+                setattr(cls, f'is{user_type}', cls.create_membership_method(user_type))
 
     @staticmethod
     def grade_options():
@@ -270,7 +270,7 @@ class BaseESPUser(object):
         values = query_set.values('first_name', 'last_name', 'username', 'id')
 
         for value in values:
-            value['ajax_str'] = '%s, %s (%s)' % (value['last_name'], value['first_name'], value['username'])
+            value['ajax_str'] = f"{value['last_name']}, {value['first_name']} ({value['username']})"
         return values
 
     @classmethod
@@ -298,13 +298,13 @@ class BaseESPUser(object):
         return cls.ajax_autocomplete(data, QObject, prog=prog, **kwargs)
 
     def ajax_str(self):
-        return "%s, %s (%s)" % (self.last_name, self.first_name, self.username)
+        return f"{self.last_name}, {self.first_name} ({self.username})"
 
     def name(self):
-        return '%s %s' % (self.first_name, self.last_name)
+        return f'{self.first_name} {self.last_name}'
 
     def name_last_first(self):
-        return '%s, %s' % (self.last_name, self.first_name)
+        return f'{self.last_name}, {self.first_name}'
 
     def nonblank_name(self):
         name = self.name()
@@ -326,7 +326,7 @@ class BaseESPUser(object):
             # enclose name in quotes per RFC 2822 so that special characters in names are handled properly
             return '"%s" <%s>' % (name.replace('\\', '\\\\').replace('"', '\\"'), email)
         else:
-            return '<%s>' % email
+            return f'<{email}>'
 
     def get_email_sendto_address(self):
         """
@@ -399,7 +399,7 @@ class BaseESPUser(object):
             # Disallow morphing into Administrators.
             # It's too broken, from a security perspective.
             # -- aseering 1/29/2010
-            raise ESPError("User '%s' is an administrator; morphing into administrators is not permitted." % user.username, log=False)
+            raise ESPError(f"User '{user.username}' is an administrator; morphing into administrators is not permitted.", log=False)
 
         logout(request)
         user.backend = 'esp.utils.auth_backend.ESPAuthBackend'
@@ -453,15 +453,14 @@ class BaseESPUser(object):
             from django.utils.encoding import force_bytes
             uid = urlsafe_base64_encode(force_bytes(otheruser.pk))
             token = default_token_generator.make_token(otheruser)
-            return 'http://%s/myesp/resetpassword/%s/%s/' % \
-                         (settings.DEFAULT_HOST, uid, token)
+            return f'http://{settings.DEFAULT_HOST}/myesp/resetpassword/{uid}/{token}/'
         elif key == 'recover_query':
             from django.contrib.auth.tokens import default_token_generator
             from django.utils.http import urlsafe_base64_encode
             from django.utils.encoding import force_bytes
             uid = urlsafe_base64_encode(force_bytes(otheruser.pk))
             token = default_token_generator.make_token(otheruser)
-            return "?uid=%s&token=%s" % (uid, token)
+            return f"?uid={uid}&token={token}"
         elif key == 'unsubscribe_link':
             return otheruser.unsubscribe_link_full()
         return ''
@@ -484,7 +483,7 @@ class BaseESPUser(object):
     def getTaughtClassesFromProgram(self, program, include_rejected = False, include_cancelled = True):
         from esp.program.models import Program # Need the Class object.
         if not isinstance(program, Program): # if we did not receive a program
-            raise ESPError("getTaughtClassesFromProgram expects a Program, not a `"+str(type(program))+"'.")
+            raise ESPError(f"getTaughtClassesFromProgram expects a Program, not a `{type(program)!s}'.")
         else:
             classes = self.classsubject_set.filter(parent_program = program)
             if not include_rejected:
@@ -499,7 +498,7 @@ class BaseESPUser(object):
     def getModeratingSectionsFromProgram(self, program):
         from esp.program.models import Program # Need the Class object.
         if not isinstance(program, Program): # if we did not receive a program
-            raise ESPError("getModeratingSectionsFromProgram expects a Program, not a `" + str(type(program)) + "'.")
+            raise ESPError(f"getModeratingSectionsFromProgram expects a Program, not a `{type(program)!s}'.")
         else:
             return self.moderating_sections.filter(parent_class__parent_program = program).annotate(start_time = Min('meeting_times__start')).order_by('start_time')
     getModeratingSectionsFromProgram.depend_on_m2m('program.ClassSection', 'moderators', lambda sec, moderator: {'self': moderator})
@@ -510,7 +509,7 @@ class BaseESPUser(object):
             If exclude is specified (as a list of classes), exclude sections from the specified classes. """
         from esp.program.models import Program # Need the Class object.
         if not isinstance(program, Program): # if we did not receive a program
-            raise ESPError("getModeratingTimesFromProgram expects a Program, not a `" + str(type(program)) + "'.")
+            raise ESPError(f"getModeratingTimesFromProgram expects a Program, not a `{type(program)!s}'.")
         else:
             sections = self.getModeratingSectionsFromProgram(program)
             times = set()
@@ -524,7 +523,7 @@ class BaseESPUser(object):
         from esp.program.models import Program
         from esp.program.models import ClassSection
         if not isinstance(program, Program): # if we did not receive a program
-            raise ESPError("getTaughtOrModeratingSectionsFromProgram expects a Program, not a `" + str(type(program)) + "'.")
+            raise ESPError(f"getTaughtOrModeratingSectionsFromProgram expects a Program, not a `{type(program)!s}'.")
         else:
             classes = list(self.getTaughtClasses(program, include_rejected = include_rejected, include_cancelled = include_cancelled))
             sections = ClassSection.objects.filter(parent_class__in=classes)
@@ -551,7 +550,7 @@ class BaseESPUser(object):
     @cache_function
     def getFullClasses_pretty(self, program):
         full_classes = [cls for cls in self.getTaughtClassesFromProgram(program) if cls.is_nearly_full()]
-        return "\n".join([cls.emailcode()+": "+cls.title for cls in full_classes])
+        return "\n".join([f"{cls.emailcode()}: {cls.title}" for cls in full_classes])
     getFullClasses_pretty.depend_on_model('program.ClassSubject') # should filter by teachers... eh.
 
     def getTaughtSections(self, program = None, include_rejected = False, include_cancelled = True):
@@ -624,11 +623,11 @@ class BaseESPUser(object):
         try:
             num = int(num)
         except (ValueError, TypeError):
-            raise ESPError('Could not find user "%s %s"' % (first, last))
+            raise ESPError(f'Could not find user "{first} {last}"')
         users = ESPUser.objects.filter(last_name__iexact = last,
                                     first_name__iexact = first).order_by('id')
         if len(users) <= num:
-            raise ESPError('"%s %s": Unknown User' % (first, last), log=False)
+            raise ESPError(f'"{first} {last}": Unknown User', log=False)
         return users[num]
 
     @cache_function
@@ -923,7 +922,7 @@ class BaseESPUser(object):
         # we have a lot of users with no email (??)
         #  let's at least display a sensible error message
         if self.email.strip() == '':
-            raise ESPError('User %s has blank email address; cannot recover password. Please contact webmasters to reset your password.' % self.username)
+            raise ESPError(f'User {self.username} has blank email address; cannot recover password. Please contact webmasters to reset your password.')
 
         # email addresses
         to_email = [self.get_email_sendto_address()]
@@ -935,7 +934,7 @@ class BaseESPUser(object):
 
         # email subject
         domainname = Site.objects.get_current().domain
-        subject = '[%s] Your Password Recovery For %s ' % (settings.ORGANIZATION_SHORT_NAME, domainname)
+        subject = f'[{settings.ORGANIZATION_SHORT_NAME}] Your Password Recovery For {domainname} '
 
         # generate the email text
         t = loader.get_template('email/password_recover')
@@ -1015,15 +1014,15 @@ class BaseESPUser(object):
         """
         def _new_method(user):
             return user.is_user_type(user_class)
-        _new_method.__name__    = str('is%s' % str(user_class))
-        _new_method.__doc__     = "Returns ``True`` if the user is a %s and False otherwise." % user_class
+        _new_method.__name__    = str(f'is{user_class!s}')
+        _new_method.__doc__     = f"Returns ``True`` if the user is a {user_class} and False otherwise."
         return _new_method
 
     def is_user_type(self, user_class):
         """
         Determines whether the user is a member of user_class.
         """
-        property_name = '_userclass_%s' % user_class
+        property_name = f'_userclass_{user_class}'
         if not hasattr(self, property_name):
             role_name = {'Officer': 'Administrator'}.get(user_class, user_class)
             setattr(self, property_name, self.groups.filter(name=role_name).exists())
@@ -1237,7 +1236,7 @@ class BaseESPUser(object):
 
     def userHash(self, program):
         user_hash = hash(str(self.id) + str(program.id))
-        return '{0:06d}'.format(abs(user_hash))[:6]
+        return f'{abs(user_hash):06d}'[:6]
 
     # modified from here:
     # https://www.grokcode.com/819/one-click-unsubscribes-for-django-apps/
@@ -1248,20 +1247,20 @@ class BaseESPUser(object):
 
     def unsubscribe_link_full(self):
         unsub_link = self.unsubscribe_link()
-        return 'https://%s%s' % (Site.objects.get_current().domain, unsub_link)
+        return f'https://{Site.objects.get_current().domain}{unsub_link}'
 
     # this is an insecure version that accepts a POST from external sources
     def unsubscribe_oneclick(self):
         unsub_link = self.unsubscribe_link()
         unsub_link = unsub_link.replace("unsubscribe", "unsubscribe_oneclick")
-        return 'http://%s%s' % (Site.objects.get_current().domain, unsub_link)
+        return f'http://{Site.objects.get_current().domain}{unsub_link}'
 
     def make_token(self):
         return TimestampSigner().sign(self.username)
 
     def check_token(self, token):
         try:
-            key = '%s:%s' % (self.username, token)
+            key = f'{self.username}:{token}'
             TimestampSigner().unsign(key, max_age=60 * 60 * 24 * 7) # Valid for 7 days
         except (BadSignature, SignatureExpired):
             return False
@@ -1286,7 +1285,7 @@ class ESPUser(User, BaseESPUser):
         self.save()
 
     def get_absolute_url(self):
-        return "/manage/userview?username="+self.username
+        return f"/manage/userview?username={self.username}"
 
 class AnonymousESPUser(BaseESPUser, AnonymousUser):
     pass
@@ -1534,7 +1533,7 @@ class StudentInfo(models.Model):
             studentInfo.user = curUser
         elif studentInfo.user != curUser: # this should never happen, but you never know....
             raise ESPError("Your registration profile is corrupted. Please contact" +
-                            "{}".format(settings.DEFAULT_EMAIL_ADDRESSES['support']) +
+                            f"{settings.DEFAULT_EMAIL_ADDRESSES['support']}" +
                             " with your name and username in the message to " +
                             "correct this issue.")
 
@@ -1575,9 +1574,9 @@ class StudentInfo(models.Model):
         studentInfo.save()
         if new_data.get('studentrep', False):
             #   Email membership notifying them of the student rep request.
-            subj = '[%s Membership] Student Rep Request: %s %s' % (settings.ORGANIZATION_SHORT_NAME, curUser.first_name, curUser.last_name)
+            subj = f'[{settings.ORGANIZATION_SHORT_NAME} Membership] Student Rep Request: {curUser.first_name} {curUser.last_name}'
             to_email = [settings.DEFAULT_EMAIL_ADDRESSES['membership']]
-            from_email = 'ESP Profile Editor <regprofile@%s>' % settings.DEFAULT_HOST
+            from_email = f'ESP Profile Editor <regprofile@{settings.DEFAULT_HOST}>'
             t = loader.get_template('email/studentreprequest')
             msgtext = t.render(Context({'user': curUser, 'info': studentInfo, 'prog': regProfile.program}))
             send_mail(subj, msgtext, from_email, to_email, fail_silently = True)
@@ -1604,7 +1603,7 @@ class StudentInfo(models.Model):
         username = "N/A"
         if self.user is not None:
             username = self.user.username
-        return 'ESP Student Info (%s) -- %s' % (username, str(self.school))
+        return f'ESP Student Info ({username}) -- {self.school!s}'
 
     def get_absolute_url(self):
         return self.user.get_absolute_url()
@@ -1679,11 +1678,11 @@ class TeacherInfo(models.Model, CustomFormsLinkModel):
 
         for value in values:
             value['user'] = ESPUser.objects.get(id=value['user'])
-            value['ajax_str'] = '%s - %s %s' % (value['user'].ajax_str(), value['college'], value['graduation_year'])
+            value['ajax_str'] = f"{value['user'].ajax_str()} - {value['college']} {value['graduation_year']}"
         return values
 
     def ajax_str(self):
-        return '%s - %s %s' % (self.user.ajax_str(), self.college, self.graduation_year)
+        return f'{self.user.ajax_str()} - {self.college} {self.graduation_year}'
 
     def updateForm(self, form_dict):
         form_dict['pronoun']         = self.pronoun
@@ -1724,7 +1723,7 @@ class TeacherInfo(models.Model, CustomFormsLinkModel):
         username = ""
         if self.user is not None:
             username = self.user.username
-        return 'ESP Teacher Info (%s)' % username
+        return f'ESP Teacher Info ({username})'
 
     def get_absolute_url(self):
         return self.user.get_absolute_url()
@@ -1787,7 +1786,7 @@ class GuardianInfo(models.Model):
         username = ""
         if self.user is not None:
             username = self.user.username
-        return 'ESP Guardian Info (%s)' % username
+        return f'ESP Guardian Info ({username})'
 
     def get_absolute_url(self):
         return self.user.get_absolute_url()
@@ -1822,11 +1821,11 @@ class EducatorInfo(models.Model):
 
         for value in values:
             value['user'] = ESPUser.objects.get(id=value['user'])
-            value['ajax_str'] = '%s - %s %s' % (value['user'].ajax_str(), value['position'], value['school'])
+            value['ajax_str'] = f"{value['user'].ajax_str()} - {value['position']} {value['school']}"
         return values
 
     def ajax_str(self):
-        return "%s - %s at %s" % (self.user.ajax_str(), self.position, self.school)
+        return f"{self.user.ajax_str()} - {self.position} at {self.school}"
 
     def updateForm(self, form_dict):
         form_dict['subject_taught'] = self.subject_taught
@@ -1864,7 +1863,7 @@ class EducatorInfo(models.Model):
         username = ""
         if self.user is not None:
             username = self.user.username
-        return 'ESP Educator Info (%s)' % username
+        return f'ESP Educator Info ({username})'
 
     def get_absolute_url(self):
         return self.user.get_absolute_url()
@@ -1909,7 +1908,7 @@ class ZipCode(models.Model):
             distance_decimal = Decimal(str(distance))
             distance_float = float(str(distance))
         except (ValueError, ArithmeticError):
-            raise ESPError('%s should be a valid decimal number!' % distance)
+            raise ESPError(f'{distance} should be a valid decimal number!')
 
         if distance < 0:
             distance *= -1
@@ -1933,9 +1932,7 @@ class ZipCode(models.Model):
         return winners
 
     def __str__(self):
-        return '%s (%s, %s)' % (self.zip_code,
-                                self.longitude,
-                                self.latitude)
+        return f'{self.zip_code} ({self.longitude}, {self.latitude})'
 
 
 class ZipCodeSearches(models.Model):
@@ -2007,7 +2004,7 @@ class ContactInfo(models.Model, CustomFormsLinkModel):
         db_table = 'users_contactinfo'
 
     def name(self):
-        return '%s %s' % (self.first_name, self.last_name)
+        return f'{self.first_name} {self.last_name}'
 
     email = property(lambda self: self.e_mail)
 
@@ -2044,11 +2041,11 @@ class ContactInfo(models.Model, CustomFormsLinkModel):
                 query_set = query_set.filter(first_name__istartswith = first.strip())
         values = query_set.order_by('last_name', 'first_name', 'id').values('first_name', 'last_name', 'e_mail', 'id')
         for value in values:
-            value['ajax_str'] = '%s, %s (%s)' % (value['last_name'], value['first_name'], value['e_mail'])
+            value['ajax_str'] = f"{value['last_name']}, {value['first_name']} ({value['e_mail']})"
         return values
 
         def ajax_str(self):
-            return "%s, %s (%s)" % (self.last_name, self.first_name, self.e_mail)
+            return f"{self.last_name}, {self.first_name} ({self.e_mail})"
 
     @staticmethod
     def addOrUpdate(curUser, regProfile, new_data, contactInfo, prefix=''):
@@ -2096,7 +2093,7 @@ class ContactInfo(models.Model, CustomFormsLinkModel):
             first_name = self.first_name
         if self.last_name is not None:
             last_name = self.last_name
-        return first_name + ' ' + last_name + ' (' + username + ')'
+        return f"{first_name} {last_name} ({username})"
 
     def get_absolute_url(self):
         return self.user.get_absolute_url()
@@ -2134,7 +2131,7 @@ class K12School(models.Model):
         query_set = cls.objects.filter(name__icontains = name)
         values = query_set.order_by('name', 'id').values('name', 'id')
         for value in values:
-            value['ajax_str'] = '%s' % (value['name'])
+            value['ajax_str'] = f"{value['name']}"
         return values
 
     def __str__(self):
@@ -2142,12 +2139,12 @@ class K12School(models.Model):
             return '%s in %s, %s' % (self.name, self.contact.address_city,
                                             self.contact.address_state)
         else:
-            return '%s' % self.name
+            return f'{self.name}'
 
     @classmethod
     def choicelist(cls, other_help_text=''):
         if other_help_text:
-            other_help_text = ' (%s)' % other_help_text
+            other_help_text = f' ({other_help_text})'
         o = cls.objects.other()
         lst = [ ( x.id, x.name ) for x in cls.objects.most() ]
         lst.append( (o.id, o.name + other_help_text) )
@@ -2267,7 +2264,7 @@ class PersistentQueryFilter(models.Model):
         return filterObj
 
     def __str__(self):
-        return str(self.useful_name) + " (" + str(self.id) + ")"
+        return f"{self.useful_name!s} ({self.id!s})"
 
 class DBList(object):
     """ Useful abstraction for the list of users.
@@ -2282,7 +2279,7 @@ class DBList(object):
             If override is true, it will not retrieve the number from cache
             or from this instance. If it's true, it will try.
         """
-        cache_id = urlencode('DBListCount: %s' % (self.key))
+        cache_id = urlencode(f'DBListCount: {self.key}')
 
         retVal   = cache.get(cache_id) # get the cached result
         if self.QObject: # if there is a q object we can just
@@ -2420,7 +2417,7 @@ class Record(models.Model):
             return True
 
     def __str__(self):
-        return str(self.user) + " has completed " + str(self.event) + " for " + str(self.program)
+        return f"{self.user!s} has completed {self.event!s} for {self.program!s}"
 
 #helper method for designing implications
 def flatten(choices):
@@ -2718,8 +2715,7 @@ class Permission(ExpirableModel):
         else:
             program = "None"
 
-        return "GRANT %s ON %s TO %s" % (self.permission_type,
-                                         program, user)
+        return f"GRANT {self.permission_type} ON {program} TO {user}"
 
     @classmethod
     def nice_name_lookup(cls, perm_type):
@@ -2783,7 +2779,7 @@ class Permission(ExpirableModel):
         m = re.match("^([^/]*)/([^/]*)/([^/]*)/(.*)", url)
         if m:
             (section, prog1, prog2, rest) = m.groups()
-            prog_url = prog1 + "/" + prog2
+            prog_url = f"{prog1}/{prog2}"
             from esp.program.models import Program, ClassSubject
             try:
                 prog = Program.objects.get(url=prog_url)
@@ -2920,7 +2916,7 @@ class GradeChangeRequest(TimeStampedModel):
         subject, message = self._confirmation_email_content()
         send_mail(subject,
                   message,
-                  Tag.getTag('full_group_name') or '%s %s' % (settings.INSTITUTION_NAME, settings.ORGANIZATION_SHORT_NAME) + ' <info@' + settings.SITE_INFO[1] + '>',
+                  Tag.getTag('full_group_name') or f"{settings.INSTITUTION_NAME} {settings.ORGANIZATION_SHORT_NAME} <info@{settings.SITE_INFO[1]}>",
                   [self.requesting_student.email, ])
 
     def get_admin_url(self):
@@ -2929,7 +2925,7 @@ class GradeChangeRequest(TimeStampedModel):
 
 
     def __str__(self):
-        return  "%s requests a grade change to %s" % (self.requesting_student, self.claimed_grade) + (" (Approved)" if self.approved else "")
+        return  f"{self.requesting_student} requests a grade change to {self.claimed_grade}{' (Approved)' if self.approved else ''}"
 
 # We can't import these earlier because of circular stuff...
 from esp.users.models.forwarder import UserForwarder # Don't delete, needed for app loading

--- a/esp/esp/users/models/forwarder.py
+++ b/esp/esp/users/models/forwarder.py
@@ -108,4 +108,4 @@ class UserForwarder(models.Model):
             return (user, False)
 
     def __str__(self):
-        return '%s to %s' % (str(self.source), str(self.target))
+        return f'{self.source!s} to {self.target!s}'

--- a/esp/esp/users/tests.py
+++ b/esp/esp/users/tests.py
@@ -61,18 +61,18 @@ class ESPUserTest(TestCase):
         self.basic_user.backend = request.backend
 
         login(request, self.user)
-        self.assertEqual(request.user, self.user, "Failed to log in as '%s'" % self.user)
+        self.assertEqual(request.user, self.user, f"Failed to log in as '{self.user}'")
 
         request.user.switch_to_user(request, self.basic_user, None, None)
-        self.assertEqual(request.user, self.basic_user, "Failed to morph into '%s'" % self.basic_user)
+        self.assertEqual(request.user, self.basic_user, f"Failed to morph into '{self.basic_user}'")
 
         request.user.switch_back(request)
-        self.assertEqual(request.user, self.user, "Failed to morph back into '%s'" % self.user)
+        self.assertEqual(request.user, self.user, f"Failed to morph back into '{self.user}'")
 
         blocked_illegal_morph = True
         try:
             request.user.switch_to_user(request, self.basic_user, None, None)
-            self.assertEqual(request.user, self.basic_user, "Failed to morph into '%s'" % self.basic_user)
+            self.assertEqual(request.user, self.basic_user, f"Failed to morph into '{self.basic_user}'")
         except ESPError():
             blocked_illegal_morph = True
 
@@ -101,8 +101,8 @@ class ESPUserTest(TestCase):
         testGrade = 11
         curYear = ESPUser.current_schoolyear()
         gradYear = curYear + (12 - testGrade)
-        self.client.get("/manage/userview?username=student&graduation_year="+str(gradYear))
-        self.assertTrue(studentUser.getGrade() == testGrade, "Grades don't match: %s %s" % (studentUser.getGrade(), testGrade))
+        self.client.get(f"/manage/userview?username=student&graduation_year={gradYear!s}")
+        self.assertTrue(studentUser.getGrade() == testGrade, f"Grades don't match: {studentUser.getGrade()} {testGrade}")
 
         # Clean up
         if (c1):
@@ -176,7 +176,7 @@ class PasswordRecoveryTest(TestCase):
                          "Token should not be valid for a different user")
 
         # Use the token to reset the password via the view
-        reset_url = '/myesp/resetpassword/%s/%s/' % (uid, token)
+        reset_url = f'/myesp/resetpassword/{uid}/{token}/'
         response = self.client.get(reset_url)
         # Django's PasswordResetConfirmView redirects to set-password URL
         # after validating the token on GET
@@ -281,7 +281,7 @@ class ValidHostEmailFieldTest(TestCase):
         # Hardcoding 'esp.mit.edu' here might be a bad idea
         # But at least it verifies that A records work in place of MX
         for domain in [ 'esp.mit.edu', 'gmail.com', 'yahoo.com' ]:
-            self.assertTrue( ValidHostEmailField().clean( 'fakeaddress@%s' % domain ) == 'fakeaddress@%s' % domain )
+            self.assertTrue( ValidHostEmailField().clean( f'fakeaddress@{domain}' ) == f'fakeaddress@{domain}' )
     def testFakeDomain(self):
         # If we have an internet connection, bad domains raise ValidationError.
         # This should be the *only* kind of error we ever raise!
@@ -298,7 +298,7 @@ class UserForwarderTest(TestCase):
         self.users = [self.ua, self.ub, self.uc]
     def test_run(self):
         def fwd_info(user):
-            return '%s forwards by: %s' % (user.username, user.forwarders_out.all())
+            return f'{user.username} forwards by: {user.forwarders_out.all()}'
         # Ensure that users have no forwarders by default
         for user in self.users:
             self.assertTrue(UserForwarder.follow(user) == (user, False), fwd_info(user))
@@ -381,11 +381,11 @@ class AjaxExistenceChecker(TestCase):
 
         response = self.client.get(self.path)
         for key in self.keys:
-            self.assertContains(response, key, msg_prefix="Key %s missing from Ajax response to %s" % (key, self.path), status_code=200)
+            self.assertContains(response, key, msg_prefix=f"Key {key} missing from Ajax response to {self.path}", status_code=200)
 
 class AjaxScheduleExistenceTest(AjaxExistenceChecker, ProgramFrameworkTest):
     def test_run(self):
-        self.path = '/learn/%s/ajax_schedule' % self.program.getUrlBase()
+        self.path = f'/learn/{self.program.getUrlBase()}/ajax_schedule'
         self.keys = ['student_schedule_html']
         user=self.students[0]
         self.assertTrue(self.client.login(username=user.username, password='password'))
@@ -844,7 +844,7 @@ class StudentInfoFormGradeTest(TestCase):
         errors = form.errors.get('graduation_year', [])
         self.assertTrue(
             any('required' in e.lower() for e in errors),
-            "Expected a 'required' error for graduation_year, got: %s" % errors,
+            f"Expected a 'required' error for graduation_year, got: {errors}",
         )
 
     def test_no_auto_default_to_lowest_grade(self):

--- a/esp/esp/users/views/__init__.py
+++ b/esp/esp/users/views/__init__.py
@@ -209,7 +209,7 @@ def unsubscribe(request, username, token, oneclick = False):
         if users_active.exists():
             user = users_active[0]
         else:
-            raise ESPError("User " + users[0].username + " is already unsubscribed.")
+            raise ESPError(f"User {users[0].username} is already unsubscribed.")
     else:
         raise ESPError("No user matching that unsubscribe request.")
 
@@ -233,7 +233,7 @@ def unsubscribe(request, username, token, oneclick = False):
     # so show the login page (with a custom alert message)
     else:
         next_url = reverse('unsubscribe', kwargs={'username': username, 'token': token,})
-        return HttpResponseRedirect('%s?next=%s' % (reverse('login'), next_url))
+        return HttpResponseRedirect(f"{reverse('login')}?next={next_url}")
 
 # have an email client (etc) POST to this view to process a
 # "oneclick" unsubscribe
@@ -258,12 +258,12 @@ def morph_into_user(request):
         onsite = None
     request.user.switch_to_user(request,
                                 morph_user,
-                                '/manage/userview?username=' + morph_user.username,
-                                'User Search for '+morph_user.name(),
+                                f"/manage/userview?username={morph_user.username}",
+                                f"User Search for {morph_user.name()}",
                                 onsite is not None)
 
     if onsite is not None:
-        return HttpResponseRedirect('/learn/%s/studentreg' % onsite.getUrlBase())
+        return HttpResponseRedirect(f'/learn/{onsite.getUrlBase()}/studentreg')
     else:
         return HttpResponseRedirect('/')
 

--- a/esp/esp/users/views/password_reset.py
+++ b/esp/esp/users/views/password_reset.py
@@ -39,7 +39,7 @@ def initial_passwd_request(request, success=None):
             for user in users:
                 user.recoverPassword()
 
-            return HttpResponseRedirect('/%s/success/' % request.path.strip('/'))
+            return HttpResponseRedirect(f"/{request.path.strip('/')}/success/")
 
 
     else:

--- a/esp/esp/users/views/registration.py
+++ b/esp/esp/users/views/registration.py
@@ -111,7 +111,7 @@ When there are already accounts with this email address (depending on some tags)
         #form is valid, and not caring about multiple accounts
         email = urllib.parse.quote(form.cleaned_data['email'])
         initial_role = urllib.parse.quote(form.cleaned_data['initial_role'])
-        return HttpResponseRedirect(reverse('esp.users.views.user_registration_phase2')+'?email='+email+'&initial_role='+initial_role)
+        return HttpResponseRedirect(f"{reverse('esp.users.views.user_registration_phase2')}?email={email}&initial_role={initial_role}")
     else: #form is not valid
         return render_to_response('registration/newuser_phase1.html',
                                   request,
@@ -173,10 +173,10 @@ def activate_account(request):
     if u.is_active:
         raise ESPError('The user account supplied has already been activated. If you have lost your password, visit the <a href="/myesp/passwdrecover/">password recovery form</a>.  Otherwise, please <a href="/accounts/login/?next=/myesp/profile/">log in</a>.', log=False)
 
-    if not u.password.endswith("_%s" % request.GET['key']):
+    if not u.password.endswith(f"_{request.GET['key']}"):
         raise ESPError("Incorrect key.  Please try again to click the link in your email, or copy the url into your browser.  If this error persists, please contact us using the contact information on the top or bottom of this page.", log=False)
 
-    u.password = u.password[:-(len("_%s" % request.GET['key']))]
+    u.password = u.password[:-(len(f"_{request.GET['key']}"))]
     u.is_active = True
     u.save()
 
@@ -223,7 +223,7 @@ class GradeChangeRequestView(CreateView):
         change_request.save()
         messages.add_message(self.request, messages.SUCCESS, "Your grade change request was sent! You will receive an email containing your approval status shortly.")
 
-        log.info('grade change request sent by user %s'%(self.request.user,))
+        log.info(f'grade change request sent by user {self.request.user}')
 
         return HttpResponseRedirect(self.success_url)
 

--- a/esp/esp/users/views/usersearch.py
+++ b/esp/esp/users/views/usersearch.py
@@ -77,13 +77,13 @@ def get_user_list(request, listDict2, extra=''):
         lists = request.POST.getlist('select_mailman')
 
         all_list_members = reduce(operator.or_, (list_members(x) for x in lists))
-        filterObj = PersistentQueryFilter.getFilterFromQ(Q(id__in=[x.id for x in all_list_members]), ESPUser, 'Custom Mailman filter: ' + ", ".join(lists))
+        filterObj = PersistentQueryFilter.getFilterFromQ(Q(id__in=[x.id for x in all_list_members]), ESPUser, f"Custom Mailman filter: {', '.join(lists)}")
 
         if request.POST['submitform'] == 'I want to search within this list':
             getUser, found = search_for_user(request, ESPUser.objects.filter(filterObj.get_Q()).distinct(), filterObj.id, True)
             if found:
                 if isinstance(getUser, User):
-                    newfilterObj = PersistentQueryFilter.getFilterFromQ(Q(id = getUser.id), ESPUser, 'User %s' % getUser.username)
+                    newfilterObj = PersistentQueryFilter.getFilterFromQ(Q(id = getUser.id), ESPUser, f'User {getUser.username}')
                 else:
                     newfilterObj = PersistentQueryFilter.getFilterFromQ(filterObj.get_Q() & getUser, ESPUser, 'Custom user filter')
                 return (newfilterObj, True)
@@ -126,7 +126,7 @@ def get_user_list(request, listDict2, extra=''):
         if request.POST['base_list'] in listDict:
             curList = listDict[request.POST['base_list']]['list']
         else:
-            raise ESPError('I do not know of list "%s".' % request.POST['base_list'])
+            raise ESPError(f"I do not know of list \"{request.POST['base_list']}\".")
 
         # we start with all the separated lists, and apply the and'd lists onto the or'd lists before
         # we or. This closely represents the sentence (it's not as powerful, but makes "sense")
@@ -136,10 +136,10 @@ def get_user_list(request, listDict2, extra=''):
         keys = request.POST['keys'].split(',,')
 
         for key in keys:
-            if request.POST.get('operator_'+key) and \
-               request.POST['operator_'+key] != 'ignore':     # and it's not ignore (it should be 'and' or 'or')
+            if request.POST.get(f"operator_{key}") and \
+               request.POST[f"operator_{key}"] != 'ignore':     # and it's not ignore (it should be 'and' or 'or')
                 # We are adding to the list of 'and'd' lists and 'or'd' lists.
-                separated[request.POST['operator_'+key]].append(opmapping[request.POST['not_'+key]](listDict[key]['list']))
+                separated[request.POST[f"operator_{key}"]].append(opmapping[request.POST[f"not_{key}"]](listDict[key]['list']))
 
         # ^ - now separated has all the necessary Q objects.
 
@@ -161,7 +161,7 @@ def get_user_list(request, listDict2, extra=''):
             getUser, found = search_for_user(request, ESPUser.objects.filter(filterObj.get_Q()).distinct(), filterObj.id, True)
             if found:
                 if isinstance(getUser, User):
-                    newfilterObj = PersistentQueryFilter.getFilterFromQ(Q(id = getUser.id), ESPUser, 'User %s' % getUser.username)
+                    newfilterObj = PersistentQueryFilter.getFilterFromQ(Q(id = getUser.id), ESPUser, f'User {getUser.username}')
                 else:
                     newfilterObj = PersistentQueryFilter.getFilterFromQ(filterObj.get_Q() & getUser, ESPUser, 'Custom user filter')
                 return (newfilterObj, True)
@@ -184,7 +184,7 @@ def get_user_list(request, listDict2, extra=''):
         getUser, found = search_for_user(request, ESPUser.objects.filter(filterObj.get_Q()).distinct(), filterObj.id, True)
         if found:
             if isinstance(getUser, ESPUser):
-                newfilterObj = PersistentQueryFilter.getFilterFromQ(Q(id = getUser.id), ESPUser, 'User %s' % getUser.username)
+                newfilterObj = PersistentQueryFilter.getFilterFromQ(Q(id = getUser.id), ESPUser, f'User {getUser.username}')
             else:
                 newfilterObj = PersistentQueryFilter.getFilterFromQ(filterObj.get_Q() & getUser, ESPUser, 'Custom user filter')
 
@@ -262,7 +262,7 @@ def search_for_user(request, user_type='Any', extra='', returnList = False, add_
     elif isinstance(user_type, QuerySet):
         QSUsers = usc.filter_from_criteria(user_type, request.GET)
     else:
-        raise ESPError('Invalid user_type: %s' % type(user_type), log=True)
+        raise ESPError(f'Invalid user_type: {type(user_type)}', log=True)
 
     #   We need to ask for more user input if no filtering options were selected
     if not usc.updated:


### PR DESCRIPTION
## Description

Hey! Following up on the modernization effort started in #4558, this PR converts the remaining `%` and `.format()` string formatting to Python 3 f-strings specifically within the `esp.users` module.

I used flynt to handle the conversion which just operates on the AST, so it guarantees the logic stays exactly the same while making the code a lot more readable and slightly faster. Ran flake8 locally and everything looks clean.
## Related Issue

N/A (Extends the work from #4558)

Closes #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## AI Disclosure

Used an AI assistant to run the automated AST conversion script (flynt) across the directory.

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced
