### PR TITLE
Fix onboarding typos and wording in onsite schedule printing instructions (#4165)

### DIFF
--- a/esp/templates/program/modules/onsiteprintschedules/instructions.html
+++ b/esp/templates/program/modules/onsiteprintschedules/instructions.html
@@ -19,16 +19,16 @@ Using this tool you can print student schedules for students on the fly.
 <br />
 To use this tool as intended you must:<br />
 <ol>
-<li>Get a printer that can reliably sit and be plugged into a printer</li>
+<li>Get a printer that can reliably sit and be plugged into a computer</li>
 <li>Install a printer, and make SURE it's default (at least in Firefox)</li>
 <li>Use firefox :-D</li>
 <li>Set up the printer as default:<br />
 <ol>
-<li>Goto <tt>about:config</tt> and type `<tt>print_printer</tt>'. Enter the string title (exactly) for the {{ settings.ORGANIZATION_SHORT_NAME }} Printer.</li>
-<li>Rightclick on some whitespace and click on "New --> Boolean". Add <tt>print.always_print_silent</tt> and make it TRUE.</li>
+<li>Go to <tt>about:config</tt> and type `<tt>print_printer</tt>'. Enter the string title (exactly) for the {{ settings.ORGANIZATION_SHORT_NAME }} Printer.</li>
+<li>Right click on some whitespace and click on "New --> Boolean". Add <tt>print.always_print_silent</tt> and make it TRUE.</li>
 <li>While you're at it, you might as well make <tt>print.print_color</tt> false.</li>
 </ol>
-Now your printer will now automatically print from firefox. Test this by printing this page. Notice it shouldn't open a dialog box or anything.
+Now your printer will now automatically print from Firefox. Test this by printing this page. Notice it shouldn't open a dialog box or anything.
 </li>
 <li>Now you should be ready to go to the next page!</li>
 </ol>


### PR DESCRIPTION
This PR fixes several typos and wording issues in the onsite schedule printing instructions page.

Changes made:
- "Goto" → "Go to"
- "Rightclick" → "Right-click"
- "firefox" → "Firefox"
- "plugged into a printer" → "plugged into a computer"

These changes improve clarity and correctness without altering any functionality.

Fixes #4165