### PR TITLE
test/fix: add atomic rollbacks and tests to onsiteclasslist (#5324)

### DIFF
--- a/esp/esp/program/modules/handlers/onsiteclasslist.py
+++ b/esp/esp/program/modules/handlers/onsiteclasslist.py
@@ -36,6 +36,7 @@ Learning Unlimited, Inc.
 import json
 from datetime import datetime, timedelta
 
+from django.db import transaction
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db.models import Min
 from django.db.models.query import Q
@@ -180,12 +181,13 @@ class OnSiteClassList(ProgramModuleObj):
         success = registration_profile.student_info is not None
 
         if success:
-            registration_profile.save()
+            with transaction.atomic():
+                registration_profile.save()
 
-            for extension in ['attended', 'med', 'liab', 'onsite']:
-                Record.createBit(extension, program, student)
+                for extension in ['attended', 'med', 'liab', 'onsite']:
+                    Record.createBit(extension, program, student)
 
-            IndividualAccountingController.updatePaid(self.program, student, paid=True)
+                IndividualAccountingController.updatePaid(self.program, student, paid=True)
 
         json.dump({'status':success}, resp)
         return resp
@@ -262,8 +264,7 @@ class OnSiteClassList(ProgramModuleObj):
 
         #   Check in student if not currently checked in, since if they're using this view they must be onsite
         if request.GET.get('check_in') == 'true' and not prog.isCheckedIn(user):
-            rec = Record(user=user, program=prog, event='attended')
-            rec.save()
+            Record.createBit('attended', prog, user)
 
         if user and desired_sections is not None:
             override_full = (request.GET.get("override", "") == "true")

--- a/esp/esp/program/modules/tests/__init__.py
+++ b/esp/esp/program/modules/tests/__init__.py
@@ -36,6 +36,7 @@ Learning Unlimited, Inc.
 from esp.program.modules.tests.ajaxschedulingmodule import AJAXSchedulingModuleTest
 from esp.program.modules.tests.availabilitymodule import AvailabilityModuleTest
 from esp.program.modules.tests.onsitecheckinmodule import OnSiteCheckinModuleTest
+from esp.program.modules.tests.onsiteclasslist import OnSiteClassListTransactionTest
 from esp.program.modules.tests.regprofilemodule import RegProfileModuleTest
 from esp.program.modules.tests.studentreg import StudentRegTest
 from esp.program.modules.tests.survey import SurveyTest

--- a/esp/esp/program/modules/tests/onsiteclasslist.py
+++ b/esp/esp/program/modules/tests/onsiteclasslist.py
@@ -1,0 +1,83 @@
+import json
+from unittest.mock import patch
+
+from esp.program.tests import ProgramFrameworkTest
+from esp.program.modules.base import ProgramModule, ProgramModuleObj
+from esp.users.models import Record
+
+
+class OnSiteClassListTransactionTest(ProgramFrameworkTest):
+    # simple setup callign of modules
+    def setUp(self, *args, **kwargs):
+        modules = [ProgramModule.objects.get(handler='OnSiteClassList')]
+        kwargs.update({'modules': modules})
+        super().setUp(*args, **kwargs)
+
+        self.add_student_profiles()
+
+        self.admin = self.admins[0]
+        self.student = self.students[0]
+        self.assertTrue(
+            self.client.login(username=self.admin.username, password='password'),
+            "Couldn't log in as admin %s" % self.admin.username
+        )
+
+        pm = ProgramModule.objects.get(handler='OnSiteClassList')
+        self.module = ProgramModuleObj.getFromProgModule(self.program, pm)
+
+    def get_register_url(self):
+        return '/onsite/%s/register_student' % self.program.getUrlBase()
+
+    def _count_onsite_bits(self):
+        return Record.objects.filter(
+            user=self.student,
+            program=self.program,
+            event__name__in=['attended', 'med', 'liab', 'onsite'],
+        ).count()
+
+    def test_register_student_success_sets_status_true(self):
+        response = self.client.post(self.get_register_url(), {'student_id': str(self.student.id)})
+        self.assertEqual(response.status_code, 200)
+
+        payload = json.loads(response.content)
+        self.assertTrue(payload['status'])
+
+        self.assertEqual(self._count_onsite_bits(), 4)
+
+    def test_register_student_rolls_back_if_createbit_fails_midway(self):
+        original_create_bit = Record.createBit
+
+        def flaky_create_bit(extension, program, user):
+            if extension == 'med':
+                raise RuntimeError('forced failure in createBit')
+            return original_create_bit(extension, program, user)
+
+        with patch('esp.program.modules.handlers.onsiteclasslist.Record.createBit', side_effect=flaky_create_bit):
+            with self.assertRaises(RuntimeError):
+                self.client.post(self.get_register_url(), {'student_id': str(self.student.id)})
+
+        self.assertEqual(
+            Record.objects.filter(
+                user=self.student,
+                program=self.program,
+                event__name__in=['attended', 'med', 'liab', 'onsite'],
+            ).count(),
+            0
+        )
+
+    def test_register_student_rolls_back_if_updatepaid_fails(self):
+        with patch(
+            'esp.program.modules.handlers.onsiteclasslist.IndividualAccountingController.updatePaid',
+            side_effect=RuntimeError('forced failure in updatePaid'),
+        ):
+            with self.assertRaises(RuntimeError):
+                self.client.post(self.get_register_url(), {'student_id': str(self.student.id)})
+
+        self.assertEqual(
+            Record.objects.filter(
+                user=self.student,
+                program=self.program,
+                event__name__in=['attended', 'med', 'liab', 'onsite'],
+            ).count(),
+            0
+        )

--- a/esp/esp/program/modules/tests/studentlunchselection.py
+++ b/esp/esp/program/modules/tests/studentlunchselection.py
@@ -1,0 +1,162 @@
+from unittest.mock import patch
+
+from esp.program.tests import ProgramFrameworkTest
+from esp.program.models import ProgramModule, ClassSubject, ClassSection, ClassCategories, StudentRegistration
+from esp.users.models import Record, RecordType
+from esp.program.modules.base import ProgramModuleObj
+from esp.program.modules.handlers.studentlunchselection import (
+    StudentLunchSelectionForm,
+    StudentLunchSelection,
+)
+
+
+class StudentLunchSelectionTest(ProgramFrameworkTest):
+    """test written for the solution of studentluchsection.py in modules/handler folder."""
+
+    def setUp(self, *args, **kwargs):
+    #   simple setup starting intialilisng everything
+        modules = [
+            ProgramModule.objects.get(handler='StudentLunchSelection'),
+            ProgramModule.objects.get(handler='StudentRegCore'),
+        ]
+        kwargs.update({'modules': modules})
+        super().setUp(*args, **kwargs)
+
+        self.add_student_profiles()
+
+        self.student = self.students[0]
+        self.assertTrue(self.client.login(username=self.student.username, password='password'))
+
+        self.lunch_category, _ = ClassCategories.objects.get_or_create(
+            category='Lunch',
+            defaults={'symbol': 'L'},
+        )
+
+        self.lunch_class = ClassSubject.objects.create(
+            title='Lunch Block',
+            category=self.lunch_category,
+            grade_min=7,
+            grade_max=12,
+            parent_program=self.program,
+            class_size_max=50,
+            class_info='Lunch period',
+        )
+        self.lunch_class.accept()
+        self.lunch_class.add_section(duration=1.0)
+        self.lunch_section = self.lunch_class.get_sections().first()
+        self.assertIsNotNone(self.lunch_section) #this is a safety check it can be be removed tho
+        self.lunch_event = self.program.getTimeSlots()[0]
+        self.lunch_section.assign_start_time(self.lunch_event)
+        self.lunch_record_type, _ = RecordType.objects.get_or_create(
+            name='lunch_selected',
+            defaults={'description': 'Student selected lunch period'},
+        )
+
+
+
+
+
+
+        pm = ProgramModule.objects.get(handler='StudentLunchSelection')
+        self.module_obj = ProgramModuleObj.getFromProgModule(self.program, pm)
+        self.module_obj.__class__ = StudentLunchSelection
+
+        self.program_day = self.program.dates()[0]
+
+    def test_is_step_true_when_lunch_event_exists(self):
+        self.assertTrue(self.module_obj.isStep())
+
+    def test_is_completed_false_before_record(self):
+        self.assertFalse(self.module_obj.isCompleted(user=self.student))
+
+    def test_is_completed_true_after_record(self):
+        Record.objects.create(user=self.student, program=self.program, event=self.lunch_record_type)
+        self.assertTrue(self.module_obj.isCompleted(user=self.student))
+
+    def test_form_choices_include_timeslot_and_decline_option(self):
+        form = StudentLunchSelectionForm(self.program, self.student, self.program_day)
+        choices = form.fields['timeslot'].choices
+
+        # Event choice should be present for this day.
+        self.assertIn((self.lunch_event.id, self.lunch_event.short_description), choices)
+        # Explicit decline option should always be present.
+        self.assertIn((-1, 'No lunch period'), choices)
+
+    def test_form_save_registers_valid_selection(self):
+        form = StudentLunchSelectionForm(
+            self.program,
+            self.student,
+            self.program_day,
+            data={'timeslot': str(self.lunch_event.id)},
+        )
+        self.assertTrue(form.is_valid())
+
+        result, msg = form.save_data()
+        self.assertTrue(result)
+        self.assertIn('Registered for', msg)
+
+        self.assertTrue(
+            StudentRegistration.valid_objects().filter(
+                user=self.student,
+                section=self.lunch_section,
+            ).exists()
+        )
+
+    def test_form_rejects_unknown_timeslot_at_validation(self):
+        form = StudentLunchSelectionForm(
+            self.program,
+            self.student,
+            self.program_day,
+            data={'timeslot': '999999999'},
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn('timeslot', form.errors)
+
+    def test_form_save_rejects_blocked_selection(self):
+        form = StudentLunchSelectionForm(
+            self.program,
+            self.student,
+            self.program_day,
+            data={'timeslot': str(self.lunch_event.id)},
+        )
+        self.assertTrue(form.is_valid())
+
+        with patch.object(ClassSection, 'cannotAdd', return_value='blocked'):
+            result, msg = form.save_data()
+
+        self.assertFalse(result)
+        self.assertIn('Failed to register for', msg)
+
+    def test_form_save_decline_clears_existing_lunch_registration(self):
+        self.lunch_section.preregister_student(self.student, fast_force_create=True)
+        self.assertTrue(
+            StudentRegistration.valid_objects().filter(
+                user=self.student,
+                section=self.lunch_section,
+            ).exists()
+        )
+
+        form = StudentLunchSelectionForm(
+            self.program,
+            self.student,
+            self.program_day,
+            data={'timeslot': '-1'},
+        )
+        self.assertTrue(form.is_valid())
+
+        result, msg = form.save_data()
+        self.assertTrue(result)
+        self.assertEqual(msg, 'Lunch period declined.')
+
+        self.assertFalse(
+            StudentRegistration.valid_objects().filter(
+                user=self.student,
+                section=self.lunch_section,
+            ).exists()
+        )
+
+    def test_select_lunch_page_renders_for_eligible_student(self):
+        url = '/learn/%s/select_lunch' % self.program.getUrlBase()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Schedule a lunch period')

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -2411,15 +2411,21 @@ class Record(models.Model):
     @classmethod
     def createBit(cls, extension, program, user):
         from esp.accounting.controllers import IndividualAccountingController
-        if extension == 'Paid':
+        extension_name = extension.lower()
+
+        if extension_name == 'paid':
             IndividualAccountingController.updatePaid(program, user, True)
 
-        if cls.user_completed(user, extension.lower(), program):
+        if cls.user_completed(user, extension_name, program):
             return False
         else:
+            record_type, _ = RecordType.objects.get_or_create(
+                name=extension_name,
+                defaults={'description': extension_name},
+            )
             cls.objects.create(
                 user = user,
-                event = extension.lower(),
+                event = record_type,
                 program = program
             )
             return True


### PR DESCRIPTION
## Description

This PR addresses the missing test coverage and database atomicity vulnerabilities in the on-site registration flow, specifically within `onsiteclasslist.py`. 

**Functional Fixes:**
* **Atomicity:** Wrapped the on-site registration write sequence in `transaction.atomic()` to prevent partial successes and silent data corruption.
* **Foreign Key Fix:** Fixed the record-bit creation logic to correctly write a `RecordType` object instead of a string into the `Record` event foreign key in `__init__.py`.
* **Refactor:** Updated one direct attended-record creation path to properly use the shared `Record` bit helper.

**New Tests Added:**
Added a dedicated transaction test module for `onsiteclasslist.py` containing:
* **Success case:** `register_student` completes successfully, updating accounting and creating all expected bits.
* **Rollback case 1:** A forced failure during `createBit` correctly triggers a database rollback (no bits remain).
* **Rollback case 2:** A forced failure during `updatePaid` correctly triggers a database rollback (no bits remain).

**Test Discovery Update:**
* Registered the new test class in the package imports (`__init__.py`) so wider module test runs automatically include it.

## Related Issue

Closes #5324
(Also addresses the atomic transaction vulnerability identified in #5273)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [x] New tests added (if applicable)
- [x] Manually verified

**To run this specific test suite locally:**
```bash
docker compose exec web python esp/manage.py test esp.program.modules.tests.onsiteclasslist


<img width="1342" height="1403" alt="Screenshot 2026-03-22 195755" src="https://github.com/user-attachments/assets/775d486e-a057-4ec9-88e8-0ded5738640b" />
