### PR TITLE
Fix template HTML validity issues

### DIFF
--- a/esp/templates/django/forms/widgets/choicewithother.html
+++ b/esp/templates/django/forms/widgets/choicewithother.html
@@ -11,6 +11,7 @@
             <li>
               <label{% if option.attrs.id %} for="{{ option.attrs.id }}"{% endif %}>
                 {% include option.template_name with widget=option %}{{ option.label }}
+              </label>
             </li>
             {% else %}
             <li>

--- a/esp/templates/elements/html
+++ b/esp/templates/elements/html
@@ -84,7 +84,7 @@
     </script>
 
     <!-- prevent forms from being submitted twice -->
-    <script text="text/javascript">
+    <script type="text/javascript">
       $j(function() {
         $j('[type=submit]:not(.stripe-button-el):not(.save):not(.custom-action)').on('click', function(event){
           <!-- prevent any other behaviors -->


### PR DESCRIPTION
## Description

Minor fixes to improve HTML template correctness and compliance:
- Close missing `</label>` tag in choicewithother widget template for proper HTML validity
- Correct invalid script tag attribute from `text="text/javascript"` to `type="text/javascript"`

These are non-breaking improvements with no functional changes-purely HTML validity and consistency fixes.

## Related Issue

Closes #5552 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## AI Disclosure

This pull request was created with assistance from GitHub Copilot for identifying and fixing HTML template validity issues.

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced
