### PR TITLE
Replace dummy logo with dynamic theme logo on generated nametags

### DIFF
--- a/esp/esp/program/modules/handlers/nametagmodule.py
+++ b/esp/esp/program/modules/handlers/nametagmodule.py
@@ -32,7 +32,11 @@ Learning Unlimited, Inc.
   Phone: 617-379-0178
   Email: web-team@learningu.org
 """
+import os
 from django.conf import settings
+from django.contrib.auth.models import Group
+from django.core.files.storage import default_storage
+from django.db.models.query import Q
 
 from esp.middleware import ESPError
 from esp.program.modules.base import ProgramModuleObj, needs_admin, main_call, aux_call
@@ -43,10 +47,6 @@ from esp.users.controllers.usersearch import UserSearchController
 from esp.tagdict.models import Tag
 from esp.users.models import ESPUser
 from esp.utils.web import render_to_response
-
-from django.contrib.auth.models import Group
-from django.db.models.query import Q
-import os
 
 class NameTagModule(ProgramModuleObj):
     doc = """This module allows you to generate a bunch of IDs for users that match specific criteria."""
@@ -242,8 +242,9 @@ class NameTagModule(ProgramModuleObj):
         context['users_and_backs'] = users_and_backs
         context['group_name'] = Tag.getTag('full_group_name') or '%s %s' % (settings.INSTITUTION_NAME, settings.ORGANIZATION_SHORT_NAME)
         context['phone_number'] = Tag.getTag('group_phone_number')
-        context['current_logo_version'] = Tag.getTag('current_logo_version')
-        context['has_logo'] = os.path.exists(os.path.join(settings.MEDIA_ROOT, 'images', 'theme', 'logo.png'))
+        current_logo_version = Tag.getTag('current_logo_version')
+        context['current_logo_version'] = current_logo_version if current_logo_version is not None else ''
+        context['has_logo'] = default_storage.exists('images/theme/logo.png')
 
         return render_to_response(self.baseDir()+'ids.html', request, context)
 

--- a/esp/esp/program/modules/handlers/nametagmodule.py
+++ b/esp/esp/program/modules/handlers/nametagmodule.py
@@ -46,6 +46,7 @@ from esp.utils.web import render_to_response
 
 from django.contrib.auth.models import Group
 from django.db.models.query import Q
+import os
 
 class NameTagModule(ProgramModuleObj):
     doc = """This module allows you to generate a bunch of IDs for users that match specific criteria."""
@@ -241,6 +242,8 @@ class NameTagModule(ProgramModuleObj):
         context['users_and_backs'] = users_and_backs
         context['group_name'] = Tag.getTag('full_group_name') or '%s %s' % (settings.INSTITUTION_NAME, settings.ORGANIZATION_SHORT_NAME)
         context['phone_number'] = Tag.getTag('group_phone_number')
+        context['current_logo_version'] = Tag.getTag('current_logo_version')
+        context['has_logo'] = os.path.exists(os.path.join(settings.MEDIA_ROOT, 'images', 'theme', 'logo.png'))
 
         return render_to_response(self.baseDir()+'ids.html', request, context)
 

--- a/esp/templates/program/modules/nametagmodule/singleid.html
+++ b/esp/templates/program/modules/nametagmodule/singleid.html
@@ -6,8 +6,10 @@
   <table class="bottom">
   <tr>
      <td class="left">
-        <img src="/media/images/my-logo-small.png" class="logo" alt="{{ group_name }} logo" />
-     </td>
+      {% if has_logo %}
+        <img src="/media/images/theme/logo.png?v={{ current_logo_version }}" class="logo" alt="{{ group_name }} logo" />
+      {% endif %}
+      </td>
      <td class="right url">
     {% if user.id %}
       <span class="studentid">{{ user.username }} (ID: {{ user.id }})</span>

--- a/esp/templates/program/modules/nametagmodule/singleid.html
+++ b/esp/templates/program/modules/nametagmodule/singleid.html
@@ -7,7 +7,7 @@
   <tr>
      <td class="left">
       {% if has_logo %}
-        <img src="/media/images/theme/logo.png?v={{ current_logo_version }}" class="logo" alt="{{ group_name }} logo" />
+        <img src="{{ MEDIA_URL }}images/theme/logo.png?v={{ current_logo_version }}" class="logo" alt="{{ group_name }} logo" />
       {% endif %}
       </td>
      <td class="right url">


### PR DESCRIPTION
## Description

This PR fixes an issue where the generated nametags for students and teachers printed an old, uncustomized dummy logo (my-logo-small.png). It updates the singleid.html template to point directly to the chapter's configured theme logo instead.

Key Changes:

1. Modified `singleid.html` to pull the image source from /`media/images/theme/logo.png`.
2. Appended `?v={{ current_logo_version }}` to the image source to prevent caching issues when an admin uploads a new logo.
3. Updated `nametagmodule.py `to fetch current_logo_version from `Tag.getTag()` and pass it to the context, allowing the template to read the cache-busting string.

## Related Issue

Closes #5083 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor/cleanup
- [ ] CI/CD or build change

## Screenshot
<img width="965" height="867" alt="image" src="https://github.com/user-attachments/assets/abce0c36-e1c0-4ef0-a4cd-c5a6c7b15b40" />

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## AI Disclosure

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced
