### PR TITLE
Improve flexibility of teacher registration custom fields (#2707)

### DIFF
--- a/docs/admin/program_modules.rst
+++ b/docs/admin/program_modules.rst
@@ -341,7 +341,7 @@ This module will prompt teachers to fill out their profile information before pr
 
 If you would like to remove a question, you can do so using the following tag:
 
-* teacherreg_hide_fields - A comma separated list of what fields (i.e. purchase_requests) you want to hide from teachers during teacher registration.
+* teacherreg_hide_fields - A comma separated list of optional fields (including custom teacher registration fields) to hide from teachers during teacher registration.
 
 The questions shown on the teacher profile are configurable via the following tags:
 
@@ -349,6 +349,8 @@ The questions shown on the teacher profile are configurable via the following ta
 * teacherreg_help_text_purchase_requests - If tag exists, overwrites text under 'Planned Purchases' in teacher registration.
 * teacherreg_label_message_for_directors - If tag exists, overwrites the label 'Message for Directors' in teacher registration.
 * teacherreg_help_text_message_for_directors - If tag exists, overwrites text under 'Message for Directors' in teacher registration.
+* teacherreg_label_overrides - A JSON object mapping field names to labels for teacher class registration (works for built-in and custom fields).
+* teacherreg_help_text_overrides - A JSON object mapping field names to help text for teacher class registration (works for built-in and custom fields).
 
 * teacherinfo_shirt_options - If it is set to 'False', teachers won't be able to specify shirt size/type on their profile.  The default behavior is to show the shirt fields on the profile form.
 * teacherinfo_shirt_type_selection - If it is set to 'False', teachers won't be able to specify whether they want straight (vertical) cut or fitted cut T-shirts.  The default behavior is to provide this choice on the profile form.

--- a/esp/esp/program/modules/forms/admincore.py
+++ b/esp/esp/program/modules/forms/admincore.py
@@ -193,7 +193,8 @@ class ProgramTagSettingsForm(BetterForm):
         self.categories = set()
         super().__init__(*args, **kwargs)
         from esp.program.modules.forms.teacherreg import TeacherClassRegForm
-        classreg_fields = [field.name for field in TeacherClassRegForm(self.program.classregmoduleinfo).visible_fields()]
+        classreg_form = TeacherClassRegForm(self.program.classregmoduleinfo)
+        classreg_fields = [field.name for field in classreg_form.visible_fields()]
         for key in all_program_tags:
             # generate field for each tag
             tag_info = all_program_tags[key]
@@ -201,7 +202,12 @@ class ProgramTagSettingsForm(BetterForm):
                 self.categories.add(tag_info.get('category'))
                 field = tag_info.get('field')
                 if key == 'teacherreg_hide_fields':
-                    self.fields[key] = forms.MultipleChoiceField(choices=[(field[0], field[1].label if field[1].label else field[0]) for field in TeacherClassRegForm.declared_fields.items() if not field[1].required])
+                    hideable_fields = [
+                        (field_name, field_obj.label if field_obj.label else field_name)
+                        for field_name, field_obj in classreg_form.fields.items()
+                        if not field_obj.required
+                    ]
+                    self.fields[key] = forms.MultipleChoiceField(choices=hideable_fields)
                 elif key in ['student_reg_records', 'teacher_reg_records']:
                     from esp.users.models import RecordType
                     self.fields[key] = forms.MultipleChoiceField(choices=list(RecordType.desc()))

--- a/esp/esp/program/modules/forms/teacherreg.py
+++ b/esp/esp/program/modules/forms/teacherreg.py
@@ -40,6 +40,7 @@ from django.utils.safestring import mark_safe
 from esp.utils.forms import StrippedCharField, FormWithRequiredCss, FormUnrestrictedOtherUser
 from esp.utils.widgets import BlankSelectWidget, SplitDateWidget
 import re
+import logging
 from esp.program.models import ClassCategories, ClassSubject, ClassSection, ClassSizeRange
 from esp.program.modules.module_ext import ClassRegModuleInfo
 from esp.users.models import UserAvailability
@@ -49,6 +50,9 @@ from django.conf import settings
 from esp.middleware.threadlocalrequest import get_current_request
 from datetime import datetime, timedelta
 import json
+
+
+logger = logging.getLogger(__name__)
 
 class TeacherClassRegForm(FormWithRequiredCss):
     location_choices = [    (True, "I will use my own space for this class (e.g. space in my laboratory).  I have explained this in 'Message for Directors' below."),
@@ -223,11 +227,38 @@ class TeacherClassRegForm(FormWithRequiredCss):
             if tag_data:
                 self.fields[field].help_text = tag_data
 
+        # Allow bulk field customization (including custom fields) via JSON maps.
+        label_overrides = Tag.getProgramTag('teacherreg_label_overrides', prog)
+        if label_overrides:
+            try:
+                for field_name, label_text in json.loads(label_overrides).items():
+                    if field_name in self.fields:
+                        self.fields[field_name].label = label_text
+            except (TypeError, ValueError, AttributeError):
+                logger.warning('Invalid teacherreg_label_overrides for program %s', prog.id)
+
+        help_text_overrides = Tag.getProgramTag('teacherreg_help_text_overrides', prog)
+        if help_text_overrides:
+            try:
+                for field_name, help_text in json.loads(help_text_overrides).items():
+                    if field_name in self.fields:
+                        self.fields[field_name].help_text = help_text
+            except (TypeError, ValueError, AttributeError):
+                logger.warning('Invalid teacherreg_help_text_overrides for program %s', prog.id)
+
         #   Hide fields as desired.
         tag_data = Tag.getProgramTag('teacherreg_hide_fields', prog)
         if tag_data:
             for field_name in [x.strip().lower() for x in tag_data.split(',')]:
-                hide_field(self.fields[field_name])
+                field = self.fields.get(field_name)
+                if field and not field.required:
+                    hide_field(field)
+
+        # Add aria-label fallback for fields intentionally shown without a visible label.
+        for field_name, field in self.fields.items():
+            if field.label in (None, '') and 'aria-label' not in field.widget.attrs:
+                fallback_label = field.help_text or field_name.replace('_', ' ').strip().title()
+                field.widget.attrs['aria-label'] = str(fallback_label)
 
         tag_data = Tag.getProgramTag('teacherreg_default_min_grade', prog)
         if tag_data:

--- a/esp/esp/program/modules/tests/admincore.py
+++ b/esp/esp/program/modules/tests/admincore.py
@@ -3,6 +3,8 @@ from esp.users.models import ESPUser
 from esp.tagdict.models import Tag
 from esp.program.models import RegistrationType, StudentRegistration, RegistrationProfile, ProgramModule
 from esp.program.modules.base import ProgramModuleObj
+from esp.program.modules.forms.admincore import ProgramTagSettingsForm
+from esp.program.modules.forms.teacherreg import TeacherClassRegForm
 
 
 class RegistrationTypeManagementTest(ProgramFrameworkTest):
@@ -350,3 +352,26 @@ class ModuleManagementLinkTitleTest(ProgramFrameworkTest):
             pmo = ProgramModuleObj.objects.get(id=mid)
             # seq should be unchanged (not reset) because default_seq was not sent
             self.assertEqual(pmo.seq, 999)
+
+
+class TeacherRegCustomFieldSettingsTest(ProgramFrameworkTest):
+    def test_hide_field_settings_include_optional_custom_fields(self):
+        Tag.setTag('teacherreg_custom_forms', value='["ChicagoTeacherQuestionsForm"]')
+        try:
+            form = ProgramTagSettingsForm(program=self.program)
+            hide_choices = dict(form.fields['teacherreg_hide_fields'].choices)
+            self.assertIn('discussion_type', hide_choices)
+            self.assertIn('other_explain', hide_choices)
+        finally:
+            Tag.unSetTag('teacherreg_custom_forms')
+
+    def test_blank_label_custom_field_gets_accessible_aria_label(self):
+        Tag.setTag('teacherreg_custom_forms', value='["ChicagoTeacherQuestionsForm"]')
+        try:
+            form = TeacherClassRegForm(self.program.classregmoduleinfo)
+            custom_field = form.fields['discussion_type']
+            self.assertEqual(custom_field.label, '')
+            self.assertIn('aria-label', custom_field.widget.attrs)
+            self.assertEqual(custom_field.widget.attrs['aria-label'], custom_field.help_text)
+        finally:
+            Tag.unSetTag('teacherreg_custom_forms')

--- a/esp/esp/tagdict/__init__.py
+++ b/esp/esp/tagdict/__init__.py
@@ -900,6 +900,22 @@ all_program_tags = {
         'category': 'class',
         'is_setting': True,
     },
+    'teacherreg_label_overrides': {
+        'is_boolean': False,
+        'help_text': 'JSON object mapping class registration field names to replacement labels (applies to built-in and custom teacher registration fields)',
+        'default': None,
+        'category': 'class',
+        'is_setting': True,
+        'field': JSONValidatedCharField(required=False),
+    },
+    'teacherreg_help_text_overrides': {
+        'is_boolean': False,
+        'help_text': 'JSON object mapping class registration field names to replacement help text (applies to built-in and custom teacher registration fields)',
+        'default': None,
+        'category': 'class',
+        'is_setting': True,
+        'field': JSONValidatedCharField(required=False),
+    },
     'teacherreg_default_min_grade': {
         'is_boolean': False,
         'help_text': 'The default minimum grade selected in the class creation/editing form',


### PR DESCRIPTION
This PR improves the flexibility and accessibility of teacher registration custom fields by reducing reliance on hardcoded field choices and supporting dynamic custom-field behavior in admin settings and form rendering.

**Changes Made**


- Added JSON-based teacher registration overrides for labels/help text:
1. teacherreg_label_overrides
2. teacherreg_help_text_overrides

- Updated teacher registration form handling to:
1. apply dynamic override maps
2. safely ignore unknown/required hide-field requests
3. add accessibility fallback ([aria-label]) when visible labels are intentionally blank

- Updated Program Tag settings to build teacherreg_hide_fields choices from runtime form fields (including optional custom fields)

- Added tests for:
1. custom optional fields appearing in hide-field settings
2. accessibility fallback on blank-label custom fields

- Updated admin docs for new tag behavior/options
Related Issue
Closes #2707

Notes
This is an initial step toward making custom fields more accessible and configurable without requiring code changes. It lays groundwork for further dynamic field improvements.

AI Usage Disclosure
AI tools were used for assistance in understanding and structuring code changes. All modifications were reviewed and validated manually.