### PR TITLE
Add default ordering for Page, Section, and Field models

### DIFF
--- a/esp/esp/customforms/models.py
+++ b/esp/esp/customforms/models.py
@@ -5,7 +5,6 @@ logger = logging.getLogger(__name__)
 from django.db import models, transaction, connection
 from django.db.utils import DatabaseError, ProgrammingError
 from esp.users.models import ESPUser
-from esp.program.models import Program
 
 class Form(models.Model):
     title = models.CharField(max_length=40, blank=True)

--- a/esp/esp/customforms/models.py
+++ b/esp/esp/customforms/models.py
@@ -25,6 +25,9 @@ class Page(models.Model):
     form = models.ForeignKey(Form, on_delete=models.CASCADE)
     seq = models.IntegerField(default=-1)
 
+    class Meta:
+        ordering = ["seq"]
+
     def __str__(self):
         return f'Page {self.seq} of {self.form.title}'
 
@@ -33,6 +36,9 @@ class Section(models.Model):
     title = models.CharField(max_length=40)
     description = models.CharField(max_length=140, blank=True)
     seq = models.IntegerField()
+
+    class Meta:
+        ordering = ["seq"]
 
     def __str__(self):
         return f'Sec. {self.seq}: {self.title}'
@@ -45,6 +51,9 @@ class Field(models.Model):
     label = models.CharField(max_length=200)
     help_text = models.TextField(blank=True)
     required = models.BooleanField(default=False)
+
+    class Meta:
+        ordering = ["seq"]
 
     def __str__(self):
         return f'{self.label}'


### PR DESCRIPTION
## Description

Adds default ordering based on the `seq` field for Page, Section, and Field models.

These models use a `seq` field to represent ordering, but no default ordering is defined at the model level. As a result, query results may be returned in nondeterministic order depending on database behavior.

This change ensures consistent and deterministic ordering aligned with the intended sequence structure.

## Related Issue

Closes #5190 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (not applicable)
- [x] Manually verified

## AI Disclosure

Tool: ChatGPT  
Scope: Assisted in identifying improvement and validation approach  
Verification: Manually reviewed and validated by running full test suite  

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (not needed)
- [x] No new warnings or errors introduced