### PR TITLE
Refactor inline styles from user auth templates into CSS classes

### DIFF
--- a/esp/public/media/default_styles/forms.css
+++ b/esp/public/media/default_styles/forms.css
@@ -4,6 +4,42 @@
     
 }
 
+
+
+/* Custom User Auth Template Alignments */
+.form-submit-centered {
+    text-align: center;
+}
+
+.auth-header {
+    text-align: center;
+}
+
+.auth-subheader {
+    text-align: center;
+    margin-bottom: 0px;
+}
+
+.auth-instruction {
+    text-align: center;
+    font-weight: normal;
+    margin-top: 0px;
+}
+
+.auth-warning-text {
+    text-align: center;
+    color: #FF0000;
+    margin-bottom: 0px;
+}
+
+.form-table-label-top {
+    vertical-align: top;
+}
+
+.auth-role-select {
+    width: 95%;
+}
+
 /* Profile editor */
 #id_receive_txt_message {
     list-style:none

--- a/esp/templates/users/login_initial.html
+++ b/esp/templates/users/login_initial.html
@@ -2,14 +2,19 @@
 
 {% block title %}Join {{ settings.ORGANIZATION_SHORT_NAME }}!{% endblock %}
 
+{% block stylesheets %}
+  {{ block.super }}
+  <link rel="stylesheet" type="text/css" href="/media/styles/forms.css" />
+{% endblock stylesheets %}
+
 {% block content %}
-<h2 style='text-align: center'>Ready to join {{ settings.INSTITUTION_NAME }} {{ settings.ORGANIZATION_SHORT_NAME }}?</h2>
-<h1 style='text-align: center; margin-bottom: 0px'>Cool!</h1>
-<h3 style="text-align: center; font-weight: normal; margin-top: 0px">Please begin by choosing a username and password for your account on our system.<br/>
+<h2 class="auth-header">Ready to join {{ settings.INSTITUTION_NAME }} {{ settings.ORGANIZATION_SHORT_NAME }}?</h2>
+<h1 class="auth-subheader">Cool!</h1>
+<h3 class="auth-instruction">Please begin by choosing a username and password for your account on our system.<br/>
 
  Your account will be your portal for all of {{ settings.ORGANIZATION_SHORT_NAME }}'s programs! </h3>
 
-<p style="text-align: center; color: #FF0000; margin-bottom: 0px;">
+<p class="auth-warning-text">
  <b>NOTE: You must have cookies enabled to login to this website.<br/>
  </b>
 </p>
@@ -20,7 +25,7 @@
 <table width='65%' cellpadding='2' align='center' border='0'>
 
 <tr>
- <td style="vertical-align: top"><b>Username:</b></td>
+<td class="form-table-label-top"><b>Username:</b></td>
  <td><input type='text' name='username' size='30' value=''><br/>
      <small>Username must be between 4 and 12 characters.</small>
  </td>
@@ -47,16 +52,15 @@
 </tr>
 
 <tr>
- <td style="vertical-align: top"><b>Confirm<br/>Password:</b></td>
+<td class="form-table-label-top"><b>Confirm<br/>Password:</b></td>
  <td><input type='password' name='confirm' size='30' value=''></td>
 </tr>
 
 <tr>
- <td style="vertical-align: top"><b>I want to be a(n)...</b></td>
- <td align='left' colspan=2><select size=5 style="width: 95%"" name="pos"><option value="1" selected>{{ settings.ORGANIZATION_SHORT_NAME }} Student (Grade 12 and under)</option><option value="2">Parent/Guardian Contact</option><option value="3">K-12 Teacher/Educator Contact</option><option value="4">Teacher for {{ settings.ORGANIZATION_SHORT_NAME }}</option></select></td>
+  <td class="form-table-label-top"><b>I want to be a(n)...</b></td>
+
+ <td align='left' colspan=2><select size=5 class="auth-role-select" name="pos"><option value="1" selected>{{ settings.ORGANIZATION_SHORT_NAME }} Student (Grade 12 and under)</option><option value="2">Parent/Guardian Contact</option><option value="3">K-12 Teacher/Educator Contact</option><option value="4">Teacher for {{ settings.ORGANIZATION_SHORT_NAME }}</option></select></td>
 </tr>
 </table>
-
-<p style="text-align: center"><input type='submit' value='-  Sign Up!  -'></p>
-</form>
+<p class="form-submit-centered"><input type='submit' value='-  Sign Up!  -'></p></form>
 {% endblock %}

--- a/esp/templates/users/passwd.html
+++ b/esp/templates/users/passwd.html
@@ -2,6 +2,11 @@
 
 {% block title %}Change Account Password{% endblock %}
 
+{% block stylesheets %}
+  {{ block.super }}
+  <link rel="stylesheet" type="text/css" href="/media/styles/forms.css" />
+{% endblock stylesheets %}
+
 {% block content %}
 <h1>Account Management &ndash; Change Password </h1>
 {% if Success %}
@@ -54,7 +59,8 @@ Your password has been successfully changed.
 
 </table>
 
-<p style="text-align: center"><input type='submit' value='-  Change My Password  -' class='btn btn-primary'></p>
+<p class="form-submit-centered"><input type='submit' value='-  Change My Password  -' class='btn btn-primary'></p>
+
 </form>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Description

This PR refactors the hardcoded inline styles (e.g., `style="text-align: center; color: #FF0000;"`) in the core `users/` authentication templates (`login_initial.html` and `passwd.html`) into proper semantic CSS classes defined in the external stylesheet (`forms.css`). 

This improves maintainability, makes chapter-specific theming significantly easier without needing `!important` overrides, and works towards better Content Security Policy (CSP) compliance.

## Related Issue

Closes #5525 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified (Tested locally via Docker to ensure UI rendering matches original layout)

## AI Disclosure

I used an AI assistant to help systematically audit the repository templates for UI tech-debt, identify deprecated inline tags across the codebase, and help draft the CSS refactoring workflow for this specific PR.

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced

---
### UI Verification / Proof
<img width="1920" height="1008" alt="image" src="https://github.com/user-attachments/assets/fb937f40-c90b-4b9f-9f58-49f29892651c" />
