### PR TITLE
[Security] Remove unnecessary @csrf_exempt decorators (Issue 1)

### DIFF
--- a/esp/esp/formstack/tests.py
+++ b/esp/esp/formstack/tests.py
@@ -44,3 +44,57 @@ class FormstackSubmissionTest(TestCase):
     def test_repr(self):
         sub = FormstackSubmission(200)
         self.assertEqual(repr(sub), '<FormstackSubmission: 200>')
+
+
+class FormstackWebhookTest(TestCase):
+    """Tests for formstack_webhook handshake key verification."""
+
+    def test_webhook_rejects_wrong_handshake_key(self):
+        """POST with wrong handshake key should return 403."""
+        with self.settings(FORMSTACK_HANDSHAKE_KEY='correct-secret'):
+            response = self.client.post('/formstack_webhook', {
+                'FormID': '123',
+                'UniqueID': '456',
+                'HandshakeKey': 'wrong-key',
+            })
+            self.assertEqual(response.status_code, 403)
+
+    def test_webhook_accepts_correct_handshake_key(self):
+        """POST with correct handshake key should succeed."""
+        with self.settings(FORMSTACK_HANDSHAKE_KEY='correct-secret'):
+            response = self.client.post('/formstack_webhook', {
+                'FormID': '123',
+                'UniqueID': '456',
+                'HandshakeKey': 'correct-secret',
+            })
+            self.assertEqual(response.status_code, 200)
+
+    def test_webhook_accepts_any_key_when_not_configured(self):
+        """When FORMSTACK_HANDSHAKE_KEY is empty, all requests pass."""
+        with self.settings(FORMSTACK_HANDSHAKE_KEY=''):
+            response = self.client.post('/formstack_webhook', {
+                'FormID': '123',
+                'UniqueID': '456',
+                'HandshakeKey': 'anything',
+            })
+            self.assertEqual(response.status_code, 200)
+
+    def test_webhook_rejects_get(self):
+        """GET requests to the webhook should return 404."""
+        response = self.client.get('/formstack_webhook')
+        self.assertEqual(response.status_code, 404)
+
+
+class MedicalsyncapiCsrfTest(TestCase):
+    """Tests that medicalsyncapi enforces CSRF protection."""
+
+    def test_medicalsyncapi_rejects_post_without_csrf(self):
+        """POST without CSRF token should return 403."""
+        from django.test import Client
+        csrf_client = Client(enforce_csrf_checks=True)
+        response = csrf_client.post('/medicalsyncapi', {
+            'username': 'admin',
+            'password': 'password',
+            'program': 'Splash 2024',
+        })
+        self.assertEqual(response.status_code, 403)

--- a/esp/esp/formstack/views.py
+++ b/esp/esp/formstack/views.py
@@ -1,4 +1,5 @@
-from django.http import HttpResponse, Http404
+from django.conf import settings
+from django.http import HttpResponse, Http404, HttpResponseForbidden
 from django.dispatch import receiver
 from django.views.decorators.csrf import csrf_exempt
 from esp.formstack.signals import formstack_post_signal
@@ -10,7 +11,10 @@ def formstack_webhook(request):
         form_id = data.pop('FormID')
         submission_id = data.pop('UniqueID')
         handshake_key = data.pop('HandshakeKey', None)
-        # TODO: verify handshake key
+        # Verify handshake key if configured
+        expected_key = getattr(settings, 'FORMSTACK_HANDSHAKE_KEY', None)
+        if expected_key and handshake_key != expected_key:
+            return HttpResponseForbidden('Invalid handshake key')
         formstack_post_signal.send(sender=None, form_id=form_id, submission_id=submission_id, fields=data)
         return HttpResponse()
     else:
@@ -19,15 +23,12 @@ def formstack_webhook(request):
 from django.contrib.auth import authenticate
 from django.http import HttpResponse, Http404, HttpResponseServerError, \
     HttpResponseForbidden, HttpResponseNotFound
-from django.dispatch import receiver
 from django.views.decorators.cache import never_cache
-from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from esp.program.models import Program
 from esp.users.models import ESPUser
 import json
 
