### PR TITLE
refactor: modernize survey fields class and remove legacy imports

### DIFF
--- a/esp/esp/survey/fields.py
+++ b/esp/esp/survey/fields.py
@@ -4,10 +4,10 @@ Kept separate from `esp.survey.models` to avoid importing heavy model modules
 from other apps at import time (which can create circular imports).
 """
 
-from __future__ import absolute_import
 
 
-class ListField(object):
+
+class ListField:
     """Create a list type field descriptor.
 
     Allows packing lists/tuples into a delimited string stored in another field.


### PR DESCRIPTION
Modernized the ListField class by removing redundant (object) inheritance and deleted the legacy absolute_import from __future__ to align with Python 3.10+ standards.

Related to #5354" (This links it to the same issue we created earlier so the maintainers know it's all part of your "Spring Cleaning" effort)

Closes #5354