### PR TITLE
Cache printer names in OnsitePrintSchedules to reduce repeated DB queries

### DIFF
--- a/esp/esp/program/modules/handlers/onsiteprintschedules.py
+++ b/esp/esp/program/modules/handlers/onsiteprintschedules.py
@@ -33,6 +33,7 @@ Learning Unlimited, Inc.
   Email: web-team@learningu.org
 """
 import json
+from django.core.cache import cache
 from django.http      import HttpResponse
 from esp.program.modules.base import ProgramModuleObj, needs_onsite, main_call
 from esp.program.modules.handlers.programprintables import ProgramPrintables
@@ -42,6 +43,19 @@ from esp.utils.models import Printer, PrintRequest
 
 class OnsitePrintSchedules(ProgramModuleObj):
     doc = """Automatically print student schedules at onsite registration."""
+    PRINTER_NAMES_CACHE_KEY = 'onsiteprintschedules:printer_names'
+    PRINTER_NAMES_CACHE_TTL_SECONDS = 300
+
+    @classmethod
+    def _get_printer_names(cls):
+        cached = cache.get(cls.PRINTER_NAMES_CACHE_KEY)
+        if cached is not None:
+            return cached
+        printers = list(Printer.objects.all().values_list('name', flat=True))
+        cache.set(cls.PRINTER_NAMES_CACHE_KEY,
+                  printers,
+                  cls.PRINTER_NAMES_CACHE_TTL_SECONDS)
+        return printers
 
     @classmethod
     def module_properties(cls):
@@ -58,7 +72,7 @@ class OnsitePrintSchedules(ProgramModuleObj):
     def printschedules(self, request, tl, one, two, module, extra, prog):
         " A link to print a schedule. "
         if not 'sure' in request.GET and not 'gen_img' in request.GET:
-            printers = Printer.objects.all().values_list('name', flat=True)
+            printers = self._get_printer_names()
 
             return render_to_response(self.baseDir()+'instructions.html',
                                     request, {'printers': printers})


### PR DESCRIPTION

## Description
This PR introduces a short-lived caching mechanism for printer names in the onsite schedule printing flow.

Previously, the instructions page queried `Printer.objects` on every request, which could lead to unnecessary database load during onsite operations where the page is accessed or polled frequently.

With this change:
- Printer names are first fetched from cache
- If not present, they are retrieved from the database and cached
- A TTL of 300 seconds is used to balance performance and data freshness

The print request execution logic remains unchanged to avoid any impact on operational behavior.

This is a performance optimization and does not change existing functionality.

## Related Issue

Closes #4150  

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## AI Disclosure

AI tools were used to assist in generating the code. But the final implementation was carefully reviewed, verified, and tested manually to ensure correctness.

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced
