### PR TITLE
Fix: replace fragile co_varnames check with getattr in autocomplete_wrapper

### DIFF
--- a/esp/esp/db/autocomplete.py
+++ b/esp/esp/db/autocomplete.py
@@ -1,0 +1,15 @@
+"""Opt-in marker for autocompletes that non-staff users are allowed to call."""
+
+
+def allow_non_staff_autocomplete(func):
+    """Mark an ajax_autocomplete as safe to expose to non-staff users.
+
+    Apply it directly to the function, inside @classmethod:
+
+        @classmethod
+        @allow_non_staff_autocomplete
+        def ajax_autocomplete(cls, data, **kwargs):
+            ...
+    """
+    func.allow_non_staff = True
+    return func

--- a/esp/esp/db/test_ajax_autocomplete.py
+++ b/esp/esp/db/test_ajax_autocomplete.py
@@ -8,6 +8,7 @@ from django.contrib.auth.models import Group
 from django.test import SimpleTestCase, TestCase
 from django.test.client import Client
 
+from esp.db.autocomplete import allow_non_staff_autocomplete
 from esp.db.views import autocomplete_wrapper
 from esp.users.models import ESPUser, K12School
 
@@ -323,11 +324,26 @@ class AutocompleteNonStaffAccessTest(TestCase):
         self.assertEqual(data['result'], [],
                          "Non-staff users must not be able to search ESPUser records")
 
+    def test_non_staff_can_search_real_k12school(self):
+        """The real K12School.ajax_autocomplete carries the marker, unpatched."""
+        response = self.client.get(AUTOCOMPLETE_URL, {
+            'model_module': 'esp.users.models',
+            'model_name': 'K12School',
+            'ajax_data': 'Test',
+            'prog': '',
+        })
+        self.assertEqual(response.status_code, 200)
+        ids = [r['id'] for r in json.loads(response.content)['result']]
+        self.assertIn(
+            K12School.objects.get(name='Test Academy').id, ids,
+            "K12School.ajax_autocomplete must stay opted in for non-staff users")
+
     def test_non_staff_can_search_k12school(self):
-        """A non-staff user can search K12School (allow_non_staff=True)."""
+        """A non-staff user can search K12School (@allow_non_staff_autocomplete)."""
         original_ajax = K12School.ajax_autocomplete.__func__
 
         @classmethod
+        @allow_non_staff_autocomplete
         def patched_ajax(cls, data, allow_non_staff=True, **kwargs):
             # Forward any additional kwargs so the test reflects production semantics
             return original_ajax(cls, data, allow_non_staff=allow_non_staff, **kwargs)
@@ -377,18 +393,42 @@ class AutocompleteNonStaffAccessTest(TestCase):
 
 
 class AutocompleteWrapperGatingTest(SimpleTestCase):
-    """autocomplete_wrapper decides non-staff access from the callee's parameters."""
+    """Non-staff access is granted by @allow_non_staff_autocomplete and nothing else."""
 
-    def test_explicit_parameter_opts_in(self):
-        """A declared allow_non_staff parameter is the opt-in."""
-        def ajax_autocomplete(data, allow_non_staff=True):
+    def test_marked_function_opts_in(self):
+        """The decorator is the opt-in."""
+        @allow_non_staff_autocomplete
+        def ajax_autocomplete(data):
             return ['called']
 
         self.assertEqual(
             autocomplete_wrapper(ajax_autocomplete, 'q', False), ['called'])
 
-    def test_var_keyword_alone_does_not_opt_in(self):
-        """**kwargs is not an opt-in, but staff callers still get through."""
+    def test_marker_survives_classmethod_binding(self):
+        """The K12School shape: the marker is readable through the bound method."""
+        class Model(object):
+            @classmethod
+            @allow_non_staff_autocomplete
+            def ajax_autocomplete(cls, data, **kwargs):
+                return ['called']
+
+        self.assertEqual(
+            autocomplete_wrapper(Model.ajax_autocomplete, 'q', False), ['called'])
+
+    def test_marker_survives_decoration(self):
+        """functools.wraps copies __dict__, so a wrapped autocomplete stays marked."""
+        @allow_non_staff_autocomplete
+        def ajax_autocomplete(data):
+            return ['called']
+
+        @functools.wraps(ajax_autocomplete)
+        def wrapper(*args, **kwargs):
+            return ajax_autocomplete(*args, **kwargs)
+
+        self.assertEqual(autocomplete_wrapper(wrapper, 'q', False), ['called'])
+
+    def test_unmarked_function_is_denied(self):
+        """Without the marker non-staff get nothing, but staff still get through."""
         def ajax_autocomplete(data, **kwargs):
             return ['called']
 
@@ -396,47 +436,34 @@ class AutocompleteWrapperGatingTest(SimpleTestCase):
         self.assertEqual(
             autocomplete_wrapper(ajax_autocomplete, 'q', True), ['called'])
 
-    def test_local_variable_is_not_an_opt_in(self):
-        """A local named allow_non_staff is not a parameter."""
-        # __code__.co_varnames lists locals, so this read as an opt-in before.
-        def ajax_autocomplete(data, **kwargs):
-            allow_non_staff = True
-            return ['called'] if allow_non_staff else []
-
-        self.assertEqual(autocomplete_wrapper(ajax_autocomplete, 'q', False), [])
-
-    def test_decorated_function_is_inspected_through_the_wrapper(self):
-        """A decorated autocomplete is judged by the parameters it forwards to."""
-        def passthrough(func):
-            @functools.wraps(func)
-            def wrapper(*args, **kwargs):
-                return func(*args, **kwargs)
-            return wrapper
-
-        @passthrough
+    def test_parameter_name_alone_does_not_opt_in(self):
+        """Declaring an allow_non_staff parameter is not an opt-in."""
         def ajax_autocomplete(data, allow_non_staff=True):
             return ['called']
 
-        self.assertEqual(
-            autocomplete_wrapper(ajax_autocomplete, 'q', False), ['called'])
+        self.assertEqual(autocomplete_wrapper(ajax_autocomplete, 'q', False), [])
 
-    def test_callable_without_introspectable_signature_is_denied(self):
-        """Callables whose signature cannot be read are denied, not guessed at."""
-        class Unintrospectable(object):
+    def test_marked_callable_without_signature_opts_in(self):
+        """The marker is read as an attribute, so signatures need not be readable."""
+        class Uninspectable(object):
             # Mirrors a C builtin, for which inspect.signature raises.
             __signature__ = 'not a signature'
+            allow_non_staff = True
 
-            def __call__(self, data, allow_non_staff=True):
+            def __call__(self, data, **kwargs):
                 return ['called']
 
-        self.assertEqual(autocomplete_wrapper(Unintrospectable(), 'q', False), [])
+        self.assertEqual(
+            autocomplete_wrapper(Uninspectable(), 'q', False), ['called'])
 
     def test_request_is_only_passed_when_accepted(self):
         """request is dropped for callees that do not declare it."""
-        def wants_request(data, allow_non_staff=True, request=None, **kwargs):
+        @allow_non_staff_autocomplete
+        def wants_request(data, request=None, **kwargs):
             return ['got request'] if request is not None else ['no request']
 
-        def no_request(data, allow_non_staff=True, **kwargs):
+        @allow_non_staff_autocomplete
+        def no_request(data, **kwargs):
             return sorted(kwargs)
 
         sentinel = object()

--- a/esp/esp/db/test_ajax_autocomplete.py
+++ b/esp/esp/db/test_ajax_autocomplete.py
@@ -1,12 +1,14 @@
 from __future__ import absolute_import
 
+import functools
 import json
 from unittest.mock import patch
 
 from django.contrib.auth.models import Group
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 from django.test.client import Client
 
+from esp.db.views import autocomplete_wrapper
 from esp.users.models import ESPUser, K12School
 
 
@@ -285,6 +287,27 @@ class AutocompleteNonStaffAccessTest(TestCase):
         self.non_staff.save()
         self.client.login(username='regular_user', password='pw')
 
+        student_group, _ = Group.objects.get_or_create(name='Student')
+        teacher_group, _ = Group.objects.get_or_create(name='Teacher')
+
+        # Records the staff-only ESPUser autocompletes can actually return, so that a
+        # gating regression shows up as leaked results rather than an empty query.
+        self.student = ESPUser.objects.create_user(
+            username='gatetest_student', email='gs@x.com', password='pw',
+            first_name='Gate', last_name='Gatetest'
+        )
+        self.student.groups.add(student_group)
+        self.teacher = ESPUser.objects.create_user(
+            username='gatetest_teacher', email='gt@x.com', password='pw',
+            first_name='Gate', last_name='Gatetest'
+        )
+        self.teacher.groups.add(teacher_group)
+        self.staff = ESPUser.objects.create_user(
+            username='gatetest_staff', email='gst@x.com', password='pw'
+        )
+        self.staff.is_staff = True
+        self.staff.save()
+
         K12School.objects.get_or_create(name='Test Academy')
 
     def test_non_staff_cannot_search_espuser(self):
@@ -322,3 +345,104 @@ class AutocompleteNonStaffAccessTest(TestCase):
         ids = [r['id'] for r in data['result']]
         school = K12School.objects.get(name='Test Academy')
         self.assertIn(school.id, ids)
+
+    def _search_espuser(self, ajax_func):
+        response = self.client.get(AUTOCOMPLETE_URL, {
+            'model_module': 'esp.users.models',
+            'model_name': 'ESPUser',
+            'ajax_func': ajax_func,
+            'ajax_data': 'Gatetest',
+            'prog': '',
+        })
+        self.assertEqual(response.status_code, 200)
+        return json.loads(response.content)['result']
+
+    def test_non_staff_cannot_search_espuser_via_kwargs_only_funcs(self):
+        """Accepting **kwargs is not an opt-in to non-staff access."""
+        for ajax_func in ('ajax_autocomplete_student', 'ajax_autocomplete_teacher'):
+            with self.subTest(ajax_func=ajax_func):
+                self.assertEqual(
+                    self._search_espuser(ajax_func), [],
+                    "%s takes **kwargs but is staff-only; non-staff users must "
+                    "not receive results from it" % ajax_func)
+
+    def test_staff_can_search_espuser_via_kwargs_only_funcs(self):
+        """Control: the records the test above must not leak are findable by staff."""
+        self.client.login(username='gatetest_staff', password='pw')
+        for ajax_func, user in (('ajax_autocomplete_student', self.student),
+                                ('ajax_autocomplete_teacher', self.teacher)):
+            with self.subTest(ajax_func=ajax_func):
+                ids = [r['id'] for r in self._search_espuser(ajax_func)]
+                self.assertIn(user.id, ids)
+
+
+class AutocompleteWrapperGatingTest(SimpleTestCase):
+    """autocomplete_wrapper decides non-staff access from the callee's parameters."""
+
+    def test_explicit_parameter_opts_in(self):
+        """A declared allow_non_staff parameter is the opt-in."""
+        def ajax_autocomplete(data, allow_non_staff=True):
+            return ['called']
+
+        self.assertEqual(
+            autocomplete_wrapper(ajax_autocomplete, 'q', False), ['called'])
+
+    def test_var_keyword_alone_does_not_opt_in(self):
+        """**kwargs is not an opt-in, but staff callers still get through."""
+        def ajax_autocomplete(data, **kwargs):
+            return ['called']
+
+        self.assertEqual(autocomplete_wrapper(ajax_autocomplete, 'q', False), [])
+        self.assertEqual(
+            autocomplete_wrapper(ajax_autocomplete, 'q', True), ['called'])
+
+    def test_local_variable_is_not_an_opt_in(self):
+        """A local named allow_non_staff is not a parameter."""
+        # __code__.co_varnames lists locals, so this read as an opt-in before.
+        def ajax_autocomplete(data, **kwargs):
+            allow_non_staff = True
+            return ['called'] if allow_non_staff else []
+
+        self.assertEqual(autocomplete_wrapper(ajax_autocomplete, 'q', False), [])
+
+    def test_decorated_function_is_inspected_through_the_wrapper(self):
+        """A decorated autocomplete is judged by the parameters it forwards to."""
+        def passthrough(func):
+            @functools.wraps(func)
+            def wrapper(*args, **kwargs):
+                return func(*args, **kwargs)
+            return wrapper
+
+        @passthrough
+        def ajax_autocomplete(data, allow_non_staff=True):
+            return ['called']
+
+        self.assertEqual(
+            autocomplete_wrapper(ajax_autocomplete, 'q', False), ['called'])
+
+    def test_callable_without_introspectable_signature_is_denied(self):
+        """Callables whose signature cannot be read are denied, not guessed at."""
+        class Unintrospectable(object):
+            # Mirrors a C builtin, for which inspect.signature raises.
+            __signature__ = 'not a signature'
+
+            def __call__(self, data, allow_non_staff=True):
+                return ['called']
+
+        self.assertEqual(autocomplete_wrapper(Unintrospectable(), 'q', False), [])
+
+    def test_request_is_only_passed_when_accepted(self):
+        """request is dropped for callees that do not declare it."""
+        def wants_request(data, allow_non_staff=True, request=None, **kwargs):
+            return ['got request'] if request is not None else ['no request']
+
+        def no_request(data, allow_non_staff=True, **kwargs):
+            return sorted(kwargs)
+
+        sentinel = object()
+        self.assertEqual(
+            autocomplete_wrapper(wants_request, 'q', False, request=sentinel),
+            ['got request'])
+        self.assertEqual(
+            autocomplete_wrapper(no_request, 'q', False, request=sentinel, prog=None),
+            ['prog'])

--- a/esp/esp/db/views.py
+++ b/esp/esp/db/views.py
@@ -15,7 +15,7 @@ def autocomplete_wrapper(function, data, is_staff, **kwargs):
     if is_staff:
         return function(data, **kwargs)
     else:
-        if 'allow_non_staff' in function.__func__.__code__.co_varnames:
+        if getattr(function.__func__, 'allow_non_staff', False):
             return function(data, **kwargs)
         else:
             return []

--- a/esp/esp/db/views.py
+++ b/esp/esp/db/views.py
@@ -15,10 +15,19 @@ def autocomplete_wrapper(function, data, is_staff, **kwargs):
     if is_staff:
         return function(data, **kwargs)
     else:
-        if getattr(function.__func__, 'allow_non_staff', False):
-            return function(data, **kwargs)
-        else:
-            return []
+        try:
+            sig = inspect.signature(function)
+        except (TypeError, ValueError):
+            sig = None
+        if sig is not None:
+            params = sig.parameters
+            supports_flag = (
+                "allow_non_staff" in params
+                or any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values())
+            )
+            if supports_flag:
+                return function(data, allow_non_staff=True, **kwargs)
+        return []
 
 @login_required
 def ajax_autocomplete(request):

--- a/esp/esp/db/views.py
+++ b/esp/esp/db/views.py
@@ -1,6 +1,7 @@
 from django.contrib.auth.decorators import login_required, user_passes_test
 from django.core import serializers
 from django.http import HttpResponse
+import inspect
 import json
 
 """ Removed the staff-only restriction and instead pass a flag to ajax_autocomplete if the user

--- a/esp/esp/db/views.py
+++ b/esp/esp/db/views.py
@@ -12,19 +12,24 @@ user_is_staff = user_passes_test(lambda u: u.is_authenticated and u.is_staff and
 
 def autocomplete_wrapper(function, data, is_staff, **kwargs):
     """Call the model's ajax_autocomplete; pass request if the function accepts it."""
-    # Only pass 'request' if the function actually accepts it
+    # Read declared parameters
     try:
         sig = inspect.signature(function)
-        if 'request' not in sig.parameters:
-            kwargs.pop('request', None)
     except (TypeError, ValueError):
+        # Some C-implemented callables have no introspectable signature.
+        params = {}
+    else:
+        params = sig.parameters
+
+    # Only pass 'request' if the function actually accepts it
+    if 'request' not in params:
         kwargs.pop('request', None)
+
     if is_staff:
         return function(data, **kwargs)
-    # Unwrap classmethod/bound method to get the underlying function
-    fn = getattr(function, '__func__', function)
-    code = getattr(fn, '__code__', None)
-    if code and 'allow_non_staff' in code.co_varnames:
+
+    # Non-staff access requires an explicit allow_non_staff parameter.
+    if 'allow_non_staff' in params:
         return function(data, **kwargs)
     return []
 

--- a/esp/esp/db/views.py
+++ b/esp/esp/db/views.py
@@ -12,24 +12,20 @@ user_is_staff = user_passes_test(lambda u: u.is_authenticated and u.is_staff and
 
 def autocomplete_wrapper(function, data, is_staff, **kwargs):
     """Call the model's ajax_autocomplete; pass request if the function accepts it."""
-    # Read declared parameters
+    # Only pass 'request' if the function actually accepts it
     try:
-        sig = inspect.signature(function)
+        params = inspect.signature(function).parameters
     except (TypeError, ValueError):
         # Some C-implemented callables have no introspectable signature.
         params = {}
-    else:
-        params = sig.parameters
-
-    # Only pass 'request' if the function actually accepts it
     if 'request' not in params:
         kwargs.pop('request', None)
 
     if is_staff:
         return function(data, **kwargs)
 
-    # Non-staff access requires an explicit allow_non_staff parameter.
-    if 'allow_non_staff' in params:
+    # Non-staff access is granted only by @allow_non_staff_autocomplete.
+    if getattr(function, 'allow_non_staff', False):
         return function(data, **kwargs)
     return []
 

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -73,6 +73,7 @@ from esp.cal.models import Event, EventType
 from argcache import cache_function, wildcard
 from esp.customforms.linkfields import CustomFormsLinkModel
 from esp.customforms.forms import AddressWidget, NameWidget
+from esp.db.autocomplete import allow_non_staff_autocomplete
 from esp.db.fields import AjaxForeignKey
 from esp.middleware import ESPError
 from esp.middleware.threadlocalrequest import get_current_request, AutoRequestContext as Context
@@ -2245,6 +2246,7 @@ class K12School(models.Model):
     AJAX_AUTOCOMPLETE_MAX_RESULTS = 25
 
     @classmethod
+    @allow_non_staff_autocomplete
     def ajax_autocomplete(cls, data, allow_non_staff=True, request=None, **kwargs):
         """
         Server-side autocomplete for K12 schools. Requires a minimum query length


### PR DESCRIPTION
## Description
`autocomplete_wrapper` decided whether a non-staff user may call a model's
`ajax_autocomplete` by looking for `allow_non_staff` in
`__func__.__code__.co_varnames`. That reads bytecode internals: `co_varnames`
lists local variables alongside parameters, and it describes the outermost
function, so a decorated autocomplete reports the decorator's
`(*args, **kwargs)` rather than the parameters it forwards.

The opt-in is now an explicit marker. `@allow_non_staff_autocomplete` sets an
attribute on the function and the wrapper reads it with `getattr`, so the grant
is greppable and independent of how the callable is spelled — it survives
`@classmethod` binding and `functools.wraps`, and works for callables with no
introspectable signature. `inspect.signature` is still used, but only to decide
whether the callee accepts `request`.

Declaring an `allow_non_staff` **parameter** no longer grants access. That
distinction matters: `ajax_func` is caller-supplied, and
`ESPUser.ajax_autocomplete_student` and its siblings take `**kwargs`, so any
inference from the signature risks exposing student and teacher records to any
logged-in user.

**Files changed**
- `esp/esp/db/autocomplete.py` (new) — the `@allow_non_staff_autocomplete` decorator
- `esp/esp/db/views.py` — gate reads the marker
- `esp/esp/users/models/__init__.py` — marks `K12School.ajax_autocomplete`, the one opted-in autocomplete
- `esp/esp/db/test_ajax_autocomplete.py` — tests

**Upgrade note:** a site-local model that opted in by declaring an
`allow_non_staff` parameter must add `@allow_non_staff_autocomplete`, or it will
return `[]` for non-staff users.

## Related Issue
Closes #5015

Note: the issue proposes `getattr(function.__func__, 'allow_non_staff', False)`.
Nothing in the tree sets that attribute, so reading it alone would have denied
every non-staff autocomplete, including `K12School`. This PR adds the decorator
that makes the attribute real, which is the contract the issue was reaching for.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing
- [x] Existing tests pass
- [x] New tests added (if applicable)
- [x] Manually verified

Adds coverage for the gating decision: the marker through a plain function, a
bound classmethod, a `functools.wraps` wrapper and an uninspectable callable;
an `allow_non_staff` parameter without the marker; `**kwargs` without the
marker; and that `request` reaches only callees that declare it. At the view
level, a non-staff user gets nothing from the `**kwargs`-only `ESPUser`
autocompletes, paired with a staff control proving those records are otherwise
returnable, plus unpatched coverage that `K12School` stays reachable.

Verified that removing `@allow_non_staff_autocomplete` from `K12School` fails
the suite, and that restoring the parameter-based check fails it too.

## AI Disclosure
The current implementation and tests were revised by a maintainer using Claude Code.

## Checklist
- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)