### PR TITLE
Fix: handle invalid filterid in GroupTextModule to prevent crash (#5475)

### DIFF
--- a/esp/esp/program/modules/handlers/listgenmodule.py
+++ b/esp/esp/program/modules/handlers/listgenmodule.py
@@ -325,10 +325,21 @@ class ListGenModule(ProgramModuleObj):
             specified in request.GET or a separate argument. """
 
         if filterObj is None:
-            if 'filterid' in request.GET:
-                filterObj = PersistentQueryFilter.objects.get(id=request.GET['filterid'])
-            else:
+            filter_id = request.GET.get('filterid')
+
+            if not filter_id:
                 raise ESPError('Could not determine the query filter ID.', log=False)
+
+            try:
+                filterObj = PersistentQueryFilter.objects.get(id=filter_id)
+            except (PersistentQueryFilter.DoesNotExist, ValueError, TypeError):
+                context['error_type'] = 'invalid_filter'
+                context['error_info'] = {'filter_id': filter_id}
+                self.send_error_email(request, context)
+                return render_to_response(self.baseDir() + 'failure.html', request, context)
+
+
+
 
         usertype = request.POST.get('recipient_type', 'combo').lower()
         if request.method == 'POST' and 'fields' in request.POST:


### PR DESCRIPTION
### Fix: Prevent crash on invalid or stale filterid in GroupTextModule

#### Problem

The handler in `grouptextfinal()` assumed that `request.GET['filterid']` always exists and refers to a valid `PersistentQueryFilter`. If the filter was missing, deleted, or invalid, this caused a `KeyError` or `DoesNotExist` exception, leading to a 500 server error.

#### Solution

* Replaced direct access to `request.GET['filterid']` with `request.GET.get('filterid')`
* Added validation to check if `filterid` is present
* Wrapped database lookup in a try/except block to handle invalid or missing filters
* Implemented graceful error handling with failure page rendering and admin notification

#### Result

* Prevents server crashes due to invalid or stale filter IDs
* Improves reliability of admin workflows
* Ensures proper error reporting and user-friendly failure handling
