### PR TITLE
fix: clarify fragile pagination loop in submissions()

### DIFF
--- a/esp/esp/formstack/objects.py
+++ b/esp/esp/formstack/objects.py
@@ -78,11 +78,10 @@ class FormstackForm(object):
         # get submissions from the API
         api_response = self.formstack.data(self.id, {'per_page': 100})
         submission_docs = api_response['submissions']
-        for i in range(1, api_response['pages']):
-            api_response = self.formstack.data(self.id,
-                                               {'per_page': 100, 'page': i+1})
+        total_pages = api_response['pages']
+        for page in range(2, total_pages + 1):
+            api_response = self.formstack.data(self.id, {'per_page': 100, 'page': page})
             submission_docs += api_response['submissions']
-
         # make FormstackSubmission objects
         submissions = []
         for submission_doc in submission_docs:


### PR DESCRIPTION
## Description

Rewrote the pagination loop in `FormstackForm.submissions()` to be easier to read and maintain. Replaced the confusing `range(1, pages)` with an `i+1` offset with a clearer `range(2, total_pages + 1)` loop. The behavior remains identical—this is purely a clarity and maintainability improvement.

## Related Issue

Closes #5221

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## AI Disclosure

none

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced