### PR TITLE
 Style: Remove unused standard library import in utils

### DIFF
--- a/esp/esp/utils/__init__.py
+++ b/esp/esp/utils/__init__.py
@@ -8,7 +8,7 @@ The functions in this file are globally relevant, too annoying to inline,
     and too small to merit their own modules.
 """
 
-import sys
+# import sys -----This library is unused throughout the program, so it is unwanted
 from urllib.parse import quote_plus
 
 def force_str(x):


### PR DESCRIPTION
## Description

Hi team!
I found a small piece of unused code while browsing the utility modules. The standard library `sys` module was imported at the top of `esp/esp/utils/__init__.py`, but it is completely unused anywhere in the file. I've removed the unused import to help keep the codebase clean and adhere to PEP 8 standards. Cheers!

## Related Issue

Closes #5578 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
**- [x] Refactor / cleanup**
- [ ] CI/CD or build change

## Testing

**- [x] Existing tests pass**
- [ ] New tests added (if applicable)
**- [x] Manually verified**

## AI Disclosure

I used an AI coding assistant to help identify minor style opportunities and format this pull request.

## Checklist

**- [x] Self-reviewed the code**
- [ ] Updated documentation (if needed)
**- [x] No new warnings or errors introduced**