### PR TITLE
Fix lottery_execute crash on malformed POST keys

### DIFF
--- a/esp/esp/program/modules/handlers/lotteryfrontendmodule.py
+++ b/esp/esp/program/modules/handlers/lotteryfrontendmodule.py
@@ -1,5 +1,5 @@
 import logging
-
+import math
 from esp.program.models import StudentRegistration
 from esp.program.modules.base import ProgramModuleObj, needs_admin, main_call, aux_call
 from esp.program.controllers.lottery import LotteryAssignmentController, LotteryException
@@ -36,9 +36,9 @@ class LotteryFrontendModule(ProgramModuleObj):
 
     def is_float(self, s):
         try:
-            float(s)
-            return True
-        except ValueError:
+            value = float(s)
+            return math.isfinite(value)
+        except (ValueError,TypeError):
             return False
 
     @aux_call
@@ -49,7 +49,7 @@ class LotteryFrontendModule(ProgramModuleObj):
         options = {}
 
         for key in request.POST:
-            if 'lottery_' in key:
+            if key.startswith("lottery_"):
                 value = request.POST[key]
 
                 if value == 'True':
@@ -61,7 +61,7 @@ class LotteryFrontendModule(ProgramModuleObj):
                 elif self.is_float(value):
                     value = float(value)
 
-                options[key.split('_', 1)[1]] = value
+                options[key[len("lottery_"):]] = value
 
         try:
             lotteryObj = LotteryAssignmentController(prog, **options)

--- a/esp/esp/program/modules/tests/test_lotteryfrontendmodule.py
+++ b/esp/esp/program/modules/tests/test_lotteryfrontendmodule.py
@@ -1,0 +1,80 @@
+import pytest
+from esp.program.modules.handlers.lotteryfrontendmodule import LotteryFrontendModule
+
+
+# --- is_float: valid numbers ---
+
+def test_is_float_valid_numbers():
+    m = LotteryFrontendModule()
+
+    assert m.is_float("3.14") is True
+    assert m.is_float("0") is True
+    assert m.is_float("-1.5") is True
+    assert m.is_float("100") is True
+
+
+# --- is_float: invalid (non-numeric) strings ---
+
+def test_is_float_invalid_numbers():
+    m = LotteryFrontendModule()
+
+    assert m.is_float("abc") is False
+    assert m.is_float("") is False
+    assert m.is_float("3.1.4") is False
+    assert m.is_float("None") is False
+
+
+# --- is_float: type-like edge cases ---
+
+def test_is_float_type_error():
+    m = LotteryFrontendModule()
+
+    assert m.is_float("True") is False
+    assert m.is_float("False") is False
+
+
+# --- is_float: whitespace-padded numbers (real-world form input) ---
+# float(" 5 ") is valid Python, so we confirm is_float handles it correctly
+
+def test_is_float_with_whitespace():
+    m = LotteryFrontendModule()
+
+    assert m.is_float(" 5 ") is True
+    assert m.is_float(" 3.5 ") is True
+
+
+# --- is_float: regression test for nan/inf (Fix 3) ---
+# math.isfinite() must reject these — test ensures the fix never regresses
+
+def test_is_float_rejects_nonfinite():
+    m = LotteryFrontendModule()
+
+    assert m.is_float("nan") is False
+    assert m.is_float("inf") is False
+    assert m.is_float("-inf") is False
+
+
+# --- Key parsing: regression test for malformed POST keys (Fix 1 + Fix 2) ---
+# Simulates the lottery_execute key-parsing logic directly.
+# Ensures malformed keys like "lotterylimit" (missing underscore) are ignored,
+# and valid keys like "lottery_limit" are stripped to "limit" correctly.
+
+def test_lottery_option_key_parsing():
+    m = LotteryFrontendModule()
+
+    data = {
+        "lottery_use_priority": "True",
+        "lottery_limit": "5",
+        "lotterylimit": "10",   # malformed key — no underscore after prefix
+    }
+
+    options = {}
+
+    for key in data:
+        if key.startswith("lottery_"):
+            options[key[len("lottery_"):]] = data[key]
+
+    assert "use_priority" in options       # valid key parsed correctly
+    assert "limit" in options              # valid key parsed correctly
+    assert "lotterylimit" not in options   # malformed key ignored safely
+    assert len(options) == 2              # no extra keys snuck in


### PR DESCRIPTION
## Description

Fixes a crash in LotteryFrontendModule.lottery_execute() caused by malformed POST keys and improves validation of numeric option values.
Previously, lottery options were extracted using:
options[key.split('_', 1)[1]] = value

If a malformed key such as lotterylimit (missing _) was received, split('_', 1)[1] raised an IndexError, crashing the lottery execution endpoint.
This PR replaces that logic with safer parsing using:
key.startswith("lottery_")

Prefix removal via string slicing
Additionally, the is_float() helper previously accepted values like nan and inf, which could propagate into LotteryAssignmentController. It now uses math.isfinite() to reject non-finite floats.

## Related Issue

<!-- Link the relevant issue. Use "Closes #123" to auto-close on merge. -->

Closes #5069 

## Type of Change

- [x] Bug fix

## Testing

- [x] Existing tests pass
- [x] New tests added (if applicable)
- [x] Manually verified

## AI Disclosure

I have ChatGpt for understanding this file lotteryfrontendmodule.py. I have write the code manually. I have made tests for this from Claude.

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced
