### PR TITLE
UI: Add admin configuration link to custom forms (Addresses #3690)

### DIFF
--- a/esp/templates/customforms/form.html
+++ b/esp/templates/customforms/form.html
@@ -8,6 +8,12 @@
 {% block title %}{{ form_title }}{% endblock title %}
 
 {% block content %}
+    {% if user.is_authenticated and user.isAdministrator %}
+    <div class="alert alert-info" style="margin-bottom: 15px; padding: 10px; background-color: #d9edf7; border: #bce8f1 1px solid; color: #31708f; border-radius: 4px;">
+        <strong>Admin:</strong> Want to edit this form? 
+        <a href="{% url 'customforms_landing' %}" style="text-decoration: underline;">Click HERE</a>
+    </div>
+    {% endif %}
     <h1 class="form_title">{{ form_title }}</h1>
     <h2 class="form_desc">{{ form_description }}</h2>
     <em class="step_count">Step {{ wizard.steps.step1 }} of {{ wizard.steps.count }}</em>


### PR DESCRIPTION
## Description

This PR adds an informational banner at the top of custom registration forms exclusively visible to authenticated Administrators. It provides a direct hyperlink to the `customforms_landing` dashboard, making it significantly easier for chapter admins to find exactly where an active form's configuration lives without digging through menus.

## Related Issue

closes #3690

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## AI Disclosure

**Tool identification:** Gemini 3.1 Pro via Antigravity Editor.
**Scope of assistance:** Used for UI templating generation.
**Human verification confirmation:** I affirm that I have thoroughly reviewed the generated `customforms/form.html` Django template changes and validated that the `is_authenticated` block correctly restricts the link exposure exclusively to the appropriate administrator roles.

## Checklist

- [x] I self-reviewed the code
