### PR TITLE
Fix old list generator crashing on invalid filter ID

### DIFF
--- a/esp/esp/program/modules/handlers/listgenmodule.py
+++ b/esp/esp/program/modules/handlers/listgenmodule.py
@@ -472,7 +472,10 @@ class ListGenModule(ProgramModuleObj):
             filterObj, found = get_user_list(request, self.program.getLists(True))
         else:
             filterid  = request.GET['filterid']
-            filterObj = PersistentQueryFilter.getFilterFromID(filterid, ESPUser)
+            try:
+                filterObj = PersistentQueryFilter.getFilterFromID(filterid, ESPUser)
+            except (AssertionError, PersistentQueryFilter.DoesNotExist, TypeError, ValueError):
+                raise ESPError("Your recipient filter is invalid or expired. Please go back and rebuild your recipient list.", log=False)
             found     = True
         if not found:
             return filterObj

--- a/esp/esp/program/modules/tests/listgenmodule.py
+++ b/esp/esp/program/modules/tests/listgenmodule.py
@@ -1,0 +1,41 @@
+"""
+Tests for List Generator Module
+"""
+
+from django.test import TestCase, Client
+from esp.program.tests import ProgramFrameworkTest
+from esp.program.models import Program
+from esp.users.models import ESPUser
+from esp.middleware import ESPError
+
+
+class ListGenModuleTest(ProgramFrameworkTest):
+    def setUp(self):
+        super().setUp()
+        # Create admin user for testing
+        self.admin = ESPUser.objects.create_user(
+            username='testadmin',
+            password='password',
+            first_name='Test',
+            last_name='Admin'
+        )
+        self.admin.makeAdmin()
+        self.client = Client()
+        self.assertTrue(self.client.login(username='testadmin', password='password'))
+
+    def test_selectList_old_handles_missing_filter_gracefully(self):
+        """
+        Test that selectList_old raises a user-friendly ESPError
+        when given an invalid/stale filter ID instead of crashing.
+        """
+        response = self.client.get(
+            '/manage/{}/selectList_old'.format(self.program.getUrlBase()),
+            {'filterid': '999999999'}
+        )
+        
+        # Should get a 500 response with friendly error message
+        self.assertEqual(response.status_code, 500)
+        self.assertIn(
+            'recipient filter is invalid or expired',
+            response.content.decode('UTF-8').lower()
+        )


### PR DESCRIPTION
## Description

Handle stale/invalid filter IDs gracefully in the old-style List Generator selector to prevent unhandled exceptions and raw error traces.

**Changes:**
- `selectList_old()`: Added defensive try/except around filter lookup
- Raises user-friendly ESPError on invalid filter ID instead of crashing
- Added regression test confirming graceful handling

**Before (Bug):**
Raw 500 traceback: `PersistentQueryFilter.DoesNotExist`
<img width="1512" height="948" alt="Screenshot 2026-03-17 at 11 26 46 PM" src="https://github.com/user-attachments/assets/3abc262d-c69d-4edc-909f-c6ce2a85ef79" />


**After (Fixed):**
Clean error page with message: "Your recipient filter is invalid or expired. Please go back and rebuild your recipient list."
<img width="1512" height="948" alt="Screenshot 2026-03-17 at 11 26 37 PM" src="https://github.com/user-attachments/assets/28764e6f-7211-4870-892e-160c1d12e599" />


## Related Issue

Closes #5176

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [x] New tests added
- [x] Manually verified in browser

## AI Disclosure

PR description generated with AI assistance. Code changes and all testing performed manually.

## Checklist

- [x] Self-reviewed the code
- [x] Updated documentation (if needed)
- [x] No new warnings or errors introduced