### PR TITLE
Fix customforms schema creation to be idempotent

### DIFF
--- a/esp/esp/customforms/models.py
+++ b/esp/esp/customforms/models.py
@@ -93,7 +93,10 @@ def create_schema(db):
 
     transaction.set_autocommit(False)
     try:
-        db.execute("CREATE SCHEMA customforms")
+        db.execute("SELECT 1 FROM information_schema.schemata WHERE schema_name = 'customforms'")
+        schema_exists = db.fetchone() is not None
+        if not schema_exists:
+            db.execute("CREATE SCHEMA customforms")
     except (DatabaseError, ProgrammingError):
         transaction.rollback()
     else:


### PR DESCRIPTION
Fixed an issue where startup always attempted to create the customforms schema, even when it already existed. That caused repeated PostgreSQL log noise like “schema customforms already exists” on subsequent runs.

This change makes schema setup idempotent. It first checks information_schema for the customforms schema, and only runs CREATE SCHEMA if it is missing. First-time setup still works the same, and repeated startups are now clean.

Key points:
- Prevents duplicate CREATE SCHEMA attempts
- Removes unnecessary PostgreSQL error logs on restart
- Keeps behavior unchanged for fresh databases

Validation:
- Started the app with Docker after the change
- Verified normal migration/startup flow
- Confirmed no new duplicate-schema error appears on repeated startup