### PR TITLE
test: rename TestProgramManager to ProgramManager (fixes #5114)

### DIFF
--- a/esp/esp/program/modules/tests/ajaxschedulingmodule.py
+++ b/esp/esp/program/modules/tests/ajaxschedulingmodule.py
@@ -33,7 +33,7 @@ Learning Unlimited, Inc.
 """
 
 from esp.program.tests import ProgramFrameworkTest
-from esp.program.modules.tests.support import TestProgramManager
+from esp.program.modules.tests.support import ProgramManager
 from esp.program.modules.module_ext import AJAXChangeLog
 import json
 import time
@@ -48,7 +48,7 @@ class AJAXSchedulingModuleTestBase(ProgramFrameworkTest):
             'num_teachers': 3, 'classes_per_teacher': 2, 'sections_per_class': 1
             })
         super().setUp(*args, **kwargs)
-        self.program_manager = TestProgramManager(self.client, self.program, self.teachers, self.rooms, self.timeslots)
+        self.program_manager = ProgramManager(self.client, self.program, self.teachers, self.rooms, self.timeslots)
 
         # Set the section durations to 1:50
         for sec in self.program.sections():

--- a/esp/esp/program/modules/tests/support/__init__.py
+++ b/esp/esp/program/modules/tests/support/__init__.py
@@ -1,1 +1,1 @@
-from esp.program.modules.tests.support.program_manager import TestProgramManager
+from esp.program.modules.tests.support.program_manager import ProgramManager

--- a/esp/esp/program/modules/tests/support/program_manager.py
+++ b/esp/esp/program/modules/tests/support/program_manager.py
@@ -1,6 +1,6 @@
 import json
 
-class TestProgramManager():
+class ProgramManager():
     def __init__(self, client, program, teachers, rooms, timeslots):
         self.client = client
         self.program = program


### PR DESCRIPTION
## Description

Fixes the `PytestCollectionWarning` that triggers on every test run.

Pytest automatically attempts to collect any class starting with `Test*` as a test suite. `TestProgramManager` (in [support/program_manager.py](cci:7://file:///Volumes/Untitled/abab/lu/ESP-Website/esp/esp/program/modules/tests/support/program_manager.py:0:0-0:0)) is a test helper/utility class, not an actual test suite, and therefore has an [__init__](cci:1://file:///Volumes/Untitled/abab/lu/ESP-Website/esp/esp/program/modules/forms/surveys.py:20:4-27:65) constructor which causes pytest to emit a warning when it tries (and fails) to collect it.

By renaming the helper class to [ProgramManager](cci:2://file:///Volumes/Untitled/abab/lu/ESP-Website/esp/esp/program/modules/tests/support/program_manager.py:2:0-45:68), we stop pytest from incorrectly parsing it as a test class, removing the warning with no functional changes to the tests themselves. 

## Related Issue

Closes #5114 

## Type of Change

- [x] Refactor / cleanup

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manually verified

## AI Disclosure

Used AI to identify the root cause of the warning and apply the rename across files.

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced
