### PR TITLE
Feature/add search filter to admin class list page

### DIFF
--- a/esp/templates/program/modules/adminclass/listclasses.html
+++ b/esp/templates/program/modules/adminclass/listclasses.html
@@ -28,7 +28,7 @@ json_data = {};
 
   function filterClassRows() {
     var filter = $j.trim($j("#classSearch").val().toLowerCase());
-    $j("#classes_anchor tr").each(function() {
+    $j("#classes_anchor tr:gt(0)").each(function() {
       var rowText = $j(this).text().toLowerCase();
       $j(this).toggle(rowText.indexOf(filter) !== -1);
     });

--- a/esp/templates/program/modules/adminclass/listclasses.html
+++ b/esp/templates/program/modules/adminclass/listclasses.html
@@ -26,6 +26,25 @@ json_data = {};
   // Set up sorting control
   $j(document).ready(setup_sort_control);
 
+  function filterClassRows() {
+    var filter = $j.trim($j("#classSearch").val().toLowerCase());
+    $j("#classes_anchor tr").each(function() {
+      var rowText = $j(this).text().toLowerCase();
+      $j(this).toggle(rowText.indexOf(filter) !== -1);
+    });
+  }
+
+  $j(document).ready(function() {
+    $j("#classSearch").on("keyup input", filterClassRows);
+
+    if (window.MutationObserver) {
+      new MutationObserver(filterClassRows).observe(
+        document.getElementById("classes_anchor"),
+        { childList: true, subtree: true }
+      );
+    }
+  });
+
   // Start the AJAX request to get the class data and display it
   json_fetch(["class_subjects"], fillClasses, json_data, function() { alert("Error loading class data"); });
 
@@ -69,6 +88,13 @@ json_data = {};
     </div>
 
     <div id="battlescreen">
+      <input
+        type="text"
+        id="classSearch"
+        placeholder="Search classes..."
+        class="form-control mb-3"
+        style="margin-bottom: 10px;"
+      />
 
       <table id="dashboard_class_table" cellpadding="4px" cellspacing="0" class="sortable">
     {% if noclasses %}


### PR DESCRIPTION
## Description

This PR adds a search filter to the admin class list page to help administrators quickly find classes when many classes are present.

**A search input field is added above the class table. As the user types, rows are filtered in real time using JavaScript.**

Key details:
- Case-insensitive filtering
- Filters based on the entire row text (class title, teacher name, etc.)
- No backend changes required
- Uses existing `$j` jQuery alias used in the codebase

## Related Issue

Closes #5469

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [X] Manually verified

Manual verification:
- Confirmed filtering works while typing
- Verified case-insensitive search
- Confirmed table updates correctly when class rows change

## AI Disclosure

No AI tools were used in preparing this pull request.

## Checklist

- [X] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [X] No new warnings or errors introduced