### PR TITLE
Filter AJAX scheduler rooms by selected section availability

### DIFF
--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Matrix.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Matrix.js
@@ -82,8 +82,8 @@ function Matrix(
         var selectedSection = this.sections.selectedSection;
         var validStartingTimeslots = [];
     
-        if (selectedSection) {
-            validStartingTimeslots = this.sections.getAvailableTimeslots(selectedSection)[0];
+        if (selectedSection && this.sections.availableTimeslots.length > 0) {
+            validStartingTimeslots = this.sections.availableTimeslots[0];
         }
     
         $j.each(this.rooms, function(index, room) {
@@ -100,8 +100,7 @@ function Matrix(
                 }
             }
     
-            // New part: if a section is selected, only keep rooms that work
-            // for at least one valid starting timeslot for that section
+            // If a section is selected, only show rooms with at least one valid placement.
             if (roomValid && selectedSection) {
                 roomValid = false;
     

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Matrix.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Matrix.js
@@ -79,24 +79,49 @@ function Matrix(
      */
     this.filteredRooms = function(){
         var returnedRooms = [];
+        var selectedSection = this.sections.selectedSection;
+        var validStartingTimeslots = [];
+    
+        if (selectedSection) {
+            validStartingTimeslots = this.sections.getAvailableTimeslots(selectedSection)[0];
+        }
+    
         $j.each(this.rooms, function(index, room) {
-            var roomValid;
-            // check every criterion in the room filter tab, short-circuiting if possible
-            roomValid = true;
+            var roomValid = true;
+    
+            // Keep existing room filters
             for (var filterName in this.filter) {
                 if (this.filter.hasOwnProperty(filterName)) {
                     var filterObject = this.filter[filterName];
-                    // this loops over properties in this.filter
                     if (filterObject.active && !filterObject.valid(room)) {
                         roomValid = false;
                         break;
                     }
                 }
             }
+    
+            // New part: if a section is selected, only keep rooms that work
+            // for at least one valid starting timeslot for that section
+            if (roomValid && selectedSection) {
+                roomValid = false;
+    
+                $j.each(validStartingTimeslots, function(i, timeslot_id) {
+                    var scheduleTimeslots =
+                        this.timeslots.get_timeslots_to_schedule_section(selectedSection, timeslot_id);
+    
+                    if (scheduleTimeslots !== null &&
+                        this.validateAssignment(selectedSection, room.id, scheduleTimeslots).valid) {
+                        roomValid = true;
+                        return false;
+                    }
+                }.bind(this));
+            }
+    
             if (roomValid) {
                 returnedRooms.push(room);
             }
         }.bind(this));
+    
         return returnedRooms;
     };
     

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
@@ -270,7 +270,7 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
                 this.unselectSection();
                 return;
             } else {
-                this.unselectSection();
+                this.unselectSection(false, true);
             }
         }
 
@@ -295,7 +295,7 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
      * panel, and unhighlight the available cells to place the section.
      * @param override: What should the availability override status be?
      */
-    this.unselectSection = function(override = false) {
+    this.unselectSection = function(override = false, skipRoomUpdate = false) {
         if(!this.selectedSection) {
             return;
         }
@@ -314,7 +314,9 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
         this.matrix.sectionInfoPanel.override = override;
         this.matrix.unhighlightTimeslots(this.availableTimeslots);
         this.unscheduleAsGhost();
-        this.matrix.updateRooms();
+        if (!skipRoomUpdate) {
+            this.matrix.updateRooms();
+        }
     };
 
     /**

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
@@ -287,6 +287,7 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
         this.matrix.sectionInfoPanel.displaySection(section);
         this.availableTimeslots = this.getAvailableTimeslots(section);
         this.matrix.highlightTimeslots(this.availableTimeslots, section);
+        this.matrix.updateRooms();
     };
 
     /**
@@ -313,6 +314,7 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
         this.matrix.sectionInfoPanel.override = override;
         this.matrix.unhighlightTimeslots(this.availableTimeslots);
         this.unscheduleAsGhost();
+        this.matrix.updateRooms();
     };
 
     /**


### PR DESCRIPTION
## Description

This PR updates the AJAX scheduler so that when a section is selected, the visible room list is filtered to rooms where that section has at least one valid placement.

It keeps the existing room filters intact and refreshes the visible rooms when selecting or unselecting a section.

## Related Issue

Closes #458 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

Manual verification:
- selected a section and confirmed the room list narrowed to rooms with at least one valid placement
- unselected the section and confirmed the full room list returned

## AI Disclosure

I used AI (ChatGPT) for debugging and reviewing the final patch.
All code changes were reviewed, edited, and tested manually by me before submission.

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced