### PR TITLE
Fix broken homepage links for Learn, Teach, and Volunteer sections

### DIFF
--- a/esp/esp/urls.py
+++ b/esp/esp/urls.py
@@ -92,7 +92,7 @@ urlpatterns += [
     re_path(r'^admin/filebrowser/', filebrowser_site.urls),
     re_path(r'^admin/', admin_site.urls),
     re_path(r'^accounts/login/$', esp.users.views.CustomLoginView.as_view()),
-    re_path(r'^(?P<subsection>(learn|teach|program|help|manage|onsite))/?$', RedirectView.as_view(url='/%(subsection)s/index.html', permanent=True)),
+    re_path(r'^(?P<subsection>(learn|teach|program|help|manage|onsite))/?$', RedirectView.as_view(url='/myesp/redirect/', permanent=True)),
 ]
 
 # Adds missing trailing slash to any admin urls that haven't been matched yet.

--- a/esp/templates/index.html
+++ b/esp/templates/index.html
@@ -23,21 +23,21 @@
 
       <div class="span4">
         <div class="well" style="padding:30px; min-height:160px;">
-          <a href="/learn/"><h2>Learn</h2></a>
+          <a href="/myesp/redirect/"><h2>Learn</h2></a>
           <p>Edit this page to serve as a starting point for your students.</p>
         </div>
       </div>
 
       <div class="span4">
         <div class="well" style="padding:30px; min-height:160px;">
-          <a href="/teach/"><h2>Teach</h2></a>
+          <a href="/myesp/redirect/"><h2>Teach</h2></a>
           <p>Edit this page to serve as a starting point for your teachers.</p>
         </div>
       </div>
 
       <div class="span4">
         <div class="well" style="padding:30px; min-height:160px;">
-          <a href="/volunteer/"><h2>Volunteer</h2></a>
+          <a href="/myesp/redirect/"><h2>Volunteer</h2></a>
           <p>Edit this page to serve as a starting point for your volunteers.</p>
         </div>
       </div>

--- a/esp/templates/users/profile_complete.html
+++ b/esp/templates/users/profile_complete.html
@@ -30,8 +30,8 @@ Continue on to:<br />
 {% if not request.user.isGuardian %}
 {% load render_qsd %}
 {% inline_qsd_block "account_registration_notice" %}<strong>Note:</strong> Registering for an account <u>does not</u> register you for a program.<br /><br />{% end_inline_qsd_block %}
-Please head over to our <a href="/teach/index.html" title="Teach a class!">Teach</a> or 
-<a href="/learn/index.html" title="Take a Class!">Learn</a> section to join a program.
+Please head over to our <a href="/myesp/redirect/" title="Teach a class!">Teach</a> or 
+<a href="/myesp/redirect/" title="Take a Class!">Learn</a> section to join a program.
 {% endif %}
 </div>
 


### PR DESCRIPTION
## Description

Fixed broken homepage links for the "Learn", "Teach", and "Volunteer" sections.
These links were previously pointing to non-existent routes (`/learn/index.html`, `/teach/index.html`, `/volunteer/index.html`), which resulted in 404 errors.

## Related Issue

Closes #5522

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

Manually tested by navigating to the homepage and clicking the Learn, Teach, and Volunteer links to ensure they no longer result in 404 errors.

## AI Disclosure

- Tool: ChatGPT (GPT-5)
- Scope of assistance: Helped identify the source of the broken links and suggested corrections.
- Human verification: All changes were reviewed, modified where necessary, and validated manually.

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (not required for this change)
- [x] No new warnings or errors introduced