### PR TITLE
Fix: Token Validation Occurs After Account Deactivation in One-Click

### DIFF
--- a/esp/esp/users/tests.py
+++ b/esp/esp/users/tests.py
@@ -5,6 +5,7 @@ from django import forms
 from django.core import mail
 from django.contrib.auth import logout, login, authenticate
 from django.contrib.auth.models import Group
+from django.test import TestCase
 from django.test.client import Client, RequestFactory
 from django.http import HttpRequest
 from django.conf import settings
@@ -141,31 +142,62 @@ class ESPUserTest(TestCase):
                 user.delete()
 
     def testUnsubscribeOneclickVulnerability(self):
-        """Test that one-click unsubscribe requires a valid token."""
+        """Test that one-click unsubscribe requires a valid token and handles edge cases."""
         user = ESPUser.objects.create(username='vuln_test_user', is_active=True)
+        user.set_password('password123')
+        user.save()
+        other_user = ESPUser.objects.create(username='other_test_user', is_active=True)
+        other_user.set_password('password123')
+        other_user.save()
+
         try:
+            # extract valid token
+            link = user.unsubscribe_link()
+            parts = [p for p in link.split('/') if p]
+            valid_token = parts[-1]
             invalid_token = 'invalid-token-123'
             
-            # Send a POST request triggering the one-click logic
+            # check token, if invalid or malformed then request should fail, user remains active
+            with self.assertRaises(ESPError):
+                self.client.post(
+                    reverse('unsubscribe_oneclick', kwargs={'username': user.username, 'token': invalid_token}),
+                    data={'List-Unsubscribe': 'One-Click'}
+                )
+            user.refresh_from_db()
+            self.assertTrue(user.is_active, "User should remain active if an invalid token is used.")
+            
+            # check logged-in user or token mismatch
+            self.client.login(username=other_user.username, password='password123')
+            with self.assertRaises(ESPError):
+                self.client.post(
+                    reverse('unsubscribe_oneclick', kwargs={'username': user.username, 'token': valid_token}),
+                    data={'List-Unsubscribe': 'One-Click'}
+                )
+            user.refresh_from_db()
+            self.assertTrue(user.is_active, "User should remain active if a different user attempts the action.")
+            
+            # Logout
+            self.client.logout()
+
+            # check token, if valid then user should be deactivated
             response = self.client.post(
-                reverse('unsubscribe_oneclick', kwargs={'username': user.username, 'token': invalid_token}),
+                reverse('unsubscribe_oneclick', kwargs={'username': user.username, 'token': valid_token}),
                 data={'List-Unsubscribe': 'One-Click'}
             )
-            
-            # The request with an invalid token should not succeed with a 2xx status.
-            self.assertFalse(
-                200 <= response.status_code < 300,
-                f"Expected invalid token request to be rejected, got status {response.status_code}",
-            )
-            
-            # Refresh user from database
+            self.assertEqual(response.status_code, 200)
             user.refresh_from_db()
-            
-            # Before the fix: user is deactivated (is_active=False) despite an invalid token.
-            # After the fix: user remains active (is_active=True).
-            self.assertTrue(user.is_active, "VULNERABILITY: User was deactivated despite an invalid token.")
+            self.assertFalse(user.is_active, "User should be deactivated with a valid token.")
+
+            # check token reusage
+            with self.assertRaises(ESPError):
+                self.client.post(
+                    reverse('unsubscribe_oneclick', kwargs={'username': user.username, 'token': valid_token}),
+                    data={'List-Unsubscribe': 'One-Click'}
+                )
+
         finally:
             user.delete()
+            other_user.delete()
 
 class PasswordRecoveryTest(TestCase):
     """Test password recovery using Django's built-in token generator.

--- a/esp/esp/users/tests.py
+++ b/esp/esp/users/tests.py
@@ -8,6 +8,7 @@ from django.contrib.auth.models import Group
 from django.test.client import Client, RequestFactory
 from django.http import HttpRequest
 from django.conf import settings
+from django.urls import reverse
 from django.utils.functional import SimpleLazyObject
 
 from esp.middleware import ESPError
@@ -138,6 +139,27 @@ class ESPUserTest(TestCase):
                                 f"Token check failed for username: {username}")
             finally:
                 user.delete()
+
+    def test_unsubscribe_oneclick_vulnerability(self):
+        """Test that one-click unsubscribe requires a valid token."""
+        user = ESPUser.objects.create(username='vuln_test_user', is_active=True)
+        try:
+            invalid_token = 'invalid-token-123'
+            
+            # Send a POST request triggering the one-click logic
+            response = self.client.post(
+                reverse('unsubscribe_oneclick', kwargs={'username': user.username, 'token': invalid_token}),
+                data={'List-Unsubscribe': 'One-Click'}
+            )
+            
+            # Refresh user from database
+            user.refresh_from_db()
+            
+            # Before the fix: user is deactivated (is_active=False) despite an invalid token.
+            # After the fix: user remains active (is_active=True).
+            self.assertTrue(user.is_active, "VULNERABILITY: User was deactivated despite an invalid token.")
+        finally:
+            user.delete()
 
 class PasswordRecoveryTest(TestCase):
     """Test password recovery using Django's built-in token generator.

--- a/esp/esp/users/tests.py
+++ b/esp/esp/users/tests.py
@@ -140,7 +140,7 @@ class ESPUserTest(TestCase):
             finally:
                 user.delete()
 
-    def test_unsubscribe_oneclick_vulnerability(self):
+    def testUnsubscribeOneclickVulnerability(self):
         """Test that one-click unsubscribe requires a valid token."""
         user = ESPUser.objects.create(username='vuln_test_user', is_active=True)
         try:
@@ -150,6 +150,12 @@ class ESPUserTest(TestCase):
             response = self.client.post(
                 reverse('unsubscribe_oneclick', kwargs={'username': user.username, 'token': invalid_token}),
                 data={'List-Unsubscribe': 'One-Click'}
+            )
+            
+            # The request with an invalid token should not succeed with a 2xx status.
+            self.assertFalse(
+                200 <= response.status_code < 300,
+                f"Expected invalid token request to be rejected, got status {response.status_code}",
             )
             
             # Refresh user from database

--- a/esp/esp/users/views/__init__.py
+++ b/esp/esp/users/views/__init__.py
@@ -212,19 +212,21 @@ def unsubscribe(request, username, token, oneclick = False):
             raise ESPError("User " + users[0].username + " is already unsubscribed.")
     else:
         raise ESPError("No user matching that unsubscribe request.")
-
-    # if POSTing, they clicked the confirm button
-    # if oneclick=True, then they came here from an email client
-    if request.POST.get("List-Unsubscribe") == "One-Click" or oneclick == True:
-        # "unsubscribe" them (deactivate their account)
-        user.is_active = False
-        user.save()
-        return render_to_response('users/unsubscribe.html', request, context = {'user': user, 'deactivated': True})
-
-    # otherwise show them a confirmation button
-    # if they are logged into the correct account or the token is valid
+    
+    # first, we need to check that user is logged into the correct account or the token is valid
+    # if authorization is true, then we proceed
     if ( (request.user.is_authenticated and request.user == user) or user.check_token(token)):
+        # if POSTing, they clicked the confirm button
+        # if oneclick=True, then they came here from an email client
+        if request.POST.get("List-Unsubscribe") == "One-Click" or oneclick == True:
+            # "unsubscribe" them (deactivate their account)
+            user.is_active = False
+            user.save()
+            return render_to_response('users/unsubscribe.html', request, context = {'user': user, 'deactivated': True})
+            
+        # if this isn't true, then show them the confirmation button
         return render_to_response('users/unsubscribe.html', request, context = {'user': user})
+
     # if they are logged into a different account
     # tell them to log out and try again
     elif request.user.is_authenticated and request.user != user:

--- a/esp/esp/users/views/__init__.py
+++ b/esp/esp/users/views/__init__.py
@@ -218,7 +218,7 @@ def unsubscribe(request, username, token, oneclick = False):
     if ( (request.user.is_authenticated and request.user == user) or user.check_token(token)):
         # if POSTing, they clicked the confirm button
         # if oneclick=True, then they came here from an email client
-        if request.POST.get("List-Unsubscribe") == "One-Click" or oneclick == True:
+        if request.POST.get("List-Unsubscribe") == "One-Click" or oneclick:
             # "unsubscribe" them (deactivate their account)
             user.is_active = False
             user.save()


### PR DESCRIPTION
## Description

before, when someone sends a fake token for example to unsubscribe a username, it wasn't validated or authorized but after the unsubscribe method.
now i made sure to authorize user and validate token to make sure no one except user himself can unsubscribe or deactivate his account. 

## Related Issue
(https://github.com/learning-unlimited/ESP-Website/issues/5214#issuecomment-4085061800)

Closes #5214 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [ ] Existing tests pass
- [x] New tests added (if applicable)
- [ ] Manually verified

## AI Disclosure

Google Gemini
used for more understanding of issue and testing

## Checklist

- [x] Self-reviewed the code
- [x] Updated documentation (if needed)
- [x] No new warnings or errors introduced
