### PR TITLE
Factor out banners from main.html

### DIFF
--- a/esp/esp/themes/theme_data/barebones/templates/main.html
+++ b/esp/esp/themes/theme_data/barebones/templates/main.html
@@ -1,7 +1,7 @@
 {% extends "elements/html" %}
 
 {% comment %}
-Customize your title formatting here.  For example:
+Customize your title formatting here. For example:
 {% block fulltitle %}Splash at UFoo - {% block title %}{% endblock %}{% endblock %}
 {% endcomment %}
 {% block fulltitle %}{% block title %}{% endblock %}{% endblock %}
@@ -9,7 +9,8 @@ Customize your title formatting here.  For example:
 {% block stylesheets %}
 {{ block.super }}
 {% comment %}
-    If you would like to customize the appearance of your site beyond the possibilities of the theme editor, you may add additional stylesheets here.
+If you would like to customize the appearance of your site beyond the possibilities of the theme editor, you may add
+additional stylesheets here.
 Example stylesheet inclusion tag:
 <link rel="stylesheet" href="/media/styles/main.css" type="text/css" />
 {% endcomment %}
@@ -43,52 +44,11 @@ Example stylesheet inclusion tag:
     {% endblock %}
 
     <div id="main" class="span12 resizable">
-      {% if request.COOKIES.esp_testing_role %}
-      <div style="background: #fcf8e3; border: 1px solid #c09853; color: #c09853; padding: 8px 15px; margin-bottom: 15px; border-radius: 4px; text-align: center;">
-        <strong>Testing Mode ({{ request.COOKIES.esp_testing_role }})</strong> &mdash;
-        You are logged in as a test account.
-        <a href="/myesp/stop_testing/" style="color: #a47e3c; text-decoration: underline;">Stop Testing &mdash; Return to Admin</a>
-      </div>
-      {% endif %}
-      {% if request.mod_required %}
-      <div class="alert alert-danger">
-        <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
-          This page is <b>required</b> for {% if request.tl == "teach" %}teacher{% elif request.tl == "learn" %}student{% elif request.tl == "volunteer" %}volunteer{% endif %} registration. You must complete it to proceed.
-      </div>
-      {% endif %}
-      {% if request.show_perm_info %}
-      <div class="alert alert-info">
-        <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
-          <a href="/manage/{{ request.one }}/{{ request.two }}/deadline_management/">Permission/deadline</a> required to view this page: {{ request.perm_names|join:", " }}
-        <br />
-        {% if request.roles_with_perm %}
-        Roles with permission to view this page: {{ request.roles_with_perm|join:", " }}
-        {% else %}
-        <strong>No (non-admin) roles have permission to view this page!</strong>
-        {% endif %}
-      </div>
-      {% endif %}
-      {% if active_program_tags %}
-      <div class="alert alert-info alert-dismissible" role="alert">
-        <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        <strong>Admin notice:</strong>
-        This program has {{ active_program_tags|length }} custom tag{{ active_program_tags|length|pluralize }} configured that may be modifying page behavior:
-        {% for tag in active_program_tags %}
-          <span class="label label-default" title="{{ tag.help_text }}">{{ tag.key }}</span>
-        {% endfor %}
-        &mdash; <a href="{{ active_program_tags_url }}" class="alert-link">View tag settings</a>
-      </div>
-      {% endif %}
-      {% if messages %}
-      {% for message in messages %}
-      <div class="alert alert-{{ message.tags }}">{{ message }}</div>
-      {% endfor %}
-      {% endif %}
+      {% include "elements/banners" %}
       {% block content %}
       {% endblock %}
     </div>
   </div>
