### PR TITLE
Fix IndexError in admin and teacher review apps

### DIFF
--- a/esp/esp/program/modules/handlers/adminreviewapps.py
+++ b/esp/esp/program/modules/handlers/adminreviewapps.py
@@ -90,7 +90,8 @@ class AdminReviewApps(ProgramModuleObj):
         students = [x for x in students if x.studentapplication_set.filter(program=self.program).count() > 0]
 
         for student in students:
-            student.added_class = student.studentregistration_set.filter(section__parent_class=cls)[0].start_date
+            registration = student.studentregistration_set.filter(section__parent_class=cls).first()
+            student.added_class = registration.start_date if registration else None
             try:
                 student.app = student.studentapplication_set.get(program = self.program)
             except StudentApplication.DoesNotExist:

--- a/esp/esp/program/modules/handlers/teacherreviewapps.py
+++ b/esp/esp/program/modules/handlers/teacherreviewapps.py
@@ -78,7 +78,8 @@ class TeacherReviewApps(ProgramModuleObj):
 
         for student in students:
             now = datetime.now()
-            student.added_class = StudentRegistration.valid_objects().filter(section__parent_class = cls, user = student)[0].start_date
+            registration = StudentRegistration.valid_objects().filter(section__parent_class=cls, user=student).first()
+            student.added_class = registration.start_date if registration else None
             try:
                 student.app = student.studentapplication_set.get(program = self.program)
             except StudentApplication.DoesNotExist:
@@ -103,7 +104,7 @@ class TeacherReviewApps(ProgramModuleObj):
                         student.app_completed = True
 
         students = list(students)
-        students.sort(key=lambda s: s.added_class)
+        students.sort(key=lambda s: (s.added_class is None, s.added_class))
 
         if 'prev' in request.GET:
             prev_id = int(request.GET.get('prev'))
@@ -213,7 +214,8 @@ class TeacherReviewApps(ProgramModuleObj):
             student.app = None
             raise ESPError('Error: Student did not start an application.', log=False)
 
-        student.added_class = StudentRegistration.valid_objects().filter(section__parent_class = cls, user = student)[0].start_date
+        registration = StudentRegistration.valid_objects().filter(section__parent_class=cls, user=student).first()
+        student.added_class = registration.start_date if registration else None
 
         teacher_reviews = student.app.reviews.all().filter(reviewer=request.user)
         if teacher_reviews.count() > 0:


### PR DESCRIPTION
Resolves a 500 IndexError crash on the teacher and admin review pages occurring when a student has a deleted or invalid registration.

Replaced unprotected .filter()[0] indexing with .first() and added a graceful None fallback, as well as handled None-safe sorting using lambda s: (s.added_class is None, s.added_class).
Closes #5530

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced
