### PR TITLE
Add tests for AdminMaterialsModule (upload, rename, delete)

### DIFF
--- a/esp/esp/program/modules/tests/__init__.py
+++ b/esp/esp/program/modules/tests/__init__.py
@@ -70,3 +70,4 @@ from esp.program.modules.tests.resolve_user import ResolveUserTest
 from esp.program.modules.tests.module_progress import RegistrationProgressTagTest, RequiredModuleProgressIntegrationTest
 from esp.program.modules.tests.test_enrolled_split import EnrolledSplitViewTest
 from esp.program.modules.tests.schedulingcheckmodule import SchedulingCheckModuleTest
+from esp.program.modules.tests.test_adminmaterials import AdminMaterialsModuleTest

--- a/esp/esp/program/modules/tests/test_adminmaterials.py
+++ b/esp/esp/program/modules/tests/test_adminmaterials.py
@@ -1,0 +1,149 @@
+__author__    = "Individual contributors (see AUTHORS file)"
+__date__      = "$DATE$"
+__rev__       = "$REV$"
+__license__   = "AGPL v.3"
+__copyright__ = """
+This file is part of the ESP Web Site
+Copyright (c) 2024 by the individual contributors
+  (see AUTHORS file)
+
+The ESP Web Site is free software; you can redistribute it and/or
+modify it under the terms of the GNU Affero General Public License
+as published by the Free Software Foundation; either version 3
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public
+License along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+"""
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from esp.program.modules.base import ProgramModule
+from esp.program.tests import ProgramFrameworkTest
+from esp.qsdmedia.models import Media
+
+
+def _make_uploaded_file(name='fixture.pdf'):
+    """Return a fresh SimpleUploadedFile suitable for Media.handle_file()."""
+    return SimpleUploadedFile(name, b'%PDF-1.4 content', content_type='application/pdf')
+
+
+def _create_media_with_file(friendly_name, filename='fixture.pdf'):
+    """Create and save a Media instance that has a real target_file attached.
+
+    Media.delete() calls get_uploaded_filename() -> target_file.url, which
+    raises ValueError when target_file is empty.  Using handle_file() here
+    mirrors what the production code does and avoids that error in tests.
+    """
+    media = Media(friendly_name=friendly_name)
+    media.handle_file(_make_uploaded_file(filename), filename)
+    media.format = ''
+    media.save()
+    return media
+
+
+class AdminMaterialsModuleTest(ProgramFrameworkTest):
+    """Unit tests for AdminMaterials.get_materials (add / rename / delete)."""
+
+    def setUp(self):
+        super().setUp(
+            modules=ProgramModule.objects.filter(handler='AdminMaterials'),
+        )
+        admin = self.admins[0]
+        self.assertTrue(
+            self.client.login(username=admin.username, password='password'),
+            'Could not log in as admin %s' % admin.username,
+        )
+        self.url = '/manage/%s/get_materials' % self.program.getUrlBase()
+
+    # ------------------------------------------------------------------
+    # Upload (command='add')
+    # ------------------------------------------------------------------
+
+    def test_upload_creates_media_with_class_prefix(self):
+        """Uploading a file for a class creates a Media object whose
+        file_name is prefixed with the class emailcode."""
+        cls = self.program.classes()[0]
+        uploaded = SimpleUploadedFile('notes.pdf', b'%PDF-1.4 content', content_type='application/pdf')
+
+        response = self.client.post(self.url, {
+            'command': 'add',
+            'title': 'Class Notes',
+            'target_obj': cls.id,
+            'uploadedfile': uploaded,
+        })
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Media.objects.count(), 1)
+
+        media = Media.objects.get()
+        self.assertEqual(media.friendly_name, 'Class Notes')
+        # file_name stores the desired_filename passed to handle_file
+        self.assertTrue(
+            media.file_name.startswith(cls.emailcode() + '_'),
+            'Expected file_name to start with "%s_", got "%s"' % (cls.emailcode(), media.file_name),
+        )
+
+    def test_upload_program_level_file_has_no_class_prefix(self):
+        """Uploading a program-level file (target_obj=0) does not prepend
+        any class emailcode to the stored file_name."""
+        uploaded = SimpleUploadedFile('waiver.pdf', b'%PDF-1.4 content', content_type='application/pdf')
+
+        response = self.client.post(self.url, {
+            'command': 'add',
+            'title': 'Liability Waiver',
+            'target_obj': 0,
+            'uploadedfile': uploaded,
+        })
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Media.objects.count(), 1)
+
+        media = Media.objects.get()
+        self.assertEqual(media.file_name, 'waiver.pdf')
+        self.assertEqual(media.owner, self.program)
+
+    # ------------------------------------------------------------------
+    # Rename (command='rename')
+    # ------------------------------------------------------------------
+
+    def test_rename_updates_friendly_name(self):
+        """POSTing command='rename' with a new title updates friendly_name."""
+        media = _create_media_with_file('old_name')
+
+        response = self.client.post(self.url, {
+            'command': 'rename',
+            'docid': media.id,
+            'title': 'new_name',
+        })
+
+        self.assertEqual(response.status_code, 200)
+        media.refresh_from_db()
+        self.assertEqual(media.friendly_name, 'new_name')
+
+    # ------------------------------------------------------------------
+    # Delete (command='delete')
+    # ------------------------------------------------------------------
+
+    def test_delete_removes_media_from_database(self):
+        """POSTing command='delete' removes the Media record.
+
+        The fixture must be created via handle_file() so that target_file
+        is populated; Media.delete() calls target_file.url internally and
+        raises ValueError when the field has no file associated with it.
+        """
+        media = _create_media_with_file('to_be_deleted')
+
+        response = self.client.post(self.url, {
+            'command': 'delete',
+            'docid': media.id,
+        })
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(Media.objects.filter(id=media.id).exists())

--- a/esp/public/media/default_styles/theme_compiled_test.css
+++ b/esp/public/media/default_styles/theme_compiled_test.css
@@ -75,10 +75,6 @@ a:focus {
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
 }
-a:hover,
-a:active {
-  outline: 0;
-}
 sub,
 sup {
   position: relative;
@@ -95,7 +91,7 @@ sub {
 img {
   /* Responsive images (ensure images don't scale beyond their parents) */
   max-width: 100%;
-  /* Part 1: Set a maximum relative to the parent */
+  /* Part 1: Set a maxium relative to the parent */
   width: auto\9;
   /* IE7-8 need help adjusting responsive images */
   height: auto;
@@ -982,7 +978,6 @@ input[type="tel"]:focus,
 input[type="color"]:focus,
 .uneditable-input:focus {
   border-color: rgba(82, 168, 236, 0.8);
-  outline: 0;
   outline: thin dotted \9;
   /* IE6-9 */
   -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(82,168,236,.6);
@@ -3212,10 +3207,6 @@ table th[class*="span"],
 .dropdown-toggle {
   *margin-bottom: -3px;
 }
-.dropdown-toggle:active,
-.open .dropdown-toggle {
-  outline: 0;
-}
 .caret {
   display: inline-block;
   width: 0;
@@ -3298,7 +3289,6 @@ table th[class*="span"],
 .dropdown-menu > .active > a:focus {
   color: #ffffff;
   text-decoration: none;
-  outline: 0;
   background-color: #0081c2;
   background-image: -moz-linear-gradient(top, #0088cc, #0077b3);
   background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#0088cc), to(#0077b3));
@@ -3512,9 +3502,10 @@ button.close {
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffffff', endColorstr='#ffe6e6e6', GradientType=0);
   border-color: #e6e6e6 #e6e6e6 #bfbfbf;
   border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
-  *background-color: #e6e6e6;
+  *background-color: #e6e6e6 !important;
   /* Darken IE7 buttons by default so they stand out more given they won't have borders */
   filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+  color: #0088cc !important;
   border: 1px solid #cccccc;
   *border: 0;
   border-bottom-color: #b3b3b3;
@@ -3533,12 +3524,12 @@ button.close {
 .btn.disabled,
 .btn[disabled] {
   color: #333333;
-  background-color: #e6e6e6;
-  *background-color: #d9d9d9;
+  background-color: #e6e6e6 !important;
+  *background-color: #d9d9d9 !important;
 }
 .btn:active,
 .btn.active {
-  background-color: #cccccc \9;
+  background-color: #cccccc \9 !important;
 }
 .btn:first-child {
   *margin-left: 0;
@@ -3562,7 +3553,6 @@ button.close {
 .btn.active,
 .btn:active {
   background-image: none;
-  outline: 0;
   -webkit-box-shadow: inset 0 2px 4px rgba(0,0,0,.15), 0 1px 2px rgba(0,0,0,.05);
   -moz-box-shadow: inset 0 2px 4px rgba(0,0,0,.15), 0 1px 2px rgba(0,0,0,.05);
   box-shadow: inset 0 2px 4px rgba(0,0,0,.15), 0 1px 2px rgba(0,0,0,.05);
@@ -3646,19 +3636,20 @@ input[type="button"].btn-block {
 .btn-primary {
   color: #ffffff;
   text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
-  background-color: #006dcc;
-  background-image: -moz-linear-gradient(top, #0088cc, #0044cc);
-  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#0088cc), to(#0044cc));
-  background-image: -webkit-linear-gradient(top, #0088cc, #0044cc);
-  background-image: -o-linear-gradient(top, #0088cc, #0044cc);
-  background-image: linear-gradient(to bottom, #0088cc, #0044cc);
+  background-color: #007ab8;
+  background-image: -moz-linear-gradient(top, #0088cc, #006699);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#0088cc), to(#006699));
+  background-image: -webkit-linear-gradient(top, #0088cc, #006699);
+  background-image: -o-linear-gradient(top, #0088cc, #006699);
+  background-image: linear-gradient(to bottom, #0088cc, #006699);
   background-repeat: repeat-x;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff0088cc', endColorstr='#ff0044cc', GradientType=0);
-  border-color: #0044cc #0044cc #002a80;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff0088cc', endColorstr='#ff006699', GradientType=0);
+  border-color: #006699 #006699 #00334d;
   border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
-  *background-color: #0044cc;
+  *background-color: #006699 !important;
   /* Darken IE7 buttons by default so they stand out more given they won't have borders */
   filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+  color: #ffffff !important;
 }
 .btn-primary:hover,
 .btn-primary:focus,
@@ -3667,12 +3658,12 @@ input[type="button"].btn-block {
 .btn-primary.disabled,
 .btn-primary[disabled] {
   color: #ffffff;
-  background-color: #0044cc;
-  *background-color: #003bb3;
+  background-color: #006699 !important;
+  *background-color: #005580 !important;
 }
 .btn-primary:active,
 .btn-primary.active {
-  background-color: #003399 \9;
+  background-color: #004466 \9 !important;
 }
 .btn-warning {
   color: #ffffff;
@@ -3687,9 +3678,10 @@ input[type="button"].btn-block {
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fffbb450', endColorstr='#fff89406', GradientType=0);
   border-color: #f89406 #f89406 #ad6704;
   border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
-  *background-color: #f89406;
+  *background-color: #f89406 !important;
   /* Darken IE7 buttons by default so they stand out more given they won't have borders */
   filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+  color: #ffffff !important;
 }
 .btn-warning:hover,
 .btn-warning:focus,
@@ -3698,12 +3690,12 @@ input[type="button"].btn-block {
 .btn-warning.disabled,
 .btn-warning[disabled] {
   color: #ffffff;
-  background-color: #f89406;
-  *background-color: #df8505;
+  background-color: #f89406 !important;
+  *background-color: #df8505 !important;
 }
 .btn-warning:active,
 .btn-warning.active {
-  background-color: #c67605 \9;
+  background-color: #c67605 \9 !important;
 }
 .btn-danger {
   color: #ffffff;
@@ -3718,9 +3710,10 @@ input[type="button"].btn-block {
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffee5f5b', endColorstr='#ffbd362f', GradientType=0);
   border-color: #bd362f #bd362f #802420;
   border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
-  *background-color: #bd362f;
+  *background-color: #bd362f !important;
   /* Darken IE7 buttons by default so they stand out more given they won't have borders */
   filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+  color: #ffffff !important;
 }
 .btn-danger:hover,
 .btn-danger:focus,
@@ -3729,12 +3722,12 @@ input[type="button"].btn-block {
 .btn-danger.disabled,
 .btn-danger[disabled] {
   color: #ffffff;
-  background-color: #bd362f;
-  *background-color: #a9302a;
+  background-color: #bd362f !important;
+  *background-color: #a9302a !important;
 }
 .btn-danger:active,
 .btn-danger.active {
-  background-color: #942a25 \9;
+  background-color: #942a25 \9 !important;
 }
 .btn-success {
   color: #ffffff;
@@ -3749,9 +3742,10 @@ input[type="button"].btn-block {
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff62c462', endColorstr='#ff51a351', GradientType=0);
   border-color: #51a351 #51a351 #387038;
   border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
-  *background-color: #51a351;
+  *background-color: #51a351 !important;
   /* Darken IE7 buttons by default so they stand out more given they won't have borders */
   filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+  color: #ffffff !important;
 }
 .btn-success:hover,
 .btn-success:focus,
@@ -3760,12 +3754,12 @@ input[type="button"].btn-block {
 .btn-success.disabled,
 .btn-success[disabled] {
   color: #ffffff;
-  background-color: #51a351;
-  *background-color: #499249;
+  background-color: #51a351 !important;
+  *background-color: #499249 !important;
 }
 .btn-success:active,
 .btn-success.active {
-  background-color: #408140 \9;
+  background-color: #408140 \9 !important;
 }
 .btn-info {
   color: #ffffff;
@@ -3780,9 +3774,10 @@ input[type="button"].btn-block {
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff5bc0de', endColorstr='#ff2f96b4', GradientType=0);
   border-color: #2f96b4 #2f96b4 #1f6377;
   border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
-  *background-color: #2f96b4;
+  *background-color: #2f96b4 !important;
   /* Darken IE7 buttons by default so they stand out more given they won't have borders */
   filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+  color: #ffffff !important;
 }
 .btn-info:hover,
 .btn-info:focus,
@@ -3791,29 +3786,30 @@ input[type="button"].btn-block {
 .btn-info.disabled,
 .btn-info[disabled] {
   color: #ffffff;
-  background-color: #2f96b4;
-  *background-color: #2a85a0;
+  background-color: #2f96b4 !important;
+  *background-color: #2a85a0 !important;
 }
 .btn-info:active,
 .btn-info.active {
-  background-color: #24748c \9;
+  background-color: #24748c \9 !important;
 }
 .btn-inverse {
   color: #ffffff;
   text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
-  background-color: #414141;
-  background-image: -moz-linear-gradient(top, #555555, #222222);
-  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#555555), to(#222222));
-  background-image: -webkit-linear-gradient(top, #555555, #222222);
-  background-image: -o-linear-gradient(top, #555555, #222222);
-  background-image: linear-gradient(to bottom, #555555, #222222);
+  background-color: #4b4b4b;
+  background-image: -moz-linear-gradient(top, #555555, #3b3b3b);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#555555), to(#3b3b3b));
+  background-image: -webkit-linear-gradient(top, #555555, #3b3b3b);
+  background-image: -o-linear-gradient(top, #555555, #3b3b3b);
+  background-image: linear-gradient(to bottom, #555555, #3b3b3b);
   background-repeat: repeat-x;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff555555', endColorstr='#ff222222', GradientType=0);
-  border-color: #222222 #222222 #000000;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff555555', endColorstr='#ff3b3b3b', GradientType=0);
+  border-color: #3b3b3b #3b3b3b #151515;
   border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
-  *background-color: #222222;
+  *background-color: #3b3b3b !important;
   /* Darken IE7 buttons by default so they stand out more given they won't have borders */
   filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+  color: #ffffff !important;
 }
 .btn-inverse:hover,
 .btn-inverse:focus,
@@ -3822,12 +3818,12 @@ input[type="button"].btn-block {
 .btn-inverse.disabled,
 .btn-inverse[disabled] {
   color: #ffffff;
-  background-color: #222222;
-  *background-color: #151515;
+  background-color: #3b3b3b !important;
+  *background-color: #2f2f2f !important;
 }
 .btn-inverse:active,
 .btn-inverse.active {
-  background-color: #080808 \9;
+  background-color: #222222 \9 !important;
 }
 .btn-approve {
   color: #333333;
@@ -3842,9 +3838,10 @@ input[type="button"].btn-block {
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffdef7c6', endColorstr='#ffb7ee83', GradientType=0);
   border-color: #b7ee83 #b7ee83 #90e440;
   border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
-  *background-color: #b7ee83;
+  *background-color: #b7ee83 !important;
   /* Darken IE7 buttons by default so they stand out more given they won't have borders */
   filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+  color: #ffffff !important;
 }
 .btn-approve:hover,
 .btn-approve:focus,
@@ -3853,12 +3850,12 @@ input[type="button"].btn-block {
 .btn-approve.disabled,
 .btn-approve[disabled] {
   color: #333333;
-  background-color: #b7ee83;
-  *background-color: #aaea6d;
+  background-color: #b7ee83 !important;
+  *background-color: #aaea6d !important;
 }
 .btn-approve:active,
 .btn-approve.active {
-  background-color: #9de756 \9;
+  background-color: #9de756 \9 !important;
 }
 .btn-unreview {
   color: #333333;
@@ -3873,9 +3870,10 @@ input[type="button"].btn-block {
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffeccc', endColorstr='#ffffd080', GradientType=0);
   border-color: #ffd080 #ffd080 #ffb333;
   border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
-  *background-color: #ffd080;
+  *background-color: #ffd080 !important;
   /* Darken IE7 buttons by default so they stand out more given they won't have borders */
   filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+  color: #ffffff !important;
 }
 .btn-unreview:hover,
 .btn-unreview:focus,
@@ -3884,12 +3882,12 @@ input[type="button"].btn-block {
 .btn-unreview.disabled,
 .btn-unreview[disabled] {
   color: #333333;
-  background-color: #ffd080;
-  *background-color: #ffc666;
+  background-color: #ffd080 !important;
+  *background-color: #ffc666 !important;
 }
 .btn-unreview:active,
 .btn-unreview.active {
-  background-color: #ffbd4d \9;
+  background-color: #ffbd4d \9 !important;
 }
 .btn-reject {
   color: #333333;
@@ -3904,9 +3902,10 @@ input[type="button"].btn-block {
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffeeee', endColorstr='#ffffa2a2', GradientType=0);
   border-color: #ffa2a2 #ffa2a2 #ff5555;
   border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
-  *background-color: #ffa2a2;
+  *background-color: #ffa2a2 !important;
   /* Darken IE7 buttons by default so they stand out more given they won't have borders */
   filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+  color: #ffffff !important;
 }
 .btn-reject:hover,
 .btn-reject:focus,
@@ -3915,12 +3914,12 @@ input[type="button"].btn-block {
 .btn-reject.disabled,
 .btn-reject[disabled] {
   color: #333333;
-  background-color: #ffa2a2;
-  *background-color: #ff8888;
+  background-color: #ffa2a2 !important;
+  *background-color: #ff8888 !important;
 }
 .btn-reject:active,
 .btn-reject.active {
-  background-color: #ff6f6f \9;
+  background-color: #ff6f6f \9 !important;
 }
 button.btn,
 input[type="submit"].btn {
@@ -4070,10 +4069,6 @@ input[type="submit"].btn.btn-mini {
 .btn-group > .btn.active {
   z-index: 2;
 }
-.btn-group .dropdown-toggle:active,
-.btn-group.open .dropdown-toggle {
-  outline: 0;
-}
 .btn-group > .btn + .dropdown-toggle {
   padding-left: 8px;
   padding-right: 8px;
@@ -4109,7 +4104,7 @@ input[type="submit"].btn.btn-mini {
   background-color: #e6e6e6;
 }
 .btn-group.open .btn-primary.dropdown-toggle {
-  background-color: #0044cc;
+  background-color: #006699;
 }
 .btn-group.open .btn-warning.dropdown-toggle {
   background-color: #f89406;
@@ -4124,7 +4119,7 @@ input[type="submit"].btn.btn-mini {
   background-color: #2f96b4;
 }
 .btn-group.open .btn-inverse.dropdown-toggle {
-  background-color: #222222;
+  background-color: #3b3b3b;
 }
 .btn .caret {
   margin-top: 8px;
@@ -4646,7 +4641,7 @@ input[type="submit"].btn.btn-mini {
   display: block;
   padding: 10px 20px 10px;
   margin-left: -20px;
-  font-size: 20px;
+  font-size: 24px;
   font-weight: 200;
   color: #999999;
   text-shadow: 0 1px 0 #333333;
@@ -4852,7 +4847,7 @@ input[type="submit"].btn.btn-mini {
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff262626', endColorstr='#ff151515', GradientType=0);
   border-color: #151515 #151515 #000000;
   border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
-  *background-color: #151515;
+  *background-color: #151515 !important;
   /* Darken IE7 buttons by default so they stand out more given they won't have borders */
   filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
   -webkit-box-shadow: inset 0 1px 0 rgba(255,255,255,.1), 0 1px 0 rgba(255,255,255,.075);
@@ -4866,12 +4861,12 @@ input[type="submit"].btn.btn-mini {
 .navbar .btn-navbar.disabled,
 .navbar .btn-navbar[disabled] {
   color: #ffffff;
-  background-color: #151515;
-  *background-color: #080808;
+  background-color: #151515 !important;
+  *background-color: #080808 !important;
 }
 .navbar .btn-navbar:active,
 .navbar .btn-navbar.active {
-  background-color: #000000 \9;
+  background-color: #000000 \9 !important;
 }
 .navbar .btn-navbar .icon-bar {
   display: block;
@@ -4979,19 +4974,18 @@ input[type="submit"].btn.btn-mini {
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff222222', endColorstr='#ff111111', GradientType=0);
   border-color: #252525;
 }
-.navbar-inverse .brand,
-.navbar-inverse .nav > li > a {
-  color: #999999;
-  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
-}
-.navbar-inverse .brand:hover,
-.navbar-inverse .nav > li > a:hover,
-.navbar-inverse .brand:focus,
-.navbar-inverse .nav > li > a:focus {
-  color: #ffffff;
-}
 .navbar-inverse .brand {
   color: #999999;
+}
+.navbar-inverse .nav > li > a {
+  color: #999999;
+}
+.navbar-inverse .nav > li > a {
+  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
+}
+.navbar-inverse .nav > li > a:hover,
+.navbar-inverse .nav > li > a:focus {
+  color: #ffffff;
 }
 .navbar-inverse .navbar-text {
   color: #999999;
@@ -5070,7 +5064,6 @@ input[type="submit"].btn.btn-mini {
   -webkit-box-shadow: 0 0 3px rgba(0, 0, 0, 0.15);
   -moz-box-shadow: 0 0 3px rgba(0, 0, 0, 0.15);
   box-shadow: 0 0 3px rgba(0, 0, 0, 0.15);
-  outline: 0;
 }
 .navbar-inverse .btn-navbar {
   color: #ffffff;
@@ -5085,7 +5078,7 @@ input[type="submit"].btn.btn-mini {
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff151515', endColorstr='#ff040404', GradientType=0);
   border-color: #040404 #040404 #000000;
   border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
-  *background-color: #040404;
+  *background-color: #040404 !important;
   /* Darken IE7 buttons by default so they stand out more given they won't have borders */
   filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
 }
@@ -5096,12 +5089,12 @@ input[type="submit"].btn.btn-mini {
 .navbar-inverse .btn-navbar.disabled,
 .navbar-inverse .btn-navbar[disabled] {
   color: #ffffff;
-  background-color: #040404;
-  *background-color: #000000;
+  background-color: #040404 !important;
+  *background-color: #000000 !important;
 }
 .navbar-inverse .btn-navbar:active,
 .navbar-inverse .btn-navbar.active {
-  background-color: #000000 \9;
+  background-color: #000000 \9 !important;
 }
 .breadcrumb {
   padding: 8px 15px;
@@ -5342,7 +5335,6 @@ input[type="submit"].btn.btn-mini {
   -webkit-background-clip: padding-box;
   -moz-background-clip: padding-box;
   background-clip: padding-box;
-  outline: none;
 }
 .modal.fade {
   -webkit-transition: opacity .3s linear, top .3s ease-out;
@@ -6176,6 +6168,1069 @@ a.badge:focus {
   color: #ffffff;
   background-color: #0077aa;
 }
+/*!
+ * Bootstrap Responsive v2.3.2
+ *
+ * Copyright 2013 Twitter, Inc
+ * Licensed under the Apache License v2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Designed and built with all the love in the world by @mdo and @fat.
+ */
+@-ms-viewport {
+  width: device-width;
+}
+.hidden {
+  display: none !important;
+  visibility: hidden !important;
+}
+.visible-phone {
+  display: none !important;
+}
+.visible-tablet {
+  display: none !important;
+}
+.hidden-desktop {
+  display: none !important;
+}
+.visible-desktop {
+  display: inherit !important;
+}
+@media (min-width: 768px) and (max-width: 979px) {
+  .hidden-desktop {
+    display: inherit !important;
+  }
+  .visible-desktop {
+    display: none !important ;
+  }
+  .visible-tablet {
+    display: inherit !important;
+  }
+  .hidden-tablet {
+    display: none !important;
+  }
+}
+@media (max-width: 767px) {
+  .hidden-desktop {
+    display: inherit !important;
+  }
+  .visible-desktop {
+    display: none !important;
+  }
+  .visible-phone {
+    display: inherit !important;
+  }
+  .hidden-phone {
+    display: none !important;
+  }
+}
+.visible-print {
+  display: none !important;
+}
+@media print {
+  .visible-print {
+    display: inherit !important;
+  }
+  .hidden-print {
+    display: none !important;
+  }
+}
+@media (min-width: 1200px) {
+  .row {
+    margin-left: -30px;
+    *zoom: 1;
+  }
+  .row:before,
+  .row:after {
+    display: table;
+    content: "";
+    line-height: 0;
+  }
+  .row:after {
+    clear: both;
+  }
+  [class*="span"] {
+    float: left;
+    min-height: 1px;
+    margin-left: 30px;
+  }
+  .container,
+  .navbar-static-top .container,
+  .navbar-fixed-top .container,
+  .navbar-fixed-bottom .container {
+    width: 1170px;
+  }
+  .span12 {
+    width: 1170px;
+  }
+  .span11 {
+    width: 1070px;
+  }
+  .span10 {
+    width: 970px;
+  }
+  .span9 {
+    width: 870px;
+  }
+  .span8 {
+    width: 770px;
+  }
+  .span7 {
+    width: 670px;
+  }
+  .span6 {
+    width: 570px;
+  }
+  .span5 {
+    width: 470px;
+  }
+  .span4 {
+    width: 370px;
+  }
+  .span3 {
+    width: 270px;
+  }
+  .span2 {
+    width: 170px;
+  }
+  .span1 {
+    width: 70px;
+  }
+  .offset12 {
+    margin-left: 1230px;
+  }
+  .offset11 {
+    margin-left: 1130px;
+  }
+  .offset10 {
+    margin-left: 1030px;
+  }
+  .offset9 {
+    margin-left: 930px;
+  }
+  .offset8 {
+    margin-left: 830px;
+  }
+  .offset7 {
+    margin-left: 730px;
+  }
+  .offset6 {
+    margin-left: 630px;
+  }
+  .offset5 {
+    margin-left: 530px;
+  }
+  .offset4 {
+    margin-left: 430px;
+  }
+  .offset3 {
+    margin-left: 330px;
+  }
+  .offset2 {
+    margin-left: 230px;
+  }
+  .offset1 {
+    margin-left: 130px;
+  }
+  .row-fluid {
+    width: 100%;
+    *zoom: 1;
+  }
+  .row-fluid:before,
+  .row-fluid:after {
+    display: table;
+    content: "";
+    line-height: 0;
+  }
+  .row-fluid:after {
+    clear: both;
+  }
+  .row-fluid [class*="span"] {
+    display: block;
+    width: 100%;
+    min-height: 30px;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+    float: left;
+    margin-left: 2.56410256%;
+    *margin-left: 2.51091107%;
+  }
+  .row-fluid [class*="span"]:first-child {
+    margin-left: 0;
+  }
+  .row-fluid .controls-row [class*="span"] + [class*="span"] {
+    margin-left: 2.56410256%;
+  }
+  .row-fluid .span12 {
+    width: 100%;
+    *width: 99.94680851%;
+  }
+  .row-fluid .span11 {
+    width: 91.45299145%;
+    *width: 91.39979996%;
+  }
+  .row-fluid .span10 {
+    width: 82.90598291%;
+    *width: 82.85279142%;
+  }
+  .row-fluid .span9 {
+    width: 74.35897436%;
+    *width: 74.30578287%;
+  }
+  .row-fluid .span8 {
+    width: 65.81196581%;
+    *width: 65.75877432%;
+  }
+  .row-fluid .span7 {
+    width: 57.26495726%;
+    *width: 57.21176578%;
+  }
+  .row-fluid .span6 {
+    width: 48.71794872%;
+    *width: 48.66475723%;
+  }
+  .row-fluid .span5 {
+    width: 40.17094017%;
+    *width: 40.11774868%;
+  }
+  .row-fluid .span4 {
+    width: 31.62393162%;
+    *width: 31.57074013%;
+  }
+  .row-fluid .span3 {
+    width: 23.07692308%;
+    *width: 23.02373159%;
+  }
+  .row-fluid .span2 {
+    width: 14.52991453%;
+    *width: 14.47672304%;
+  }
+  .row-fluid .span1 {
+    width: 5.98290598%;
+    *width: 5.92971449%;
+  }
+  .row-fluid .offset12 {
+    margin-left: 105.12820513%;
+    *margin-left: 105.02182215%;
+  }
+  .row-fluid .offset12:first-child {
+    margin-left: 102.56410256%;
+    *margin-left: 102.45771959%;
+  }
+  .row-fluid .offset11 {
+    margin-left: 96.58119658%;
+    *margin-left: 96.4748136%;
+  }
+  .row-fluid .offset11:first-child {
+    margin-left: 94.01709402%;
+    *margin-left: 93.91071104%;
+  }
+  .row-fluid .offset10 {
+    margin-left: 88.03418803%;
+    *margin-left: 87.92780506%;
+  }
+  .row-fluid .offset10:first-child {
+    margin-left: 85.47008547%;
+    *margin-left: 85.36370249%;
+  }
+  .row-fluid .offset9 {
+    margin-left: 79.48717949%;
+    *margin-left: 79.38079651%;
+  }
+  .row-fluid .offset9:first-child {
+    margin-left: 76.92307692%;
+    *margin-left: 76.81669394%;
+  }
+  .row-fluid .offset8 {
+    margin-left: 70.94017094%;
+    *margin-left: 70.83378796%;
+  }
+  .row-fluid .offset8:first-child {
+    margin-left: 68.37606838%;
+    *margin-left: 68.2696854%;
+  }
+  .row-fluid .offset7 {
+    margin-left: 62.39316239%;
+    *margin-left: 62.28677941%;
+  }
+  .row-fluid .offset7:first-child {
+    margin-left: 59.82905983%;
+    *margin-left: 59.72267685%;
+  }
+  .row-fluid .offset6 {
+    margin-left: 53.84615385%;
+    *margin-left: 53.73977087%;
+  }
+  .row-fluid .offset6:first-child {
+    margin-left: 51.28205128%;
+    *margin-left: 51.1756683%;
+  }
+  .row-fluid .offset5 {
+    margin-left: 45.2991453%;
+    *margin-left: 45.19276232%;
+  }
+  .row-fluid .offset5:first-child {
+    margin-left: 42.73504274%;
+    *margin-left: 42.62865976%;
+  }
+  .row-fluid .offset4 {
+    margin-left: 36.75213675%;
+    *margin-left: 36.64575377%;
+  }
+  .row-fluid .offset4:first-child {
+    margin-left: 34.18803419%;
+    *margin-left: 34.08165121%;
+  }
+  .row-fluid .offset3 {
+    margin-left: 28.20512821%;
+    *margin-left: 28.09874523%;
+  }
+  .row-fluid .offset3:first-child {
+    margin-left: 25.64102564%;
+    *margin-left: 25.53464266%;
+  }
+  .row-fluid .offset2 {
+    margin-left: 19.65811966%;
+    *margin-left: 19.55173668%;
+  }
+  .row-fluid .offset2:first-child {
+    margin-left: 17.09401709%;
+    *margin-left: 16.98763412%;
+  }
+  .row-fluid .offset1 {
+    margin-left: 11.11111111%;
+    *margin-left: 11.00472813%;
+  }
+  .row-fluid .offset1:first-child {
+    margin-left: 8.54700855%;
+    *margin-left: 8.44062557%;
+  }
+  input,
+  textarea,
+  .uneditable-input {
+    margin-left: 0;
+  }
+  .controls-row [class*="span"] + [class*="span"] {
+    margin-left: 30px;
+  }
+  input.span12,
+  textarea.span12,
+  .uneditable-input.span12 {
+    width: 1156px;
+  }
+  input.span11,
+  textarea.span11,
+  .uneditable-input.span11 {
+    width: 1056px;
+  }
+  input.span10,
+  textarea.span10,
+  .uneditable-input.span10 {
+    width: 956px;
+  }
+  input.span9,
+  textarea.span9,
+  .uneditable-input.span9 {
+    width: 856px;
+  }
+  input.span8,
+  textarea.span8,
+  .uneditable-input.span8 {
+    width: 756px;
+  }
+  input.span7,
+  textarea.span7,
+  .uneditable-input.span7 {
+    width: 656px;
+  }
+  input.span6,
+  textarea.span6,
+  .uneditable-input.span6 {
+    width: 556px;
+  }
+  input.span5,
+  textarea.span5,
+  .uneditable-input.span5 {
+    width: 456px;
+  }
+  input.span4,
+  textarea.span4,
+  .uneditable-input.span4 {
+    width: 356px;
+  }
+  input.span3,
+  textarea.span3,
+  .uneditable-input.span3 {
+    width: 256px;
+  }
+  input.span2,
+  textarea.span2,
+  .uneditable-input.span2 {
+    width: 156px;
+  }
+  input.span1,
+  textarea.span1,
+  .uneditable-input.span1 {
+    width: 56px;
+  }
+  .thumbnails {
+    margin-left: -30px;
+  }
+  .thumbnails > li {
+    margin-left: 30px;
+  }
+  .row-fluid .thumbnails {
+    margin-left: 0;
+  }
+}
+@media (min-width: 768px) and (max-width: 979px) {
+  .row {
+    margin-left: -20px;
+    *zoom: 1;
+  }
+  .row:before,
+  .row:after {
+    display: table;
+    content: "";
+    line-height: 0;
+  }
+  .row:after {
+    clear: both;
+  }
+  [class*="span"] {
+    float: left;
+    min-height: 1px;
+    margin-left: 20px;
+  }
+  .container,
+  .navbar-static-top .container,
+  .navbar-fixed-top .container,
+  .navbar-fixed-bottom .container {
+    width: 724px;
+  }
+  .span12 {
+    width: 724px;
+  }
+  .span11 {
+    width: 662px;
+  }
+  .span10 {
+    width: 600px;
+  }
+  .span9 {
+    width: 538px;
+  }
+  .span8 {
+    width: 476px;
+  }
+  .span7 {
+    width: 414px;
+  }
+  .span6 {
+    width: 352px;
+  }
+  .span5 {
+    width: 290px;
+  }
+  .span4 {
+    width: 228px;
+  }
+  .span3 {
+    width: 166px;
+  }
+  .span2 {
+    width: 104px;
+  }
+  .span1 {
+    width: 42px;
+  }
+  .offset12 {
+    margin-left: 764px;
+  }
+  .offset11 {
+    margin-left: 702px;
+  }
+  .offset10 {
+    margin-left: 640px;
+  }
+  .offset9 {
+    margin-left: 578px;
+  }
+  .offset8 {
+    margin-left: 516px;
+  }
+  .offset7 {
+    margin-left: 454px;
+  }
+  .offset6 {
+    margin-left: 392px;
+  }
+  .offset5 {
+    margin-left: 330px;
+  }
+  .offset4 {
+    margin-left: 268px;
+  }
+  .offset3 {
+    margin-left: 206px;
+  }
+  .offset2 {
+    margin-left: 144px;
+  }
+  .offset1 {
+    margin-left: 82px;
+  }
+  .row-fluid {
+    width: 100%;
+    *zoom: 1;
+  }
+  .row-fluid:before,
+  .row-fluid:after {
+    display: table;
+    content: "";
+    line-height: 0;
+  }
+  .row-fluid:after {
+    clear: both;
+  }
+  .row-fluid [class*="span"] {
+    display: block;
+    width: 100%;
+    min-height: 30px;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+    float: left;
+    margin-left: 2.76243094%;
+    *margin-left: 2.70923945%;
+  }
+  .row-fluid [class*="span"]:first-child {
+    margin-left: 0;
+  }
+  .row-fluid .controls-row [class*="span"] + [class*="span"] {
+    margin-left: 2.76243094%;
+  }
+  .row-fluid .span12 {
+    width: 100%;
+    *width: 99.94680851%;
+  }
+  .row-fluid .span11 {
+    width: 91.43646409%;
+    *width: 91.3832726%;
+  }
+  .row-fluid .span10 {
+    width: 82.87292818%;
+    *width: 82.81973669%;
+  }
+  .row-fluid .span9 {
+    width: 74.30939227%;
+    *width: 74.25620078%;
+  }
+  .row-fluid .span8 {
+    width: 65.74585635%;
+    *width: 65.69266486%;
+  }
+  .row-fluid .span7 {
+    width: 57.18232044%;
+    *width: 57.12912895%;
+  }
+  .row-fluid .span6 {
+    width: 48.61878453%;
+    *width: 48.56559304%;
+  }
+  .row-fluid .span5 {
+    width: 40.05524862%;
+    *width: 40.00205713%;
+  }
+  .row-fluid .span4 {
+    width: 31.49171271%;
+    *width: 31.43852122%;
+  }
+  .row-fluid .span3 {
+    width: 22.9281768%;
+    *width: 22.87498531%;
+  }
+  .row-fluid .span2 {
+    width: 14.36464088%;
+    *width: 14.31144939%;
+  }
+  .row-fluid .span1 {
+    width: 5.80110497%;
+    *width: 5.74791348%;
+  }
+  .row-fluid .offset12 {
+    margin-left: 105.52486188%;
+    *margin-left: 105.4184789%;
+  }
+  .row-fluid .offset12:first-child {
+    margin-left: 102.76243094%;
+    *margin-left: 102.65604796%;
+  }
+  .row-fluid .offset11 {
+    margin-left: 96.96132597%;
+    *margin-left: 96.85494299%;
+  }
+  .row-fluid .offset11:first-child {
+    margin-left: 94.19889503%;
+    *margin-left: 94.09251205%;
+  }
+  .row-fluid .offset10 {
+    margin-left: 88.39779006%;
+    *margin-left: 88.29140708%;
+  }
+  .row-fluid .offset10:first-child {
+    margin-left: 85.63535912%;
+    *margin-left: 85.52897614%;
+  }
+  .row-fluid .offset9 {
+    margin-left: 79.83425414%;
+    *margin-left: 79.72787116%;
+  }
+  .row-fluid .offset9:first-child {
+    margin-left: 77.0718232%;
+    *margin-left: 76.96544023%;
+  }
+  .row-fluid .offset8 {
+    margin-left: 71.27071823%;
+    *margin-left: 71.16433525%;
+  }
+  .row-fluid .offset8:first-child {
+    margin-left: 68.50828729%;
+    *margin-left: 68.40190431%;
+  }
+  .row-fluid .offset7 {
+    margin-left: 62.70718232%;
+    *margin-left: 62.60079934%;
+  }
+  .row-fluid .offset7:first-child {
+    margin-left: 59.94475138%;
+    *margin-left: 59.8383684%;
+  }
+  .row-fluid .offset6 {
+    margin-left: 54.14364641%;
+    *margin-left: 54.03726343%;
+  }
+  .row-fluid .offset6:first-child {
+    margin-left: 51.38121547%;
+    *margin-left: 51.27483249%;
+  }
+  .row-fluid .offset5 {
+    margin-left: 45.5801105%;
+    *margin-left: 45.47372752%;
+  }
+  .row-fluid .offset5:first-child {
+    margin-left: 42.81767956%;
+    *margin-left: 42.71129658%;
+  }
+  .row-fluid .offset4 {
+    margin-left: 37.01657459%;
+    *margin-left: 36.91019161%;
+  }
+  .row-fluid .offset4:first-child {
+    margin-left: 34.25414365%;
+    *margin-left: 34.14776067%;
+  }
+  .row-fluid .offset3 {
+    margin-left: 28.45303867%;
+    *margin-left: 28.3466557%;
+  }
+  .row-fluid .offset3:first-child {
+    margin-left: 25.69060773%;
+    *margin-left: 25.58422476%;
+  }
+  .row-fluid .offset2 {
+    margin-left: 19.88950276%;
+    *margin-left: 19.78311978%;
+  }
+  .row-fluid .offset2:first-child {
+    margin-left: 17.12707182%;
+    *margin-left: 17.02068884%;
+  }
+  .row-fluid .offset1 {
+    margin-left: 11.32596685%;
+    *margin-left: 11.21958387%;
+  }
+  .row-fluid .offset1:first-child {
+    margin-left: 8.56353591%;
+    *margin-left: 8.45715293%;
+  }
+  input,
+  textarea,
+  .uneditable-input {
+    margin-left: 0;
+  }
+  .controls-row [class*="span"] + [class*="span"] {
+    margin-left: 20px;
+  }
+  input.span12,
+  textarea.span12,
+  .uneditable-input.span12 {
+    width: 710px;
+  }
+  input.span11,
+  textarea.span11,
+  .uneditable-input.span11 {
+    width: 648px;
+  }
+  input.span10,
+  textarea.span10,
+  .uneditable-input.span10 {
+    width: 586px;
+  }
+  input.span9,
+  textarea.span9,
+  .uneditable-input.span9 {
+    width: 524px;
+  }
+  input.span8,
+  textarea.span8,
+  .uneditable-input.span8 {
+    width: 462px;
+  }
+  input.span7,
+  textarea.span7,
+  .uneditable-input.span7 {
+    width: 400px;
+  }
+  input.span6,
+  textarea.span6,
+  .uneditable-input.span6 {
+    width: 338px;
+  }
+  input.span5,
+  textarea.span5,
+  .uneditable-input.span5 {
+    width: 276px;
+  }
+  input.span4,
+  textarea.span4,
+  .uneditable-input.span4 {
+    width: 214px;
+  }
+  input.span3,
+  textarea.span3,
+  .uneditable-input.span3 {
+    width: 152px;
+  }
+  input.span2,
+  textarea.span2,
+  .uneditable-input.span2 {
+    width: 90px;
+  }
+  input.span1,
+  textarea.span1,
+  .uneditable-input.span1 {
+    width: 28px;
+  }
+}
+@media (max-width: 767px) {
+  body {
+    padding-left: 20px;
+    padding-right: 20px;
+  }
+  .navbar-fixed-top,
+  .navbar-fixed-bottom,
+  .navbar-static-top {
+    margin-left: -20px;
+    margin-right: -20px;
+  }
+  .container-fluid {
+    padding: 0;
+  }
+  .dl-horizontal dt {
+    float: none;
+    clear: none;
+    width: auto;
+    text-align: left;
+  }
+  .dl-horizontal dd {
+    margin-left: 0;
+  }
+  .container {
+    width: auto;
+  }
+  .row-fluid {
+    width: 100%;
+  }
+  .row,
+  .thumbnails {
+    margin-left: 0;
+  }
+  .thumbnails > li {
+    float: none;
+    margin-left: 0;
+  }
+  [class*="span"],
+  .uneditable-input[class*="span"],
+  .row-fluid [class*="span"] {
+    float: none;
+    display: block;
+    width: 100%;
+    margin-left: 0;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+  }
+  .span12,
+  .row-fluid .span12 {
+    width: 100%;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+  }
+  .row-fluid [class*="offset"]:first-child {
+    margin-left: 0;
+  }
+  .input-large,
+  .input-xlarge,
+  .input-xxlarge,
+  input[class*="span"],
+  select[class*="span"],
+  textarea[class*="span"],
+  .uneditable-input {
+    display: block;
+    width: 100%;
+    min-height: 30px;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+  }
+  .input-prepend input,
+  .input-append input,
+  .input-prepend input[class*="span"],
+  .input-append input[class*="span"] {
+    display: inline-block;
+    width: auto;
+  }
+  .controls-row [class*="span"] + [class*="span"] {
+    margin-left: 0;
+  }
+  .modal {
+    position: fixed;
+    top: 20px;
+    left: 20px;
+    right: 20px;
+    width: auto;
+    margin: 0;
+  }
+  .modal.fade {
+    top: -100px;
+  }
+  .modal.fade.in {
+    top: 20px;
+  }
+}
+@media (max-width: 480px) {
+  .nav-collapse {
+    -webkit-transform: translate3d(0, 0, 0);
+  }
+  .page-header h1 small {
+    display: block;
+    line-height: 20px;
+  }
+  input[type="checkbox"],
+  input[type="radio"] {
+    border: 1px solid #ccc;
+  }
+  .form-horizontal .control-label {
+    float: none;
+    width: auto;
+    padding-top: 0;
+    text-align: left;
+  }
+  .form-horizontal .controls {
+    margin-left: 0;
+  }
+  .form-horizontal .control-list {
+    padding-top: 0;
+  }
+  .form-horizontal .form-actions {
+    padding-left: 10px;
+    padding-right: 10px;
+  }
+  .media .pull-left,
+  .media .pull-right {
+    float: none;
+    display: block;
+    margin-bottom: 10px;
+  }
+  .media-object {
+    margin-right: 0;
+    margin-left: 0;
+  }
+  .modal {
+    top: 10px;
+    left: 10px;
+    right: 10px;
+  }
+  .modal-header .close {
+    padding: 10px;
+    margin: -10px;
+  }
+  .carousel-caption {
+    position: static;
+  }
+}
+@media (max-width: 979px) {
+  body {
+    padding-top: 0;
+  }
+  .navbar-fixed-top,
+  .navbar-fixed-bottom {
+    position: static;
+  }
+  .navbar-fixed-top {
+    margin-bottom: 20px;
+  }
+  .navbar-fixed-bottom {
+    margin-top: 20px;
+  }
+  .navbar-fixed-top .navbar-inner,
+  .navbar-fixed-bottom .navbar-inner {
+    padding: 5px;
+  }
+  .navbar .container {
+    width: auto;
+    padding: 0;
+  }
+  .navbar .brand {
+    padding-left: 10px;
+    padding-right: 10px;
+    margin: 0 0 0 -5px;
+  }
+  .nav-collapse {
+    clear: both;
+  }
+  .nav-collapse .nav {
+    float: none;
+    margin: 0 0 10px;
+  }
+  .nav-collapse .nav > li {
+    float: none;
+  }
+  .nav-collapse .nav > li > a {
+    margin-bottom: 2px;
+  }
+  .nav-collapse .nav > .divider-vertical {
+    display: none;
+  }
+  .nav-collapse .nav .nav-header {
+    color: #999999;
+    text-shadow: none;
+  }
+  .nav-collapse .nav > li > a,
+  .nav-collapse .dropdown-menu a,
+  .nav-collapse .dropdown-menu div {
+    padding: 9px 15px;
+    font-weight: bold;
+    color: #999999;
+    -webkit-border-radius: 3px;
+    -moz-border-radius: 3px;
+    border-radius: 3px;
+  }
+  .nav-collapse .btn {
+    padding: 4px 10px 4px;
+    font-weight: normal;
+    -webkit-border-radius: 4px;
+    -moz-border-radius: 4px;
+    border-radius: 4px;
+  }
+  .nav-collapse .dropdown-menu li + li a {
+    margin-bottom: 2px;
+  }
+  .nav-collapse .nav > li > a:hover,
+  .nav-collapse .nav > li > a:focus,
+  .nav-collapse .dropdown-menu a:hover,
+  .nav-collapse .dropdown-menu a:focus {
+    background-color: #222222;
+  }
+  .navbar-inverse .nav-collapse .nav > li > a,
+  .navbar-inverse .nav-collapse .dropdown-menu a,
+  .navbar-inverse .nav-collapse .dropdown-menu div {
+    color: #999999;
+  }
+  .navbar-inverse .nav-collapse .nav > li > a:hover,
+  .navbar-inverse .nav-collapse .nav > li > a:focus,
+  .navbar-inverse .nav-collapse .dropdown-menu a:hover,
+  .navbar-inverse .nav-collapse .dropdown-menu a:focus {
+    background-color: #111111;
+  }
+  .nav-collapse.in .btn-group {
+    margin-top: 5px;
+    padding: 0;
+  }
+  .nav-collapse .dropdown-menu {
+    position: static;
+    top: auto;
+    left: auto;
+    float: none;
+    display: none;
+    max-width: none;
+    margin: 0 15px;
+    padding: 0;
+    background-color: transparent;
+    border: none;
+    -webkit-border-radius: 0;
+    -moz-border-radius: 0;
+    border-radius: 0;
+    -webkit-box-shadow: none;
+    -moz-box-shadow: none;
+    box-shadow: none;
+  }
+  .nav-collapse .open > .dropdown-menu {
+    display: block;
+  }
+  .nav-collapse .dropdown-menu:before,
+  .nav-collapse .dropdown-menu:after {
+    display: none;
+  }
+  .nav-collapse .dropdown-menu .divider {
+    display: none;
+  }
+  .nav-collapse .nav > li > .dropdown-menu:before,
+  .nav-collapse .nav > li > .dropdown-menu:after {
+    display: none;
+  }
+  .nav-collapse .navbar-form,
+  .nav-collapse .navbar-search {
+    float: none;
+    padding: 10px 15px;
+    margin: 10px 0;
+    border-top: 1px solid #222222;
+    border-bottom: 1px solid #222222;
+    -webkit-box-shadow: inset 0 1px 0 rgba(255,255,255,.1), 0 1px 0 rgba(255,255,255,.1);
+    -moz-box-shadow: inset 0 1px 0 rgba(255,255,255,.1), 0 1px 0 rgba(255,255,255,.1);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,.1), 0 1px 0 rgba(255,255,255,.1);
+  }
+  .navbar-inverse .nav-collapse .navbar-form,
+  .navbar-inverse .nav-collapse .navbar-search {
+    border-top-color: #111111;
+    border-bottom-color: #111111;
+  }
+  .navbar .nav-collapse .nav.pull-right {
+    float: none;
+    margin-left: 0;
+  }
+  .nav-collapse,
+  .nav-collapse.collapse {
+    overflow: hidden;
+    height: 0;
+  }
+  .navbar .btn-navbar {
+    display: block;
+  }
+  .navbar-static .navbar-inner {
+    padding-left: 10px;
+    padding-right: 10px;
+  }
+}
+@media (min-width: calc( 979px + 1px)) {
+  .nav-collapse.collapse {
+    height: auto !important;
+    overflow: visible !important;
+  }
+}
 /*
  * theme_editor/less/main.less - LESS stylesheet to be included by all themes
  *
@@ -6203,6 +7258,10 @@ input[type="checkbox"] + label {
 input.hasDatepicker {
   max-width: 10em;
 }
+:focus-visible {
+  outline: 3px solid #005fcc;
+  outline-offset: 2px;
+}
 /* tabcolor0 */
 #page.tabcolor0 .forecolor {
   color: #88cf00;
@@ -6224,9 +7283,11 @@ input.hasDatepicker {
 }
 #page.tabcolor0 #login_submit {
   background: #456900;
+  color: #233600;
 }
 #page.tabcolor0 #login_signup {
   background: #233600;
+  color: #88cf00;
 }
 li.tabcolor0 a {
   background-color: #88cf00;
@@ -6288,9 +7349,11 @@ li.tabcolor0 a {
 }
 #page.tabcolor1 #login_submit {
   background: #0091d6;
+  color: #006ea3;
 }
 #page.tabcolor1 #login_signup {
   background: #006ea3;
+  color: #3dc0ff;
 }
 li.tabcolor1 a {
   background-color: #3dc0ff;
@@ -6352,9 +7415,11 @@ li.tabcolor1 a {
 }
 #page.tabcolor2 #login_submit {
   background: #4a159a;
+  color: #350f6d;
 }
 #page.tabcolor2 #login_signup {
   background: #350f6d;
+  color: #7932e3;
 }
 li.tabcolor2 a {
   background-color: #7932e3;
@@ -6416,9 +7481,11 @@ li.tabcolor2 a {
 }
 #page.tabcolor3 #login_submit {
   background: #88311d;
+  color: #5e2214;
 }
 #page.tabcolor3 #login_signup {
   background: #5e2214;
+  color: #d45437;
 }
 li.tabcolor3 a {
   background-color: #d45437;
@@ -6480,9 +7547,11 @@ li.tabcolor3 a {
 }
 #page.tabcolor4 #login_submit {
   background: #995e00;
+  color: #663f00;
 }
 #page.tabcolor4 #login_signup {
   background: #663f00;
+  color: #ff9d00;
 }
 li.tabcolor4 a {
   background-color: #ff9d00;
@@ -6544,9 +7613,11 @@ li.tabcolor4 a {
 }
 #page.tabcolor5 #login_submit {
   background: #876800;
+  color: #544100;
 }
 #page.tabcolor5 #login_signup {
   background: #544100;
+  color: #edb600;
 }
 li.tabcolor5 a {
   background-color: #edb600;
@@ -6608,9 +7679,11 @@ li.tabcolor5 a {
 }
 #page.tabcolor6 #login_submit {
   background: #52873b;
+  color: #3d642b;
 }
 #page.tabcolor6 #login_signup {
   background: #3d642b;
+  color: #84be6a;
 }
 li.tabcolor6 a {
   background-color: #84be6a;
@@ -6672,9 +7745,11 @@ li.tabcolor6 a {
 }
 #page.tabcolor7 #login_submit {
   background: #132400;
+  color: #000000;
 }
 #page.tabcolor7 #login_signup {
   background: #000000;
+  color: #478a00;
 }
 li.tabcolor7 a {
   background-color: #478a00;
@@ -6736,9 +7811,11 @@ li.tabcolor7 a {
 }
 #page.tabcolor8 #login_submit {
   background: #333333;
+  color: #1a1a1a;
 }
 #page.tabcolor8 #login_signup {
   background: #1a1a1a;
+  color: #666666;
 }
 li.tabcolor8 a {
   background-color: #666666;
@@ -6800,9 +7877,11 @@ li.tabcolor8 a {
 }
 #page.tabcolor9 #login_submit {
   background: #000000;
+  color: #000000;
 }
 #page.tabcolor9 #login_signup {
   background: #000000;
+  color: #333333;
 }
 li.tabcolor9 a {
   background-color: #333333;
@@ -6939,11 +8018,18 @@ body {
 #menu li .accent {
   position: absolute;
   left: -10px;
-  width: 20px;
+  transition: left 0.25s ease-out;
+  width: 26px;
+  /* the below bezier hits -16.06px so this gives >1px bleed margin */
   border-top-left-radius: 8px;
   border-bottom-left-radius: 8px;
   height: 100%;
   z-index: -1;
+}
+#menu li:hover .accent {
+  left: -15px;
+  transition: left 0.2s cubic-bezier(0.6, 2, 0.8, 0.9);
+  /* small bounce */
 }
 #menu a {
   display: block;
@@ -6965,8 +8051,12 @@ body {
 }
 #menu #tab_logo #logo {
   border: none;
-  margin-left: 9px;
-  margin-top: 9px;
+  max-height: 100%;
+  max-width: calc(91%);
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 }
 #menu #tab_proveit {
   margin-bottom: 10px;
@@ -7102,9 +8192,10 @@ body {
   position: absolute;
   top: 9px;
   right: 48px;
-  height: 21px;
+  height: 20px;
   width: 45px;
-  font-size: 10.5px;
+  font-size: 1em;
+  font-size: 1.3vmin;
   text-decoration: none;
   border-radius: 0px;
   border: none;
@@ -7135,13 +8226,16 @@ body {
 #login_signup {
   position: absolute;
   top: 9px;
-  right: 8px;
-  height: 17px;
+  right: 4px;
+  line-height: 20px;
   width: 40px;
-  padding-top: 4px;
-  font-size: 10.5px;
+  padding-top: 0px;
+  padding-right: 4px;
+  font-size: 1em;
+  font-size: 1.3vmin;
   text-decoration: none;
   border: none;
+  white-space: nowrap;
 }
 #login_help {
   position: absolute;
@@ -7356,18 +8450,6 @@ background: #e4e4e4;
 #content a:focus {
   color: #0077aa;
   text-decoration: underline;
-}
-#content .btn {
-  background: #ffffff;
-  color: #0088cc;
-}
-#content .btn-primary {
-  background: #0088cc;
-  color: #ffffff;
-}
-#content .btn-inverse {
-  background: #555555;
-  color: #ffffff;
 }
 #admin_link {
   padding: 30px 0px 0px 0px;


### PR DESCRIPTION
## Description
This PR adds test coverage for the AdminMaterialsModule.

It includes tests for:
- Uploading files (with class email prefix)
- Uploading program-level files
- Renaming materials
- Deleting materials

Closes #5127

## Fix
Previously, Media objects created in tests did not include an associated file, causing delete() to fail with:
ValueError: The 'target_file' attribute has no file associated with it.

This is fixed by using handle_file() to properly attach files, matching real application behavior.

## Type of Change
- [x] Bug fix
- [x] New feature (test coverage)

## Testing
- [x] All new tests pass
- [x] Verified using Docker environment

Command used:
python manage.py test esp.program.modules.tests.test_adminmaterials