### PR TITLE
fix:1680 by deactivating old class 5+ years old

### DIFF
--- a/esp/dbmail_cron.py
+++ b/esp/dbmail_cron.py
@@ -5,6 +5,8 @@ import os
 import fcntl
 import logging
 from io import open
+from django.utils import timezone
+     
 logger = logging.getLogger('esp.dbmail_cron')   # __name__ is not very useful
 os.environ['DJANGO_SETTINGS_MODULE'] = 'esp.settings'
 
@@ -25,6 +27,13 @@ if os.environ.get('VIRTUAL_ENV') is None:
 
 import django
 django.setup()
+from esp.program.models import ClassSubject
+#I wanted ClassSubject.old_Class() to autorun without depending on any external factors dependancy or user 
+now = timezone.now()
+if now.month == 1 and now.day == 1:
+    if 2 <= now.hour < 3:      #the condition can be 2 == now.hour but i am not sure while running it will aline perfectly or not
+        total = ClassSubject.old_Class()  #even if it run 4 time as this cron file autorun every 15 min it shouldnt cause a problem 
+   
 from esp.dbmail.cronmail import process_messages, send_email_requests
 
 # This import must be after the evaluation of the Django settings, because
@@ -58,3 +67,5 @@ finally:
     lock_file_handle.close()
 
 logger.info('dbmail_cron: done.')
+
+

--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -66,6 +66,7 @@ from esp.utils.query_utils import nest_Q
 from esp.utils import cmp
 from esp.tagdict.models import Tag
 from esp.mailman import add_list_member, remove_list_member
+from django.utils import timezone
 
 # ESP models
 from esp.cal.models import Event
@@ -2147,6 +2148,18 @@ class ClassSubject(models.Model, CustomFormsLinkModel):
                     teachers_list_name = f"{mailing_list_name}-teachers"
                     remove_list_member(teachers_list_name, t.email)
 
+#in future this code can be modify to deleate old class if we want 
+#for now it change status to deactivate them from getting spam
+    @classmethod
+    def old_Class(cls):
+        cutoff = timezone.now() - timezone.timedelta(days=1825)
+        targets = cls.objects.filter(sections__meeting_times__start__lt=cutoff).exclude(status=ClassStatus.REJECTED).distinct()
+        count = 0
+        for item in targets:
+            item.set_all_sections_to_status(ClassStatus.REJECTED)
+            count += 1
+        return count
+
     class Meta:
         db_table = 'program_class'
         app_label = 'program'
@@ -2194,3 +2207,4 @@ def install():
     if not ClassCategories.objects.exists():
         for key in category_dict:
             ClassCategories.objects.create(symbol=key, category=category_dict[key])
+


### PR DESCRIPTION
Description
close: #1680 
This PR introduces an automated annual cleanup task to maintain the database by rejecting old class entries.

Key Changes:

ClassSubject.old_Class(): Added a @classmethod to esp/program/models/class_.py that identifies classes with meeting times older than 5 years (1825 days) and sets their status (and all associated sections) to REJECTED.

dbmail_cron.py Integration: Integrated the cleanup logic into the existing cron script. The task is time-gated to run only on January 1st between 2:00 AM and 3:00 AM, ensuring it executes during low-traffic hours and doesn't conflict with other processes.

Optimized Querying: Used .distinct() and exclude(status=ClassStatus.REJECTED) to ensure database efficiency and prevent redundant processing.

Related Issue
Closes # ## Type of Change

[ ] Bug fix

[x] New feature

[ ] Breaking change

[ ] Documentation update

[x] Refactor / cleanup

[ ] CI/CD or build change

Testing
[x] Existing tests pass

[ ] New tests added (if applicable)

[x] Manually verified: Tested the query logic and old_Class method inside the Django shell within the Docker container. Verified that the dbmail_cron.py script triggers the logic correctly when conditions are met.

AI Disclosure
I used Gemini to verify Django 2.2 syntax for multi-table filtering, and ensure proper Python indentation during the implementation of the cron logic.

Checklist
[x] Self-reviewed the code

[ ] Updated documentation (if needed)

[x] No new warnings or errors introduced