-</div>
 </div>
 {% endblock %} {# end block main #}
 
@@ -103,7 +63,9 @@ Example stylesheet inclusion tag:
       {% end_inline_qsd_block %}
     </div>
     <div>
-    <p>Copyright {{ theme.mtime.year }}, {{ settings.ORGANIZATION_SHORT_NAME }} at {{ settings.INSTITUTION_NAME }} - <a href="mailto:{{ settings.DEFAULT_EMAIL_ADDRESSES.default }}">Email us</a> - <a href="/contact/contact/">Contact Form</a></p>
+      <p>Copyright {{ theme.mtime.year }}, {{ settings.ORGANIZATION_SHORT_NAME }} at {{ settings.INSTITUTION_NAME }} -
+        <a href="mailto:{{ settings.DEFAULT_EMAIL_ADDRESSES.default }}">Email us</a> - <a
+          href="/contact/contact/">Contact Form</a></p>
     </div>
     {% endblock %}
   </footer>

--- a/esp/esp/themes/theme_data/bigpicture/templates/main.html
+++ b/esp/esp/themes/theme_data/bigpicture/templates/main.html
@@ -5,11 +5,7 @@
 {% block stylesheets %}
 {{ block.super }}
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Patrick+Hand" />
-<style>
-  .jumbotron {
-    background-image: url(/media/images/theme/header.png?v={{ current_header_version }});
-  }
-</style>
+
 {% endblock stylesheets %}
 
 {% block body %}
@@ -26,7 +22,7 @@
 {% endblock navbar%}
 
 {% block heading %}
-<header class="jumbotron subhead" id="overview">
+<header class="jumbotron subhead" id="overview" style="background-image: url('/media/images/theme/header.png?v={{ current_header_version }}');">
   <div>
     <div class="header-cell">
       <a href="/">
@@ -34,13 +30,13 @@
       </a>
       <div id="contact_info">
         {% if theme.show_group_name %}
-        <span class="title accentcolor">{{ theme.full_group_name }}</span></br>
+        <span class="title accentcolor">{{ theme.full_group_name }}</span><br />
         {% endif %}
         {% if theme.contact_info %}
-        <span class="normal">{{ theme.contact_info|linebreaksbr }}</span></br>
+        <span class="normal">{{ theme.contact_info|linebreaksbr }}</span><br />
         {% endif %}
         {% if theme.show_email %}
-        <span class="normal">Email: <a href="mailto:{{ settings.DEFAULT_EMAIL_ADDRESSES.default }}">{{ settings.DEFAULT_EMAIL_ADDRESSES.default }}</a></span></br>
+        <span class="normal">Email: <a href="mailto:{{ settings.DEFAULT_EMAIL_ADDRESSES.default }}">{{ settings.DEFAULT_EMAIL_ADDRESSES.default }}</a></span><br />
         {% endif %}
         {% if theme.contact_links %}
         <span class="normal">
@@ -49,7 +45,7 @@
           {% if forloop.counter|divisibleby:3 %}<br />
           {% elif not forloop.last %} | {% endif %}
           {% endfor %}
-        </span></br>
+        </span><br />
         {% endif %}
         {% if theme.faq_link or theme.facebook_link %}
         <span class="normal">
@@ -60,7 +56,7 @@
           {% if theme.facebook_link %}
           <a href="{{ theme.facebook_link }}">facebook</a>
           {% endif %}
-        </span></br>
+        </span><br />
         {% endif %}
         <span class="normal"><a href="https://www.learningu.org/about/privacy/" target="_blank">Privacy Policy</a></span>
       </div>
@@ -86,47 +82,7 @@
     {% endblock %}
 
     <div id="main" class="span9 resizable">
-      {% if request.COOKIES.esp_testing_role %}
-      <div style="background: #fcf8e3; border: 1px solid #c09853; color: #c09853; padding: 8px 15px; margin-bottom: 15px; border-radius: 4px; text-align: center;">
-        <strong>Testing Mode ({{ request.COOKIES.esp_testing_role }})</strong> &mdash;
-        You are logged in as a test account.
-        <a href="/myesp/stop_testing/" style="color: #a47e3c; text-decoration: underline;">Stop Testing &mdash; Return to Admin</a>
-      </div>
-      {% endif %}
-      {% if request.mod_required %}
-      <div class="alert alert-danger">
-        <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
-          This page is <b>required</b> for {% if request.tl == "teach" %}teacher{% elif request.tl == "learn" %}student{% elif request.tl == "volunteer" %}volunteer{% endif %} registration. You must complete it to proceed.
-      </div>
-      {% endif %}
-      {% if request.show_perm_info %}
-      <div class="alert alert-info">
-        <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
-          <a href="/manage/{{ request.one }}/{{ request.two }}/deadline_management/">Permission/deadline</a> required to view this page: {{ request.perm_names|join:", " }}
-        <br />
-        {% if request.roles_with_perm %}
-        Roles with permission to view this page: {{ request.roles_with_perm|join:", " }}
-        {% else %}
-        <strong>No (non-admin) roles have permission to view this page!</strong>
-        {% endif %}
-      </div>
-      {% endif %}
-      {% if active_program_tags %}
-      <div class="alert alert-info alert-dismissible" role="alert">
-        <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        <strong>Admin notice:</strong>
-        This program has {{ active_program_tags|length }} custom tag{{ active_program_tags|length|pluralize }} configured that may be modifying page behavior:
-        {% for tag in active_program_tags %}
-          <span class="label label-default" title="{{ tag.help_text }}">{{ tag.key }}</span>
-        {% endfor %}
-        &mdash; <a href="{{ active_program_tags_url }}" class="alert-link">View tag settings</a>
-      </div>
-      {% endif %}
-      {% if messages %}
-      {% for message in messages %}
-      <div class="alert alert-{{ message.tags }}">{{ message }}</div>
-      {% endfor %}
-      {% endif %}
+      {% include "elements/banners" %}
       {% block content %}
       {% endblock content %}
 
@@ -144,11 +100,10 @@
     </div>
   </div>
 </div>
-</div>
-</br>
-</br>
+<br />
+<br />
 <script>
-  {# TODO(benkraft): this is ugly, find a better way #}
+  // TODO(benkraft): this is ugly, find a better way
   $j('.button').addClass('btn').removeClass('button');
   $j('.fancybutton').addClass('btn').addClass('btn-primary');
 </script>

--- a/esp/esp/themes/theme_data/circles/templates/main.html
+++ b/esp/esp/themes/theme_data/circles/templates/main.html
@@ -106,47 +106,7 @@
 <div id="chicago_main_header">{% block welcome_message %}<!-- CSS2 doesn't allow vertical alignment without a table.  So, give it a table. --><table width="600px" height="30px"><tr><td valign="middle">{{ theme.welcome_message }}</td></tr></table>{% endblock %}</div>
 
 <div id="chicago_main_content">
-  {% if request.COOKIES.esp_testing_role %}
-  <div style="background: #fcf8e3; border: 1px solid #c09853; color: #c09853; padding: 8px 15px; margin-bottom: 15px; border-radius: 4px; text-align: center;">
-    <strong>Testing Mode ({{ request.COOKIES.esp_testing_role }})</strong> &mdash;
-    You are logged in as a test account.
-    <a href="/myesp/stop_testing/" style="color: #a47e3c; text-decoration: underline;">Stop Testing &mdash; Return to Admin</a>
-  </div>
-  {% endif %}
-  {% if request.mod_required %}
-  <div class="alert alert-danger">
-      <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
-      This page is <b>required</b> for {% if request.tl == "teach" %}teacher{% elif request.tl == "learn" %}student{% elif request.tl == "volunteer" %}volunteer{% endif %} registration. You must complete it to proceed.
-      </div>
-      {% endif %}
-      {% if request.show_perm_info %}
-      <div class="alert alert-info">
-        <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
-      <a href="/manage/{{ request.one }}/{{ request.two }}/deadline_management/">Permission/deadline</a> required to view this page: {{ request.perm_names|join:", " }}
-        <br />
-        {% if request.roles_with_perm %}
-        Roles with permission to view this page: {{ request.roles_with_perm|join:", " }}
-        {% else %}
-        <strong>No (non-admin) roles have permission to view this page!</strong>
-        {% endif %}
-      </div>
-      {% endif %}
-      {% if active_program_tags %}
-      <div class="alert alert-info alert-dismissible" role="alert">
-        <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        <strong>Admin notice:</strong>
-        This program has {{ active_program_tags|length }} custom tag{{ active_program_tags|length|pluralize }} configured that may be modifying page behavior:
-        {% for tag in active_program_tags %}
-          <span class="label label-default" title="{{ tag.help_text }}">{{ tag.key }}</span>
-        {% endfor %}
-        &mdash; <a href="{{ active_program_tags_url }}" class="alert-link">View tag settings</a>
-      </div>
-      {% endif %}
-      {% if messages %}
-      {% for message in messages %}
-      <div class="alert alert-{{ message.tags }}">{{ message }}</div>
-      {% endfor %}
-      {% endif %}
+      {% include "elements/banners" %}
       {% block content %}{% endblock %}
       {% if theme.show_footer_textbox %}
       <div>

--- a/esp/esp/themes/theme_data/droplets/templates/main.html
+++ b/esp/esp/themes/theme_data/droplets/templates/main.html
@@ -67,47 +67,7 @@
 
 <div class="container">
   <div id="main" class="resizable">
-    {% if request.COOKIES.esp_testing_role %}
-    <div style="background: #fcf8e3; border: 1px solid #c09853; color: #c09853; padding: 8px 15px; margin-bottom: 15px; border-radius: 4px; text-align: center;">
-      <strong>Testing Mode ({{ request.COOKIES.esp_testing_role }})</strong> &mdash;
-      You are logged in as a test account.
-      <a href="/myesp/stop_testing/" style="color: #a47e3c; text-decoration: underline;">Stop Testing &mdash; Return to Admin</a>
-    </div>
-    {% endif %}
-    {% if request.mod_required %}
-    <div class="alert alert-danger">
-        <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
-        This page is <b>required</b> for {% if request.tl == "teach" %}teacher{% elif request.tl == "learn" %}student{% elif request.tl == "volunteer" %}volunteer{% endif %} registration. You must complete it to proceed.
-    </div>
-    {% endif %}
-    {% if request.show_perm_info %}
-    <div class="alert alert-info">
-        <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
-        <a href="/manage/{{ request.one }}/{{ request.two }}/deadline_management/">Permission/deadline</a> required to view this page: {{ request.perm_names|join:", " }}
-        <br />
-        {% if request.roles_with_perm %}
-            Roles with permission to view this page: {{ request.roles_with_perm|join:", " }}
-        {% else %}
-            <strong>No (non-admin) roles have permission to view this page!</strong>
-        {% endif %}
-    </div>
-    {% endif %}
-    {% if active_program_tags %}
-    <div class="alert alert-info alert-dismissible" role="alert">
-      <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-      <strong>Admin notice:</strong>
-      This program has {{ active_program_tags|length }} custom tag{{ active_program_tags|length|pluralize }} configured that may be modifying page behavior:
-      {% for tag in active_program_tags %}
-        <span class="label label-default" title="{{ tag.help_text }}">{{ tag.key }}</span>
-      {% endfor %}
-      &mdash; <a href="{{ active_program_tags_url }}" class="alert-link">View tag settings</a>
-    </div>
-    {% endif %}
-    {% if messages %}
-    {% for message in messages %}
-    <div class="alert alert-{{ message.tags }}">{{ message }}</div>
-    {% endfor %}
-    {% endif %}
+    {% include "elements/banners" %}
     {% block content %}
     {% endblock content %}
 

--- a/esp/esp/themes/theme_data/floaty/templates/main.html
+++ b/esp/esp/themes/theme_data/floaty/templates/main.html
@@ -100,47 +100,7 @@
 </div>
 
 <div id="content_area">
-    {% if request.COOKIES.esp_testing_role %}
-    <div style="background: #fcf8e3; border: 1px solid #c09853; color: #c09853; padding: 8px 15px; margin-bottom: 15px; border-radius: 4px; text-align: center;">
-      <strong>Testing Mode ({{ request.COOKIES.esp_testing_role }})</strong> &mdash;
-      You are logged in as a test account.
-      <a href="/myesp/stop_testing/" style="color: #a47e3c; text-decoration: underline;">Stop Testing &mdash; Return to Admin</a>
-    </div>
-    {% endif %}
-    {% if request.mod_required %}
-    <div class="alert alert-danger">
-        <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
-        This page is <b>required</b> for {% if request.tl == "teach" %}teacher{% elif request.tl == "learn" %}student{% elif request.tl == "volunteer" %}volunteer{% endif %} registration. You must complete it to proceed.
-    </div>
-    {% endif %}
-    {% if request.show_perm_info %}
-    <div class="alert alert-info">
-        <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
-        <a href="/manage/{{ request.one }}/{{ request.two }}/deadline_management/">Permission/deadline</a> required to view this page: {{ request.perm_names|join:", " }}
-        <br />
-        {% if request.roles_with_perm %}
-            Roles with permission to view this page: {{ request.roles_with_perm|join:", " }}
-        {% else %}
-            <strong>No (non-admin) roles have permission to view this page!</strong>
-        {% endif %}
-    </div>
-    {% endif %}
-    {% if active_program_tags %}
-    <div class="alert alert-info alert-dismissible" role="alert">
-      <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-      <strong>Admin notice:</strong>
-      This program has {{ active_program_tags|length }} custom tag{{ active_program_tags|length|pluralize }} configured that may be modifying page behavior:
-      {% for tag in active_program_tags %}
-        <span class="label label-default" title="{{ tag.help_text }}">{{ tag.key }}</span>
-      {% endfor %}
-      &mdash; <a href="{{ active_program_tags_url }}" class="alert-link">View tag settings</a>
-    </div>
-    {% endif %}
-    {% if messages %}
-    {% for message in messages %}
-    <div class="alert alert-{{ message.tags }}">{{ message }}</div>
-    {% endfor %}
-    {% endif %}
+    {% include "elements/banners" %}
     {% block content %}
     {% endblock %}
 

--- a/esp/esp/themes/theme_data/fruitsalad/templates/main.html
+++ b/esp/esp/themes/theme_data/fruitsalad/templates/main.html
@@ -198,47 +198,7 @@ var toolbarLinks = Array.isArray(rawToolbarLinks) ? rawToolbarLinks : [];
       {% endblock %}
 
       <div id="content">
-          {% if request.COOKIES.esp_testing_role %}
-          <div style="background: #fcf8e3; border: 1px solid #c09853; color: #c09853; padding: 8px 15px; margin-bottom: 15px; border-radius: 4px; text-align: center;">
-            <strong>Testing Mode ({{ request.COOKIES.esp_testing_role }})</strong> &mdash;
-            You are logged in as a test account.
-            <a href="/myesp/stop_testing/" style="color: #a47e3c; text-decoration: underline;">Stop Testing &mdash; Return to Admin</a>
-          </div>
-          {% endif %}
-          {% if request.mod_required %}
-          <div class="alert alert-danger">
-              <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
-              This page is <b>required</b> for {% if request.tl == "teach" %}teacher{% elif request.tl == "learn" %}student{% elif request.tl == "volunteer" %}volunteer{% endif %} registration. You must complete it to proceed.
-        </div>
-        {% endif %}
-        {% if request.show_perm_info %}
-        <div class="alert alert-info">
-          <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
-              <a href="/manage/{{ request.one }}/{{ request.two }}/deadline_management/">Permission/deadline</a> required to view this page: {{ request.perm_names|join:", " }}
-          <br />
-          {% if request.roles_with_perm %}
-          Roles with permission to view this page: {{ request.roles_with_perm|join:", " }}
-          {% else %}
-          <strong>No (non-admin) roles have permission to view this page!</strong>
-          {% endif %}
-        </div>
-        {% endif %}
-          {% if active_program_tags %}
-          <div class="alert alert-info alert-dismissible" role="alert">
-            <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-            <strong>Admin notice:</strong>
-            This program has {{ active_program_tags|length }} custom tag{{ active_program_tags|length|pluralize }} configured that may be modifying page behavior:
-            {% for tag in active_program_tags %}
-              <span class="label label-default" title="{{ tag.help_text }}">{{ tag.key }}</span>
-            {% endfor %}
-            &mdash; <a href="{{ active_program_tags_url }}" class="alert-link">View tag settings</a>
-          </div>
-          {% endif %}
-        {% if messages %}
-        {% for message in messages %}
-        <div class="alert alert-{{ message.tags }}">{{ message }}</div>
-        {% endfor %}
-        {% endif %}
+          {% include "elements/banners" %}
         {% block content %}{% endblock %}
       </div>
       <!--[if lte IE 6]>

--- a/esp/templates/elements/banners
+++ b/esp/templates/elements/banners
@@ -1,0 +1,41 @@
+{% if request.COOKIES.esp_testing_role %}
+<div style="background: #fcf8e3; border: 1px solid #c09853; color: #c09853; padding: 8px 15px; margin-bottom: 15px; border-radius: 4px; text-align: center;">
+  <strong>Testing Mode ({{ request.COOKIES.esp_testing_role }})</strong> &mdash;
+  You are logged in as a test account.
+  <a href="/myesp/stop_testing/" style="color: #a47e3c; text-decoration: underline;">Stop Testing &mdash; Return to Admin</a>
+</div>
+{% endif %}
+{% if request.mod_required %}
+<div class="alert alert-danger">
+  <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+  This page is <b>required</b> for {% if request.tl == "teach" %}teacher{% elif request.tl == "learn" %}student{% elif request.tl == "volunteer" %}volunteer{% endif %} registration. You must complete it to proceed.
+</div>
+{% endif %}
+{% if request.show_perm_info %}
+<div class="alert alert-info">
+  <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+  <a href="/manage/{{ request.one }}/{{ request.two }}/deadline_management/">Permission/deadline</a> required to view this page: {{ request.perm_names|join:", " }}
+  <br />
+  {% if request.roles_with_perm %}
+  Roles with permission to view this page: {{ request.roles_with_perm|join:", " }}
+  {% else %}
+  <strong>No (non-admin) roles have permission to view this page!</strong>
+  {% endif %}
+</div>
+{% endif %}
+{% if active_program_tags %}
+<div class="alert alert-info alert-dismissible" role="alert">
+  <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+  <strong>Admin notice:</strong>
+  This program has {{ active_program_tags|length }} custom tag{{ active_program_tags|length|pluralize }} configured that may be modifying page behavior:
+  {% for tag in active_program_tags %}
+    <span class="label label-default" title="{{ tag.help_text }}">{{ tag.key }}</span>
+  {% endfor %}
+  &mdash; <a href="{{ active_program_tags_url }}" class="alert-link">View tag settings</a>
+</div>
+{% endif %}
+{% if messages %}
+{% for message in messages %}
+<div class="alert alert-{{ message.tags }}">{{ message }}</div>
+{% endfor %}
+{% endif %}

--- a/esp/templates/main.html
+++ b/esp/templates/main.html
@@ -12,45 +12,20 @@
 
 {% block main %}
 
-    <div class="container">
-      {% if request.COOKIES.esp_testing_role %}
-      <div
-       style="background: #fbf0b3; border: 1px solid #c09852; color: #c09852; padding: 0px 15px; margin-bottom: 15px; border-radius: 4px; text-align: center;">
-       <strong>Testing Mode ({{ request.COOKIES.esp_testing_role }}):</strong> &mdash;
-       You are logged in as a test account.
-       <a href="/myesp/stop_testing/" style="color: #a1702c; text-decoration: underline;">Stop testing &mdash; Return to
-         Admin</a>
-      </div>
-      {% endif %}
-      <div class="row-fluid">
-        {% block sidebar %}
-          <div style="margin-bottom: 20px;">
-            <h3>Navigation</h3>
-            {% load navbar %}
-            {% navbar_gen request.path None navbar_list %}
-            {% include "users/loginbox_content.html" %}
-          </div>
-        {% endblock sidebar %}
+<div class="container">
+  {% include "elements/banners" %}
+  <div class="row-fluid">
+    {% block sidebar %}
+    <div style="margin-bottom: 20px;">
+      <h3>Navigation</h3>
+      {% load navbar %}
+      {% navbar_gen request.path None navbar_list %}
+      {% include "users/loginbox_content.html" %}
+    </div>
+    {% endblock sidebar %}
 
     <div id="main" class="span12 resizable">
-      {% if messages %}
-      {% for message in messages %}
-      <div class="alert alert-{{ message.tags }}">
-        {{ message }}
-      </div>
-      {% endfor %}
-      {% endif %}
-      {% if active_program_tags %}
-      <div class="alert alert-info alert-dismissible" role="alert">
-        <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        <strong>Admin notice:</strong>
-        This program has {{ active_program_tags|length }} custom tag{{ active_program_tags|length|pluralize }} configured that may be modifying page behavior:
-        {% for tag in active_program_tags %}
-          <span class="label label-default" title="{{ tag.help_text }}">{{ tag.key }}</span>
-        {% endfor %}
-        &mdash; <a href="{{ active_program_tags_url }}" class="alert-link">View tag settings</a>
-      </div>
-      {% endif %}
+
       {% block content %}
       {% endblock content %}
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,313 @@
+{
+  "name": "esp-website",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "esp-website",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "htmlhint": "^1.9.2"
+      }
+    },
+    "node_modules/@types/sarif": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz",
+      "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
+      "license": "MIT"
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/htmlhint": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/htmlhint/-/htmlhint-1.9.2.tgz",
+      "integrity": "sha512-PweWSPA1Pb+AVFIOSpIGu5KhLdmtk/uf/0CpjvrDf6XUWmdTyqUljlylwSxQ0AWLvPGcBxK2n8uISsI4lCOkBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "async": "3.2.6",
+        "chalk": "4.1.2",
+        "commander": "11.1.0",
+        "glob": "^13.0.6",
+        "is-glob": "^4.0.3",
+        "node-sarif-builder": "3.2.0",
+        "strip-json-comments": "3.1.1",
+        "xml": "1.0.1"
+      },
+      "bin": {
+        "htmlhint": "bin/htmlhint"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "Open Collective",
+        "url": "https://opencollective.com/htmlhint"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/node-sarif-builder": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/node-sarif-builder/-/node-sarif-builder-3.2.0.tgz",
+      "integrity": "sha512-kVIOdynrF2CRodHZeP/97Rh1syTUHBNiw17hUCIVhlhEsWlfJm19MuO56s4MdKbr22xWx6mzMnNAgXzVlIYM9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/sarif": "^2.1.7",
+        "fs-extra": "^11.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "esp-website",
+  "version": "1.0.0",
+  "description": "[![Lint and Unit Tests](https://github.com/learning-unlimited/ESP-Website/actions/workflows/tests.yml/badge.svg)](https://github.com/learning-unlimited/ESP-Website/actions/workflows/tests.yml)\r [![codecov](https://codecov.io/gh/learning-unlimited/ESP-Website/branch/main/graph/badge.svg?token=eY0C5a1Lju)](https://codecov.io/gh/learning-unlimited/ESP-Website)",
+  "main": "index.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sahoo-tech/ESP-Website.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/sahoo-tech/ESP-Website/issues"
+  },
+  "homepage": "https://github.com/sahoo-tech/ESP-Website#readme",
+  "dependencies": {
+    "htmlhint": "^1.9.2"
+  }
+}


### PR DESCRIPTION
## Description

Extracted five duplicated warning and notification banners (Testing Mode, Required Page, Permission Info, Active Program Tags, and Django Messages) out from the default `main.html` and 6 theme-specific `main.html` templates. 

These banners have all been consolidated into a single shared partial (`esp/templates/elements/banners`). Each of the 7 main templates now uses `{% include "elements/banners" %}`. This creates a single source of truth, ensuring that future banner changes or typo fixes only ever need to be made in one place, preventing themes from drifting out of sync.

## Related Issue

Closes #5502 
*(Also helps resolve #4172, #3432, and #2325)*

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## AI Disclosure

Generated with the assistance of an AI coding agent pair programmer (Gemini/Antigravity).

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced