### PR TITLE
Fix theme editor crash when images/theme contains a subdirectory

### DIFF
--- a/esp/esp/themes/controllers.py
+++ b/esp/esp/themes/controllers.py
@@ -398,7 +398,7 @@ class ThemeController(object):
             if filename == '__pycache__':
                 continue
             full_filename = os.path.join(dir, filename)
-            if os.path.isdir(filename):
+            if os.path.isdir(full_filename):
                 result += self.get_file_summaries(full_filename)
             else:
                 file_data = open(full_filename, 'rb').read()


### PR DESCRIPTION
## Description
Get_file_summaries() was checking os.path.isdir(filename) using the bare filename (relative to CWD) instead of the full path. This caused it to always evaluate False for subdirectories, then attempt to open() the directory as a file, raising IsADirectoryError during recompile.

Fix: use os.path.isdir(full_filename) so subdirectories are correctly recursed into rather than opened as files.

## Related Issue

Closes #1764

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manually verified

## Checklist

- [ ] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [ ] No new warnings or errors introduced
