### PR TITLE
Update INSTALL with troubleshooting for macOS and Python 3.10

### DIFF
--- a/esp/INSTALL
+++ b/esp/INSTALL
@@ -19,7 +19,7 @@ Note: I will refer to the directory which contains this README file as '/'.
 
 Note: The ESP Web site is based on the Django Web framework; the Django
 documentation will be very helpful.  Refer to it at:
-http://docs.djangoproject.com/en/dev/
+https://docs.djangoproject.com/en/dev/
 
 Automatic install (for Ubuntu):
 
@@ -164,3 +164,14 @@ and access the site you've set up in a Web browser.  You can now:
 Please refer to the documentation pages on the Learning Unlimited Wiki, which
 explain how to perform many common tasks with your newly set-up site:
   http://wiki.learningu.org/How_to_use_the_website
+---------------------------------------------------------
+Troubleshooting: macOS (Apple Silicon) & Python 3.10+
+---------------------------------------------------------
+If you are setting up the project locally on a newer Mac (M1/M2/M3) or using Python 3.10+, you may encounter a few common dependency errors during the `pip install` phase. 
+
+1. psycopg2 "pg_config executable not found" error:
+   Your system may lack the specific C-compiler tools for PostgreSQL. To bypass this, open `esp/requirements.txt`, find the `psycopg2` line, and change it to `psycopg2-binary`. 
+
+2. pytz "cannot import name 'Mapping' from 'collections'" error:
+   Python 3.10+ removed legacy code that older versions of pytz rely on. You can fix this by force-upgrading the library in your virtual environment: 
+   Run `pip install --upgrade pytz` before running your database migrations.


### PR DESCRIPTION
Updated the Django documentation link to use https:// and added a troubleshooting section to help future contributors on Apple Silicon or Python 3.10+ bypass common pg_config and collections.Mapping errors during local setup.

## Description

<!-- Brief summary of the changes and their purpose. -->

## Related Issue

<!-- Link the relevant issue. Use "Closes #123" to auto-close on merge. -->

Closes #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manually verified

## AI Disclosure

<!-- If you used AI tools for any part of this pull request, please disclose this here -->

## Checklist

- [ ] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [ ] No new warnings or errors introduced

Closes #5354
