### PR TITLE
Add independent footer styling — decouple footer from navbar colors

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,18 @@
+{
+  "configurations": [
+    {
+      "name": "windows-gcc-x86",
+      "includePath": [
+        "${workspaceFolder}/**"
+      ],
+      "compilerPath": "C:/MinGW/bin/gcc.exe",
+      "cStandard": "${default}",
+      "cppStandard": "${default}",
+      "intelliSenseMode": "windows-gcc-x86",
+      "compilerArgs": [
+        ""
+      ]
+    }
+  ],
+  "version": 4
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "C/C++ Runner: Debug Session",
+      "type": "cppdbg",
+      "request": "launch",
+      "args": [],
+      "stopAtEntry": false,
+      "externalConsole": true,
+      "cwd": "c:/Users/LENOVO/Desktop/ESP-Website/esp/esp/themes/theme_data/bigpicture/less",
+      "program": "c:/Users/LENOVO/Desktop/ESP-Website/esp/esp/themes/theme_data/bigpicture/less/build/Debug/outDebug",
+      "MIMode": "gdb",
+      "miDebuggerPath": "gdb",
+      "setupCommands": [
+        {
+          "description": "Enable pretty-printing for gdb",
+          "text": "-enable-pretty-printing",
+          "ignoreFailures": true
+        }
+      ]
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,59 @@
+{
+  "C_Cpp_Runner.cCompilerPath": "gcc",
+  "C_Cpp_Runner.cppCompilerPath": "g++",
+  "C_Cpp_Runner.debuggerPath": "gdb",
+  "C_Cpp_Runner.cStandard": "",
+  "C_Cpp_Runner.cppStandard": "",
+  "C_Cpp_Runner.msvcBatchPath": "C:/Program Files/Microsoft Visual Studio/VR_NR/Community/VC/Auxiliary/Build/vcvarsall.bat",
+  "C_Cpp_Runner.useMsvc": false,
+  "C_Cpp_Runner.warnings": [
+    "-Wall",
+    "-Wextra",
+    "-Wpedantic",
+    "-Wshadow",
+    "-Wformat=2",
+    "-Wcast-align",
+    "-Wconversion",
+    "-Wsign-conversion",
+    "-Wnull-dereference"
+  ],
+  "C_Cpp_Runner.msvcWarnings": [
+    "/W4",
+    "/permissive-",
+    "/w14242",
+    "/w14287",
+    "/w14296",
+    "/w14311",
+    "/w14826",
+    "/w44062",
+    "/w44242",
+    "/w14905",
+    "/w14906",
+    "/w14263",
+    "/w44265",
+    "/w14928"
+  ],
+  "C_Cpp_Runner.enableWarnings": true,
+  "C_Cpp_Runner.warningsAsError": false,
+  "C_Cpp_Runner.compilerArgs": [],
+  "C_Cpp_Runner.linkerArgs": [],
+  "C_Cpp_Runner.includePaths": [],
+  "C_Cpp_Runner.includeSearch": [
+    "*",
+    "**/*"
+  ],
+  "C_Cpp_Runner.excludeSearch": [
+    "**/build",
+    "**/build/**",
+    "**/.*",
+    "**/.*/**",
+    "**/.vscode",
+    "**/.vscode/**"
+  ],
+  "C_Cpp_Runner.useAddressSanitizer": false,
+  "C_Cpp_Runner.useUndefinedSanitizer": false,
+  "C_Cpp_Runner.useLeakSanitizer": false,
+  "C_Cpp_Runner.showCompilationTime": false,
+  "C_Cpp_Runner.useLinkTimeOptimization": false,
+  "C_Cpp_Runner.msvcSecureNoWarnings": false
+}

--- a/esp/esp/themes/tests.py
+++ b/esp/esp/themes/tests.py
@@ -232,3 +232,27 @@ class ThemesTest(TestCase):
 
         #   We're done.  Log out.
         self.client.logout()
+    def testFooterVariables(self):
+        """ Check that Droplets footer variables compile correctly into CSS. """
+
+        self.client.login(username=self.admin.username, password='password')
+
+        tc = ThemeController()
+        tc.clear_theme()
+        tc.load_theme('droplets')
+
+        # Apply a known footer background color
+        test_color = '#123456'
+        config_dict = {'apply': True, 'footerBackground': test_color}
+        response = self.client.post('/themes/customize/', config_dict)
+        self.assertEqual(response.status_code, 200)
+
+        # Verify it compiled into the CSS output
+        css_filename = os.path.join(
+            settings.MEDIA_ROOT, 'styles', themes_settings.COMPILED_CSS_FILE
+        )
+        with open(css_filename) as f:
+            css_content = f.read()
+        self.assertIn(test_color.lower(), css_content.lower())
+
+        self.client.logout()

--- a/esp/esp/themes/theme_data/droplets/config_form.py
+++ b/esp/esp/themes/theme_data/droplets/config_form.py
@@ -12,6 +12,10 @@ class ConfigForm(ThemeConfigurationForm):
     show_logo_header = forms.BooleanField(initial = True, required = False, help_text=mark_safe('Should the logo be shown in the <b>header banner</b>?'))
     show_header_home = forms.BooleanField(initial = True, required = False, help_text=mark_safe('Should the header banner be shown on the <b>homepage</b>?'))
     show_header_other = forms.BooleanField(initial = True, required = False, help_text=mark_safe('Should the header banner be shown on <b>non-homepage pages</b>?'))
+    jumbotronFallbackColor = forms.CharField(label='Hero Fallback Color (shows when no image is uploaded)', required=False)
+    footerBackground = forms.CharField(label='Footer Background Color', required=False)
+    footerText = forms.CharField(label='Footer Text Color', required=False)
+    footerLinkColor = forms.CharField(label='Footer Link Color', required=False)
     contact_info = forms.CharField(required = False, widget=forms.Textarea,
                                    help_text='Generic text to include in the "About Us" dropdown in the navigation bar. Leave blank to omit this field.')
     show_email = forms.BooleanField(required = False, help_text='Should the group email address be shown in the "About Us" dropdown in the navigation bar?')

--- a/esp/esp/themes/theme_data/droplets/config_form.py
+++ b/esp/esp/themes/theme_data/droplets/config_form.py
@@ -12,10 +12,36 @@ class ConfigForm(ThemeConfigurationForm):
     show_logo_header = forms.BooleanField(initial = True, required = False, help_text=mark_safe('Should the logo be shown in the <b>header banner</b>?'))
     show_header_home = forms.BooleanField(initial = True, required = False, help_text=mark_safe('Should the header banner be shown on the <b>homepage</b>?'))
     show_header_other = forms.BooleanField(initial = True, required = False, help_text=mark_safe('Should the header banner be shown on <b>non-homepage pages</b>?'))
-    jumbotronFallbackColor = forms.CharField(label='Hero Fallback Color (shows when no image is uploaded)', required=False)
-    footerBackground = forms.CharField(label='Footer Background Color', required=False)
-    footerText = forms.CharField(label='Footer Text Color', required=False)
-    footerLinkColor = forms.CharField(label='Footer Link Color', required=False)
+# NOTE: Field names use camelCase to match LESS variable names directly.
+# ThemeController maps form field names to @variableName in compile_css().
+# Renaming to snake_case would break the LESS variable substitution.
+    jumbotronFallbackColor = forms.CharField(
+        label='Hero Fallback Color (shows when no image is uploaded)',
+        required=False,
+        help_text='Enter a valid CSS color e.g. #336699 or rgb(0, 120, 255)',
+        widget=forms.TextInput(attrs={'placeholder': '#4F87BB'}),
+    )
+
+    footerBackground = forms.CharField(
+        label='Footer Background Color',
+        required=False,
+        help_text='Enter a valid CSS color e.g. #111111 or rgb(0, 0, 0)',
+        widget=forms.TextInput(attrs={'placeholder': '#111111'}),
+    )
+
+    footerText = forms.CharField(
+        label='Footer Text Color',
+        required=False,
+        help_text='Enter a valid CSS color e.g. #999999 or rgb(153, 153, 153)',
+        widget=forms.TextInput(attrs={'placeholder': '#999999'}),
+    )
+
+    footerLinkColor = forms.CharField(
+        label='Footer Link Color',
+        required=False,
+        help_text='Enter a valid CSS color e.g. #ffffff or rgb(255, 255, 255)',
+        widget=forms.TextInput(attrs={'placeholder': '#ffffff'}),
+    )
     contact_info = forms.CharField(required = False, widget=forms.Textarea,
                                    help_text='Generic text to include in the "About Us" dropdown in the navigation bar. Leave blank to omit this field.')
     show_email = forms.BooleanField(required = False, help_text='Should the group email address be shown in the "About Us" dropdown in the navigation bar?')

--- a/esp/esp/themes/theme_data/droplets/config_form.py
+++ b/esp/esp/themes/theme_data/droplets/config_form.py
@@ -12,7 +12,7 @@ class ConfigForm(ThemeConfigurationForm):
     show_logo_header = forms.BooleanField(initial = True, required = False, help_text=mark_safe('Should the logo be shown in the <b>header banner</b>?'))
     show_header_home = forms.BooleanField(initial = True, required = False, help_text=mark_safe('Should the header banner be shown on the <b>homepage</b>?'))
     show_header_other = forms.BooleanField(initial = True, required = False, help_text=mark_safe('Should the header banner be shown on <b>non-homepage pages</b>?'))
-# NOTE: Field names use camelCase to match LESS variable names directly.
+# NOTE:- Field names use camelCase to match LESS variable names directly.
 # ThemeController maps form field names to @variableName in compile_css().
 # Renaming to snake_case would break the LESS variable substitution.
     jumbotronFallbackColor = forms.CharField(

--- a/esp/esp/themes/theme_data/droplets/less/main.less
+++ b/esp/esp/themes/theme_data/droplets/less/main.less
@@ -317,7 +317,7 @@ select {
 }
 
 #footer {
-    background: @footerBackground;
+    background-color: @footerBackground;
     color: @footerText;
 
     a {

--- a/esp/esp/themes/theme_data/droplets/less/main.less
+++ b/esp/esp/themes/theme_data/droplets/less/main.less
@@ -315,3 +315,12 @@ textarea:not([class*="span"]),
 select {
     width: auto;
 }
+
+#footer {
+    background: @footerBackground;
+    color: @footerText;
+
+    a {
+        color: @footerLinkColor;
+    }
+}

--- a/esp/esp/themes/theme_data/droplets/less/variables.less
+++ b/esp/esp/themes/theme_data/droplets/less/variables.less
@@ -1,3 +1,11 @@
 @navbarBrandFontSize: 24px;
 @navbarFontSize: 20px;
 @navbarCollapseWidth: 979px;
+@jumbotronFallbackColor:    @accent1;
+@jumbotronFallbackGradient: linear-gradient(
+                              135deg, @accent1 0%, @accent2 100%
+                            );
+
+@footerBackground:  @navbarInverseBackground;
+@footerText:        @navbarInverseText;
+@footerLinkColor:   @navbarInverseLinkColor;


### PR DESCRIPTION

Closes #5028 
Part of #3810

## Changes
- `variables.less` — added @footerBackground, @footerText, 
   @footerLinkColor all defaulting to @navbarInverse equivalents
- `main.less` — added #footer block using new independent variables
- `config_form.py` — added footer color fields to theme editor
- `variables.less` — also added @jumbotronFallbackColor and 
  @jumbotronFallbackGradient (these were part of the related 
  jumbotron fallback fix and share the same file

## Why These Defaults
All new variables default to existing @navbarInverse values so 
every existing chapter deployment is visually unchanged on day one.
Admins only see a difference if they actively change the new 
footer fields in the theme editor.