### PR TITLE
Refactor legacy inline text-alignment styles in accounting module. Cl…

### DIFF
--- a/esp/templates/program/modules/accountingmodule/accounting.html
+++ b/esp/templates/program/modules/accountingmodule/accounting.html
@@ -63,52 +63,52 @@ table {
             <p><strong>Registration Count:</strong> {{ cc_totals.gross_count }}</p>
             <table class="table" style="width: auto; min-width: 500px; margin-bottom: 0;">
                 <tr>
-                    <th style="text-align:left;">Description</th>
-                    <th style="text-align:right;">To Chapter</th>
-                    <th style="text-align:right;">To LU</th>
+                    <th class="text-left">Description</th>
+                    <th class="text-right">To Chapter</th>
+                    <th class="text-right">To LU</th>
                 </tr>
                 <tr>
-                    <td style="text-align:left;">Gross Amount</td>
-                    <td style="text-align:right;">{{ cc_totals.gross_amount|floatformat:"2" }}</td>
-                    <td style="text-align:right;"></td>
+                    <td class="text-left">Gross Amount</td>
+                    <td class="text-right">{{ cc_totals.gross_amount|floatformat:"2" }}</td>
+                    <td class="text-right"></td>
                 </tr>
                 <tr>
-                    <td style="text-align:left;">Refunds</td>
-                    <td style="text-align:right;"></td>
-                    <td style="text-align:right;">{{ cc_totals.refunded_amount|floatformat:"2" }}</td>
+                    <td class="text-left">Refunds</td>
+                    <td class="text-right"></td>
+                    <td class="text-right">{{ cc_totals.refunded_amount|floatformat:"2" }}</td>
                 </tr>
                 <tr>
-                    <td style="text-align:left;">Fees</td>
-                    <td style="text-align:right;"></td>
-                    <td style="text-align:right;">{{ cc_totals.total_stripe_fees|floatformat:"2" }}</td>
+                    <td class="text-left">Fees</td>
+                    <td class="text-right"></td>
+                    <td class="text-right">{{ cc_totals.total_stripe_fees|floatformat:"2" }}</td>
                 </tr>
                 <tr>
-                    <td style="text-align:left;">Gross LU Donations</td>
-                    <td style="text-align:right;"></td>
-                    <td style="text-align:right;">{{ cc_totals.donation_amount|floatformat:"2" }}</td>
+                    <td class="text-left">Gross LU Donations</td>
+                    <td class="text-right"></td>
+                    <td class="text-right">{{ cc_totals.donation_amount|floatformat:"2" }}</td>
                 </tr>
                 <tr>
-                    <td style="text-align:left;">LU Donation Fees</td>
-                    <td style="text-align:right;">{{ cc_totals.cc_donation_fees|floatformat:"2" }}</td>
-                    <td style="text-align:right;"></td>
+                    <td class="text-left">LU Donation Fees</td>
+                    <td class="text-right">{{ cc_totals.cc_donation_fees|floatformat:"2" }}</td>
+                    <td class="text-right"></td>
                 </tr>
                 <tr>
-                    <td style="text-align:left;">Additional donation to LU</td>
-                    <td style="text-align:right;"></td>
-                    <td style="text-align:right;">
-                        <input type="number" id="additional_donation" value="0.00" step="0.01" min="0" style="width: 80px; text-align: right;" onchange="updateNet();" onkeyup="updateNet();">
+                    <td class="text-left">Additional donation to LU</td>
+                    <td class="text-right"></td>
+                    <td class="text-right">
+                        <input type="number" id="additional_donation" value="0.00" step="0.01" min="0" class="text-right" style="width: 80px;" onchange="updateNet();" onkeyup="updateNet();">
                         <div id="donation_error" style="color: red; display: none; font-size: 0.9em; margin-top: 5px;">* Net amount to chapter cannot be negative</div>
                     </td>
                 </tr>
                 <tr style="background-color: #eee;">
-                    <td style="text-align:left;"><strong>Totals</strong></td>
-                    <td style="text-align:right;"><strong><span id="total_chapter"></span></strong></td>
-                    <td style="text-align:right;"><strong><span id="total_lu"></span></strong></td>
+                    <td class="text-left"><strong>Totals</strong></td>
+                    <td class="text-right"><strong><span id="total_chapter"></span></strong></td>
+                    <td class="text-right"><strong><span id="total_lu"></span></strong></td>
                 </tr>
                 <tr style="background-color: #ddd;">
-                    <td style="text-align:left;"><strong>Net Amount to Chapter</strong></td>
-                    <td style="text-align:right;"><strong><span id="net_chapter">0.00</span></strong></td>
-                    <td style="text-align:right;"></td>
+                    <td class="text-left"><strong>Net Amount to Chapter</strong></td>
+                    <td class="text-right"><strong><span id="net_chapter">0.00</span></strong></td>
+                    <td class="text-right"></td>
                 </tr>
             </table>
             <p style="margin-top: 10px; font-size: 0.9em; color: #555;">
@@ -162,7 +162,7 @@ table {
         <td>{{ transfer.type }}</td>
         <td>{{ transfer.transfer.line_item }}</td>
         <td>{% if transfer.transfer.line_item.for_finaid %}&#10003;{% endif %}</td>
-        <td style="text-align:right;">{% if transfer.type == "Payment" %}-{% endif %}${{ transfer.transfer.amount|floatformat:"2" }}</td>
+        <td class="text-right">{% if transfer.type == "Payment" %}-{% endif %}${{ transfer.transfer.amount|floatformat:"2" }}</td>
     </tr>
 {% endfor %}
 </table>
@@ -172,8 +172,8 @@ table {
 <table class="table">
     <tr>
         <td width="70%" style="border-top: none;"></td>
-        <th style="text-align:right;">Amount</th>
-        <td style="text-align:right;">
+        <th class="text-right">Amount</th>
+        <td class="text-right">
             {% if grant.amount_max_dec %}
             ${{ grant.amount_max_dec|floatformat:"2" }}
             {% else %}
@@ -183,8 +183,8 @@ table {
     </tr>
     <tr>
         <td style="border-top: none;"></td>
-        <th style="text-align:right;">Percent</th>
-        <td style="text-align:right;">
+        <th class="text-right">Percent</th>
+        <td class="text-right">
             {% if grant.percent %}
             {{ grant.percent|floatformat:"2" }}%
             {% else %}
@@ -194,8 +194,8 @@ table {
     </tr>
     <tr>
         <td style="border-top: none;"></td>
-        <th style="text-align:right;">Total</th>
-        <td style="text-align:right;">${{ result.finaid|floatformat:"2" }}</td>
+        <th class="text-right">Total</th>
+        <td class="text-right">${{ result.finaid|floatformat:"2" }}</td>
     </tr>
 </table>
 {% endif %}
@@ -204,44 +204,44 @@ table {
 <table class="table">
     <tr>
         <td width="70%" style="border-top: none;"></td>
-        <th style="text-align:right;">Category</th>
-        <th style="text-align:right;">Amount</th>
+        <th class="text-right">Category</th>
+        <th class="text-right">Amount</th>
     </tr>
     <tr>
         <td style="border-top: none;"></td>
-        <td style="text-align:right;">Total Owed</td>
-        <td style="text-align:right;">${{ result.requested|floatformat:"2" }}</td>
+        <td class="text-right">Total Owed</td>
+        <td class="text-right">${{ result.requested|floatformat:"2" }}</td>
     </tr>
     {% if result.finaid > 0 %}
     <tr>
         <td style="border-top: none;"></td>
-        <td style="text-align:right;">Financial Aid</td>
-        <td style="text-align:right;">${{ result.finaid|floatformat:"2" }}</td>
+        <td class="text-right">Financial Aid</td>
+        <td class="text-right">${{ result.finaid|floatformat:"2" }}</td>
     </tr>
     {% endif %}
     {% if result.siblingdiscount > 0 %}
     <tr>
         <td style="border-top: none;"></td>
-        <td style="text-align:right;">Sibling Discount</td>
-        <td style="text-align:right;">${{ result.siblingdiscount|floatformat:"2" }}</td>
+        <td class="text-right">Sibling Discount</td>
+        <td class="text-right">${{ result.siblingdiscount|floatformat:"2" }}</td>
     </tr>
     {% endif %}
     <tr>
         <td style="border-top: none;"></td>
-        <td style="text-align:right;"><em>Total Paid</em></td>
-        <td style="text-align:right;"><em>${{ result.paid|floatformat:"2" }}</em></td>
+        <td class="text-right"><em>Total Paid</em></td>
+        <td class="text-right"><em>${{ result.paid|floatformat:"2" }}</em></td>
     </tr>
     {% if result.refunded > 0 %}
     <tr>
         <td style="border-top: none;"></td>
-        <td style="text-align:right;"><em>Total Refunded</em></td>
-        <td style="text-align:right;"><em>${{ result.refunded|floatformat:"2" }}</em></td>
+        <td class="text-right"><em>Total Refunded</em></td>
+        <td class="text-right"><em>${{ result.refunded|floatformat:"2" }}</em></td>
     </tr>
     {% endif %}
     <tr>
         <td style="border-top: none;"></td>
-        <td style="text-align:right;"><strong>Balance</strong></td>
-        <td style="text-align:right;"><strong>${{ result.due|floatformat:"2" }}</strong></td>
+        <td class="text-right"><strong>Balance</strong></td>
+        <td class="text-right"><strong>${{ result.due|floatformat:"2" }}</strong></td>
     </tr>
 </table>
 <p><code>{{ result.identifier }}</code></p>


### PR DESCRIPTION
## Description

This PR refactors [esp/templates/program/modules/accountingmodule/accounting.html](cci:7://file:///c:/Users/krama/OneDrive/Desktop/resume%20projects/Aman-Portfolio/ESP-Website/esp/templates/program/modules/accountingmodule/accounting.html:0:0-0:0) by migrating all instances of inline legacy styles (`style="text-align: left;"` and `style="text-align: right;"`) over to their standardized CSS class counterparts (`class="text-left"` and `class="text-right"`). This cleans up the DOM structure of the Accounting Module dramatically and ensures UI consistency with the global stylesheet.

## Related Issue

Closes #5284

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## Checklist

- [x] Self-reviewed the code
- [x] No new warnings or errors introduced
