### PR TITLE
docs: themes.rst contains placeholder URL and vague contact references

### DIFF
--- a/docs/admin/themes.rst
+++ b/docs/admin/themes.rst
@@ -11,7 +11,8 @@ To simplify front end design, there is now an app for configuring the front end
 (appearance and navigation) of your site.  Behind the scenes, the app is
 generating template overrides and CSS stylesheets based on your configuration.
 
-The themes app can be accessed at https://[yoursite].learningu.org/themes/.  There are 3 steps:
+The themes app can be accessed at ``/themes/`` on your site.
+There are 3 steps:
 
 * Select a theme (/themes/select/)
 


### PR DESCRIPTION
The file docs/admin/themes.rst has not been updated in 9 years and contains:

1. A placeholder URL: https://[yoursite].learningu.org/themes/ 
   which should be written as a relative path instead
2. Vague references to "contact web support" with no link or 
   contact information provided

Steps to Reproduce:
1. Go to docs/admin/themes.rst
2. Find the line mentioning https://[yoursite].learningu.org/themes/
3. Find the two mentions of "contact web support"

Expected Behavior:
Documentation should use relative paths and provide clear contact information.

Actual Behavior:
Documentation contains a placeholder URL and vague support references.


Closes #5383