### PR TITLE
Add flags to admin dashboard (#1354)

### DIFF
--- a/esp/esp/program/modules/handlers/jsondatamodule.py
+++ b/esp/esp/program/modules/handlers/jsondatamodule.py
@@ -567,6 +567,7 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
     class_subjects.cached_function.depend_on_row(ClassSubject, lambda cls: {'prog': cls.parent_program})
     class_subjects.cached_function.depend_on_cache(ClassSubject.get_teachers, lambda cls=wildcard, **kwargs: {'prog': cls.parent_program})
     class_subjects.cached_function.depend_on_row(ClassFlag, lambda flag: {'prog': flag.subject.parent_program})
+    class_subjects.cached_function.depend_on_row(ClassFlagType, lambda ft: {})
 
     @aux_call
     @json_response({

--- a/esp/esp/program/modules/handlers/jsondatamodule.py
+++ b/esp/esp/program/modules/handlers/jsondatamodule.py
@@ -497,7 +497,8 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
         moderators = []
         classes = []
         qs = prog.classes().prefetch_related(
-            'category', 'sections', 'teachers')
+            'category', 'sections', 'teachers',
+            'flags__flag_type')
 
         for c in qs:
             class_teachers = c.get_teachers()
@@ -519,6 +520,11 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
                 cls['difficulty'] = c.hardness_rating
                 cls['prereqs'] = c.prereqs
             cls['emailcode'] = c.emailcode()
+            cls['dashboard_flags'] = [
+                {'name': f.flag_type.name, 'color': f.flag_type.getColor()}
+                for f in c.flags.all()
+                if f.flag_type.show_in_dashboard
+            ]
             if c.duration:
                 cls['length'] = float(c.duration)
             cls['sections'] = [s.id for s in c.sections.all()]
@@ -560,6 +566,7 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
         return {'classes': classes, 'teachers': teachers, 'moderators': moderators}
     class_subjects.cached_function.depend_on_row(ClassSubject, lambda cls: {'prog': cls.parent_program})
     class_subjects.cached_function.depend_on_cache(ClassSubject.get_teachers, lambda cls=wildcard, **kwargs: {'prog': cls.parent_program})
+    class_subjects.cached_function.depend_on_row(ClassFlag, lambda flag: {'prog': flag.subject.parent_program})
 
     @aux_call
     @json_response({
@@ -806,7 +813,16 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
             'comments': cls.message_for_directors,
             'special_requests': cls.requested_special_resources,
             'purchases': cls.purchase_requests,
-            'flags': ', '.join(cls.flags.values_list('flag_type__name', flat=True)),
+            'flags': [
+                {
+                    'name': f.flag_type.name,
+                    'color': f.flag_type.getColor(),
+                    'comment': f.comment,
+                    'modified_by': f.modified_by.username if f.modified_by_id else '',
+                    'modified_time': f.modified_time.strftime('%Y-%m-%d %H:%M'),
+                }
+                for f in cls.flags.select_related('flag_type', 'modified_by').all()
+            ],
         }
 
         return {return_key: [return_dict]}

--- a/esp/public/media/scripts/program/modules/adminclass.js
+++ b/esp/public/media/scripts/program/modules/adminclass.js
@@ -169,6 +169,33 @@ function fill_status_row(clsid, classes_data) {
         .append(sections_table)
     );
   
+  if (class_info.flags && class_info.flags.length > 0) {
+      var flags_div = $j("<div/>").css({"padding-top": "10px", "padding-left": "10px"});
+      flags_div.append($j("<b>Flags:</b>"));
+      var flags_list = $j("<ul/>");
+      $j.each(class_info.flags, function(i, flag) {
+          var badge = $j('<span/>')
+              .text(flag.name)
+              .css({
+                  'background-color': flag.color,
+                  'color': '#fff',
+                  'border-radius': '3px',
+                  'padding': '1px 6px',
+                  'margin-right': '6px',
+                  'font-size': '0.85em',
+              });
+          var detail = $j("<li/>");
+          detail.append(badge);
+          if (flag.comment) {
+              detail.append($j("<span/>").text(flag.comment + ' '));
+          }
+          detail.append($j("<small/>").text('(by ' + flag.modified_by + ' at ' + flag.modified_time + ')').css('color', '#888'));
+          flags_list.append(detail);
+      });
+      flags_div.append(flags_list);
+      status_wrapper.append(flags_div);
+  }
+
   if (class_info.special_requests || class_info.purchases || class_info.comments) {
       var comments_div = $j("<div/>").css("padding-top", "10px").css("justify-content", "space-around");
       if (class_info.special_requests) comments_div.append(make_attrib_para("Requests", class_info.special_requests));
@@ -299,7 +326,33 @@ function createClassTitleTd(clsObj) {
     }).append(
         $j('<span/>', {'class': title_css_class})
             .text(clsObj.title)
-    ).attr("data-st-key", clsObj.title);
+    ).append(createFlagBadges(clsObj))
+     .attr("data-st-key", clsObj.title);
+}
+
+function createFlagBadges(clsObj) {
+    if (!clsObj.dashboard_flags || clsObj.dashboard_flags.length === 0) {
+        return $j('<span/>');
+    }
+    var container = $j('<span/>', {'class': 'class-flag-badges'}).css('margin-left', '6px');
+    $j.each(clsObj.dashboard_flags, function(i, flag) {
+        container.append(
+            $j('<span/>', {'class': 'class-flag-badge'})
+                .text(flag.name)
+                .attr('title', flag.name)
+                .css({
+                    'background-color': flag.color,
+                    'color': '#fff',
+                    'border-radius': '3px',
+                    'padding': '1px 5px',
+                    'margin-right': '3px',
+                    'font-size': '0.75em',
+                    'white-space': 'nowrap',
+                    'display': 'inline-block',
+                })
+        );
+    });
+    return container;
 }
 
 function createClassStatusTd(clsObj) {


### PR DESCRIPTION
## Summary

This PR adds support for displaying class flags directly in the admin dashboard to improve visibility of important class metadata.

Flags are now accessible in two places:
1. Class list view (inline badges)
2. Class status popup (detailed view)

This improves the ability for admins to quickly identify flagged classes and inspect associated metadata without navigating away.

---

## Changes

### Backend
- Extended class data API to include:
  - `dashboard_flags` → lightweight flag data for list view
  - `flags` → detailed flag information for status popup
- Each flag includes:
  - name
  - color
  - comment
  - modified_by
  - modified_time

### Frontend
- Added inline flag badges next to class titles in admin dashboard
- Implemented flag rendering in status popup:
  - Displays badge + metadata
  - Includes comments and modification details
- Introduced helper function to generate consistent badge UI

---

## Behavior

### Class List
- Flags with `show_in_dashboard=True` appear as colored badges
- Positioned next to class title for quick scanning

### Status Popup
- Displays all flags associated with a class
- Includes:
  - flag name (badge)
  - comment (if present)
  - modifier and timestamp

---

## Scope

This PR is intentionally limited to **flags display functionality (#1354)**.

It does NOT include:
- module scheduling changes (#3854 / #2895)
- unrelated test additions

This keeps the PR atomic and easy to review.

---

## Testing

- Manually verified:
  - Flags appear correctly in class list
  - Status popup shows complete flag details
- Existing functionality remains unaffected

---

## Related Issue

Closes #1354