### PR TITLE
Fix spacing issue for login inputs in navigation bar

### DIFF
--- a/esp/templates/main.html
+++ b/esp/templates/main.html
@@ -13,6 +13,15 @@
 {% block main %}
 
     <div class="container">
+      {% if request.COOKIES.esp_testing_role %}
+      <div
+       style="background: #fbf0b3; border: 1px solid #c09852; color: #c09852; padding: 0px 15px; margin-bottom: 15px; border-radius: 4px; text-align: center;">
+       <strong>Testing Mode ({{ request.COOKIES.esp_testing_role }}):</strong> &mdash;
+       You are logged in as a test account.
+       <a href="/myesp/stop_testing/" style="color: #a1702c; text-decoration: underline;">Stop testing &mdash; Return to
+         Admin</a>
+      </div>
+      {% endif %}
       <div class="row-fluid">
         {% block sidebar %}
           <div style="margin-bottom: 20px;">


### PR DESCRIPTION
## Description
This PR fixes the spacing issue in the navigation bar login section where the username and password input fields were too close to the container edges.

## Changes Made
- Added margin to the navigation section to improve spacing.
- Updated the layout in `esp/templates/index.html` and `esp/templates/main.html`.

## Result
The login input fields now have proper spacing from the container, improving the layout and visual clarity of the navigation bar.

## Related Issue
Fixes #4992
<img width="1137" height="623" alt="Screenshot 2026-03-12 232621" src="https://github.com/user-attachments/assets/a308ecbf-deba-4a3b-87fb-7b2bf14ae7ed" />
