### PR TITLE
Tests: Add unit test coverage for no_autocookie and try_multi decorators (#3780)

### DIFF
--- a/esp/esp/utils/tests.py
+++ b/esp/esp/utils/tests.py
@@ -524,6 +524,39 @@ class StripBase64ImagesTest(DjangoTestCase):
         self.assertEqual(count, 0)
 
 
+class UtilsDecoratorsTest(DjangoTestCase):
+    def test_disable_csrf_cookie_update(self):
+        from esp.utils.no_autocookie import disable_csrf_cookie_update
+        
+        def dummy_view(request):
+            class Response: pass
+            return Response()
+            
+        decorated = disable_csrf_cookie_update(dummy_view)
+        response = decorated(None)
+        self.assertTrue(getattr(response, 'csrf_processing_done', False))
+        self.assertTrue(getattr(response, 'no_set_cookies', False))
+
+    def test_try_multi(self):
+        from esp.utils.try_multi import try_multi
+        self.tries = 0
+        def fail_twice():
+            self.tries += 1
+            if self.tries < 3:
+                raise ValueError("Fail")
+            return "Success"
+            
+        decorated = try_multi(3)(fail_twice)
+        self.assertEqual(decorated(), "Success")
+        self.assertEqual(self.tries, 3)
+
+        # Test failure
+        self.tries = 0
+        decorated_fail = try_multi(2)(fail_twice)
+        with self.assertRaises(ValueError):
+            decorated_fail()
+
+
 def suite():
     """Choose tests to expose to the Django tester."""
     s = unittest.TestSuite()


### PR DESCRIPTION
(#3780)

## Description

This PR introduces comprehensive unit tests for two previously untested utility decorators in `esp.utils`: `no_autocookie` (`disable_csrf_cookie_update`) and `try_multi`. This improves overall code coverage as part of the Regression Tests Expansion initiative, ensuring these decorators behave exactly as expected under both success and failure conditions.

## Related Issue

closes #3780

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [x] New tests added (if applicable)
- [ ] Manually verified

## AI Disclosure

**Tool identification:** Gemini 3.1 Pro via Antigravity Editor.
**Scope of assistance:** Used for targeted code generation and test scaffolding.
**Human verification confirmation:** I affirm that I have thoroughly reviewed the generated tests for `esp.utils` logic to ensure correctness and architectural continuity.

## Checklist

- [x] I self-reviewed the code
