### PR TITLE
pull highcharts javascript from cdn.learningu.org

### DIFF
--- a/esp/templates/program/modules/bigboardmodule/bigboard.html
+++ b/esp/templates/program/modules/bigboardmodule/bigboard.html
@@ -12,10 +12,10 @@
 {% endblock %}
 
 {% block xtrajs %}
-  <script type="text/javascript" src="//code.highcharts.com/highcharts.js"></script>
-  <script type="text/javascript" src="//code.highcharts.com/highcharts-more.js"></script>
-  <script type="text/javascript" src="//code.highcharts.com/modules/no-data-to-display.js"></script>
-  <script type="text/javascript" src="//code.highcharts.com/modules/solid-gauge.js"></script>
+  <script type="text/javascript" src="https://cdn.learningu.org/highcharts/highcharts.js"></script>
+  <script type="text/javascript" src="https://cdn.learningu.org/highcharts/highcharts-more.js"></script>
+  <script type="text/javascript" src="https://cdn.learningu.org/highcharts/no-data-to-display.js"></script>
+  <script type="text/javascript" src="https://cdn.learningu.org/highcharts/solid-gauge.js"></script>
   <script type="text/javascript">
     // Fix for vertical panning from https://github.com/highcharts/highcharts/issues/16217
     (function(H) {

--- a/esp/templates/program/modules/mapgenmodule/map.html
+++ b/esp/templates/program/modules/mapgenmodule/map.html
@@ -4,12 +4,12 @@
 
 {% block xtrajs %}
 {{block.super}}
-<script src="https://code.highcharts.com/maps/highmaps.js"></script>
-<script src="https://code.highcharts.com/maps/modules/data.js"></script>
-<script src="https://code.highcharts.com/maps/modules/drilldown.js"></script>
-<script src="https://code.highcharts.com/maps/modules/exporting.js"></script>
-<script src="https://code.highcharts.com/maps/modules/offline-exporting.js"></script>
-<script src="https://code.highcharts.com/mapdata/countries/us/us-all.js"></script>
+<script src="https://cdn.learningu.org/highcharts/highmaps.js"></script>
+<script src="https://cdn.learningu.org/highcharts/data.js"></script>
+<script src="https://cdn.learningu.org/highcharts/drilldown.js"></script>
+<script src="https://cdn.learningu.org/highcharts/exporting.js"></script>
+<script src="https://cdn.learningu.org/highcharts/offline-exporting.js"></script>
+<script src="https://cdn.learningu.org/highcharts/us-all.js"></script>
 {% endblock %}
 {% block stylesheets %}
 {{block.super}}

--- a/esp/templates/program/modules/onsiteattendance/attendance.html
+++ b/esp/templates/program/modules/onsiteattendance/attendance.html
@@ -22,9 +22,9 @@
     {{ block.super }}
     <script src="/media/scripts/sorttable.js"></script>
     {% if not timeslot %}
-        <script type="text/javascript" src="//code.highcharts.com/highcharts.js"></script>
-        <script type="text/javascript" src="//code.highcharts.com/highcharts-more.js"></script>
-        <script type="text/javascript" src="//code.highcharts.com/modules/no-data-to-display.js"></script>
+        <script type="text/javascript" src="https://cdn.learningu.org/highcharts/highcharts.js"></script>
+        <script type="text/javascript" src="https://cdn.learningu.org/highcharts/highcharts-more.js"></script>
+        <script type="text/javascript" src="https://cdn.learningu.org/highcharts/no-data-to-display.js"></script>
     {% endif %}
 {% endblock %}
 

--- a/esp/templates/program/modules/studentregphasezero/status.html
+++ b/esp/templates/program/modules/studentregphasezero/status.html
@@ -47,9 +47,9 @@ td {
 {% endblock %}
 
 {% block xtrajs %}
-  <script type="text/javascript" src="//code.highcharts.com/highcharts.js"></script>
-  <script type="text/javascript" src="//code.highcharts.com/highcharts-more.js"></script>
-  <script type="text/javascript" src="//code.highcharts.com/modules/no-data-to-display.js"></script>
+  <script type="text/javascript" src="https://cdn.learningu.org/highcharts/highcharts.js"></script>
+  <script type="text/javascript" src="https://cdn.learningu.org/highcharts/highcharts-more.js"></script>
+  <script type="text/javascript" src="https://cdn.learningu.org/highcharts/no-data-to-display.js"></script>
   <script type="text/javascript">base_url = "{{ program.getUrlBase }}"</script>
   <script type="text/javascript">prog_id = "{{ program.id }}"</script>
   <script type="text/javascript" src="/media/scripts/program/modules/studentregphasezero.js"></script>

--- a/esp/templates/program/statistics.html
+++ b/esp/templates/program/statistics.html
@@ -10,9 +10,9 @@
 {% endblock %}
 
 {% block xtrajs %}
-  <script type="text/javascript" src="//code.highcharts.com/highcharts.js"></script>
-  <script type="text/javascript" src="//code.highcharts.com/highcharts-more.js"></script>
-  <script type="text/javascript" src="//code.highcharts.com/modules/no-data-to-display.js"></script>
+  <script type="text/javascript" src="https://cdn.learningu.org/highcharts/highcharts.js"></script>
+  <script type="text/javascript" src="https://cdn.learningu.org/highcharts/highcharts-more.js"></script>
+  <script type="text/javascript" src="https://cdn.learningu.org/highcharts/no-data-to-display.js"></script>
 {% endblock xtrajs %}
 
 {% block content %}


### PR DESCRIPTION
## Description

Since we cannot pull the Highcharts JS code from highcharts website directly anymore, we hosted it in our CDN. Update the URLs to pull from our CDN.

## Related Issue

<!-- Link the relevant issue. Use "Closes #123" to auto-close on merge. -->

Closes #5432 

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [X] Manually verified

## AI Disclosure

<!-- If you used AI tools for any part of this pull request, please disclose this here -->

## Checklist

- [ ] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [ ] No new warnings or errors introduced
