### PR TITLE
Add unit tests and JSONDecodeError safety net for AutoSchedulerFronte…

### DIFF
--- a/esp/esp/program/modules/handlers/autoschedulerfrontendmodule.py
+++ b/esp/esp/program/modules/handlers/autoschedulerfrontendmodule.py
@@ -98,7 +98,11 @@ class AutoschedulerFrontendModule(ProgramModuleObj):
             return {'response': [
                 {'error_msg': 'missing autoscheduler_data POST field'}]}
 
-        data, options = json.loads(request.POST['autoscheduler_data'])
+        try:
+            data, options = json.loads(request.POST['autoscheduler_data'])
+        except (ValueError, TypeError):
+            return {'response': [{'error_msg': 'malformed JSON payload for autoscheduler_data'}]}
+
         try:
             schedulerObj = AutoschedulerController(prog, **options)
             schedulerObj.import_assignments(data)

--- a/esp/esp/program/modules/handlers/autoschedulerfrontendmodule.py
+++ b/esp/esp/program/modules/handlers/autoschedulerfrontendmodule.py
@@ -99,9 +99,17 @@ class AutoschedulerFrontendModule(ProgramModuleObj):
                 {'error_msg': 'missing autoscheduler_data POST field'}]}
 
         try:
-            data, options = json.loads(request.POST['autoscheduler_data'])
+            payload = json.loads(request.POST['autoscheduler_data'])
         except (ValueError, TypeError):
             return {'response': [{'error_msg': 'malformed JSON payload for autoscheduler_data'}]}
+
+        if not isinstance(payload, (list, tuple)) or len(payload) != 2:
+            return {'response': [{'error_msg': 'invalid autoscheduler_data format; expected [data, options]'}]}
+            
+        data, options = payload
+        
+        if not isinstance(options, dict):
+            return {'response': [{'error_msg': 'invalid autoscheduler_data options; expected object/dict'}]}
 
         try:
             schedulerObj = AutoschedulerController(prog, **options)

--- a/esp/esp/program/modules/tests/test_autoschedulerfrontendmodule.py
+++ b/esp/esp/program/modules/tests/test_autoschedulerfrontendmodule.py
@@ -1,0 +1,66 @@
+from django.test import TestCase, RequestFactory
+from unittest.mock import patch, MagicMock
+from esp.program.modules.handlers.autoschedulerfrontendmodule import AutoschedulerFrontendModule
+from esp.program.controllers.autoscheduler.exceptions import SchedulingError
+import json
+
+class TestAutoschedulerFrontendModule(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.module = AutoschedulerFrontendModule()
+        self.prog = MagicMock()
+
+    @patch('esp.program.modules.handlers.autoschedulerfrontendmodule.AutoschedulerController')
+    def test_autoscheduler_execute_parsing(self, MockController):
+        # Setup mock controller
+        mock_instance = MockController.return_value
+        mock_instance.get_scheduling_info.return_value = {}
+        mock_instance.export_assignments.return_value = [{}, {}]
+        
+        # Simulate request with floating-point configs and string-based booleans
+        request = self.factory.post('/execute', {
+            'autoscheduler_use_heuristics': 'True',
+            'autoscheduler_allow_overrides': 'False',
+            'autoscheduler_null_value': 'None',
+            'autoscheduler_alpha_weight': '0.75',
+            'autoscheduler_beta_weight': '1.5',
+            'autoscheduler_random_string': 'hello'
+        })
+        
+        response = self.module.autoscheduler_execute(request, 'manage', 'one', 'two', 'module', 'extra', self.prog)
+        
+        # Verify AutoschedulerController was called with appropriately cast types
+        MockController.assert_called_once_with(self.prog, 
+            use_heuristics=True,
+            allow_overrides=False,
+            null_value=None,
+            alpha_weight=0.75,
+            beta_weight=1.5,
+            random_string='hello'
+        )
+        self.assertIn('response', response)
+
+    def test_autoscheduler_save_malformed_json(self):
+        # Simulate request with malformed autoscheduler_data payload
+        request = self.factory.post('/save', {
+            'autoscheduler_data': '{"malformed": json'
+        })
+        
+        response = self.module.autoscheduler_save(request, 'manage', 'one', 'two', 'module', 'extra', self.prog)
+        
+        self.assertIn('response', response)
+        self.assertEqual(len(response['response']), 1)
+        self.assertIn('error_msg', response['response'][0])
+
+    @patch('esp.program.modules.handlers.autoschedulerfrontendmodule.AutoschedulerController')
+    def test_autoscheduler_save_scheduling_error(self, MockController):
+        # Simulate scheduler throwing a SchedulingError
+        MockController.side_effect = SchedulingError("Graceful constraint failure")
+        
+        request = self.factory.post('/save', {
+            'autoscheduler_data': json.dumps([{}, {}])
+        })
+        
+        response = self.module.autoscheduler_save(request, 'manage', 'one', 'two', 'module', 'extra', self.prog)
+        
+        self.assertEqual(response['response'][0]['error_msg'], "Graceful constraint failure")

--- a/esp/esp/program/modules/tests/test_autoschedulerfrontendmodule.py
+++ b/esp/esp/program/modules/tests/test_autoschedulerfrontendmodule.py
@@ -27,7 +27,9 @@ class TestAutoschedulerFrontendModule(TestCase):
             'autoscheduler_random_string': 'hello'
         })
         
