### PR TITLE
modify forms and controller to add validation for duplicate timeslots

### DIFF
--- a/esp/esp/program/controllers/resources.py
+++ b/esp/esp/program/controllers/resources.py
@@ -62,8 +62,16 @@ class ResourceController(object):
         else:
             new_timeslot = Event()
 
-        form.save_timeslot(self.program, new_timeslot)
+        try:
+            form.save_timeslot(self.program, new_timeslot)
+        except:
+            raise ESPError(
+                "An identical timeslot already exists for this program.",
+                log=False
+            )
+
         return new_timeslot
+
 
     def delete_restype(self, id):
         #   delete restype

--- a/esp/esp/program/modules/forms/resources.py
+++ b/esp/esp/program/modules/forms/resources.py
@@ -65,8 +65,16 @@ class TimeslotForm(forms.Form):
             slot.event_type = EventType.get_from_desc("Class Time Block")    # default event type for now
         slot.group = self.cleaned_data['group']
         slot.program = program
-        slot.save()
-
+        qs=Event.objects.filter(program=program, start=self.cleaned_data['start'], end=slot.end,short_description=self.cleaned_data.get('name'),
+                description=self.cleaned_data.get('description'),
+                event_type=slot.event_type,
+                group=self.cleaned_data.get('group')).exists()
+        if qs is False:
+            slot.save()
+        
+        if qs is True:
+                raise forms.ValidationError("A timeslot with the same data already exists for this program.")
+      
 class ResourceTypeForm(forms.Form):
     id = forms.IntegerField(required=False, widget=forms.HiddenInput)
     name = forms.CharField()


### PR DESCRIPTION
## Description

<!-- Brief summary of the changes and their purpose. -->
There was no validation for duplicate timeslots on manual add/edit. As a result, identical rows were inserted into the Event table, creating redundant timeslots. Import has a duplicate check, but manual entry didn’t, so the UI allowed the same data to be saved repeatedly.


## Related Issue

<!-- Link the relevant issue. Use "Closes #123" to auto-close on merge. -->

Closes #5412 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## AI Disclosure

<!-- If you used AI tools for any part of this pull request, please disclose this here -->
Github copilot was used for guidance

## Checklist

- [x ] Self-reviewed the code
- [x ] Updated documentation (if needed)
- [x ] No new warnings or errors introduced
