### PR TITLE
Fix contributing.rst to use Docker-only workflow and remove native commands (#5387)

### DIFF
--- a/docs/dev/contributing.rst
+++ b/docs/dev/contributing.rst
@@ -38,12 +38,11 @@ From the directory ``/esp``: ::
   git pull
   git checkout -b new-branch-name
 
-If you've changed dependencies (for example, ``requirements.txt``)
-or modified the Dockerfile, rebuild first::
+If you've changed dependencies (for example, ``requirements.txt``) or modified the Dockerfile, rebuild first::
 
   docker compose up --build
 
-Otherwise, you don't need to rebuild, just start the server:
+Otherwise, you don't need to rebuild, just start the server::
 
   docker compose up
 

--- a/docs/dev/contributing.rst
+++ b/docs/dev/contributing.rst
@@ -11,7 +11,10 @@ Remove ``--global`` if you don't want it to apply to other git repos on your com
   git config --global user.name "Your Name"
   git config --global user.email you@something.edu
 
+Set up pre-commit hooks to automatically lint staged files before each commit: ::
 
+  pip install pre-commit
+  pre-commit install
 
 Other git config you might find useful: ::
 
@@ -31,20 +34,21 @@ The following workflow applies if you've already been added as a collaborator to
 
 From the directory ``/esp``: ::
 
-  git checkout main  # for historical reasons we use 'main' instead of 'master'
+  git checkout main
   git pull
-  docker compose up -d 
-  docker compose exec web python esp/manage.py update
   git checkout -b new-branch-name
 
-For routine development, ``docker compose up`` is usually sufficient.
 If you've changed dependencies (for example, ``requirements.txt``)
 or modified the Dockerfile, rebuild first::
 
-  docker compose down
-  docker compose up --build   
+  docker compose up --build
+
+Otherwise, you don't need to rebuild, just start the server:
+
+  docker compose up
 
 Write some code!
+(the server will automatically reload when you save changes to Python files, but you might need to refresh the page in your browser to see changes to HTML/CSS/JS files).
 Test your code!
 
 Look at what you've changed (``git status`` and/or ``git diff``), and then run ``git commit -a -m``, and type a commit message (see `<https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html>` for good commit message style), like so: ::
@@ -111,8 +115,6 @@ This project uses Django's built-in test framework. Tests generally live in thei
 
 Running Tests
 ~~~~~~~~~~~~~
-
-Docker is the supported development environment.
 
 To run all tests::
 

--- a/docs/dev/contributing.rst
+++ b/docs/dev/contributing.rst
@@ -36,8 +36,8 @@ From the directory ``/esp``: ::
 
   git checkout main  # for historical reasons we use 'main' instead of 'master'
   git pull
-  ./update_deps.sh # if using Docker: docker compose up --build; no need to bother if deps haven’t changed
-  ./manage.py update # if using Docker: docker compose exec web python esp/manage.py update
+  docker compose up --build
+  docker compose exec web python esp/manage.py update
   git checkout -b new-branch-name
 
 Write some code!
@@ -108,7 +108,7 @@ This project uses Django's built-in test framework. Tests generally live in thei
 Running Tests
 ~~~~~~~~~~~~~
 
-**Using Docker (recommended):**
+Docker is the supported development environment.
 
 To run all tests::
 
@@ -118,12 +118,6 @@ To run tests for a specific module (e.g. ``accounting``)::
 
   docker compose exec web python esp/manage.py test esp.accounting.tests
 
-**Without Docker:**
-
-If you are running the server natively without Docker::
-
-  cd esp
-  python manage.py test --settings=esp.settings
 
 Test Suite Reference
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/dev/contributing.rst
+++ b/docs/dev/contributing.rst
@@ -11,10 +11,7 @@ Remove ``--global`` if you don't want it to apply to other git repos on your com
   git config --global user.name "Your Name"
   git config --global user.email you@something.edu
 
-Set up pre-commit hooks to automatically lint staged files before each commit: ::
 
-  pip install pre-commit
-  pre-commit install
 
 Other git config you might find useful: ::
 
@@ -36,9 +33,16 @@ From the directory ``/esp``: ::
 
   git checkout main  # for historical reasons we use 'main' instead of 'master'
   git pull
-  docker compose up --build
+  docker compose up -d 
   docker compose exec web python esp/manage.py update
   git checkout -b new-branch-name
+
+For routine development, ``docker compose up`` is usually sufficient.
+If you've changed dependencies (for example, ``requirements.txt``)
+or modified the Dockerfile, rebuild first::
+
+  docker compose down
+  docker compose up --build   
 
 Write some code!
 Test your code!


### PR DESCRIPTION
## Description

## Description

This PR updates `docs/dev/contributing.rst` to align with the project's Docker-only development workflow.

Previously, the documentation mixed native commands with Docker equivalents (often as inline comments), which created confusion for new contributors following the Docker setup.

This change removes all native command references and replaces them with their corresponding Docker commands. It also simplifies the Testing section by eliminating the dual workflow and keeping only Docker-based instructions.

These updates ensure a consistent, unambiguous onboarding experience and reflect the current supported development environment.

## Related Issue

Closes #5387



## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manually verified

## AI Disclosure

No AI tools were used in the development of this pull request.

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [ ] No new warnings or errors introduced