-@csrf_exempt
 @never_cache
 @require_POST
 def medicalsyncapi(request):

--- a/esp/esp/settings.py
+++ b/esp/esp/settings.py
@@ -263,6 +263,10 @@ if not getattr(tempfile, 'alreadytwiddled', False): # Python appears to run this
 # that set a cookie on the top-level domain
 CSRF_COOKIE_NAME = 'esp_csrftoken'
 
+# Formstack webhook handshake key for verifying incoming webhook requests.
+# Set this to your Formstack webhook handshake key via environment variable.
+FORMSTACK_HANDSHAKE_KEY = os.environ.get('FORMSTACK_HANDSHAKE_KEY', '')
+
 if SENTRY_DSN:
     # If SENTRY_DSN is set, send errors to Sentry via the Raven exception
     # handler. Note that our exception middleware (i.e., ESPErrorMiddleware)

--- a/esp/templates/program/newprogram.html
+++ b/esp/templates/program/newprogram.html
@@ -63,6 +63,7 @@ In addition to importing the settings listed in the form below, using this progr
 
 <div id="alumni_form">
   <form action="{{ request.path }}" method="post">
+  {% csrf_token %}
   {% autoescape off %}
   {% if form.non_field_errors %}{{ form.non_field_errors }}{% endif %}
 

--- a/scripts/check_csrf_exempt.sh
+++ b/scripts/check_csrf_exempt.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# check_csrf_exempt.sh — CI check that flags new uses of @csrf_exempt.
+#
+# Allowed usages (add justifications here as comments):
+#   - esp/formstack/views.py:formstack_webhook  — External webhook; verified via handshake key
+#   - esp/program/views.py:submit_transaction    — Cybersource payment postback
+#   - esp/users/views/__init__.py:unsubscribe_oneclick — RFC 8058 List-Unsubscribe-Post
+#
+# Usage:
+#   ./scripts/check_csrf_exempt.sh
+#   Exit code 0 = only known usages found.
+#   Exit code 1 = new/unknown csrf_exempt usage detected.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Known allowed files (relative to repo root)
+ALLOWED_FILES=(
+    "esp/esp/formstack/views.py"
+    "esp/esp/program/views.py"
+    "esp/esp/users/views/__init__.py"
+)
+
+# Find all Python files using @csrf_exempt (excluding tests and migrations)
+# Use while-read loop to handle paths with spaces
+EXIT_CODE=0
+
+while IFS= read -r file; do
+    [ -z "$file" ] && continue
+    rel_path="${file#"$REPO_ROOT"/}"
+    is_allowed=false
+    for allowed in "${ALLOWED_FILES[@]}"; do
+        if [[ "$rel_path" == "$allowed" ]]; then
+            is_allowed=true
+            break
+        fi
+    done
+    if [[ "$is_allowed" == "false" ]]; then
+        echo "❌ NEW @csrf_exempt usage found in: $rel_path"
+        grep -n "@csrf_exempt" "$file"
+        EXIT_CODE=1
+    fi
+done < <(grep -rl "@csrf_exempt" "$REPO_ROOT/esp/esp/" \
+    --include="*.py" \
+    | grep -v "test" \
+    | grep -v "migration" \
+    | sort -u || true)
+
+if [[ "$EXIT_CODE" == "0" ]]; then
+    echo "✅ No unexpected @csrf_exempt usages found."
+fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
Fixes Issue 1

This PR:
- Adds handshake key verification to `formstack_webhook` (implementing the existing TODO comment)
- Removes `@csrf_exempt` from `medicalsyncapi`
- Adds `FORMSTACK_HANDSHAKE_KEY` to settings
- Adds `{% csrf_token %}` to the `newprogram.html` form
- Adds regression tests for webhook verification and `medicalsyncapi` CSRF enforcement
- Adds `scripts/check_csrf_exempt.sh` CI script to detect future violations

Note: As discovered during exploration, `submit_transaction` relies on a direct server-to-server POST from Cybersource, so its `@csrf_exempt` is kept intact as expected. The original issue description accidentally identified `medicalsyncapi` as `formstack_post` and referenced the wrong line numbers; this PR uses the corrected analysis.