### PR TITLE
Refactor send_text_messages script to use argparse

### DIFF
--- a/esp/useful_scripts/send_text_messages.py
+++ b/esp/useful_scripts/send_text_messages.py
@@ -1,16 +1,19 @@
 import sys
+import argparse
 from twilio.rest import Client
 
-# TODO(jmoldow): Use Python built-in argparse module.
-if len(sys.argv) < 6:
-  print(("Usage: %s <account SID> <auth token> <file with line-separated phone numbers to send from> <file with line-separated phone numbers recipients> <message to send>" % sys.argv[0]))
-  exit(1)
+parser = argparse.ArgumentParser(description="Send text messages using Twilio.")
+parser.add_argument("account_sid", help="Twilio Account SID")
+parser.add_argument("auth_token", help="Twilio Auth Token")
+parser.add_argument("senders_file", help="File with line-separated phone numbers to send from")
+parser.add_argument("recipients_file", help="File with line-separated phone numbers recipients")
+parser.add_argument("message_body", help="Message to send")
 
-account_sid = sys.argv[1]
-auth_token = sys.argv[2]
-ourNumbers = [x.strip() for x in open(sys.argv[3], "r").readlines() if x.strip()]
-recipients = [x.strip() for x in open(sys.argv[4], "r").readlines() if x.strip()]
-body = sys.argv[5]
+args = parser.parse_args()
+
+ourNumbers = [x.strip() for x in open(args.senders_file, "r").readlines() if x.strip()]
+recipients = [x.strip() for x in open(args.recipients_file, "r").readlines() if x.strip()]
+body = args.message_body
 
 numberIndex = 0
 


### PR DESCRIPTION
## Description

This PR refactors [esp/useful_scripts/send_text_messages.py](cci:7://file:///c:/Users/krama/OneDrive/Desktop/resume%20projects/Aman-Portfolio/ESP-Website/esp/useful_scripts/send_text_messages.py:0:0-0:0) to use Python's built-in `argparse` module for parsing command-line arguments instead of relying on manual `sys.argv` arrays. This fulfills an existing `TODO(jmoldow)` comment in the file and improves the script's readability, maintainability, and error handling capabilities.

## Related Issue

Resolves an inline `TODO` inside [send_text_messages.py](cci:7://file:///c:/Users/krama/OneDrive/Desktop/resume%20projects/Aman-Portfolio/ESP-Website/esp/useful_scripts/send_text_messages.py:0:0-0:0).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## AI Disclosure

I utilized an AI coding assistant to help formulate the `argparse` configuration accurately as part of preparing my local environment for future contributions.

## Checklist

- [x] Self-reviewed the code
- [x] Updated documentation (if needed)
- [x] No new warnings or errors introduced
