### PR TITLE
Fix program creation integrity hardening

### DIFF
--- a/esp/esp/accounting/controllers.py
+++ b/esp/esp/accounting/controllers.py
@@ -81,6 +81,10 @@ class ProgramAccountingController(BaseAccountingController):
         self.refund_items = ['Student refund']
         self.admission_items = ["Program admission", "Student payment"]
 
+    def program_account_name(self):
+        program = self.program
+        return f'program-{program.id}-{slugify(program.url)}'
+
     @transaction.atomic
     def clear_all_data(self):
         #   Clear all financial data for the program
@@ -93,8 +97,14 @@ class ProgramAccountingController(BaseAccountingController):
         #   For now, just create a single account for the program.  In the
         #   future we may want finer grained accounting per program.
         program = self.program
-        (account, created) = Account.objects.get_or_create(name=slugify(program.name), description='Main account', program_id=program.id)
-        return account
+        account = Account.objects.filter(program_id=program.id).order_by('id').first()
+        if account is not None:
+            return account
+        return Account.objects.create(
+            name=self.program_account_name(),
+            description='Main account',
+            program_id=program.id,
+        )
 
     def setup_lineitemtypes(self, base_cost, optional_items=None, select_items=None):
         result = []

--- a/esp/esp/django_settings.py
+++ b/esp/esp/django_settings.py
@@ -276,7 +276,9 @@ SESSION_EXPIRE_AT_BROWSER_CLOSE=True
 
 SESSION_ENGINE = 'django.contrib.sessions.backends.cached_db' #which is persistent storage
 
-ATOMIC_REQUESTS = True
+# Keep request-scoped transactions opt-in. Multi-step workflows that need
+# rollback safety should use explicit transaction.atomic() boundaries close to
+# the write path instead of relying on an implicit global wrapper here.
 
 # Dotted path to callable to be used as view when a request is
 # rejected by the CSRF middleware.

--- a/esp/esp/program/test_newprogram_creation.py
+++ b/esp/esp/program/test_newprogram_creation.py
@@ -1,0 +1,120 @@
+from unittest.mock import patch
+
+from django.db import IntegrityError
+
+from esp.accounting.controllers import ProgramAccountingController
+from esp.accounting.models import Account
+from esp.program.models import ClassCategories, Program, ProgramModule
+from esp.tests.util import CacheFlushTestCase as TestCase, user_role_setup
+from esp.users.models import ESPUser
+
+
+class NewProgramCreationRegressionTest(TestCase):
+    def setUp(self):
+        user_role_setup()
+
+        self.admin = ESPUser.objects.create_user(
+            first_name='Admin',
+            last_name='User',
+            username='programadmin',
+            email='programadmin@test.learningu.org',
+        )
+        self.admin.set_password('pubbasswubbord')
+        self.admin.save()
+        self.admin.makeRole('Administrator')
+
+        self.client.login(username=self.admin.username, password='pubbasswubbord')
+
+        ClassCategories.objects.create(symbol='X', category='Everything')
+        ClassCategories.objects.create(symbol='N', category='Nothing')
+        ProgramModule.objects.create(
+            link_title='Default Module',
+            admin_title='Default Module (do stuff)',
+            module_type='learn',
+            handler='StudentRegCore',
+            seq=0,
+            required=False,
+        )
+        ProgramModule.objects.create(
+            link_title='Register Your Classes',
+            admin_title='Teacher Class Registration',
+            module_type='teach',
+            handler='TeacherClassRegModule',
+            inline_template='listclasses.html',
+            seq=10,
+            required=False,
+        )
+        ProgramModule.objects.create(
+            link_title='Sign up for Classes',
+            admin_title='Student Class Registration',
+            module_type='learn',
+            handler='StudentClassRegModule',
+            seq=10,
+            required=True,
+        )
+        ProgramModule.objects.create(
+            link_title='Sign up for a Program',
+            admin_title='Student Registration Core',
+            module_type='learn',
+            handler='StudentRegCore',
+            seq=-9999,
+            required=False,
+        )
+
+    def _program_post_data(self):
+        return {
+            'term': '3001_Winter',
+            'term_friendly': 'Winter 3001',
+            'grade_min': '7',
+            'grade_max': '12',
+            'director_email': 'info@test.learningu.org',
+            'director_cc_email': '',
+            'director_confidential_email': '',
+            'program_size_max': '3000',
+            'program_type': 'Prubbogrubbam!',
+            'program_modules': [x.id for x in ProgramModule.objects.all()],
+            'class_categories': [x.id for x in ClassCategories.objects.all()],
+            'teacher_reg_start': '2000-01-01 00:00:00',
+            'teacher_reg_end': '3001-01-01 00:00:00',
+            'student_reg_start': '2000-01-01 00:00:00',
+            'student_reg_end': '3001-01-01 00:00:00',
+            'base_cost': '666',
+            'sibling_discount': '',
+        }
+
+    def test_newprogram_rolls_back_on_account_setup_conflict(self):
+        with patch(
+            'esp.program.setup.ProgramAccountingController.setup_accounts',
+            side_effect=IntegrityError('duplicate account'),
+        ):
+            response = self.client.post('/manage/newprogram', self._program_post_data())
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'No changes were saved')
+        self.assertEqual(Program.objects.count(), 0)
+        self.assertEqual(Account.objects.count(), 0)
+
+    def test_setup_accounts_uses_unique_name_per_program(self):
+        shared_name = 'Splash Spring 2026'
+        program_a = Program.objects.create(
+            url='Splash/2026_A',
+            name=shared_name,
+            grade_min=7,
+            grade_max=12,
+        )
+        program_b = Program.objects.create(
+            url='Splash/2026_B',
+            name=shared_name,
+            grade_min=7,
+            grade_max=12,
+        )
+
+        account_a = ProgramAccountingController(program_a).setup_accounts()
+        account_b = ProgramAccountingController(program_b).setup_accounts()
+
+        self.assertEqual(account_a.program, program_a)
+        self.assertEqual(account_b.program, program_b)
+        self.assertNotEqual(account_a.id, account_b.id)
+        self.assertNotEqual(account_a.name, account_b.name)
+        self.assertTrue(account_a.name.startswith(f'program-{program_a.id}-'))
+        self.assertTrue(account_b.name.startswith(f'program-{program_b.id}-'))

--- a/esp/esp/program/views.py
+++ b/esp/esp/program/views.py
@@ -56,7 +56,7 @@ from django.contrib.redirects.models import Redirect
 from django.contrib.sites.models import Site
 from django.db.models.query import Q
 from django.db.models import Min
-from django.db import transaction
+from django.db import transaction, IntegrityError
 from django.core.mail import mail_admins
 from django.core.cache import cache
 from django.urls import reverse
@@ -730,6 +730,85 @@ def manage_programs(request):
                'user': request.user}
     return render_to_response('program/manage_programs.html', request, context)
 