-        response = self.module.autoscheduler_execute(request, 'manage', 'one', 'two', 'module', 'extra', self.prog)
+        # Bypass @needs_admin and @json_response decorators to test only parsing logic
+        undecorated_execute = AutoschedulerFrontendModule.autoscheduler_execute.__wrapped__
+        response = undecorated_execute(self.module, request, 'manage', 'one', 'two', 'module', 'extra', self.prog)
         
         # Verify AutoschedulerController was called with appropriately cast types
         MockController.assert_called_once_with(self.prog, 
@@ -46,7 +48,8 @@ class TestAutoschedulerFrontendModule(TestCase):
             'autoscheduler_data': '{"malformed": json'
         })
         
-        response = self.module.autoscheduler_save(request, 'manage', 'one', 'two', 'module', 'extra', self.prog)
+        undecorated_save = AutoschedulerFrontendModule.autoscheduler_save.__wrapped__
+        response = undecorated_save(self.module, request, 'manage', 'one', 'two', 'module', 'extra', self.prog)
         
         self.assertIn('response', response)
         self.assertEqual(len(response['response']), 1)
@@ -61,6 +64,7 @@ class TestAutoschedulerFrontendModule(TestCase):
             'autoscheduler_data': json.dumps([{}, {}])
         })
         
-        response = self.module.autoscheduler_save(request, 'manage', 'one', 'two', 'module', 'extra', self.prog)
+        undecorated_save = AutoschedulerFrontendModule.autoscheduler_save.__wrapped__
+        response = undecorated_save(self.module, request, 'manage', 'one', 'two', 'module', 'extra', self.prog)
         
         self.assertEqual(response['response'][0]['error_msg'], "Graceful constraint failure")


### PR DESCRIPTION
## Description

This PR fulfills the acceptance criteria for missing unit tests on the `AutoSchedulerFrontendModule` UI-to-Backend glue layer. 

1. Defined [TestAutoschedulerFrontendModule](cci:2://file:///c:/Users/krama/OneDrive/Desktop/resume%20projects/Aman-Portfolio/ESP-Website/esp/esp/program/modules/tests/test_autoschedulerfrontendmodule.py:6:0-65:93) inside [esp/esp/program/modules/tests/test_autoschedulerfrontendmodule.py](cci:7://file:///c:/Users/krama/OneDrive/Desktop/resume%20projects/Aman-Portfolio/ESP-Website/esp/esp/program/modules/tests/test_autoschedulerfrontendmodule.py:0:0-0:0).
2. Built [test_autoscheduler_execute_parsing](cci:1://file:///c:/Users/krama/OneDrive/Desktop/resume%20projects/Aman-Portfolio/ESP-Website/esp/esp/program/modules/tests/test_autoschedulerfrontendmodule.py:12:4-40:43) using `unittest.mock` to verify that [autoscheduler_execute](cci:1://file:///c:/Users/krama/OneDrive/Desktop/resume%20projects/Aman-Portfolio/ESP-Website/esp/esp/program/modules/handlers/autoschedulerfrontendmodule.py:57:4-90:71) manually parses ambiguous strings (`"True"`, `"None"`, `"0.75"`) and successfully casts them before hitting the `AutoschedulerController`.
3. Created [test_autoscheduler_save_malformed_json](cci:1://file:///c:/Users/krama/OneDrive/Desktop/resume%20projects/Aman-Portfolio/ESP-Website/esp/esp/program/modules/tests/test_autoschedulerfrontendmodule.py:42:4-52:59). In order for this test to pass properly, I applied a `try/except (ValueError, TypeError)` wrapper around the fragile `json.loads` call in [autoscheduler_save](cci:1://file:///c:/Users/krama/OneDrive/Desktop/resume%20projects/Aman-Portfolio/ESP-Website/esp/esp/program/modules/handlers/autoschedulerfrontendmodule.py:92:4-111:49) to safely bounce corrupted frontend requests back without causing a fatal HTTP 500 error.
4. Created [test_autoscheduler_save_scheduling_error](cci:1://file:///c:/Users/krama/OneDrive/Desktop/resume%20projects/Aman-Portfolio/ESP-Website/esp/esp/program/modules/tests/test_autoschedulerfrontendmodule.py:54:4-65:93) to ensure gracefully mocked controller errors propagate to the response payload.

## Related Issue

Closes #5133

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [x] New tests added
- [x] Manually verified

## Checklist

- [x] Self-reviewed the code
- [x] No new warnings or errors introduced
