### PR TITLE
Add test coverage for DeactivationModule bulk user deactivation

### DIFF
--- a/esp/esp/program/modules/tests/deactivationmodule.py
+++ b/esp/esp/program/modules/tests/deactivationmodule.py
@@ -1,0 +1,72 @@
+from __future__ import absolute_import
+
+from django.db.models import Q
+
+from esp.program.tests import ProgramFrameworkTest
+from esp.users.models import ESPUser, PersistentQueryFilter
+
+
+class DeactivationModuleTest(ProgramFrameworkTest):
+    def setUp(self, *args, **kwargs):
+        super(DeactivationModuleTest, self).setUp(*args, **kwargs)
+
+        self.admin = self.admins[0]
+        self.admin.set_password('password')
+        self.admin.save()
+        self.client.login(username=self.admin.username, password='password')
+
+        # Sanity check that the module is present.
+        self.assertTrue(self.program.hasModule('DeactivationModule'))
+
+    def _deactivatefinal_url(self):
+        return '/manage/%s/deactivatefinal' % self.program.url
+
+    def test_deactivatefinal_rejects_non_post_or_missing_filterid(self):
+        response = self.client.get(self._deactivatefinal_url())
+        self.assertEqual(response.status_code, 500)
+        self.assertContains(response, 'Filter has not been properly set', status_code=500)
+
+        # Post without filterid still fails
+        response = self.client.post(self._deactivatefinal_url(), {'confirm': 'true'})
+        self.assertEqual(response.status_code, 500)
+        self.assertContains(response, 'Filter has not been properly set', status_code=500)
+
+    def test_deactivatefinal_rejects_missing_confirmation(self):
+        q = Q(id__in=[self.students[0].id])
+        filter_obj = PersistentQueryFilter.create_from_Q(ESPUser, q)
+        filter_obj.save()
+
+        response = self.client.post(self._deactivatefinal_url() + '?filterid=%s' % filter_obj.id, {})
+        self.assertEqual(response.status_code, 500)
+        self.assertContains(response, 'You must confirm that you want to deactivate these users.', status_code=500)
+
+    def test_deactivatefinal_handles_empty_filter_query(self):
+        q = Q(id__in=[])
+        filter_obj = PersistentQueryFilter.create_from_Q(ESPUser, q)
+        filter_obj.save()
+
+        response = self.client.post(self._deactivatefinal_url() + '?filterid=%s' % filter_obj.id, {'confirm': 'true'})
+        self.assertEqual(response.status_code, 500)
+        self.assertContains(response, 'Your query did not match any users', status_code=500)
+
+    def test_deactivatefinal_deactivates_filtered_users(self):
+        # choose a couple of students
+        targets = self.students[:2]
+        active_ids = [u.id for u in targets]
+        for u in targets:
+            self.assertTrue(u.is_active)
+
+        q = Q(id__in=active_ids)
+        filter_obj = PersistentQueryFilter.create_from_Q(ESPUser, q)
+        filter_obj.save()
+
+        response = self.client.post(self._deactivatefinal_url() + '?filterid=%s' % filter_obj.id, {'confirm': 'true'})
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Congratulations! 2 users were deactivated!', status_code=200)
+
+        deactivated = ESPUser.objects.filter(id__in=active_ids)
+        self.assertEqual(deactivated.filter(is_active=False).count(), 2)
+
+        # preserve other users
+        remaining = ESPUser.objects.exclude(id__in=active_ids)
+        self.assertTrue(remaining.filter(is_active=True).exists())


### PR DESCRIPTION
## Description

This PR adds detailed test coverage for the `DeactivationModule`, focusing on the `deactivatefinal()` method responsible for performing bulk user deactivation based on query filters.

This module involves high-risk operations such as mass updates to user accounts (`is_active=False`), along with multiple validation steps (admin access, filter presence, and confirmation). The added tests ensure that these behaviors are properly validated and function as expected under different scenarios.

The goal of this change is to improve reliability, prevent accidental bulk deactivation, and ensure that both edge cases and success flows are explicitly tested.

## Related Issue

Closes #5198 

## Type of Change

* [x] New feature
## Testing

* [x] Existing tests pass
* [x] New tests added (if applicable)
* [x] Manually verified

### Test Coverage Includes:

* Rejection of non-POST requests and requests without `filterid`
* Rejection when confirmation is not provided
* Handling of filters that return no users
* Successful deactivation of users matching a filter
* Verification that affected users are marked as inactive in the database
* Ensuring unrelated users remain unaffected
* Validation of expected success and error messages in responses

All tests were executed locally using the Docker-based development setup, and they pass successfully.

## AI Disclosure

AI assistance was used for guidance in structuring test cases and debugging environment issues. All code has been carefully reviewed, tested, and validated manually before submission.

## Checklist

* [x] Self-reviewed the code
* [x] Updated documentation (if needed)
* [x] No new warnings or errors introduced
