### PR TITLE
Strengthen password validation for registration and password changes

### DIFF
--- a/esp/esp/django_settings.py
+++ b/esp/esp/django_settings.py
@@ -298,6 +298,24 @@ AUTHENTICATION_BACKENDS = (
     'esp.utils.auth_backend.ESPAuthBackend',
     )
 
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+        'OPTIONS': {
+            'min_length': 8,
+        }
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+    },
+]
+
 CONTACTFORM_EMAIL_CHOICES = (
     ('esp', 'Unknown'),
     ('general', 'General'),

--- a/esp/esp/users/forms/password_reset.py
+++ b/esp/esp/users/forms/password_reset.py
@@ -1,6 +1,8 @@
 
 
 from django import forms
+from django.contrib.auth.password_validation import validate_password
+from django.core.exceptions import ValidationError as DjangoValidationError
 from esp.users.models import ESPUser
 from django.utils.html import conditional_escape, mark_safe
 from esp.utils.forms import FormWithRequiredCss, SizedCharField
@@ -65,4 +67,12 @@ class UserPasswdForm(FormWithRequiredCss):
 
         if self.cleaned_data['newpasswd'] != new_passwd:
             raise forms.ValidationError('Password and confirmation are not equal.')
+        return new_passwd
+
+    def clean_newpasswd(self):
+        new_passwd = self.cleaned_data['newpasswd'].strip()
+        try:
+            validate_password(new_passwd, user=self.user)
+        except DjangoValidationError as e:
+            raise forms.ValidationError(e.messages)
         return new_passwd

--- a/esp/esp/users/forms/user_reg.py
+++ b/esp/esp/users/forms/user_reg.py
@@ -1,4 +1,6 @@
 from django import forms
+from django.contrib.auth.password_validation import validate_password
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db.models.query import Q
 from django.forms.fields import HiddenInput, TextInput
 
@@ -111,6 +113,20 @@ class UserRegForm(forms.Form):
         if not (('confirm_password' in self.cleaned_data) and ('password' in self.cleaned_data)) or (self.cleaned_data['confirm_password'] != self.cleaned_data['password']):
             raise forms.ValidationError('Ensure the password and password confirmation are equal.')
         return self.cleaned_data['confirm_password']
+
+    def clean_password(self):
+        password = self.cleaned_data['password']
+        temp_user = ESPUser(
+            username=self.cleaned_data.get('username', ''),
+            first_name=self.cleaned_data.get('first_name', ''),
+            last_name=self.cleaned_data.get('last_name', ''),
+            email=self.cleaned_data.get('email', ''),
+        )
+        try:
+            validate_password(password, user=temp_user)
+        except DjangoValidationError as e:
+            raise forms.ValidationError(e.messages)
+        return password
 
     def clean_confirm_email(self):
         if not (('confirm_email' in self.cleaned_data) and ('email' in self.cleaned_data)) or (self.cleaned_data['confirm_email'] != self.cleaned_data['email']):

--- a/esp/esp/users/tests.py
+++ b/esp/esp/users/tests.py
@@ -15,6 +15,7 @@ from esp.program.models import RegistrationProfile, Program
 from esp.program.tests import ProgramFrameworkTest
 from esp.tagdict.models import Tag
 from esp.tests.util import CacheFlushTestCase as TestCase, user_role_setup
+from esp.users.forms.password_reset import UserPasswdForm
 from esp.users.forms.user_reg import ValidHostEmailField
 from esp.users.forms.user_profile import StudentProfileForm
 from esp.users.models import User, ESPUser, UserForwarder, StudentInfo, Permission, Record, RecordType
@@ -454,8 +455,8 @@ class AccountCreationTest(TestCase):
             url+="information/"
         response = self.client.post(url,
                                    data={"username":"username",
-                                         "password":"passw",
-                                         "confirm_password":"passw",
+                                 "password":"StrongPass123!",
+                                 "confirm_password":"StrongPass123!",
                                          "first_name":"first",
                                          "last_name":"last",
                                          "email":"tsutton125@gmail.com",
@@ -485,6 +486,47 @@ class AccountCreationTest(TestCase):
         match = re.search("\?username=(?P<user>[^&]*)&key=(?P<key>\d+)", mail.outbox[0].body)
         self.assertEqual(match.group("user"), u.username)
         self.assertEqual(match.group("key"), u.password.rsplit("_")[-1])
+
+    def test_phase_2_rejects_weak_password(self):
+        url = "/myesp/register/"
+        if Tag.getBooleanTag("ask_about_duplicate_accounts"):
+            url += "information/"
+
+        response = self.client.post(url,
+                                    data={"username": "weakpassuser",
+                                          "password": "password",
+                                          "confirm_password": "password",
+                                          "first_name": "first",
+                                          "last_name": "last",
+                                          "email": "weakpass@example.com",
+                                          "confirm_email": "weakpass@example.com",
+                                          "initial_role": "Teacher"})
+
+        self.assertTemplateUsed(response, "registration/newuser.html")
+        self.assertFalse(ESPUser.objects.filter(username="weakpassuser").exists())
+        self.assertIn('password', response.context['form'].errors)
+
+
+class PasswordStrengthValidationTest(TestCase):
+    def setUp(self):
+        self.user = ESPUser.objects.create_user(
+            username='password_strength_user',
+            email='password_strength@example.com',
+            password='StrongPass123!'
+        )
+
+    def test_change_password_form_rejects_common_password(self):
+        form = UserPasswdForm(
+            user=self.user,
+            data={
+                'password': 'StrongPass123!',
+                'newpasswd': 'password',
+                'newpasswdconfirm': 'password',
+            },
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertIn('newpasswd', form.errors)
 
 from esp.users.models import GradeChangeRequest
 


### PR DESCRIPTION
This PR strengthens password security by rejecting weak passwords during signup and password change.

It enables Django’s built-in password validators and applies them to the custom registration and password update forms, with tests added to cover the behavior.

Closes #5591