### PR TITLE
Feature/add search filter to class

### DIFF
--- a/esp/templates/program/modules/adminclass/listclasses.html
+++ b/esp/templates/program/modules/adminclass/listclasses.html
@@ -28,7 +28,7 @@ json_data = {};
 
   function filterClassRows() {
     var filter = $j.trim($j("#classSearch").val().toLowerCase());
-    $j("#classes_anchor tr").each(function() {
+    $j("#classes_anchor tr:gt(0)").each(function() {
       var rowText = $j(this).text().toLowerCase();
       $j(this).toggle(rowText.indexOf(filter) !== -1);
     });


### PR DESCRIPTION
## Description

This PR adds a search filter to the admin class list page to help administrators quickly find classes when many classes are present.

**A search input field is added above the class table. As the user types, rows are filtered in real time using JavaScript.**

Key details:
- Case-insensitive filtering
- Filters based on the entire row text (class title, teacher name, etc.)
- No backend changes required
- Uses existing `$j` jQuery alias used in the codebase

## Related Issue

Closes #5469

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [X] Manually verified

Manual verification:
- Confirmed filtering works while typing
- Verified case-insensitive search
- Confirmed table updates correctly when class rows change

## AI Disclosure

No AI tools were used in preparing this pull request.

## Checklist

- [X] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [X] No new warnings or errors introduced