### PR TITLE
Add save_as = True to ModelAdmin classes to enable object duplication (Fixes #596)

### DIFF
--- a/esp/esp/accounting/admin.py
+++ b/esp/esp/accounting/admin.py
@@ -41,6 +41,7 @@ class LIOInline(admin.TabularInline):
     model = LineItemOptions
 
 class LITAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ['text', 'amount_dec', 'program', 'required', 'for_finaid', 'num_options', 'max_quantity']
     search_fields = ['text', 'amount_dec', 'program__url', 'program__name']
     list_filter = ['program']
@@ -48,6 +49,7 @@ class LITAdmin(admin.ModelAdmin):
 admin_site.register(LineItemType, LITAdmin)
 
 class TransferAdmin(admin.ModelAdmin):
+    save_as = True
     def option_description(self, obj):
         if obj.option:
             return obj.option.description
@@ -67,6 +69,7 @@ class TransferAdmin(admin.ModelAdmin):
 admin_site.register(Transfer, TransferAdmin)
 
 class AccountAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ['name', 'program', 'balance']
 admin_site.register(Account, AccountAdmin)
 
@@ -74,6 +77,7 @@ def finalize_finaid_grants(modeladmin, request, queryset):
     for grant in queryset:
         grant.finalize()
 class FinancialAidGrantAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ['id', 'request', 'user', 'program', 'finalized', 'amount_max_dec', 'percent']
     readonly_fields=('finalized',)
     list_filter = ['request__program']
@@ -82,6 +86,7 @@ class FinancialAidGrantAdmin(admin.ModelAdmin):
 admin_site.register(FinancialAidGrant, FinancialAidGrantAdmin)
 
 class CybersourcePostbackAdmin(admin.ModelAdmin):
+    save_as = True
     readonly_fields = ['timestamp']
     list_display = ['timestamp', 'transfer']
     search_fields = ['post_data', '=transfer__id', '=transfer__user__id',

--- a/esp/esp/application/admin.py
+++ b/esp/esp/application/admin.py
@@ -45,6 +45,7 @@ from esp.application.models import FormstackAppSettings, FormstackStudentProgram
 from esp.utils.admin_user_search import default_user_search
 
 class FormstackAppSettingsAdmin(admin.ModelAdmin):
+    save_as = True
     fields = ['program', 'api_key', 'forms_for_api_key',
               'form_id', 'form_fields',
               'username_field', 'coreclass_fields',
@@ -97,6 +98,7 @@ class FormstackStudentClassAppInline(admin.TabularInline):
     max_num = 0
 
 class FormstackStudentProgramAppAdmin(admin.ModelAdmin):
+    save_as = True
     fields = ['submission_id', 'program', 'user',
               'admin_status', 'admin_comment',
               'admissions_pretty',
@@ -146,6 +148,7 @@ class FormstackStudentProgramAppAdmin(admin.ModelAdmin):
 admin_site.register(FormstackStudentProgramApp, FormstackStudentProgramAppAdmin)
 
 class FormstackStudentClassAppAdmin(admin.ModelAdmin):
+    save_as = True
     fields = ['user', 'student_preference', 'subject',
               'admin_status', 'admin_comment',
               'teacher_rating', 'teacher_ranking', 'teacher_comment',

--- a/esp/esp/cal/admin.py
+++ b/esp/esp/cal/admin.py
@@ -37,6 +37,7 @@ from esp.admin import admin_site
 from esp.cal.models import EventType, Event
 
 class EventTypeAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ('description', 'is_teacher_type')
     list_filter = ('is_teacher_type',)
     search_fields = ['description']
@@ -49,6 +50,7 @@ class EventTypeAdmin(admin.ModelAdmin):
 admin_site.register(EventType, EventTypeAdmin)
 
 class EventAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ('id', 'program', 'name', 'short_time', 'pretty_date', 'event_type', 'short_description')
     list_filter = ('program', 'start', 'end', 'event_type')
     date_hierarchy = 'start'

--- a/esp/esp/customforms/admin.py
+++ b/esp/esp/customforms/admin.py
@@ -25,23 +25,27 @@ field_form.short_description = 'Form'
 """ Classes to control display of instances on admin site """
 
 class FormAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ['title', 'date_created', 'created_by', num_fields]
     search_fields = default_user_search('created_by') + ['title', 'description']
     date_hierarchy = 'date_created'
 admin_site.register(Form, FormAdmin)
 
 class PageAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ['__str__', 'form', 'seq', num_sections]
     list_filter = ('form',)
 admin_site.register(Page, PageAdmin)
 
 class SectionAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ['title', page_form, 'page', 'seq', num_fields]
     search_fields = ('title', 'description')
     list_filter = ('page', 'page__form')
 admin_site.register(Section, SectionAdmin)
 
 class FieldAdmin(admin.ModelAdmin):
+    save_as = True
     list_filter = ('form',)
     search_fields = ('label',)
     list_display = ['__str__', 'form', 'label', 'field_type', 'section', 'seq', 'required']
@@ -49,6 +53,7 @@ class FieldAdmin(admin.ModelAdmin):
 admin_site.register(Field, FieldAdmin)
 
 class AttributeAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ['attr_type', 'field', 'value', field_form]
     list_filter = ('attr_type', 'field__form')
     list_editable = ['value']

--- a/esp/esp/dbmail/admin.py
+++ b/esp/esp/dbmail/admin.py
@@ -39,21 +39,25 @@ from esp.dbmail.models import MessageVars, EmailList, PlainRedirect, MessageRequ
 from esp.utils.admin_user_search import default_user_search
 
 class MessageVarsAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ('id', 'messagerequest', 'provider_name')
     list_filter = ('provider_name',)
     search_fields = ('messagerequest__subject',)
 admin_site.register(MessageVars, MessageVarsAdmin)
 
 class EmailListAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ('description', 'regex')
 admin_site.register(EmailList, EmailListAdmin)
 
 class PlainRedirectAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ('original', 'destination')
     search_fields = ('original', 'destination')
 admin_site.register(PlainRedirect, PlainRedirectAdmin)
 
 class MessageRequestAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ('subject', 'creator', 'sender', 'recipients', 'created_at', 'processed_by', 'processed', 'public')
     list_filter = ('processed', 'processed_by', 'public')
     search_fields = default_user_search('creator') + ['subject', 'sender']
@@ -61,6 +65,7 @@ class MessageRequestAdmin(admin.ModelAdmin):
 admin_site.register(MessageRequest, MessageRequestAdmin)
 
 class TextOfEmailAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ('id', 'send_from', 'send_to', 'subject', 'sent', 'user')
     search_fields = ('=id', 'send_from', 'send_to', 'subject', 'user')
     date_hierarchy = 'sent'

--- a/esp/esp/program/admin.py
+++ b/esp/esp/program/admin.py
@@ -57,6 +57,7 @@ from esp.utils.admin_user_search import default_user_search
 from esp.users.admin import ExpiredListFilter
 
 class ProgramModuleAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ('link_title', 'admin_title', 'handler')
     search_fields = ['link_title', 'admin_title', 'handler']
 
@@ -67,12 +68,14 @@ class ProgramModuleAdmin(admin.ModelAdmin):
 admin_site.register(ProgramModule, ProgramModuleAdmin)
 
 class ArchiveClassAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ('id', 'title', 'year', 'date', 'category', 'program', 'teacher')
     search_fields = ['id', 'description', 'title', 'program', 'teacher', 'category']
     pass
 admin_site.register(ArchiveClass, ArchiveClassAdmin)
 
 class ProgramAdmin(admin.ModelAdmin):
+    save_as = True
     class Media:
         css = { 'all': ( 'styles/admin.css', ) }
     list_display = ('id', 'name', 'url', 'director_email', 'grade_min', 'grade_max',)
@@ -86,6 +89,7 @@ class ProgramAdmin(admin.ModelAdmin):
 admin_site.register(Program, ProgramAdmin)
 
 class RegistrationProfileAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ('id', 'user', 'contact_user', 'contact_guardian', 'contact_emergency', 'program', 'last_ts')
     search_fields = default_user_search() + ['contact_user__first_name', 'contact_user__last_name',
                                             'contact_guardian__first_name', 'contact_guardian__last_name',
@@ -99,6 +103,7 @@ class RegistrationProfileAdmin(admin.ModelAdmin):
 admin_site.register(RegistrationProfile, RegistrationProfileAdmin)
 
 class TeacherBioAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ('user', 'program', 'slugbio')
     search_fields = default_user_search() + ['slugbio', 'bio']
 
@@ -111,6 +116,7 @@ class FinancialAidGrantInline(admin.TabularInline):
     verbose_name_plural = 'Financial aid grant - enter 100 in "Percent" field to waive entire cost'
 
 class FinancialAidRequestAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ('user', 'approved', 'reduced_lunch', 'program', 'household_income', 'extra_explaination')
     search_fields = default_user_search() + ['id', 'program__url']
     list_filter = ['program']
@@ -141,6 +147,7 @@ class FinancialAidRequestAdmin(admin.ModelAdmin):
 admin_site.register(FinancialAidRequest, FinancialAidRequestAdmin)
 
 class Admin_SplashInfo(admin.ModelAdmin):
+    save_as = True
     list_display = (
         'student',
         'program',
@@ -159,17 +166,20 @@ def subclass_instance_type(obj):
 subclass_instance_type.short_description = 'Instance type'
 
 class BooleanTokenAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ('expr', 'seq', subclass_instance_type, 'text')
     search_fields = ['text']
 admin_site.register(BooleanToken, BooleanTokenAdmin)
 
 class BooleanExpressionAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ('label', subclass_instance_type, 'num_tokens')
     def num_tokens(self, obj):
         return len(obj.get_stack())
 admin_site.register(BooleanExpression, BooleanExpressionAdmin)
 
 class Admin_ScheduleConstraint(admin.ModelAdmin):
+    save_as = True
     list_display = (
         'program',
         'condition',
@@ -179,6 +189,7 @@ class Admin_ScheduleConstraint(admin.ModelAdmin):
 admin_site.register(ScheduleConstraint, Admin_ScheduleConstraint)
 
 class ScheduleTestOccupiedAdmin(admin.ModelAdmin):
+    save_as = True
     def program(obj):
         return obj.timeblock.program
     list_display = ('timeblock', program, 'expr', 'seq', subclass_instance_type, 'text')
@@ -186,6 +197,7 @@ class ScheduleTestOccupiedAdmin(admin.ModelAdmin):
 admin_site.register(ScheduleTestOccupied, ScheduleTestOccupiedAdmin)
 
 class ScheduleTestCategoryAdmin(admin.ModelAdmin):
+    save_as = True
     def program(obj):
         return obj.timeblock.program
     list_display = ('timeblock', program, 'category', 'expr', 'seq', subclass_instance_type, 'text')
@@ -193,6 +205,7 @@ class ScheduleTestCategoryAdmin(admin.ModelAdmin):
 admin_site.register(ScheduleTestCategory, ScheduleTestCategoryAdmin)
 
 class ScheduleTestSectionListAdmin(admin.ModelAdmin):
+    save_as = True
     def program(obj):
         return obj.timeblock.program
     list_display = ('timeblock', program, 'section_ids', 'expr', 'seq', subclass_instance_type, 'text')
@@ -202,6 +215,7 @@ admin_site.register(ScheduleTestSectionList, ScheduleTestSectionListAdmin)
 class VolunteerOfferInline(admin.StackedInline):
     model = VolunteerOffer
 class VolunteerRequestAdmin(admin.ModelAdmin):
+    save_as = True
     def description(obj):
         return obj.timeslot.description
     def time(obj):
@@ -214,6 +228,7 @@ class VolunteerRequestAdmin(admin.ModelAdmin):
 admin_site.register(VolunteerRequest, VolunteerRequestAdmin)
 
 class VolunteerOfferAdmin(admin.ModelAdmin):
+    save_as = True
     def program(obj):
         return obj.request.program
     def description(obj):
@@ -230,6 +245,7 @@ admin_site.register(VolunteerOffer, VolunteerOfferAdmin)
 ## class_.py
 
 class Admin_RegistrationType(admin.ModelAdmin):
+    save_as = True
     list_display = ('name', 'category', 'displayName', 'description', )
 
     def get_readonly_fields(self, request, obj=None):
@@ -249,6 +265,7 @@ def renew_student_registrations(modeladmin, request, queryset):
     modeladmin.message_user(request, "%s registration(s) successfully renewed" % len(queryset))
 
 class StudentRegistrationAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ('id', 'section', 'user', 'relationship', 'start_date', 'end_date',)
     actions = [ expire_student_registrations, renew_student_registrations ]
     search_fields = default_user_search() + ['id', 'section__id', 'section__parent_class__title', 'section__parent_class__id']
@@ -257,6 +274,7 @@ class StudentRegistrationAdmin(admin.ModelAdmin):
 admin_site.register(StudentRegistration, StudentRegistrationAdmin)
 
 class StudentSubjectInterestAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ('id', 'subject', 'user', 'start_date', 'end_date', )
     actions = [ expire_student_registrations, ]
     search_fields = default_user_search() + ['id', 'subject__id', 'subject__title']
@@ -269,6 +287,7 @@ def sec_classrooms(obj):
 def sec_teacher_optimal_capacity(obj):
     return (obj.parent_class.class_size_max if obj.parent_class.class_size_max else obj.parent_class.class_size_optimal)
 class SectionAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ('emailcode', 'title', 'friendly_times', 'status', 'duration', 'max_class_capacity', sec_teacher_optimal_capacity, sec_classrooms)
     list_display_links = ('title',)
     list_filter = ['status', 'parent_class__parent_program']
@@ -287,6 +306,7 @@ class SectionInline(admin.TabularInline):
     can_delete = False
 
 class SubjectAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ('category', 'id', 'title', 'parent_program',
                     'pretty_teachers')
     list_display_links = ('title',)
@@ -325,6 +345,7 @@ class SubjectAdmin(admin.ModelAdmin):
 admin_site.register(ClassSubject, SubjectAdmin)
 
 class Admin_ClassCategories(admin.ModelAdmin):
+     save_as = True
      list_display = ('category', 'symbol', 'seq', )
 
      def get_readonly_fields(self, request, obj=None):
@@ -335,6 +356,7 @@ class Admin_ClassCategories(admin.ModelAdmin):
 admin_site.register(ClassCategories, Admin_ClassCategories)
 
 class Admin_ClassSizeRange(admin.ModelAdmin):
+     save_as = True
      list_display = ('program', 'range_min', 'range_max', )
      list_filter = ('program',)
 admin_site.register(ClassSizeRange, Admin_ClassSizeRange)
@@ -342,12 +364,14 @@ admin_site.register(ClassSizeRange, Admin_ClassSizeRange)
 ## app_.py
 
 class StudentAppAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ('user', 'program', 'done')
     search_fields = default_user_search()
     list_filter = ('program',)
 admin_site.register(StudentApplication, StudentAppAdmin)
 
 class Admin_StudentAppQuestion(admin.ModelAdmin):
+    save_as = True
     list_display = (
         'program',
         'subject',
@@ -359,6 +383,7 @@ class Admin_StudentAppQuestion(admin.ModelAdmin):
 admin_site.register(StudentAppQuestion, Admin_StudentAppQuestion)
 
 class Admin_StudentAppResponse(admin.ModelAdmin):
+    save_as = True
     list_display = (
         'question',
         'response',
@@ -371,6 +396,7 @@ class Admin_StudentAppResponse(admin.ModelAdmin):
 admin_site.register(StudentAppResponse, Admin_StudentAppResponse)
 
 class Admin_StudentAppReview(admin.ModelAdmin):
+    save_as = True
     list_display = (
         'reviewer',
         'date',
@@ -382,12 +408,14 @@ class Admin_StudentAppReview(admin.ModelAdmin):
 admin_site.register(StudentAppReview, Admin_StudentAppReview)
 
 class ClassFlagTypeAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ('name', 'show_in_scheduler', 'show_in_dashboard', 'show_to_teacher', 'notify_teacher_by_email')
     search_fields = ['name']
     list_filter = ['program']
 admin_site.register(ClassFlagType, ClassFlagTypeAdmin)
 
 class ClassFlagAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ('flag_type', 'subject', 'comment', 'created_by', 'modified_by')
     readonly_fields = ['modified_by', 'modified_time', 'created_by', 'created_time']
     search_fields = default_user_search('modified_by') + default_user_search('created_by') + ['flag_type__name', 'flag_type__id', 'subject__id', 'subject__title', 'subject__parent_program__url', 'comment']
@@ -395,12 +423,14 @@ class ClassFlagAdmin(admin.ModelAdmin):
 admin_site.register(ClassFlag, ClassFlagAdmin)
 
 class PhaseZeroRecordAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ('id', 'display_user', 'program')
     search_fields = ['user__username']
     list_filter = ['program']
 admin_site.register(PhaseZeroRecord, PhaseZeroRecordAdmin)
 
 class ModeratorRecordAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ('id', 'user', 'program', 'will_moderate', 'num_slots')
     search_fields = ['user__username']
     list_filter = ['program', 'will_moderate']

--- a/esp/esp/program/modules/admin.py
+++ b/esp/esp/program/modules/admin.py
@@ -39,6 +39,7 @@ from esp.program.modules.module_ext import DBReceipt, StudentClassRegModuleInfo,
 from esp.program.modules.base import ProgramModuleObj
 
 class Admin_DBReceipt(admin.ModelAdmin):
+    save_as = True
     list_display = (
         'action',
         'program',
@@ -47,18 +48,21 @@ class Admin_DBReceipt(admin.ModelAdmin):
 admin_site.register(DBReceipt, Admin_DBReceipt)
 
 class SCRMIAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ('program',)
     list_filter = ('program',)
     search_fields = ('program__name',)
 admin_site.register(StudentClassRegModuleInfo, SCRMIAdmin)
 
 class CRMIAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ('program',)
     list_filter = ('program',)
     search_fields = ('program__name',)
 admin_site.register(ClassRegModuleInfo, CRMIAdmin)
 
 class ProgramModelObjAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = (
         'program',
         'module',

--- a/esp/esp/qsdmedia/admin.py
+++ b/esp/esp/qsdmedia/admin.py
@@ -38,6 +38,7 @@ from esp.admin import admin_site
 from esp.qsdmedia.models import Media
 
 class MediaAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ['owner_type', 'owner_id', 'friendly_name', 'target_file', ]
     list_display_links = ['friendly_name']
     search_fields = ['friendly_name', 'owner_id', ]

--- a/esp/esp/resources/admin.py
+++ b/esp/esp/resources/admin.py
@@ -38,6 +38,7 @@ from esp.admin import admin_site
 from esp.resources.models import ResourceType, ResourceRequest, Resource, ResourceAssignment
 
 class ResourceTypeAdmin(admin.ModelAdmin):
+    save_as = True
     def rt_choices(self, obj):
         return str(obj.choices)
     rt_choices.short_description = 'Choices'
@@ -47,6 +48,7 @@ class ResourceTypeAdmin(admin.ModelAdmin):
             'attributes_dumped', 'program__name']
 
 class ResourceRequestAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ('target', 'res_type', 'desired_value')
     list_filter = ('res_type__program',)
     search_fields = ['target__parent_class__title', '=target__parent_class__id', 'res_type__name',
@@ -54,6 +56,7 @@ class ResourceRequestAdmin(admin.ModelAdmin):
             'desired_value']
 
 class ResourceAdmin(admin.ModelAdmin):
+    save_as = True
     def program(obj):
         return obj.event.program.name
     list_display = ('name', 'res_type', 'num_students', 'event', 'res_group', program)
@@ -64,6 +67,7 @@ class ResourceAdmin(admin.ModelAdmin):
             '=res_group__id')
 
 class ResourceAssignmentAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ('id', 'resource', 'target', 'assignment_group', 'returned')
     search_fields = ('=id', 'resource__name', 'target__parent_class__title')
 

--- a/esp/esp/survey/admin.py
+++ b/esp/esp/survey/admin.py
@@ -41,16 +41,19 @@ from esp.admin import admin_site
 from esp.survey.models import Survey, SurveyResponse, QuestionType, Question, Answer
 
 class SurveyAdmin(admin.ModelAdmin):
+    save_as = True
     list_filter = ('category',)
 admin_site.register(Survey, SurveyAdmin)
 
 class SurveyResponseAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ('survey', 'time_filled')
     date_hierarchy = 'time_filled'
     list_filter = ('survey', 'time_filled')
 admin_site.register(SurveyResponse, SurveyResponseAdmin)
 
 class QuestionTypeAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ('name', '_param_names', 'is_numeric', 'is_countable')
 
     def get_readonly_fields(self, request, obj=None):
@@ -60,6 +63,7 @@ class QuestionTypeAdmin(admin.ModelAdmin):
 admin_site.register(QuestionType, QuestionTypeAdmin)
 
 class QuestionAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ['seq', 'name', 'question_type', 'survey', 'per_class']
     list_display_links = ['name']
     list_filter = ['survey']

--- a/esp/esp/tagdict/admin.py
+++ b/esp/esp/tagdict/admin.py
@@ -3,6 +3,7 @@ from django.contrib import admin
 from esp.admin import admin_site
 
 class TagAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ('key', 'value', 'target', )
     list_filter = ('key', 'object_id', 'content_type__model', )
 admin_site.register(Tag, TagAdmin)

--- a/esp/esp/users/admin.py
+++ b/esp/esp/users/admin.py
@@ -12,16 +12,19 @@ import datetime
 
 
 class UserForwarderAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ('source', 'target')
     search_fields = default_user_search('source') + default_user_search('target')
 admin_site.register(UserForwarder, UserForwarderAdmin)
 
 class ZipCodeAdmin(admin.ModelAdmin):
+    save_as = True
     search_fields = ('=zip_code',)
     list_display = ('zip_code', 'latitude', 'longitude')
 admin_site.register(ZipCode, ZipCodeAdmin)
 
 class ZipCodeSearchesAdmin(admin.ModelAdmin):
+    save_as = True
     def count(obj):
         return len(obj.zipcodes.split(','))
     count.short_description = "Number of zip codes"
@@ -30,6 +33,7 @@ class ZipCodeSearchesAdmin(admin.ModelAdmin):
 admin_site.register(ZipCodeSearches, ZipCodeSearchesAdmin)
 
 class UserAvailabilityAdmin(admin.ModelAdmin):
+    save_as = True
     def parent_program(obj): #because 'event__program' for some reason doesn't want to work...
         return obj.event.program
     list_display = ['id', 'user', 'event', parent_program]
@@ -54,6 +58,7 @@ class ESPUserAdmin(UserAdmin):
 admin_site.register(ESPUser, ESPUserAdmin)
 
 class RecordTypeAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ['id', 'name', 'description']
     search_fields = ['name', 'description']
 
@@ -64,6 +69,7 @@ class RecordTypeAdmin(admin.ModelAdmin):
 admin_site.register(RecordType, RecordTypeAdmin)
 
 class RecordAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ['id', 'user', 'event', 'program', 'time',]
     list_filter = ['event', 'program', 'time']
     search_fields = default_user_search()
@@ -87,6 +93,7 @@ class ExpiredListFilter(admin.SimpleListFilter):
             return queryset.filter(end_date__lte=datetime.datetime.now())
 
 class PermissionAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ['id', 'user', 'role', 'permission_type', 'program', 'start_date', 'end_date']
     search_fields = default_user_search() + ['permission_type', 'program__url']
     list_filter = ['permission_type', 'program', 'role', ExpiredListFilter]
@@ -114,11 +121,13 @@ class PermissionAdmin(admin.ModelAdmin):
 admin_site.register(Permission, PermissionAdmin)
 
 class ContactInfoAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ['id', 'user', 'e_mail', 'phone_day']
     search_fields = default_user_search() + ['e_mail']
 admin_site.register(ContactInfo, ContactInfoAdmin)
 
 class UserInfoAdmin(admin.ModelAdmin):
+    save_as = True
     search_fields = default_user_search()
 
 class StudentInfoAdmin(UserInfoAdmin):
@@ -144,6 +153,7 @@ class EducatorInfoAdmin(UserInfoAdmin):
 admin_site.register(EducatorInfo, EducatorInfoAdmin)
 
 class K12SchoolAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ['name', 'grades', 'contact_title', 'contact_name', 'school_type']
     formfield_overrides = {
         models.TextField: {'widget': forms.TextInput(attrs={'size': '50',}),},
@@ -159,6 +169,7 @@ class K12SchoolAdmin(admin.ModelAdmin):
 admin_site.register(K12School, K12SchoolAdmin)
 
 class GradeChangeRequestAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ['requesting_student', 'claimed_grade', 'approved', 'acknowledged_by', 'acknowledged_time', 'created']
     readonly_fields = ['grade_before_request', 'requesting_student', 'acknowledged_by', 'acknowledged_time', 'claimed_grade']
     search_fields = default_user_search('requesting_student')

--- a/esp/esp/utils/admin.py
+++ b/esp/esp/utils/admin.py
@@ -19,9 +19,11 @@ class TemplateOverrideAdmin(VersionAdmin):
         js = ('/media/scripts/admin_templateoverride.js',)
 
 class PrinterAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ['name', 'printer_type']
 
 class PrintRequestAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ['user', 'printer', 'time_requested', 'time_executed']
     list_filter = ['printer', 'time_requested', 'time_executed']
     date_hierarchy = 'time_requested'

--- a/esp/esp/web/admin.py
+++ b/esp/esp/web/admin.py
@@ -1,4 +1,3 @@
-
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
 __rev__       = "$REV$"
@@ -38,10 +37,12 @@ from esp.admin import admin_site
 from esp.web.models import NavBarEntry, NavBarCategory
 
 class NavBarEntryAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ('category', 'sort_rank', 'text', 'link')
     list_filter = ('category',)
 
 class NavBarCategoryAdmin(admin.ModelAdmin):
+    save_as = True
     list_display = ('name', 'path')
     search_fields = ['name', 'path']
 


### PR DESCRIPTION
Fixes #596

## Problem
The admin panel had no way to duplicate/copy existing objects. 
Users had to manually recreate similar objects from scratch every time.

## Solution
Added `save_as = True` to all ModelAdmin classes across the codebase.
This enables Django's built-in "Save as new" button on all admin object pages,
allowing users to duplicate any object and modify only the fields they need.

## Files Changed
- esp/esp/accounting/admin.py
- esp/esp/application/admin.py
- esp/esp/cal/admin.py
- esp/esp/customforms/admin.py
- esp/esp/dbmail/admin.py
- esp/esp/program/admin.py
- esp/esp/program/modules/admin.py
- esp/esp/qsdmedia/admin.py
- esp/esp/resources/admin.py
- esp/esp/survey/admin.py
- esp/esp/tagdict/admin.py
- esp/esp/users/admin.py
- esp/esp/utils/admin.py
- esp/esp/web/admin.py

## Testing
Verified locally that "Save as new" button appears on admin object pages.
screenshot below:
<img width="1342" height="497" alt="image" src="https://github.com/user-attachments/assets/c86d6879-0cb6-489d-839b-7247eb6c0867" />
