### PR TITLE
Fix: Remove eval() to prevent XSS vulnerability

### DIFF
--- a/esp/public/media/scripts/ajax_tools.js
+++ b/esp/public/media/scripts/ajax_tools.js
@@ -86,12 +86,18 @@ var apply_fragment_changes = function(data)
                 matching_node.html(data[key]);
             }
         }
-        
-        if (key == 'script')
-        {
-            //  console.log("Evaluating: " + data[key]);
-            eval(data[key]);
-        }
+
+        // SECURITY: Removed eval() execution to prevent XSS vulnerabilities
+        // If you need to execute callbacks from server responses, use predefined
+        // callback functions instead:
+        //
+        // Server response: {"callback": "myPredefinedFunction"}
+        // Client code:
+        //   if (key == 'callback' && typeof window[data[key]] === 'function') {
+        //       window[data[key]]();
+        //   }
+        //
+        // This ensures only whitelisted functions can be called, not arbitrary code.
     }
 }
 


### PR DESCRIPTION
## Description

Removes dangerous `eval()` execution from AJAX response handler in `ajax_tools.js` to prevent XSS vulnerabilities. The eval() function was executing arbitrary JavaScript code from server JSON responses, creating a critical security risk if the server is compromised or a MITM attack occurs.

## Related Issue

Closes #5511

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

**Manual Testing Performed:**
- Verified no server-side code sends `{"script": "..."}` responses in the codebase
- Tested all existing AJAX handlers continue to work (registration toggle, section APIs)
- No JavaScript errors in browser console after change
- Backward compatible - no existing functionality depends on this eval() call

## AI Disclosure

This PR was created with assistance from Claude Code (Claude Sonnet 4.5). The security vulnerability was identified through code review, and the fix was implemented following OWASP security best practices.

## Checklist

- [x] Self-reviewed the code
- [x] Updated documentation (if needed)
- [x] No new warnings or errors introduced

---

### Security Impact

- **Prevents arbitrary code execution** from server JSON responses
- **Mitigates XSS attacks** (CWE-94: Code Injection)
- **Safe alternative provided** in code comments using predefined callback functions

### Code Changes

**Before (Vulnerable):**
```javascript
if (key == 'script')
{
    eval(data[key]);  // CRITICAL XSS VULNERABILITY
}
