### PR TITLE
Refactor catalog-new.js onbeforeunload to share phase 1 & 2 logic

### DIFF
--- a/esp/public/media/scripts/catalog-new.js
+++ b/esp/public/media/scripts/catalog-new.js
@@ -544,22 +544,17 @@ var CatalogViewModel = function () {
     };
 
     // warn user if leaving with unsaved changes
-    // TODO: figure out how to share this between phases 1 and 2
-    if (catalog_type == 'phase1') {
-        window.onbeforeunload = function () {
-            if (!saving && getDirtyInterested()) {
-                return 'Your preferences have not been saved.';
+    window.onbeforeunload = function () {
+        if (!saving) {
+            var hasUnsavedChanges = getDirtyInterested();
+            if (catalog_type == 'phase2') {
+                hasUnsavedChanges = hasUnsavedChanges || dirty_priorities;
             }
-        };
-    }
-    else if (catalog_type == 'phase2') {
-        window.onbeforeunload = function() {
-            if (!saving && (dirty_priorities || getDirtyInterested())) {
-                return ('Warning: You have unsaved changes. Please click save' +
-                        ' and exit if you wish to preserve your changes.')
+            if (hasUnsavedChanges) {
+                return 'Warning: You have unsaved changes. Please click save and exit if you wish to preserve your changes.';
             }
         }
-    }
+    };
 };
 
 


### PR DESCRIPTION
## Description

This PR refactors the `window.onbeforeunload` logic inside [catalog-new.js](cci:7://file:///c:/Users/krama/OneDrive/Desktop/resume%20projects/Aman-Portfolio/ESP-Website/esp/public/media/scripts/catalog-new.js:0:0-0:0) to share state handling between `phase1` and `phase2` catalog types. This fulfills the `TODO` comment requesting the logic be unified, reducing code duplication and standardizing the unsaved-changes UI warning across both registration phases.

## Related Issue

Resolves an inline `TODO` inside [catalog-new.js](cci:7://file:///c:/Users/krama/OneDrive/Desktop/resume%20projects/Aman-Portfolio/ESP-Website/esp/public/media/scripts/catalog-new.js:0:0-0:0).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## Checklist

- [x] Self-reviewed the code
- [x] No new warnings or errors introduced
