### PR TITLE
Handle invalid filter IDs in comm panel gracefully

### DIFF
--- a/esp/esp/program/modules/handlers/commmodule.py
+++ b/esp/esp/program/modules/handlers/commmodule.py
@@ -120,11 +120,16 @@ class CommModule(ProgramModuleObj):
             mailer_warnings.append(f"Caution: You are about to send a massive mailer to {listcount_int} recipients.")
 
         # b. Warn if no grade range filter is used
-        filter_obj = PersistentQueryFilter.getFilterFromID(filterid, ESPUser)
-        filter_name = getattr(filter_obj, 'useful_name', '') or ''
+        filter_obj = None
+        try:
+            filter_obj = PersistentQueryFilter.getFilterFromID(filterid, ESPUser)
+        except (AssertionError, PersistentQueryFilter.DoesNotExist, TypeError, ValueError):
+            mailer_warnings.append("Warning: Recipient filter is invalid or expired. Please go back and rebuild your recipient list.")
 
-        if filter_name and 'grade' not in filter_name.lower():
-            mailer_warnings.append("Warning: You haven't selected a grade range filter.")
+        if filter_obj is not None:
+            filter_name = getattr(filter_obj, 'useful_name', '') or ''
+            if filter_name and 'grade' not in filter_name.lower():
+                mailer_warnings.append("Warning: You haven't selected a grade range filter.")
 
         # c. Warn if parent/emergency contact emails are included
         guardian_or_emergency_sentto_values = set()
@@ -188,7 +193,12 @@ class CommModule(ProgramModuleObj):
             "websupport@learningu.org and tell us how you got this error," +
             "and we'll look into it.")
 
-        userlist = PersistentQueryFilter.getFilterFromID(filterid, ESPUser).getList(ESPUser)
+        try:
+            filterobj = PersistentQueryFilter.getFilterFromID(filterid, ESPUser)
+        except (AssertionError, PersistentQueryFilter.DoesNotExist, TypeError, ValueError):
+            raise ESPError("Your recipient filter is invalid or expired. Please go back and rebuild your recipient list.", log=False)
+
+        userlist = filterobj.getList(ESPUser)
 
         try:
             firstuser = userlist[0]
@@ -312,7 +322,10 @@ class CommModule(ProgramModuleObj):
             "websupport@learningu and tell us how you got this error, " +
             "and we'll look into it.")
 
-        filterobj = PersistentQueryFilter.getFilterFromID(filterid, ESPUser)
+        try:
+            filterobj = PersistentQueryFilter.getFilterFromID(filterid, ESPUser)
+        except (AssertionError, PersistentQueryFilter.DoesNotExist, TypeError, ValueError):
+            raise ESPError("Your recipient filter is invalid or expired. Please go back and rebuild your recipient list.", log=False)
 
         sendto_fn = MessageRequest.assert_is_valid_sendto_fn_or_ESPError(sendto_fn_name)
 

--- a/esp/esp/program/modules/tests/commpanel.py
+++ b/esp/esp/program/modules/tests/commpanel.py
@@ -170,3 +170,25 @@ class CommunicationsPanelTest(ProgramFrameworkTest):
         self.assertIn(expected_first_day, rendered, 'program.date should render as first program day')
         self.assertIn(expected_date_range, rendered, 'program.date_range should render as program date range')
         self.assertIn(expected_teacher_reg_deadline, rendered, 'program.teacher_reg_deadline should render as Teacher/Classes/Create end_date')
+
+    def test_get_mailer_warnings_handles_invalid_filterid(self):
+        warnings = self.moduleobj.get_mailer_warnings(
+            listcount=25,
+            filterid='not-a-valid-filter-id',
+            sendto_fn_name=MessageRequest.SEND_TO_SELF_REAL,
+        )
+        self.assertTrue(any('invalid or expired' in warning.lower() for warning in warnings))
+
+    def test_commfinal_handles_missing_filter_gracefully(self):
+        self.assertTrue(self.client.login(username=self.admins[0].username, password='password'))
+
+        response = self.client.post('/manage/%s/%s' % (self.program.getUrlBase(), 'commfinal'), {
+            'subject': 'Test Subject',
+            'body': 'Test Body',
+            'from': 'info@testserver.learningu.org',
+            'replyto': 'replyto@testserver.learningu.org',
+            'filterid': '999999999',
+        })
+
+        self.assertEqual(response.status_code, 500)
+        self.assertIn('recipient filter is invalid or expired', response.content.decode('UTF-8').lower())


### PR DESCRIPTION
## Description

Catch stale/invalid filter IDs in the Communications Panel to prevent unhandled exceptions and raw error traces. When an invalid filter ID is used, users now see a friendly error message instead of a technical traceback.

**Changes:**
- `get_mailer_warnings()`: Appends warning message instead of crashing on invalid filter ID
- `commprev()`: Raises user-friendly ESPError on invalid filter ID
- `commfinal()`: Raises user-friendly ESPError on invalid filter ID
- Added 2 regression tests to verify graceful handling

**Before (Bug):**
<img width="1512" height="860" alt="Screenshot 2026-03-17 at 9 13 27 PM" src="https://github.com/user-attachments/assets/cd04556d-a6a3-4126-82c3-fd27211d820e" />


**After (Fixed):**
<img width="1512" height="860" alt="Screenshot 2026-03-17 at 9 07 45 PM" src="https://github.com/user-attachments/assets/027a235d-12ad-452a-8d1d-f4cff50b4e15" />


## Related Issue

Closes #5116


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [x] New tests added
- [x] Manually verified in browser

## AI Disclosure

PR description generated with AI assistance. Code changes and all testing performed manually.

## Checklist

- [x] Self-reviewed the code
- [x] Updated documentation (if needed)
- [x] No new warnings or errors introduced