### PR TITLE
Fix #5396: Handle missing or invalid Stripe keys in check_setup gracefully

### DIFF
--- a/esp/esp/program/modules/handlers/creditcardmodule_stripe.py
+++ b/esp/esp/program/modules/handlers/creditcardmodule_stripe.py
@@ -49,6 +49,7 @@ from decimal import Decimal
 import stripe
 import json
 import re
+import logging
 
 class CreditCardModule_Stripe(ProgramModuleObj):
     doc = """Accept credit card payments via Stripe."""
@@ -145,29 +146,55 @@ class CreditCardModule_Stripe(ProgramModuleObj):
     def studentDesc(self):
         return {'creditcard': """Students who have filled out the credit card form"""}
 
-    def check_setup(self):
-        """ Validate the keys specified in the stripe_settings Tag.
-            If something is wrong, return False, otherwise return True. """
 
+logger = logging.getLogger(__name__)
+def check_setup(self):
+    """
+    Validate the keys specified in the stripe_settings tag.
+    Returns False if configuration is invalid, otherwise True.
+    """
+
+    try:
         self.apply_settings()
+    except Exception as e:
+        logger.warning(f"Stripe setup failed while applying settings: {e}")
+        return False
 
-        #   Check for a 'donation' line item type on this program, which we will need
-        #   Note: This could also be created by default for every program,
-        #   in the accounting controllers.
-        if self.settings['offer_donation']:
-            (lit, created) = LineItemType.objects.get_or_create(
-                text=self.settings['donation_text'],
+    # Handle donation setup safely
+    if self.settings.get('offer_donation'):
+        try:
+            LineItemType.objects.get_or_create(
+                text=self.settings.get('donation_text', 'Donation'),
                 program=self.program,
                 required=False
             )
-
-        #   A Stripe account comes with 4 keys, starting with e.g. sk_test_
-        #   and followed by a 24 character base64-encoded string.
-        valid_pk_re = r'pk_(test|live)_([A-Za-z0-9+/=]){24}'
-        valid_sk_re = r'sk_(test|live)_([A-Za-z0-9+/=]){24}'
-        if not re.match(valid_pk_re, self.settings['publishable_key']) or not re.match(valid_sk_re, self.settings['secret_key']):
+        except Exception as e:
+            logger.warning(f"Error creating donation LineItemType: {e}")
             return False
-        return True
+
+    # Regex patterns
+    valid_pk_re = r'pk_(test|live)_([A-Za-z0-9+/=]){24}'
+    valid_sk_re = r'sk_(test|live)_([A-Za-z0-9+/=]){24}'
+
+    # Safely get keys
+    publishable_key = self.settings.get('publishable_key')
+    secret_key = self.settings.get('secret_key')
+
+    # Validate presence first
+    if not publishable_key or not secret_key:
+        logger.warning("Stripe keys missing: publishable_key or secret_key not set.")
+        return False
+
+    # Validate format
+    if not re.match(valid_pk_re, publishable_key):
+        logger.warning("Invalid Stripe publishable_key format.")
+        return False
+
+    if not re.match(valid_sk_re, secret_key):
+        logger.warning("Invalid Stripe secret_key format.")
+        return False
+
+    return True
 
     @main_call
     @needs_student_in_grade


### PR DESCRIPTION
## Description

Fixes an issue in check_setup where missing or invalid Stripe keys (publishable_key or secret_key) could lead to unexpected exceptions.

This change ensures that the function handles such cases gracefully by validating key presence and format before processing, and returning False instead of raising exceptions. Logging has also been added for better debugging.

## Related Issue

Closes #5396 

## Type of Change

- [ ] Bug fix

## Testing 

- [ ] Existing tests pass

- [ ] Manually verified
- [ ] 
## Checklist

- [ ] Self-reviewed the code
- [ ] No new warnings or errors introduced

#issue5396
<img width="1332" height="592" alt="Screenshot 2026-03-26 115149" src="https://github.com/user-attachments/assets/c77104d1-0fe1-4078-b313-e69877ef20a0" />

#bug_solution5396
<img width="1029" height="787" alt="Screenshot 2026-03-26 123501" src="https://github.com/user-attachments/assets/94921953-5236-452c-92b1-69fbd160af60" />
    

Thank you!

