### PR TITLE
Fix: Add handshake key verification to Formstack webhook

### DIFF
--- a/esp/esp/formstack/README.md
+++ b/esp/esp/formstack/README.md
@@ -1,0 +1,41 @@
+# Formstack Integration
+
+## Security Configuration
+
+### Webhook Handshake Key
+
+The Formstack webhook endpoint (`/formstack/webhook/`) requires a handshake key for security. This prevents unauthorized parties from sending fake form submissions.
+
+**To configure:**
+
+1. Add to your `local_settings.py`:
+   ```python
+   # Formstack webhook handshake key
+   # Get this from your Formstack form settings > Webhooks
+   FORMSTACK_HANDSHAKE_KEY = 'your-secret-handshake-key-here'
+   ```
+
+2. In your Formstack form settings:
+   - Go to **Settings** → **Webhooks**
+   - Set the webhook URL: `https://yourdomain.com/formstack/webhook/`
+   - Configure the handshake key to match your `FORMSTACK_HANDSHAKE_KEY` setting
+   - Include `HandshakeKey` in the webhook payload
+
+**Security Notes:**
+- Keep the handshake key secret (don't commit to version control)
+- Use a strong, randomly generated key
+- If `FORMSTACK_HANDSHAKE_KEY` is not configured, a warning will be logged but webhooks will still be processed (backwards compatibility)
+- Once configured, invalid or missing handshake keys will return HTTP 403 Forbidden
+
+**Example Formstack webhook payload:**
+```json
+{
+  "FormID": "12345",
+  "UniqueID": "abc123",
+  "HandshakeKey": "your-secret-key",
+  "field_name": "field_value"
+}
+```
+
+## References
+- [Formstack Webhooks Documentation](https://www.formstack.com/developers/webhooks)

--- a/esp/esp/formstack/views.py
+++ b/esp/esp/formstack/views.py
@@ -1,16 +1,38 @@
-from django.http import HttpResponse, Http404
+from django.http import HttpResponse, Http404, HttpResponseForbidden
 from django.dispatch import receiver
 from django.views.decorators.csrf import csrf_exempt
+from django.conf import settings
 from esp.formstack.signals import formstack_post_signal
 
 @csrf_exempt
 def formstack_webhook(request):
+    """
+    Webhook endpoint for Formstack form submissions.
+
+    Verifies the handshake key to ensure requests are from authorized sources.
+    The handshake key should be configured in settings.FORMSTACK_HANDSHAKE_KEY.
+    """
     if request.method == 'POST':
         data = request.POST.dict()
         form_id = data.pop('FormID')
         submission_id = data.pop('UniqueID')
         handshake_key = data.pop('HandshakeKey', None)
-        # TODO: verify handshake key
+
+        # Verify handshake key for security
+        expected_key = getattr(settings, 'FORMSTACK_HANDSHAKE_KEY', None)
+
+        if not expected_key:
+            # If no key is configured, log error but allow (backwards compatibility)
+            import logging
+            logger = logging.getLogger(__name__)
+            logger.warning(
+                "FORMSTACK_HANDSHAKE_KEY not configured in settings. "
+                "Webhook security is disabled. Please configure this setting."
+            )
+        elif not handshake_key or handshake_key != expected_key:
+            # Handshake key is configured but doesn't match
+            return HttpResponseForbidden("Invalid or missing handshake key")
+
         formstack_post_signal.send(sender=None, form_id=form_id, submission_id=submission_id, fields=data)
         return HttpResponse()
     else:


### PR DESCRIPTION
## Description
Fixes the security vulnerability where the Formstack webhook endpoint accepts any POST request without verifying the handshake key.

closes #5510 

**Addresses TODO at:** `esp/esp/formstack/views.py:13`

## Changes
- [x] Added handshake key verification in `formstack_webhook()` function
- [x] Returns HTTP 403 Forbidden for invalid/missing keys
- [x] Backwards compatible (logs warning if not configured)
- [x] Added documentation in `esp/esp/formstack/README.md`

## Files Changed (2 files, 65 additions, 2 deletions)
- `esp/esp/formstack/views.py` - Security fix
- `esp/esp/formstack/README.md` - Configuration documentation

## Security Impact
**Before:** Any attacker could send fake webhook data  
**After:** Only requests with valid handshake key are processed

## Testing
1. **Without `FORMSTACK_HANDSHAKE_KEY` in settings:**
   - Webhook processes normally
   - Warning logged to console
   - Maintains backwards compatibility 

2. **With `FORMSTACK_HANDSHAKE_KEY` configured:**
   - Valid key: Webhook processes 
   - Invalid/missing key: Returns 403 Forbidden 

## Backwards Compatibility
- [x] Existing deployments without the setting continue to work
- [x] Warning message encourages migration to secure configuration
- [x] No breaking changes
