### PR TITLE
Fix DBListCount cache staleness by adding dependency registration and invalidation (#5213)

### DIFF
--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -1291,6 +1291,22 @@ class ESPUser(User, BaseESPUser):
 class AnonymousESPUser(BaseESPUser, AnonymousUser):
     pass
 
+def invalidate_DBListCount_caches():
+    keys = cache.get('DBListCount_keys', [])
+    for key in keys:
+        cache.delete(key)
+    cache.delete('DBListCount_keys')
+
+@dispatch.receiver(signals.post_save, sender=ESPUser,
+                     dispatch_uid='invalidate_DBListCount_caches_save')
+def invalidate_DBListCount_caches_on_save(sender, instance, **kwargs):
+    invalidate_DBListCount_caches()
+
+@dispatch.receiver(signals.post_delete, sender=ESPUser,
+                     dispatch_uid='invalidate_DBListCount_caches_delete')
+def invalidate_DBListCount_caches_on_delete(sender, instance, **kwargs):
+    invalidate_DBListCount_caches()
+
 @dispatch.receiver(signals.post_save, sender=User,
                      dispatch_uid='make_admin_save')
 def make_admin_save(sender, instance, **kwargs):
@@ -2286,15 +2302,25 @@ class DBList(object):
 
         retVal   = cache.get(cache_id) # get the cached result
         if self.QObject: # if there is a q object we can just
-            if not self.totalnum:
+            if not self.totalnum or cache.get(cache_id) is None:
                 if override:
                     self.totalnum = ESPUser.objects.filter(self.QObject).distinct().count()
                     cache.set(cache_id, self.totalnum, 60)
+                    # register cache key
+                    keys = cache.get('DBListCount_keys', [])
+                    if cache_id not in keys:
+                        keys.append(cache_id)
+                        cache.set('DBListCount_keys', keys, 60*60*24*7)
                 else:
                     cachedval = cache.get(cache_id)
                     if cachedval is None:
                         self.totalnum = ESPUser.objects.filter(self.QObject).distinct().count()
                         cache.set(cache_id, self.totalnum, 60)
+                        # register cache key
+                        keys = cache.get('DBListCount_keys', [])
+                        if cache_id not in keys:
+                            keys.append(cache_id)
+                            cache.set('DBListCount_keys', keys, 60*60*24*7)
                     else:
                         self.totalnum = cachedval
 

--- a/esp/esp/users/tests.py
+++ b/esp/esp/users/tests.py
@@ -10,6 +10,7 @@ from django.http import HttpRequest
 from django.conf import settings
 from django.utils.functional import SimpleLazyObject
 
+from django.db.models import Q
 from esp.middleware import ESPError
 from esp.program.models import RegistrationProfile, Program
 from esp.program.tests import ProgramFrameworkTest
@@ -17,7 +18,7 @@ from esp.tagdict.models import Tag
 from esp.tests.util import CacheFlushTestCase as TestCase, user_role_setup
 from esp.users.forms.user_reg import ValidHostEmailField
 from esp.users.forms.user_profile import StudentProfileForm
-from esp.users.models import User, ESPUser, UserForwarder, StudentInfo, Permission, Record, RecordType
+from esp.users.models import User, ESPUser, UserForwarder, StudentInfo, Permission, Record, RecordType, DBList
 
 class ESPUserTest(TestCase):
     def setUp(self):
@@ -197,6 +198,53 @@ class PasswordRecoveryTest(TestCase):
         # Other user's password is unaffected
         self.assertTrue(self.client.login(username='innocent', password='remembered_pw'),
                         "User innocent's old password no longer works")
+
+class DBListCountCacheTest(TestCase):
+    """Test that DBList count cache is properly invalidated on user operations."""
+    
+    def test_count_cache_invalidation_on_delete(self):
+        # Test that DBList count cache is invalidated on user delete
+        q = Q(username__startswith='testdblist')
+        dblist = DBList(key='test_list', QObject=q)
+        
+        # Get baseline count (before creating test user)
+        count_before = dblist.count()
+        
+        # Create a user that matches the filter
+        user = ESPUser.objects.create(username='testdblist1', email='test@example.com')
+        count_after_create = dblist.count()
+        self.assertEqual(count_after_create, count_before + 1,
+                        "Count should increase by 1 after user creation")
+        
+        # Delete the user
+        user.delete()
+        count_after_delete = dblist.count()
+        self.assertEqual(count_after_delete, count_before,
+                        "Count should return to baseline after user deletion")
+    
+    def test_count_cache_invalidation_on_update(self):
+        # Test that DBList count cache is invalidated on user update
+        q = Q(username__startswith='updatetest')
+        dblist = DBList(key='update_test_list', QObject=q)
+        
+        # Get baseline count
+        count_before = dblist.count()
+        
+        # Create a user that doesn't match the filter
+        user = ESPUser.objects.create(username='nomatch', email='nomatch@example.com')
+        count_no_match = dblist.count()
+        self.assertEqual(count_no_match, count_before,
+                        "Count should not change when creating non-matching user")
+        
+        # Update user to match the filter
+        user.username = 'updatetest_user'
+        user.save()
+        count_after_update = dblist.count()
+        self.assertEqual(count_after_update, count_before + 1,
+                        "Count should increase by 1 when user is updated to match filter")
+        
+        # Cleanup
+        user.delete()
 
 class TeacherInfo__validationtest(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Description
 
## Description

This PR fixes stale cache issues in `DBListCount` that occur after user create, update, or delete operations.

Previously, cache entries generated by `DBListCount.count()` were not associated with any invalidation mechanism. As a result, changes to user data did not refresh cached counts, leading to inconsistent and outdated results.

This PR introduces cache dependency tracking by registering cache keys at write time and ensures proper invalidation through Django signals (`post_save` and `post_delete`) on the user model.

Additionally, regression tests have been added to verify that cached counts are correctly updated after user modifications.

## Related Issue

## Related Issue

Closes #5213  
Parent issue: #995



## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [x] New tests added (if applicable)
- [x] Manually verified

## AI Disclosure

    No AI tools were used in the development of this pull request.

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced
