### PR TITLE
Fix empty bullet in navbar by hiding admin element

### DIFF
--- a/esp/templates/inclusion/web/navbar_left.html
+++ b/esp/templates/inclusion/web/navbar_left.html
@@ -1,27 +1,32 @@
 {% if navbar_list.entries %}
-  <!-- secondary nav -->
-  <ul id="submenu">
+<!-- secondary nav -->
+<ul id="submenu">
   {% for nav_entry in navbar_list.entries %}
-    <li class="divsecondarynavlink {% if nav_entry.entry.indent %}indent{% endif %}">
-      {% if nav_entry.entry.is_link %}
-        <a href="{{ nav_entry.entry.makeUrl }}"
-          title="Click for `{{ nav_entry.entry.makeTitle }}'">
-          {{ nav_entry.entry.makeTitle }}
-        </a>
-      {% else %}
-          {{ nav_entry.entry.makeTitle }}
-      {% endif %}
-   </li>
+  <li class="divsecondarynavlink {% if nav_entry.entry.indent %}indent{% endif %}">
+    {% if nav_entry.entry.is_link %}
+    <a href="{{ nav_entry.entry.makeUrl }}" title="Click for `{{ nav_entry.entry.makeTitle }}'">
+      {{ nav_entry.entry.makeTitle }}
+    </a>
+    {% else %}
+    {{ nav_entry.entry.makeTitle }}
+    {% endif %}
+  </li>
   {% endfor %}
   {% if navbar_list.category %}
   {% with navbar_list.category as cat %}
-  <li class="hidden navbar-manage admin">
-      <span role="button" class="navbar-manage-expander"><span class="glyphicon glyphicon-option-horizontal" aria-hidden="true"></span> <span class="navbar-manage-contractible">Navbar Category: {{ cat.name }}</span></span>
-      <a href="/admin/web/navbarcategory/{{ cat.id }}/" class="navbar-manage-contractible"><span class="glyphicon glyphicon-cog" aria-hidden="true"></span> Set navbar name/path/description</a>
-      <a href="/admin/web/navbarentry/?category__id__exact={{ cat.id }}&amp;o=2" class="navbar-manage-contractible"><span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> Edit navbar contents</a>
-      <a href="/admin/web/navbarentry/add/?category={{ cat.id }}&amp;sort_rank={{ navbar_list.next_sort_rank }}" class="navbar-manage-contractible"><span class="glyphicon glyphicon-plus" aria-hidden="true"></span> Add navbar entry</a>
+  <li class="hidden navbar-manage admin" style="display: none;">
+    <span role="button" class="navbar-manage-expander"><span class="glyphicon glyphicon-option-horizontal"
+        aria-hidden="true"></span> <span class="navbar-manage-contractible">Navbar Category: {{ cat.name
+        }}</span></span>
+    <a href="/admin/web/navbarcategory/{{ cat.id }}/" class="navbar-manage-contractible"><span
+        class="glyphicon glyphicon-cog" aria-hidden="true"></span> Set navbar name/path/description</a>
+    <a href="/admin/web/navbarentry/?category__id__exact={{ cat.id }}&amp;o=2" class="navbar-manage-contractible"><span
+        class="glyphicon glyphicon-pencil" aria-hidden="true"></span> Edit navbar contents</a>
+    <a href="/admin/web/navbarentry/add/?category={{ cat.id }}&amp;sort_rank={{ navbar_list.next_sort_rank }}"
+      class="navbar-manage-contractible"><span class="glyphicon glyphicon-plus" aria-hidden="true"></span> Add navbar
+      entry</a>
   </li>
   {% endwith %}
   {% endif %}
-  </ul>
+</ul>
 {% endif %}


### PR DESCRIPTION
The admin navbar management element was visible due to CSS specificity issues. Added inline style to ensure it's hidden.

Fixes #5633

## Description

An empty bullet point was appearing in the navigation sidebar on /teach/, /volunteer/, and /learn/ pages when users were logged in.

## Investigation Process

**Initial Hypothesis (Incorrect):**
Suspected empty `NavBarEntry` records in database. Attempted fixes:
- Template guards with `{% if nav_entry.entry.makeTitle %}`
- Model validation in `NavBarEntry.clean()`
- Widget filters in `NavStructureWidget`
- Theme template guards across `bigpicture/droplets/fruitsalad/floaty`

**Result:** Issue persisted - these weren't the root cause.

**Root Cause Discovery:**
1. Used browser DevTools to inspect the empty bullet element
2. Found: The empty `<li>` had class `navbar-manage admin` (line 18)
...

## Solution

Added inline `style="display: none;"` to the admin navbar management `<li>` element to ensure it's always hidden by default. JavaScript can still toggle visibility for admin users when needed.

## Related Issue

Closes #5633

## Type of Change

- [x] Bug fix

## Testing

1. Run `docker compose up --build`
2. Run `docker compose exec web python esp/manage.py seed_dummy_data`
3. Login as admin (`admin`/`admin`)
4. Navigate to `/teach/`, `/volunteer/`, `/learn/` pages
5. ✅ Verify no empty bullet point appears in the Navigation sidebar
6. Test both logged-in and logged-out states

## Screenshots

### Before Fix
![Empty bullet visible in navbar]
<img width="1919" height="1023" alt="Screenshot 2026-04-02 193930" src="https://github.com/user-attachments/assets/b00716e7-b265-4d9f-8a39-e32eca0967e1" />


The empty bullet appears between "Volunteer" and "Hello, Admin!" in the Navigation sidebar.

### After Fix
![Clean navigation without empty bullet]<img width="1918" height="840" alt="image" src="https://github.com/user-attachments/assets/987015f8-50b5-488b-9714-0885cb880eaa" />

Navigation sidebar now displays correctly with no empty bullets.


The `<li class="navbar-manage admin">` element with `style="display: none;"` is now properly hidden.