### PR TITLE
Refactor CacheClass to subclass PyLibMCCache instead of proxy

### DIFF
--- a/esp/esp/program/views.py
+++ b/esp/esp/program/views.py
@@ -977,11 +977,8 @@ def flushcache(request):
     if request.POST:
         if "reason" in request.POST and len(request.POST['reason']) > 5:
             reason = request.POST['reason']
-            _cache = cache
-            while hasattr(_cache, "_wrapped_cache"):
-                _cache = _cache._wrapped_cache
-            if hasattr(_cache, "clear"):
-                _cache.clear()
+            if hasattr(cache, "clear"):
+                cache.clear()
                 mail_admins("Cache Flushed on server '%s'!" % request.META['SERVER_NAME'], "The cache was flushed by %s!  The following reason was given:\n\n%s" % (request.user.username, reason))
                 context['success'] = "Cache Cleared."
             else:

--- a/esp/esp/utils/management/commands/flushcache.py
+++ b/esp/esp/utils/management/commands/flushcache.py
@@ -6,8 +6,5 @@ class Command(BaseCommand):
     This clears the cache just like /manage/flushcache
     """
     def handle(self, *args, **options):
-        _cache = cache
-        while hasattr(_cache, "_wrapped_cache"):
-            _cache = _cache._wrapped_cache
-        if hasattr(_cache, "clear"):
-            _cache.clear()
+        if hasattr(cache, "clear"):
+            cache.clear()

--- a/esp/esp/utils/memcached_multikey.py
+++ b/esp/esp/utils/memcached_multikey.py
@@ -3,7 +3,7 @@
 import logging
 logger = logging.getLogger(__name__)
 
-from django.core.cache.backends.memcached import PyLibMCCache as PylibmcCacheClass
+from django.core.cache.backends.memcached import PyLibMCCache
 from django.conf import settings
 from esp.utils.try_multi import try_multi
 from esp.utils import ascii
@@ -15,7 +15,7 @@ MAX_KEY_LENGTH = 250
 NO_HASH_PREFIX = "NH_"
 HASH_PREFIX = "H_"
 
-class CacheClass(PylibmcCacheClass):
+class CacheClass(PyLibMCCache):
     def __init__(self, server, params):
         super().__init__(server, params)
         if not hasattr(settings, 'CACHE_PREFIX'):
@@ -46,39 +46,34 @@ class CacheClass(PylibmcCacheClass):
     @try_multi(8)
     def add(self, key, value, timeout=None, version=None):
         self._failfast_test(key, value)
-        return super().add(self.make_key(key, version), value, timeout=timeout, version=version)
+        return super().add(key, value, timeout=timeout, version=version)
 
     @try_multi(8)
     def get(self, key, default=None, version=None):
-        return super().get(self.make_key(key, version), default=default, version=version)
+        return super().get(key, default=default, version=version)
 
     @try_multi(8)
     def set(self, key, value, timeout=None, version=None):
         self._failfast_test(key, value)
-        return super().set(self.make_key(key, version), value, timeout=timeout, version=version)
+        return super().set(key, value, timeout=timeout, version=version)
 
     @try_multi(8)
     def delete(self, key, version=None):
-        return super().delete(self.make_key(key, version), version=version)
+        return super().delete(key, version=version)
 
     @try_multi(8)
     def get_many(self, keys, version=None):
-        keys_dict = dict((self.make_key(key, version), key) for key in keys)
-        wrapped_ans = super().get_many(list(keys_dict.keys()), version=version)
-        ans = {}
-        for k, v in wrapped_ans.items():
-            ans[keys_dict[k]] = v
-        return ans
+        return super().get_many(keys, version=version)
 
     # Django 1.1 feature
     # Don't try_multi, that could be all kinds of bad...
     def incr(self, key, delta=1, version=None):
-        return super().incr(self.make_key(key, version), delta, version=version)
+        return super().incr(key, delta, version=version)
 
     # Django 1.1 feature
     # Don't try_multi, that could be all kinds of bad...
     def decr(self, key, delta=1, version=None):
-        return super().decr(self.make_key(key, version), delta, version=version)
+        return super().decr(key, delta, version=version)
 
     def close(self, **kwargs):
         super().close(**kwargs)

--- a/esp/esp/utils/memcached_multikey.py
+++ b/esp/esp/utils/memcached_multikey.py
@@ -3,8 +3,6 @@
 import logging
 logger = logging.getLogger(__name__)
 
-from django.core.cache.backends.base import BaseCache
-import pylibmc
 from django.core.cache.backends.memcached import PyLibMCCache as PylibmcCacheClass
 from django.conf import settings
 from esp.utils.try_multi import try_multi
@@ -17,10 +15,9 @@ MAX_KEY_LENGTH = 250
 NO_HASH_PREFIX = "NH_"
 HASH_PREFIX = "H_"
 
-class CacheClass(BaseCache):
+class CacheClass(PylibmcCacheClass):
     def __init__(self, server, params):
-        BaseCache.__init__(self, params)
-        self._wrapped_cache = PylibmcCacheClass(server, params)
+        super().__init__(server, params)
         if not hasattr(settings, 'CACHE_PREFIX'):
             settings.CACHE_PREFIX = ''
 
@@ -49,25 +46,25 @@ class CacheClass(BaseCache):
     @try_multi(8)
     def add(self, key, value, timeout=None, version=None):
         self._failfast_test(key, value)
-        return self._wrapped_cache.add(self.make_key(key, version), value, timeout=timeout, version=version)
+        return super().add(self.make_key(key, version), value, timeout=timeout, version=version)
 
     @try_multi(8)
     def get(self, key, default=None, version=None):
-        return self._wrapped_cache.get(self.make_key(key, version), default=default, version=version)
+        return super().get(self.make_key(key, version), default=default, version=version)
 
     @try_multi(8)
     def set(self, key, value, timeout=None, version=None):
         self._failfast_test(key, value)
-        return self._wrapped_cache.set(self.make_key(key, version), value, timeout=timeout, version=version)
+        return super().set(self.make_key(key, version), value, timeout=timeout, version=version)
 
     @try_multi(8)
     def delete(self, key, version=None):
-        return self._wrapped_cache.delete(self.make_key(key, version), version=version)
+        return super().delete(self.make_key(key, version), version=version)
 
     @try_multi(8)
     def get_many(self, keys, version=None):
         keys_dict = dict((self.make_key(key, version), key) for key in keys)
-        wrapped_ans = self._wrapped_cache.get_many(list(keys_dict.keys()), version=version)
+        wrapped_ans = super().get_many(list(keys_dict.keys()), version=version)
         ans = {}
         for k, v in wrapped_ans.items():
             ans[keys_dict[k]] = v
@@ -76,12 +73,12 @@ class CacheClass(BaseCache):
     # Django 1.1 feature
     # Don't try_multi, that could be all kinds of bad...
     def incr(self, key, delta=1, version=None):
-        return self._wrapped_cache.incr(self.make_key(key, version), delta, version=version)
+        return super().incr(self.make_key(key, version), delta, version=version)
 
     # Django 1.1 feature
     # Don't try_multi, that could be all kinds of bad...
     def decr(self, key, delta=1, version=None):
-        return self._wrapped_cache.decr(self.make_key(key, version), delta, version=version)
+        return super().decr(self.make_key(key, version), delta, version=version)
 
     def close(self, **kwargs):
-        self._wrapped_cache.close()
+        super().close(**kwargs)

--- a/esp/esp/utils/tests.py
+++ b/esp/esp/utils/tests.py
@@ -99,10 +99,11 @@ class DependenciesTestCase(unittest.TestCase):
         # Patch can be found at:  <https://code.djangoproject.com/ticket/11675>
         from pylibmc import Client
         from django.core.cache import cache
-        if hasattr(cache, "_cache"):
-            self.assertTrue(isinstance(cache._cache, Client))
-        elif hasattr(cache, "_wrapped_cache") and hasattr(cache._wrapped_cache, "_cache"):
-            self.assertTrue(isinstance(cache._wrapped_cache._cache, Client))
+        from django.core.cache.backends.memcached import PyLibMCCache
+        from esp.utils.memcached_multikey import CacheClass
+        self.assertTrue(issubclass(CacheClass, PyLibMCCache))
+        self.assertTrue(hasattr(cache, "_cache"))
+        self.assertTrue(isinstance(cache._cache, Client))
 
         self.tryExecutable("latex")  # Used for a whole pile of program printables, as well as inline LaTeX
         self.tryExecutable("dvips")  # Used to convert LaTeX output (.dvi) to .ps files
@@ -577,5 +578,4 @@ def suite():
     # Add doctests from esp.utils.__init__.py
     s.addTest(doctest.DocTestSuite(utils))
     return s
-
 


### PR DESCRIPTION
## Description

This PR refactors `memcached_multikey.CacheClass` to subclass `memcached.PyLibMCCache` instead of using a proxy-based implementation.

Previously, `CacheClass` stored a `PyLibMCCache` instance internally and proxied method calls through `_wrapped_cache`. This added unnecessary indirection without providing clear benefits.

With the current dependency setup, we can directly subclass `PyLibMCCache`, resulting in a cleaner and more maintainable design that aligns with standard Django caching patterns.

---

## Related Issue

Closes #1305

---

## Type of Change

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation update
* [x] Refactor / cleanup
* [ ] CI/CD or build change

---

## Testing

* [x] Existing tests pass
* [ ] New tests added (if applicable)
* [x] Manually verified

---

## AI Disclosure

* Tool used: Codex
* Scope of assistance: Helped in understanding the refactoring approach and improving the structure of the solution and PR description
* Verification: All code changes were manually reviewed, tested, and validated before submission

---

## Checklist

* [x] Self-reviewed the code
* [ ] Updated documentation (if needed)
* [x] No new warnings or errors introduced
