### PR TITLE
Issue 995: invalidate DBListCount cache on user save/delete

### DIFF
--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -99,6 +99,31 @@ DEFAULT_USER_TYPES = [
     ['Volunteer', {'label': 'Onsite Volunteer', 'profile_form': 'VolunteerProfileForm'}]
 ]
 
+DBLISTCOUNT_CACHE_KEY_REGISTRY = 'DBListCount:registered_cache_keys'
+
+
+def _register_dblistcount_cache_key(cache_id):
+    """Track DBList count cache IDs so they can be invalidated on user writes."""
+    cache_ids = cache.get(DBLISTCOUNT_CACHE_KEY_REGISTRY)
+    if not cache_ids:
+        cache_ids = []
+
+    if cache_id not in cache_ids:
+        cache_ids.append(cache_id)
+        cache.set(DBLISTCOUNT_CACHE_KEY_REGISTRY, cache_ids)
+
+
+def invalidate_dblistcount_cache():
+    """Invalidate all cached DBList counts.
+
+    DBList count keys are dynamically generated from query keys, so we keep a
+    registry of observed keys and clear them when user rows change.
+    """
+    cache_ids = cache.get(DBLISTCOUNT_CACHE_KEY_REGISTRY) or []
+    if cache_ids:
+        cache.delete_many(cache_ids)
+    cache.delete(DBLISTCOUNT_CACHE_KEY_REGISTRY)
+
 def admin_required(func):
     @functools.wraps(func)
     def wrapped(request, *args, **kwargs):
@@ -1309,6 +1334,18 @@ def make_admin_save(sender, instance, **kwargs):
         espuser = ESPUser.objects.get(id=instance.id)
         espuser.makeAdmin()
 
+
+@dispatch.receiver(signals.post_save, sender=User,
+                   dispatch_uid='invalidate_dblistcount_user_save')
+def invalidate_dblistcount_user_save(**kwargs):
+    invalidate_dblistcount_cache()
+
+
+@dispatch.receiver(signals.pre_delete, sender=User,
+                   dispatch_uid='invalidate_dblistcount_user_delete')
+def invalidate_dblistcount_user_delete(**kwargs):
+    invalidate_dblistcount_cache()
+
 @dispatch.receiver(signals.pre_save, sender=ESPUser,
                    dispatch_uid='update_email_save')
 def update_email_save(**kwargs):
@@ -2292,11 +2329,13 @@ class DBList(object):
                 if override:
                     self.totalnum = ESPUser.objects.filter(self.QObject).distinct().count()
                     cache.set(cache_id, self.totalnum, 60)
+                    _register_dblistcount_cache_key(cache_id)
                 else:
                     cachedval = cache.get(cache_id)
                     if cachedval is None:
                         self.totalnum = ESPUser.objects.filter(self.QObject).distinct().count()
                         cache.set(cache_id, self.totalnum, 60)
+                        _register_dblistcount_cache_key(cache_id)
                     else:
                         self.totalnum = cachedval
 

--- a/esp/esp/users/tests.py
+++ b/esp/esp/users/tests.py
@@ -17,7 +17,8 @@ from esp.tagdict.models import Tag
 from esp.tests.util import CacheFlushTestCase as TestCase, user_role_setup
 from esp.users.forms.user_reg import ValidHostEmailField
 from esp.users.forms.user_profile import StudentProfileForm
-from esp.users.models import User, ESPUser, UserForwarder, StudentInfo, Permission, Record, RecordType
+from esp.users.models import User, ESPUser, UserForwarder, StudentInfo, Permission, Record, RecordType, DBList
+from django.db.models import Q
 
 class ESPUserTest(TestCase):
     def setUp(self):
@@ -138,6 +139,19 @@ class ESPUserTest(TestCase):
                                 f"Token check failed for username: {username}")
             finally:
                 user.delete()
+
+    def test_db_list_count_cache_invalidated_on_user_save(self):
+        ESPUser.objects.create(username='dblist_before_1')
+        ESPUser.objects.create(username='dblist_before_2')
+
+        baseline = DBList(key='all-users', QObject=Q(id__gt=0)).count()
+
+        ESPUser.objects.create(username='dblist_after_3')
+
+        # Use a fresh DBList instance so the result must come from cache or DB.
+        refreshed = DBList(key='all-users', QObject=Q(id__gt=0)).count()
+
+        self.assertEqual(refreshed, baseline + 1)
 
 class PasswordRecoveryTest(TestCase):
     """Test password recovery using Django's built-in token generator.


### PR DESCRIPTION
Description
This PR fixes stale DBListCount values by adding cache dependency invalidation for user writes.

What changed
Register DBListCount cache keys when count values are cached
Invalidate registered DBListCount keys on user save/delete
Add a regression test to verify DBList count refreshes after user changes

Related Issue
Closes #5213