### PR TITLE
Fix: Ensure time-based validity in getModules() to prevent stale cached modules (#4935)

### DIFF
--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -1,4 +1,3 @@
-from django.utils.encoding import python_2_unicode_compatible
 from functools import reduce
 __author__    = "Individual contributors (see AUTHORS file)"
 __date__      = "$DATE$"
@@ -72,7 +71,6 @@ from esp.utils.formats import format_lazy
 from esp.qsdmedia.models import Media
 
 # Create your models here.
-@python_2_unicode_compatible
 class ProgramModule(models.Model):
     """ Program Modules for a Program """
 
@@ -121,7 +119,7 @@ class ProgramModule(models.Model):
         Raises a ProgramModule.CannotGetClassException() if the class can't be imported.
         """
         try:
-            path = "esp.program.modules.handlers.%s" % (self.handler.lower())
+            path = f"esp.program.modules.handlers.{self.handler.lower()}"
             mod = __import__(path, (), (), [self.handler])
             return getattr(mod, self.handler)
         except ImportError:
@@ -135,9 +133,8 @@ class ProgramModule(models.Model):
             super(ProgramModule.CannotGetClassException, self).__init__(msg)
 
     def __str__(self):
-        return '{}'.format(self.admin_title)
+        return f'{self.admin_title}'
 
-@python_2_unicode_compatible
 class ArchiveClass(models.Model):
     """ Old classes throughout the years """
     program = models.CharField(max_length=256)
@@ -187,7 +184,7 @@ class ArchiveClass(models.Model):
 
     def heading(self):
         if len(self.date) > 1:
-            year_display = self.year + ' (%s)' % self.date
+            year_display = self.year + f' ({self.date})'
         else:
             year_display = self.year
 
@@ -212,15 +209,15 @@ class ArchiveClass(models.Model):
 
     def add_students(self, users):
         if self.student_ids is not None:
-            self.student_ids += '%s|' % '|'.join([str(u.id) for u in users])
+            self.student_ids += f'{"|".join([str(u.id) for u in users])}|'
         else:
-            self.student_ids = '|%s|' % '|'.join([str(u.id) for u in users])
+            self.student_ids = f'|{"|".join([str(u.id) for u in users])}|'
 
     def add_teachers(self, users):
         if self.teacher_ids is not None:
-            self.teacher_ids += '%s|' % '|'.join([str(u.id) for u in users])
+            self.teacher_ids += f'{"|".join([str(u.id) for u in users])}|'
         else:
-            self.teacher_ids = '|%s|' % '|'.join([str(u.id) for u in users])
+            self.teacher_ids = f'|{"|".join([str(u.id) for u in users])}|'
 
     def students(self):
         useridlist = [int(x) for x in self.student_ids.strip('|').split('|')]
@@ -234,8 +231,8 @@ class ArchiveClass(models.Model):
     def getForUser(user):
         """ Get a list of archive classes for a specific user. """
         from django.db.models.query import Q
-        Q_ClassTeacher = Q(teacher_ids__icontains = ('|%s|' % user.id))
-        Q_ClassStudent = Q(student_ids__icontains = ('|%s|' % user.id))
+        Q_ClassTeacher = Q(teacher_ids__icontains = (f'|{user.id}|'))
+        Q_ClassStudent = Q(student_ids__icontains = (f'|{user.id}|'))
         #   We want to only show archive classes for teachers.  At least for now.
         Q_Class = Q_ClassTeacher #  | Q_ClassStudent
         return ArchiveClass.objects.filter(Q_Class).order_by('-year', '-date', 'title')
@@ -248,14 +245,19 @@ def _get_type_url(type):
         else:
             self._type_url = {}
 
-        self._type_url[type] = '/%s/%s/' % (type, self.url)
+        self._type_url[type] = f'/{type}/{self.url}/'
 
         return self._type_url[type]
 
     return _really_get_type_url
 
-@python_2_unicode_compatible
+class ProgramManager(models.Manager):
+    def get_queryset(self):
+        # this explicitly adds the ordering to every query
+        return super().get_queryset().order_by('-id')
+
 class Program(models.Model, CustomFormsLinkModel):
+    objects = ProgramManager()
     """ An ESP Program, such as HSSP Summer 2006, Splash Fall 2006, Delve 2005, etc. """
     #customforms definitions
     form_link_name='Program'
@@ -266,7 +268,7 @@ class Program(models.Model, CustomFormsLinkModel):
     grade_max = models.IntegerField()
     # director contact email address used for from field and display
     director_email = models.EmailField(default='info@' + settings.SITE_INFO[1], max_length=75,
-                                       validators=[validators.RegexValidator(r'(^.+@{0}$)|(^.+@(\w+\.)?learningu\.org$)'.format(settings.SITE_INFO[1].replace('.', '\.')))],
+                                       validators=[validators.RegexValidator(rf'(^.+@{settings.SITE_INFO[1].replace(".", ".")}$)|(^.+@(\w+\.)?learningu\.org$)')],
                                        help_text=mark_safe('The director email address must end in @' + settings.SITE_INFO[1] + ' (your website), ' +
                                                            '@learningu.org, or a valid subdomain of learningu.org (i.e., @subdomain.learningu.org). ' +
                                                            'The default is <b>info@' + settings.SITE_INFO[1] + '</b>, which redirects to the "default" ' +
@@ -379,7 +381,7 @@ class Program(models.Model, CustomFormsLinkModel):
                     users.update(tmpusers)
             return users
         get_users.__name__  = method_name
-        get_users.__doc__   = "Returns a dictionary of different sets of %s for this program, as defined by the enabled ProgramModules" % method_name
+        get_users.__doc__   = f"Returns a dictionary of different sets of {method_name} for this program, as defined by the enabled ProgramModules"
         return get_users
 
     @staticmethod
@@ -393,7 +395,7 @@ class Program(models.Model, CustomFormsLinkModel):
                     labels.update(tmplabels)
             return labels
         get_labels.__name__  = method_name
-        get_labels.__doc__   = "Returns a dictionary of labels for the different sets of %s for this program, as defined by the enabled ProgramModules" % method_name
+        get_labels.__doc__   = f"Returns a dictionary of labels for the different sets of {method_name} for this program, as defined by the enabled ProgramModules"
         return get_labels
 
     @staticmethod
@@ -408,7 +410,7 @@ class Program(models.Model, CustomFormsLinkModel):
                     result_dict[key] = len(value)
             return result_dict
         _get_num.__name__   = "num_" + query_func.__name__
-        _get_num.__doc__    = "Returns a dictionary of the sizes of the various sets of %s that are returned by Program.%s()" % (query_func.__name__, query_func.__name__)
+        _get_num.__doc__    = f"Returns a dictionary of the sizes of the various sets of {query_func.__name__} that are returned by Program.{query_func.__name__}()"
         return _get_num
 
     @cache_function
@@ -519,6 +521,22 @@ class Program(models.Model, CustomFormsLinkModel):
 
         return lists
 
+    def get_test_user_ids(self):
+        """Return PKs of the designated test accounts for this program.
+
+        Test accounts are stored as program-scoped Tags so that no migration
+        is needed.  Keys: 'test_student_id', 'test_teacher_id'.
+        """
+        ids = set()
+        for key in ('test_student_id', 'test_teacher_id'):
+            val = Tag.getTag(key, target=self)
+            if val:
+                try:
+                    ids.add(int(val))
+                except (ValueError, TypeError):
+                    pass
+        return ids
+
     def students_union(self, QObject = False):
         import operator
         if len(list(self.students().values())) == 0:
@@ -531,7 +549,11 @@ class Program(models.Model, CustomFormsLinkModel):
         if QObject:
             return union
         else:
-            return ESPUser.objects.filter(union).distinct()
+            test_ids = self.get_test_user_ids()
+            qs = ESPUser.objects.filter(union).distinct()
+            if test_ids:
+                qs = qs.exclude(id__in=test_ids)
+            return qs
 
     def teachers_union(self, QObject = False):
         import operator
@@ -544,7 +566,11 @@ class Program(models.Model, CustomFormsLinkModel):
         if QObject:
             return union
         else:
-            return ESPUser.objects.filter(union).distinct()
+            test_ids = self.get_test_user_ids()
+            qs = ESPUser.objects.filter(union).distinct()
+            if test_ids:
+                qs = qs.exclude(id__in=test_ids)
+            return qs
 
     def volunteers_union(self, QObject = False):
         import operator
@@ -991,17 +1017,15 @@ class Program(models.Model, CustomFormsLinkModel):
                     if d1.day == d2.day:
                         return '%s' % d1.strftime('%b. %d, %Y')
                     else:
-                        return '%s - %s' % (d1.strftime('%b. %d'), d2.strftime('%d, %Y'))
+                        return f'{d1.strftime("%b. %d")} - {d2.strftime("%d, %Y")}'
                 else:
-                    return '%s - %s' % (d1.strftime('%b. %d'), d2.strftime('%b. %d, %Y'))
+                    return f'{d1.strftime("%b. %d")} - {d2.strftime("%b. %d, %Y")}'
             else:
-                return '%s - %s' % (d1.strftime('%b. %d, %Y'), d2.strftime('%b. %d, %Y'))
+                return f'{d1.strftime("%b. %d, %Y")} - {d2.strftime("%b. %d, %Y")}'
         else:
             return None
 
-    def get_teacher_event_times(self, event_type):
-        """event_type should be 'interview' or 'training'"""
-        event_type_obj = EventType.teacher_event_types()[event_type]
+    def get_teacher_event_times(self, event_type_obj):
         return Event.objects.filter(
             program=self, event_type=event_type_obj).order_by('start')
 
@@ -1051,8 +1075,26 @@ class Program(models.Model, CustomFormsLinkModel):
             return [result[c] for c in result]
 
     def getAvailableResources(self, timeslot, queryset=False):
-        #   Filters down the floating resources to those that are not taken.
-        return [x for x in self.getFloatingResources(timeslot=timeslot, queryset=queryset) if x.is_available()]
+        from esp.resources.models import ResourceAssignment
+        #   Filters down the floating resources to those that are not taken
+        #   and that have been returned from any earlier assignment.
+        floating = list(self.getFloatingResources(timeslot=timeslot, queryset=queryset))
+        if not floating:
+            return []
+        floating_names = [r.name for r in floating]
+        floating_type_ids = set(r.res_type_id for r in floating)
+        unreturned_keys = set(
+            ResourceAssignment.objects.filter(
+                resource__name__in=floating_names,
+                resource__res_type_id__in=floating_type_ids,
+                resource__event__end__lte=timeslot.start,
+                resource__event__program=self,
+                resource__is_unique=True,
+                returned=False,
+            ).values_list('resource__name', 'resource__res_type_id')
+        )
+        return [x for x in floating
+                if x.is_available() and (x.name, x.res_type_id) not in unreturned_keys]
 
     def getDurations(self, round_15=False):
         """ Find all contiguous time blocks and provide a list of duration options. """
@@ -1088,6 +1130,35 @@ class Program(models.Model, CustomFormsLinkModel):
         durationList = list(durationDict.items())
 
         return sorted(durationList, key=lambda x: x[0])
+
+    def countTimeSlots(self, round_15=False):
+        """Calculate the number of instances of each duration that can fit in a given block. Returns dictionary mapping timeslot length to number of timeslots"""
+        from decimal import Decimal
+
+        times = Event.group_contiguous(list(self.getTimeSlots()), int(Tag.getProgramTag('timeblock_contiguous_tolerance', program = self)))
+        durations = [x[0] for x in self.getDurations(round_15)]
+        numDurations = {}
+
+        #iterates over all durations
+        for duration in durations:
+            numDurations[str(duration.quantize(Decimal('.01')))] = 0
+            lenDuration = duration * 3600
+            #iterates over blocks
+            for block in times:
+                numSections = len(block)
+                i = 0
+                while i < numSections:
+                    #makes an increasing list of lengths for each block, section by section
+                    for j in range(i, numSections):
+                        time_option = Event.total_length([block[i], block[j]])
+                        #if enough time exists, increment
+                        if lenDuration <= time_option.seconds:
+                            numDurations[str(duration.quantize(Decimal('.01')))] += 1
+                            i = j
+                            break
+                    i += 1
+
+        return numDurations
 
     def getSurveys(self):
         from esp.survey.models import Survey
@@ -1128,13 +1199,20 @@ class Program(models.Model, CustomFormsLinkModel):
     getModules_cached.depend_on_row('modules.ClassRegModuleInfo', lambda modinfo: {'self': modinfo.program})
     getModules_cached.depend_on_row('modules.StudentClassRegModuleInfo', lambda modinfo: {'self': modinfo.program})
 
-    def getModules(self, user = None, tl = None, old_prog = None):
+    def getModules(self, user=None, tl=None, old_prog=None):
         """ Gets modules for this program, optionally attaching a user. """
+        
         modules = self.getModules_cached(tl, old_prog)
+    
+        # Attach user if provided
         if user:
             for module in modules:
                 module.user = user
-            modules.sort(key=lambda mod: not mod.isCompleted())
+            modules.sort(key=lambda mod: not mod.isCompleted(user))
+    
+        # ✅ FIX: Real-time validity filter (Issue #4935)
+        modules = [m for m in modules if m.deadline_met()]
+    
         return modules
 
     @cache_function
@@ -1309,7 +1387,7 @@ class Program(models.Model, CustomFormsLinkModel):
 
     @cache_function
     def by_prog_inst(cls, program, instance):
-        prog_inst = Program.objects.select_related().get(url='%s/%s' % (program, instance))
+        prog_inst = Program.objects.select_related().get(url=f'{program}/{instance}')
         return prog_inst
     by_prog_inst.depend_on_row('program.Program', lambda prog: {'program': prog})
     by_prog_inst = classmethod(by_prog_inst)
@@ -1354,7 +1432,6 @@ class Program(models.Model, CustomFormsLinkModel):
 
 Program.setup_user_filters()
 
-@python_2_unicode_compatible
 class SplashInfo(models.Model):
     """ A model that can be used to track additional student preferences specific to
         a program.  Stanford has used this for lunch selection and a sibling discount.
@@ -1366,16 +1443,16 @@ class SplashInfo(models.Model):
     program = AjaxForeignKey(Program, null=True, on_delete=models.CASCADE)
     lunchsat = models.CharField(max_length=32, blank=True, null=True) # No longer used, kept for backwards compatibility
     lunchsun = models.CharField(max_length=32, blank=True, null=True) # No longer used, kept for backwards compatibility
-    siblingdiscount = models.NullBooleanField(default=False, blank=True)
+    siblingdiscount = models.BooleanField(default=False, blank=True, null=True)
     siblingname = models.CharField(max_length=64, blank=True, null=True)
-    submitted = models.NullBooleanField(default=False, blank=True)
+    submitted = models.BooleanField(default=False, blank=True, null=True)
 
     class Meta:
         app_label = 'program'
         db_table = 'program_splashinfo'
 
     def __str__(self):
-        return 'Lunch/sibling info for %s at %s' % (self.student, self.program)
+        return f'Lunch/sibling info for {self.student} at {self.program}'
 
     @staticmethod
     def hasForUser(user, program=None):
@@ -1415,7 +1492,6 @@ class SplashInfo(models.Model):
         super().save()
         self.execute_sibling_discount()
 
-@python_2_unicode_compatible
 class RegistrationProfile(models.Model):
     """ A student registration form """
     user = AjaxForeignKey(ESPUser, on_delete=models.CASCADE)
@@ -1430,7 +1506,7 @@ class RegistrationProfile(models.Model):
     last_ts = models.DateTimeField(default=timezone.now)
     most_recent_profile = models.BooleanField(default=False)
 
-    old_text_reminder = models.NullBooleanField(db_column='text_reminder')  ## Kept around for database-migration purposes
+    old_text_reminder = models.BooleanField(null=True, db_column='text_reminder')  ## Kept around for database-migration purposes
 
     ## Oops, I didn't see this field, and I reimplemented its functionality...
     ## Wrap it for backwards compatibility. -- aseering 8/18/2010
@@ -1480,6 +1556,7 @@ class RegistrationProfile(models.Model):
 
         return regProf
     getLastProfile.depend_on_row('program.RegistrationProfile', lambda profile: {'user': profile.user})
+    getLastProfile.depend_on_row('users.StudentInfo', lambda si: {'user': si.user})
     getLastProfile = staticmethod(getLastProfile) # a bit annoying, but meh
 
     @cache_function
@@ -1557,13 +1634,14 @@ class RegistrationProfile(models.Model):
     # Thanks to our attempts to be smart and steal profiles from other programs,
     # the cache can't depend only on profiles with the same (user, program).
     getLastForProgram.depend_on_row('program.RegistrationProfile', lambda rp: {'user': rp.user})
+    getLastForProgram.depend_on_row('users.StudentInfo', lambda si: {'user': si.user})
     getLastForProgram = staticmethod(getLastForProgram)
 
     def __str__(self):
         if self.program_id is None:
-            return '<Registration for %s>' % str(self.user)
+            return f'<Registration for {self.user}>'
         if self.user is not None:
-            return '<Registration for %s in %s>' % (str(self.user), str(self.program))
+            return f'<Registration for {self.user} in {self.program}>'
 
 
     def updateForm(self, form_data, specificInfo = None):
@@ -1621,10 +1699,10 @@ class TeacherBio(models.Model):
         super().save(*args, **kwargs)
 
     def url(self):
-        return '/teach/teachers/%s/bio.html' % self.user.username
+        return f'/teach/teachers/{self.user.username}/bio.html'
 
     def edit_url(self):
-        return '/teach/teachers/%s/bio.edit.html' % self.user.username
+        return f'/teach/teachers/{self.user.username}/bio.edit.html'
 
     @staticmethod
     def getLastForProgram(user, program):
@@ -1638,7 +1716,6 @@ class TeacherBio(models.Model):
             lastBio = bios[0]
         return lastBio
 
-@python_2_unicode_compatible
 class FinancialAidRequest(models.Model):
     """
     Student financial Aid Request
@@ -1701,9 +1778,9 @@ class FinancialAidRequest(models.Model):
                 self.done = True
                 self.save()
                 # send email to student
-                email_from = '%s Registration System <server@%s>' % (self.program.program_type, settings.EMAIL_HOST_SENDER)
+                email_from = f'{self.program.program_type} Registration System <server@{settings.EMAIL_HOST_SENDER}>'
                 email_to = [self.user.get_email_sendto_address()]
-                subj = 'Financial Aid Approved for %s for %s' % (self.user.name(), self.program.niceName())
+                subj = f'Financial Aid Approved for {self.user.name()} for {self.program.niceName()}'
                 email_context = {'student': self.user,
                                  'program': self.program,
                                  'grant': f,
@@ -1727,14 +1804,13 @@ def get_subclass_instance(cls, obj):
         result = None
         try:
             result = c.objects.get(id=obj.id)
-        except:
+        except c.DoesNotExist:
             pass
         if result:
             return get_subclass_instance(c, result)
     #   If you couldn't find any, return the original object.
     return obj
 
-@python_2_unicode_compatible
 class BooleanToken(models.Model):
     """ A true/false value or Boolean operation.
         Meant to be extended to more meaningful Boolean functions operating on
@@ -1759,7 +1835,7 @@ class BooleanToken(models.Model):
     expr = property(get_expr)
 
     def __str__(self):
-        return '[%d] %s' % (self.seq, self.text)
+        return f'[{self.seq}] {self.text}'
 
     @cache_function
     def subclass_instance(self):
@@ -1813,7 +1889,6 @@ class BooleanToken(models.Model):
         else:
             return False
 
-@python_2_unicode_compatible
 class BooleanExpression(models.Model):
     """ A combination of BooleanTokens that can be manipulated and evaluated.
         Arbitrary arguments can be supplied to the evaluate function in order
@@ -1826,7 +1901,7 @@ class BooleanExpression(models.Model):
     label = models.CharField(max_length=80, help_text='Description of the expression')
 
     def __str__(self):
-        return '(%d tokens) %s' % (len(self.get_stack()), self.label)
+        return f'({len(self.get_stack())} tokens) {self.label}'
 
     def subclass_instance(self):
         return get_subclass_instance(BooleanExpression, self)
@@ -1874,7 +1949,6 @@ class BooleanExpression(models.Model):
         (value, post_stack) = BooleanToken.evaluate(stack, *args, **kwargs)
         return value
 
-@python_2_unicode_compatible
 class ScheduleMap:
     """ The schedule map is a dictionary mapping Event IDs to lists of class sections.
         It can be generated and cached for a user, then modified
@@ -1909,12 +1983,11 @@ class ScheduleMap:
     def __marinade__(self):
         import hashlib
         import pickle
-        return 'ScheduleMap_%s' % hashlib.md5(pickle.dumps(self)).hexdigest()[:8]
+        return f'ScheduleMap_{hashlib.md5(pickle.dumps(self)).hexdigest()[:8]}'
 
     def __str__(self):
-        return '%s' % self.map
+        return f'{self.map}'
 
-@python_2_unicode_compatible
 class ScheduleConstraint(models.Model):
     """ A scheduling constraint that can be tested:
         IF [condition] THEN [requirement]
@@ -1940,7 +2013,7 @@ class ScheduleConstraint(models.Model):
         app_label = 'program'
 
     def __str__(self):
-        return '%s: "%s" requires "%s"' % (self.program.niceName(), str(self.condition), str(self.requirement))
+        return f'{self.program.niceName()}: "{self.condition}" requires "{self.requirement}"'
 
     def evaluate(self, smap, recursive=True):
         self.schedule_map = smap
@@ -1966,7 +2039,7 @@ class ScheduleConstraint(models.Model):
         #   Try the on_failure callback but be very lenient about it (fail silently)
         try:
             func_str = """def _f(schedule_map):
-%s""" % ('\n'.join('    %s' % l.rstrip() for l in self.on_failure.strip().split('\n')))
+{chr(10).join(f'    {l.rstrip()}' for l in self.on_failure.strip().split(chr(10)))}"""
             exec(func_str)
             result = _f(self.schedule_map)
             return result
@@ -2047,11 +2120,10 @@ class ScheduleTestSectionList(ScheduleTestTimeblock):
         import operator
         q_list = []
         for section in sections:
-            q_list.append(Q(Q(section_ids='%s' % section.id) | Q(section_ids__startswith='%s,' % section.id) | Q(section_ids__contains=',%s,' % section.id) | Q(section_ids__endswith=',%s' % section.id)))
+            q_list.append(Q(Q(section_ids=f'{section.id}') | Q(section_ids__startswith=f'{section.id},') | Q(section_ids__contains=f',{section.id},') | Q(section_ids__endswith=f',{section.id}')))
 
         return cls.objects.filter( reduce(operator.or_, q_list) )
 
-@python_2_unicode_compatible
 class VolunteerRequest(models.Model):
     program = models.ForeignKey(Program, on_delete=models.CASCADE)
     timeslot = models.ForeignKey('cal.Event', on_delete=models.CASCADE)
@@ -2067,9 +2139,8 @@ class VolunteerRequest(models.Model):
         return self.volunteeroffer_set.all()
 
     def __str__(self):
-        return '%s (%s)' % (self.timeslot.description, self.timeslot.short_time())
+        return f'{self.timeslot.description} ({self.timeslot.short_time()})'
 
-@python_2_unicode_compatible
 class VolunteerOffer(models.Model):
     request = models.ForeignKey(VolunteerRequest, on_delete=models.CASCADE)
     confirmed = models.BooleanField(default=False)
@@ -2091,7 +2162,7 @@ class VolunteerOffer(models.Model):
         app_label = 'program'
 
     def __str__(self):
-        return '%s (%s, %s) for %s' % (self.name, self.email, self.phone, self.request)
+        return f'{self.name} ({self.email}, {self.phone}) for {self.request}'
 
 
 """ This class provides the information that was provided by the DataTree
@@ -2108,7 +2179,6 @@ class VolunteerOffer(models.Model):
     Note: These models fit better in class_.py but cause validation errors
     due to Django's import scheme if they are placed there.
 """
-@python_2_unicode_compatible
 class RegistrationType(models.Model):
     #   The 'key' (not really the primary key since we may want duplicate names)
     name = models.CharField(max_length=32)
@@ -2157,7 +2227,6 @@ class RegistrationType(models.Model):
         else:
             return self.name
 
-@python_2_unicode_compatible
 class PhaseZeroRecord(models.Model):
     def __str__(self):
         return str(self.id)
@@ -2171,7 +2240,6 @@ class PhaseZeroRecord(models.Model):
         return ', '.join([user.username for user in self.user.all()])
     display_user.short_description = 'Username(s)'
 
-@python_2_unicode_compatible
 class ModeratorRecord(models.Model):
     def __str__(self):
         return str(self.id)
@@ -2186,7 +2254,6 @@ class ModeratorRecord(models.Model):
     class Meta:
         app_label = 'program'
 
-@python_2_unicode_compatible
 class StudentRegistration(ExpirableModel):
     """
     Model relating a student with a class section (interest, priority,
@@ -2200,9 +2267,8 @@ class StudentRegistration(ExpirableModel):
         app_label = 'program'
 
     def __str__(self):
-        return '%s %s in %s' % (self.user, self.relationship, self.section)
+        return f'{self.user} {self.relationship} in {self.section}'
 
-@python_2_unicode_compatible
 class StudentSubjectInterest(ExpirableModel):
     """
     Model indicating a student interest in a class section.
@@ -2214,7 +2280,7 @@ class StudentSubjectInterest(ExpirableModel):
         app_label = 'program'
 
     def __str__(self):
-        return '%s interest in %s' % (self.user, self.subject)
+        return f'{self.user} interest in {self.subject}'
 
 
 # Hooked up in program.modules.signals and formstack.signals
@@ -2233,7 +2299,7 @@ def maybe_create_module_ext(handler, ext):
     TODO(benkraft): Should we just do this on program creation instead?  We'll
     end up with a bunch of unused settings, but maybe that's fine.
     """
-    uid = 'maybe_create_module_ext:%s:%s' % (handler, ext.__name__)
+    uid = f'maybe_create_module_ext:{handler}:{ext.__name__}'
     @receiver(m2m_changed, sender=Program.program_modules.through,
               weak=False, dispatch_uid=uid)
     def signal_handler(sender, **kwargs):


### PR DESCRIPTION
## Summary
This PR fixes the stale cache behavior in Program.getModules() where time-based transitions (e.g., start_date / end_date) are not reflected because cache invalidation relies only on database writes.

## Approach
Instead of modifying the caching mechanism in getModules_cached(), this PR applies a post-processing filter in getModules() to ensure only currently valid modules are returned.

modules = [m for m in modules if m.deadline_met()]


Details

Keeps existing caching behavior unchanged

Evaluates module validity at request time

Uses existing helper (deadline_met()) to account for time-based transitions and permission logic

Applies filtering independently of user-specific logic to ensure correctness in all contexts

Avoids introducing TTLs or scheduled invalidation

Notes

The original issue suggested using is_valid() via ExpirableModel.
However, since ProgramModuleObj currently exposes deadline_met(), this implementation uses that helper for evaluating runtime validity.

Happy to update the implementation if alignment with ExpirableModel is preferred.

Impact

Prevents stale modules from appearing after expiration

Ensures newly active modules are reflected immediately

Maintains performance by preserving existing cache behavior