### PR TITLE
Update account creation page message to explain Program registration

### DIFF
--- a/esp/templates/elements/html
+++ b/esp/templates/elements/html
@@ -1,3 +1,4 @@
+<h1>Welcome to ESP Website</h1>
 <?xml version="1.0" encoding="UTF-8"?>
 {% block doctype %}<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">{% endblock doctype %}
 <html xmlns="http://www.w3.org/1999/xhtml">

--- a/esp/templates/registration/account_created_activation_required.html
+++ b/esp/templates/registration/account_created_activation_required.html
@@ -11,8 +11,9 @@
 <h1>Create a new account</h1>
 
 <p>
-You have successfully registered a new account!  Before you can use
-your new account, however, you will have to activate it.  An email
+You have successfully registered a new account! 
+Note: Registering for an account does not register you for a program.
+Before you can use your new account, however, you will have to activate it.  An email
 has been sent to your address with activation instructions.  Please
 follow those instructions in order to continue with program
 registration.


### PR DESCRIPTION
Fixes #833 
This PR updates the message shown after account creation to clarify that creating an account doesn't automatically register the user for programs.

Changes made:
-Updated the Text on the account creation page to inform users that they still need to register for programs after creating an account.

Type of Change:
- [ ] Documentation update

Testing:
- Ran the website locally 
- Created a new account and verified that updated message appears on the account creation page.

AI disclosure:
Some assistance from AI tool was used to help draft the wording for the updated message and the pull request description. All code changes were reviewed and tested manually to ensure they work correctly within the project.

Checklist:
-  Self-reviewed the code
- Updated documentation 

