### PR TITLE
Fix: correct comment in end_w_buffer method

### DIFF
--- a/esp/esp/cal/models.py
+++ b/esp/esp/cal/models.py
@@ -92,7 +92,7 @@ class Event(models.Model):
         return self.start - buffer
 
     def end_w_buffer(self, buffer = timedelta(minutes=15)):
-        #Adds a buffer to the start time
+        #Adds a buffer to the end time
         return self.end + buffer
 
     def duration_str(self):


### PR DESCRIPTION
## Description
The comment in end_w_buffer said "Adds a buffer to the start time" but the method works on self.end, not self.start. Changed it to "Adds a buffer to the end time". Looks like a copy paste mistake from start_w_buffer above it.

## Related Issue
Closes #5139

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing
- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## AI Disclosure
None

## Checklist
- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced