### PR TITLE
Fix variable shadowing in ESPError: swap log and message assignment order

### DIFF
--- a/esp/esp/middleware/esperrormiddleware.py
+++ b/esp/esp/middleware/esperrormiddleware.py
@@ -79,8 +79,8 @@ def ESPError(message=None, log=True):
     if isinstance(message, bool):
         # trying to pass a bool argument: assume they meant log rather than message
         # this should become deprecated -lua 2013-02-15
-        message = None
         log = message
+        message = None
 
     if log:
         cls = ESPError_Log


### PR DESCRIPTION
…rder

log = message was executed after message = None, causing log to always be None instead of the intended boolean. Swapped the two lines to fix the shadowing bug.

## Description

Fixes a variable shadowing bug where `message = None` was executed before `log = message`, causing `log` to always be `None` instead of the intended boolean value passed by the caller.

## Related Issue

Closes #5562

## Type of Change

✅ Bug fix

## Testing

✅ Manually verified

## AI Disclosure

AI tools were used for general research and understanding the codebase. The bug identification, fix decision, and code change were made and verified by me personally.

## Checklist

✅ Self-reviewed the code
✅ No new warnings or errors introduced
