### PR TITLE
fix: upgrade Markdown to resolve deprecation warnings

### DIFF
--- a/esp/requirements.txt
+++ b/esp/requirements.txt
@@ -27,7 +27,7 @@ pytest-cov==4.1.0 # Coverage measurement compatible with pytest-xdist parallel r
 pytest-django==4.5.2 # Django integration for pytest
 pytest-xdist==3.3.1 # Parallel test execution via -n auto
 ipython==7.34.0 # Used for shell_plus
-Markdown==2.3.1 # Used in QSD
+Markdown==3.4.4 # Used in QSD, last version supporting Python 3.7
 numpy==1.16.6 # Used mainly in the lottery and class change controller
 pillow==8.3.2 # Required for ImageField, which we use in teacher bios
 psycopg2==2.8.6 # Talks to postgres


### PR DESCRIPTION
Fixes #5089 — deprecation warnings about treeprocessors.py in markdown library

The warnings were appearing because the project was using Markdown 2.3.1 (from 2013), which uses deprecated ElementTree methods.

## Solution
Upgraded Markdown from 2.3.1 to 3.4.4:
- Last version supporting Python 3.7 (as required by the pytest==7.4.4 constraint)  
- Fixes deprecation warnings by using modern ElementTree methods
- No breaking changes for the simple markdown usage in this codebase
- Maintains backward compatibility for basic md.markdown() calls

## Compatibility  
The codebase only uses basic markdown functionality like md.markdown() which is fully compatible with Markdown 3.4.4.

Greetings, saschabuehrle