### PR TITLE
Add Google Summer of Code 2026 section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ Then visit http://localhost:8000. See the [Docker setup guide](/docs/dev/docker.
 ## Looking to contribute?
 
 [Check out our wiki for details](https://github.com/learning-unlimited/ESP-Website/wiki#i-want-to-get-involved). We also have a strict [code of conduct](https://github.com/learning-unlimited/ESP-Website?tab=coc-ov-file).
+
+## Google Summer of Code 2026
+
+This project is participating in Google Summer of Code 2026 with Learning Unlimited.


### PR DESCRIPTION
## Description
Added a Google Summer of Code 2026 section to the README to inform contributors about GSoC participation.

## Related Issue
Closes #3780

## Type of Change
- [x] Documentation update

## Testing
- [x] Existing tests pass
- [x] Manually verified

## AI Disclosure
No AI tools were used for this pull request.

## Checklist
- [x] Self-reviewed the code
- [x] Updated documentation (if needed)
- [x] No new warnings or errors introduced