+
+def _schedule_program_mailing_lists(program):
+    if not (settings.USE_MAILMAN and 'mailman_moderator' in list(settings.DEFAULT_EMAIL_ADDRESSES.keys())):
+        return
+
+    def create_program_lists():
+        mailing_list_name = "%s_%s" % (program.program_type, program.program_instance)
+        teachers_list_name = "%s-%s" % (mailing_list_name, "teachers")
+        students_list_name = "%s-%s" % (mailing_list_name, "students")
+
+        create_list(students_list_name, settings.DEFAULT_EMAIL_ADDRESSES['mailman_moderator'])
+        create_list(teachers_list_name, settings.DEFAULT_EMAIL_ADDRESSES['mailman_moderator'])
+
+        load_list_settings(teachers_list_name, "lists/program_mailman.config")
+        load_list_settings(students_list_name, "lists/program_mailman.config")
+
+        apply_list_settings(teachers_list_name, {'owner': [settings.DEFAULT_EMAIL_ADDRESSES['mailman_moderator'], program.director_email]})
+        apply_list_settings(students_list_name, {'owner': [settings.DEFAULT_EMAIL_ADDRESSES['mailman_moderator'], program.director_email]})
+
+        if 'archive' in list(settings.DEFAULT_EMAIL_ADDRESSES.keys()):
+            add_list_members(students_list_name, [program.director_email, settings.DEFAULT_EMAIL_ADDRESSES['archive']])
+            add_list_members(teachers_list_name, [program.director_email, settings.DEFAULT_EMAIL_ADDRESSES['archive']])
+
+    transaction.on_commit(create_program_lists)
+
+
+def _create_program_from_form(form, template_prog_id=None):
+    with transaction.atomic():
+        perms, _ = prepare_program(form.save(commit=False), form.cleaned_data)
+        new_prog = form.save(commit=True)
+        commit_program(new_prog, perms, form.cleaned_data['base_cost'], form.cleaned_data['sibling_discount'])
+
+        # Create the default resource types now
+        default_restypes = Tag.getTag('default_restypes')
+        if default_restypes:
+            resource_type_labels = json.loads(default_restypes)
+            for label in resource_type_labels:
+                ResourceType.get_or_create(label, new_prog)
+
+        # If a template program was chosen, load modules based on that program's
+        if template_prog_id is not None:
+            # Force all ProgramModuleObjs and their extensions to be created now
+            old_prog = Program.objects.get(id=template_prog_id)
+            # If we are using another program as a template, let's copy the seq and required values from that program.
+            new_prog.getModules(old_prog=old_prog)
+            # Copy CRMI settings from old program
+            old_crmi = ClassRegModuleInfo.objects.get(program=old_prog)
+            new_crmi = ClassRegModuleInfo.objects.get(program=new_prog)
+            for field in old_crmi._meta.fields:
+                if field.name not in ["id", "program"]:
+                    setattr(new_crmi, field.name, getattr(old_crmi, field.name))
+            new_crmi.save()
+            # Copy SCRMI settings from old program
+            old_scrmi = StudentClassRegModuleInfo.objects.get(program=old_prog)
+            new_scrmi = StudentClassRegModuleInfo.objects.get(program=new_prog)
+            for field in old_scrmi._meta.fields:
+                if field.name not in ["id", "program"]:
+                    setattr(new_scrmi, field.name, getattr(old_scrmi, field.name))
+            new_scrmi.save()
+            # Copy tags from old program
+            ct = ContentType.objects.get_for_model(old_prog)
+            old_tags = Tag.objects.filter(content_type=ct, object_id=old_prog.id)
+            for old_tag in old_tags:
+                # Some tags we don't want to import
+                if old_tag.key not in ['learn_extraform_id', 'teach_extraform_id', 'quiz_form_id', 'student_lottery_run']:
+                    new_tag, created = Tag.objects.get_or_create(key=old_tag.key, content_type=ct, object_id=new_prog.id)
+                    # Some tags get created during program creation (e.g. sibling discount), and we don't want to override those
+                    if created:
+                        new_tag.value = old_tag.value
+                        new_tag.save()
+        # If no template program is selected, create new modules
+        else:
+            # Create new modules
+            new_prog.getModules()
+
+        _schedule_program_mailing_lists(new_prog)
+        return new_prog
+
+
 @admin_required
 def newprogram(request):
     # First, if the user selected a template program, pre-populate fields with that program's data.
@@ -775,71 +854,24 @@ def newprogram(request):
     if request.method == 'POST':
         form = ProgramCreationForm(request.POST)
         if form.is_valid():
-            temp_prog = form.save(commit=False)
-            perms, modules = prepare_program(temp_prog, form.cleaned_data)
-            new_prog = form.save(commit = True)
-            commit_program(new_prog, perms, form.cleaned_data['base_cost'], form.cleaned_data['sibling_discount'])
-            # Create the default resource types now
-            default_restypes = Tag.getTag('default_restypes')
-            if default_restypes:
-                resource_type_labels = json.loads(default_restypes)
-                resource_types = [ResourceType.get_or_create(x, new_prog) for x in resource_type_labels]
-            # If a template program was chosen, load modules based on that program's
-            if template_prog is not None:
-                # Force all ProgramModuleObjs and their extensions to be created now
-                old_prog = Program.objects.get(id=template_prog_id)
-                # If we are using another program as a template, let's copy the seq and required values from that program.
-                new_prog.getModules(old_prog=old_prog)
-                # Copy CRMI settings from old program
-                old_crmi = ClassRegModuleInfo.objects.get(program=old_prog)
-                new_crmi = ClassRegModuleInfo.objects.get(program=new_prog)
-                for field in old_crmi._meta.fields:
-                    if field.name not in ["id", "program"]:
-                        setattr(new_crmi, field.name, getattr(old_crmi, field.name))
-                new_crmi.save()
-                # Copy SCRMI settings from old program
-                old_scrmi = StudentClassRegModuleInfo.objects.get(program=old_prog)
-                new_scrmi = StudentClassRegModuleInfo.objects.get(program=new_prog)
-                for field in old_scrmi._meta.fields:
-                    if field.name not in ["id", "program"]:
-                        setattr(new_scrmi, field.name, getattr(old_scrmi, field.name))
-                new_scrmi.save()
-                # Copy tags from old program
-                ct = ContentType.objects.get_for_model(old_prog)
-                old_tags = Tag.objects.filter(content_type=ct, object_id=old_prog.id)
-                for old_tag in old_tags:
-                    # Some tags we don't want to import
-                    if old_tag.key not in ['learn_extraform_id', 'teach_extraform_id', 'quiz_form_id', 'student_lottery_run']:
-                        new_tag, created = Tag.objects.get_or_create(key=old_tag.key, content_type=ct, object_id=new_prog.id)
-                        # Some tags get created during program creation (e.g. sibling discount), and we don't want to override those
-                        if created:
-                            new_tag.value = old_tag.value
-                            new_tag.save()
-            # If no template program is selected, create new modules
+            try:
+                new_prog = _create_program_from_form(form, template_prog_id=template_prog_id)
+            except IntegrityError:
+                existing_program = Program.objects.filter(url=form.cleaned_data.get('new_url')).order_by('id').first()
+                if existing_program and existing_program.name == form.cleaned_data.get('new_name'):
+                    logger.warning(
+                        'Duplicate program creation submission detected for %s; redirecting to program %s.',
+                        existing_program.url,
+                        existing_program.id,
+                    )
+                    return HttpResponseRedirect('/manage/' + existing_program.url + '/resources')
+                logger.warning('Program creation rolled back due to database conflict.', exc_info=True)
+                form.add_error(
+                    None,
+                    'Program creation hit a database conflict while finalizing related data. No changes were saved. Please reload and try again.',
+                )
             else:
-                # Create new modules
-                new_prog.getModules()
-            manage_url = '/manage/' + new_prog.url + '/resources'
-            # While we're at it, create the program's mailing list
-            if settings.USE_MAILMAN and 'mailman_moderator' in list(settings.DEFAULT_EMAIL_ADDRESSES.keys()):
-                mailing_list_name = "%s_%s" % (new_prog.program_type, new_prog.program_instance)
-                teachers_list_name = "%s-%s" % (mailing_list_name, "teachers")
-                students_list_name = "%s-%s" % (mailing_list_name, "students")
-
-                create_list(students_list_name, settings.DEFAULT_EMAIL_ADDRESSES['mailman_moderator'])
-                create_list(teachers_list_name, settings.DEFAULT_EMAIL_ADDRESSES['mailman_moderator'])
-
-                load_list_settings(teachers_list_name, "lists/program_mailman.config")
-                load_list_settings(students_list_name, "lists/program_mailman.config")
-
-                apply_list_settings(teachers_list_name, {'owner': [settings.DEFAULT_EMAIL_ADDRESSES['mailman_moderator'], new_prog.director_email]})
-                apply_list_settings(students_list_name, {'owner': [settings.DEFAULT_EMAIL_ADDRESSES['mailman_moderator'], new_prog.director_email]})
-
-                if 'archive' in list(settings.DEFAULT_EMAIL_ADDRESSES.keys()):
-                    add_list_members(students_list_name, [new_prog.director_email, settings.DEFAULT_EMAIL_ADDRESSES['archive']])
-                    add_list_members(teachers_list_name, [new_prog.director_email, settings.DEFAULT_EMAIL_ADDRESSES['archive']])
-            # Submit and create the program
-            return HttpResponseRedirect(manage_url)
+                return HttpResponseRedirect('/manage/' + new_prog.url + '/resources')
     # If the form has not been submitted, the default view is a blank form (or the pre-populated form with the template data).
     else:
         if template_prog:

--- a/esp/templates/program/newprogram.html
+++ b/esp/templates/program/newprogram.html
@@ -11,6 +11,21 @@
 {% block javascript %}
 {{ block.super }}
 <script src="/media/scripts/program/modules/modulequestions.js"></script>
+<script>
+function submitProgramCreation() {
+    questionsToModules();
+    var submitButton = document.getElementById('make-program-happen');
+    if (!submitButton) {
+        return true;
+    }
+    if (submitButton.disabled) {
+        return false;
+    }
+    submitButton.disabled = true;
+    submitButton.value = 'Creating Program...';
+    return true;
+}
+</script>
 {% endblock %}
 
 {% block content %}
@@ -62,7 +77,7 @@ In addition to importing the settings listed in the form below, using this progr
 {% endif %}
 
 <div id="alumni_form">
-  <form action="{{ request.path }}" method="post">
+  <form action="{{ request.path }}" method="post" onsubmit="return submitProgramCreation();">
   {% autoescape off %}
   {% if form.non_field_errors %}{{ form.non_field_errors }}{% endif %}
 
@@ -114,7 +129,7 @@ In addition to importing the settings listed in the form below, using this progr
     <tr> 
       <td colspan="2" class="submit">
         <br /><br /><br />
-        <center><input class="btn btn-primary" type="submit" value="Make Program Happen!" onclick="questionsToModules();" /></center>
+        <center><input class="btn btn-primary" id="make-program-happen" type="submit" value="Make Program Happen!" /></center>
       </td>
     </tr>
   </table>


### PR DESCRIPTION
## Description

Fixes the program creation integrity issue in the `newprogram` workflow where partially created programs could be left behind in the database upon error. 
Previously, the global `ATOMIC_REQUESTS = True` setting was inert because Django only honors it inside the `DATABASES` configuration. This meant any `IntegrityError` triggered after `form.save()` would leave behind partially saved related records without a full transaction rollback.

This PR hardens the overall program creation integrity by:
1. Wrapping the entire database portion of program creation in an explicit `atomic` block.
2. Moving external side effects (like Mailman list creation) to `transaction.on_commit(...)` to ensure they don't execute unless the database commit truly succeeds.
3. Adding explicit `IntegrityError` handling: it redirects to an existing program if a concurrent duplicate is detected, or safely returns a non-field error indicating no changes were saved.
4. Changing the program account naming from relying on a fragile `slugify(program.name)` to a per-program unique identifier based on the program ID and URL.
5. Adding a client-side submit lock to the "Make Program Happen!" button to mitigate accidental double-submit races.
6. Removing the misleading, inert `ATOMIC_REQUESTS` global setting and adding an explanatory comment regarding our explicit-transaction approach instead.

## Related Issue

Closes #2181

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [x] New tests added (validates clean rollback on `IntegrityError` and verifies that same-named programs successfully get distinct accounts)
- [x] Manually verified

## AI Disclosure

This pull request was developed with the assistance of an AI coding agent. The code optimization and regression tests were subsequently reviewed to verify their logic, accuracy, and adherence to the project patterns.

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced
