### PR TITLE
Fix: handle invalid filterid in GroupTextModule (#5475)

### DIFF
--- a/esp/esp/program/modules/handlers/listgenmodule.py
+++ b/esp/esp/program/modules/handlers/listgenmodule.py
@@ -325,10 +325,21 @@ class ListGenModule(ProgramModuleObj):
             specified in request.GET or a separate argument. """
 
         if filterObj is None:
-            if 'filterid' in request.GET:
-                filterObj = PersistentQueryFilter.objects.get(id=request.GET['filterid'])
-            else:
+            filter_id = request.GET.get('filterid')
+
+            if not filter_id:
                 raise ESPError('Could not determine the query filter ID.', log=False)
+
+            try:
+                filterObj = PersistentQueryFilter.objects.get(id=filter_id)
+            except (PersistentQueryFilter.DoesNotExist, ValueError, TypeError):
+                context['error_type'] = 'invalid_filter'
+                context['error_info'] = {'filter_id': filter_id}
+                self.send_error_email(request, context)
+                return render_to_response(self.baseDir() + 'failure.html', request, context)
+
+
+
 
         usertype = request.POST.get('recipient_type', 'combo').lower()
         if request.method == 'POST' and 'fields' in request.POST:

--- a/esp/esp/program/modules/handlers/listgenmodule.py
+++ b/esp/esp/program/modules/handlers/listgenmodule.py
@@ -338,7 +338,7 @@ class ListGenModule(ProgramModuleObj):
                 self.send_error_email(request, context)
                 return render_to_response(self.baseDir() + 'failure.html', request, context)
 
-
+# fix applied for invalid filterid
 
 
         usertype = request.POST.get('recipient_type', 'combo').lower()


### PR DESCRIPTION
Closes #5475

## Problem
GroupTextModule crashes when filterid is invalid or missing.

## Solution
- Used request.GET.get('filterid') instead of direct access
- Added validation for filter existence
- Handled DoesNotExist exception
- Prevented 500 error and improved error handling