### PR TITLE
Add unit tests for AJAX autocomplete (#1452)

### DIFF
--- a/esp/esp/users/tests.py
+++ b/esp/esp/users/tests.py
@@ -868,6 +868,18 @@ class AjaxAutocompleteViewTest(TestCase):
         self.assertEqual(len(payload['result']), 1)
         self.assertEqual(payload['result'][0]['id'], self.target_user.id)
 
+    def test_invalid_model_does_not_crash(self):
+        self.assertTrue(self.client.login(username='staff_autocomplete', password='password'))
+
+        response = self.client.get('/admin/ajax_autocomplete/', {
+            'model_module': 'esp.users.models',
+            'model_name': 'InvalidModel',
+            'ajax_data': 'test',
+        })
+
+        self.assertNotEqual(response.status_code, 500)
+        self.assertIn(response.status_code, [200, 400])
+
 class StudentInfoFormGradeTest(TestCase):
     """Registration Profile grade validation.
 


### PR DESCRIPTION
This pull request adds a unit test for the AJAX autocomplete feature to ensure that invalid model input does not crash the view.

- Adds a test method in `AjaxAutocompleteViewTest` to cover the invalid model edge case.
- Ensures the view responds with a safe status code (200 or 400) instead of a server error.
- Improves test coverage for AJAX-related logic.
- Closes #1452

All tests pass in the local Docker environment before submission.
