### PR TITLE
feat: add AJAX scheduler history panel with undo support

### DIFF
--- a/esp/esp/program/modules/handlers/jsondatamodule.py
+++ b/esp/esp/program/modules/handlers/jsondatamodule.py
@@ -332,7 +332,7 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
             sections.append(section)
             section['index'] = s.index()
             section['emailcode'] = s.emailcode()
-            section['length'] = float(s.duration)
+            section['length'] = float(s.duration) if s.duration is not None else 0.0
             if catalog:
                 section['times'] = s.friendly_times_with_date()
                 section['capacity'] = s.capacity
@@ -413,7 +413,7 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
             sections.append(section)
             section['index'] = s.index()
             section['emailcode'] = s.emailcode()
-            section['length'] = float(s.duration)
+            section['length'] = float(s.duration) if s.duration is not None else 0.0
             section['moderators'] = [m.id for m in s.get_moderators()]
             class_teachers = cls.get_teachers()
             section['teachers'] = [t.id for t in class_teachers]

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/ChangelogFetcher.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/ChangelogFetcher.js
@@ -37,6 +37,7 @@ function ChangelogFetcher(matrix, api_client){
             this.applyChangeLog.bind(this),
             function(msg) {
                 console.log(msg);
+                $j("#loadingOverlay").remove();
             }
         );
     };
@@ -47,26 +48,31 @@ function ChangelogFetcher(matrix, api_client){
      * @param data: the data to apply to the matrix
      */
     this.applyChangeLog = function(data){
-        $j.each(data.changelog, function(id, change){
-            var section = matrix.sections.getById(change.id);
-            if (change.is_scheduling) {
-                if (change.timeslots.length == 0){
-                    this.matrix.sections.unscheduleSectionLocal(section);
+        try {
+            $j.each(data.changelog, function(id, change){
+                var section = matrix.sections.getById(change.id);
+                if (change.is_scheduling) {
+                    if (change.timeslots.length == 0){
+                        this.matrix.sections.unscheduleSectionLocal(section);
+                    } else {
+                        this.matrix.sections.scheduleSectionLocal(section, parseInt(change.room_name,10), change.timeslots);
+                    }
+                } else if (change.is_moderator) {
+                    if (this.matrix.moderatorDirectory) {
+                        this.matrix.moderatorDirectory.selectModerator(this.matrix.moderatorDirectory.getById(change.moderator));
+                        if (change.assigned) {
+                            this.matrix.moderatorDirectory.assignModeratorLocal(section);
+                        } else {
+                            this.matrix.moderatorDirectory.unassignModeratorLocal(section);
+                        }
+                    }
                 } else {
-                    this.matrix.sections.scheduleSectionLocal(section, parseInt(change.room_name,10), change.timeslots);
+                    this.matrix.sections.setComment(section, change.comment, change.locked, true);
                 }
-            } else if (change.is_moderator) {
-                this.matrix.moderatorDirectory.selectModerator(this.matrix.moderatorDirectory.getById(change.moderator));
-                if (change.assigned) {
-                    this.matrix.moderatorDirectory.assignModeratorLocal(section);
-                } else {
-                    this.matrix.moderatorDirectory.unassignModeratorLocal(section);
-                }
-            } else {
-                this.matrix.sections.setComment(section, change.comment, change.locked, true);
-            }
-            this.last_applied_index = change.index;
-        }.bind(this));
-        $j("#loadingOverlay").remove(); // remove the loading overlay
+                this.last_applied_index = change.index;
+            }.bind(this));
+        } finally {
+            $j("#loadingOverlay").remove();
+        }
     };
 };

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/HistoryPanel.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/HistoryPanel.js
@@ -66,29 +66,30 @@ HistoryPanel.prototype.render = function() {
         if (!isNewest) {
             btn.prop("disabled", true);
             btn.attr("title", "Undo the most recent action first");
-        }
-        (function(entry) {
+        } else {
             btn.on("click", function() {
-                if (!isNewest) {
-                    return;
-                }
-                self.runUndo(entry);
+                self.runUndoLatest();
             });
-        })(item);
+        }
         li.append(span).append(btn);
         this.container.append(li);
     }
 };
 
-HistoryPanel.prototype.runUndo = function(item) {
+/**
+ * Pop and run the latest undo callback. Does not rely on entry object identity
+ * (avoids stale closure bugs after multiple add/remove/render cycles).
+ */
+HistoryPanel.prototype.runUndoLatest = function() {
     var self = this;
-    if (this.items.length === 0 || this.items[this.items.length - 1] !== item) {
+    if (this.undoing || this.items.length === 0) {
         return;
     }
+    var last = this.items[this.items.length - 1];
     this.items.pop();
     this.render();
     this.undoing = true;
-    item.undo(function() {
+    last.undo(function() {
         self.undoing = false;
     });
 };

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/HistoryPanel.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/HistoryPanel.js
@@ -1,0 +1,94 @@
+/**
+ * Session-only list of recent scheduling actions with undo (most recent only).
+ *
+ * @param containerEl jQuery element for the <ul> list
+ * @param clearButtonEl optional jQuery element for "Clear" (wired to clear())
+ */
+function HistoryPanel(containerEl, clearButtonEl) {
+    this.container = containerEl;
+    this.MAX_ITEMS = 20;
+    this.items = [];
+    this.undoing = false;
+
+    if (clearButtonEl && clearButtonEl.length) {
+        clearButtonEl.on("click", function() {
+            this.clear();
+        }.bind(this));
+    }
+    this.render();
+}
+
+HistoryPanel.prototype.clear = function() {
+    this.items = [];
+    this.render();
+};
+
+/**
+ * @param description string shown in the list
+ * @param undoFn function(endUndo) must call endUndo() when the async undo finishes (success or error)
+ */
+HistoryPanel.prototype.addAction = function(description, undoFn) {
+    if (this.undoing) {
+        return;
+    }
+    this.items.push({ description: description, undo: undoFn });
+    if (this.items.length > this.MAX_ITEMS) {
+        this.items.shift();
+    }
+    this.render();
+};
+
+HistoryPanel.prototype.render = function() {
+    var self = this;
+    this.container.empty();
+    var n = this.items.length;
+    if (n === 0) {
+        this.container.append(
+            $j("<li/>")
+                .addClass("scheduler-history-empty")
+                .text("No actions yet. Schedule or edit a class to see entries here.")
+        );
+        return;
+    }
+    for (var i = n - 1; i >= 0; i--) {
+        var item = this.items[i];
+        var isNewest = i === n - 1;
+        var li = $j("<li/>").addClass("scheduler-history-row");
+        if (isNewest) {
+            li.addClass("scheduler-history-row--latest");
+        }
+        var span = $j("<span/>")
+            .addClass("scheduler-history-desc")
+            .text(item.description);
+        var btn = $j("<button type='button'/>")
+            .addClass("scheduler-history-undo")
+            .text("Undo");
+        if (!isNewest) {
+            btn.prop("disabled", true);
+            btn.attr("title", "Undo the most recent action first");
+        }
+        (function(entry) {
+            btn.on("click", function() {
+                if (!isNewest) {
+                    return;
+                }
+                self.runUndo(entry);
+            });
+        })(item);
+        li.append(span).append(btn);
+        this.container.append(li);
+    }
+};
+
+HistoryPanel.prototype.runUndo = function(item) {
+    var self = this;
+    if (this.items.length === 0 || this.items[this.items.length - 1] !== item) {
+        return;
+    }
+    this.items.pop();
+    this.render();
+    this.undoing = true;
+    item.undo(function() {
+        self.undoing = false;
+    });
+};

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Matrix.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Matrix.js
@@ -482,14 +482,40 @@ function Matrix(
      * Render the matrix.
      */
     this.render = function(){
+        this.el.empty();
+        var room_ids = Object.keys(this.rooms).sort(function(room1, room2) {
+            return this.rooms[room1].text.localeCompare(this.rooms[room2].text, undefined, {
+                numeric: true,
+                sensitivity: "base",
+            });
+        }.bind(this));
+        if (!this.timeslots.timeslots_sorted.length || !room_ids.length) {
+            var wrap = $j("<div/>").addClass("scheduler-matrix-empty-state");
+            var toolbar = $j("<div/>").addClass("scheduler-matrix-empty-toolbar");
+            toolbar.append($j("<button type='button' id='print_button' class='scheduler-matrix-toolbar-btn'>Print matrix</button>"));
+            toolbar.append($j("<button type='button' id='legend_button' class='scheduler-matrix-toolbar-btn'>Show legend</button>"));
+            wrap.append(toolbar);
+            if (!this.timeslots.timeslots_sorted.length) {
+                wrap.append($j("<p/>").html("<strong>No time blocks</strong> are configured for this program."));
+            }
+            if (!room_ids.length) {
+                wrap.append($j("<p/>").html("<strong>No classrooms</strong> are available for this program."));
+            }
+            wrap.append($j("<p/>").addClass("scheduler-matrix-empty-hint").text(
+                "Add program time slots and classroom resources in the admin site, then reload this page."));
+            this.el.append(wrap);
+            return;
+        }
+
         var table = $j("<table/>");
         var tbody = $j("<tbody/>");
         var colModal = [{width: 140, align: "center"}];
 
         //Time headers
         var header_row = $j("<tr/>").appendTo($j("<thead/>").appendTo(table));
-        var header_corner = $j("<th/>").append($j("<button id = 'print_button'>Print Matrix</button>"));
-        header_corner.append($j("<button id = 'legend_button'>Show Legend</button>"));
+        var header_corner = $j("<th/>").addClass("scheduler-matrix-toolbar-cell");
+        header_corner.append($j("<button type='button' id='print_button' class='scheduler-matrix-toolbar-btn'>Print matrix</button>"));
+        header_corner.append($j("<button type='button' id='legend_button' class='scheduler-matrix-toolbar-btn'>Show legend</button>"));
         header_row.append(header_corner);
         $j.each(this.timeslots.timeslots_sorted, function(index, timeslot){
             var timeslotHeader = $j("<th>" + timeslot.label + "</th>");
@@ -499,14 +525,6 @@ function Matrix(
         }.bind(this));
         //Room headers
         var rows = {}; //table rows by room name
-        var room_ids = Object.keys(this.rooms);
-        room_ids = room_ids.sort(function (room1, room2) {
-            // sort by building number
-            return rooms[room1].text.localeCompare(rooms[room2].text, undefined, {
-                numeric: true,
-                sensitivity: 'base'
-            })
-        });
         $j.each(this.rooms, function(id, room){
             room = this.rooms[id];
             var room_header = $j("<td>")

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Moderators.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Moderators.js
@@ -300,7 +300,7 @@ function ModeratorDirectory(el, moderators, historyPanel) {
                 }
             }.bind(this),
             function(msg) {
-                this.matrix.messagePanel.addMessage("Error: " + msg, color = "red");
+                this.matrix.messagePanel.addMessage("Error: " + msg, "red");
                 this.matrix.messagePanel.show();
                 console.log(msg);
             }.bind(this)
@@ -321,7 +321,7 @@ function ModeratorDirectory(el, moderators, historyPanel) {
             section.moderator_data.push(moderator);
             $j("body").trigger("schedule-changed");
             if (showMessage) {
-                this.matrix.messagePanel.addMessage("Success: " + moderator.first_name + " " + moderator.last_name + " was assigned to " + section.emailcode, color = "blue");
+                this.matrix.messagePanel.addMessage("Success: " + moderator.first_name + " " + moderator.last_name + " was assigned to " + section.emailcode, "blue");
             }
             this.matrix.updateCells();
         }
@@ -337,7 +337,7 @@ function ModeratorDirectory(el, moderators, historyPanel) {
                 if (endUndo) endUndo();
             }.bind(this),
             function(msg) {
-                this.matrix.messagePanel.addMessage("Error: " + msg, color = "red");
+                this.matrix.messagePanel.addMessage("Error: " + msg, "red");
                 this.matrix.messagePanel.show();
                 console.log(msg);
                 if (endUndo) endUndo();
@@ -354,7 +354,7 @@ function ModeratorDirectory(el, moderators, historyPanel) {
                 if (endUndo) endUndo();
             }.bind(this),
             function(msg) {
-                this.matrix.messagePanel.addMessage("Error: " + msg, color = "red");
+                this.matrix.messagePanel.addMessage("Error: " + msg, "red");
                 this.matrix.messagePanel.show();
                 console.log(msg);
                 if (endUndo) endUndo();
@@ -384,7 +384,7 @@ function ModeratorDirectory(el, moderators, historyPanel) {
                 }
             }.bind(this),
             function(msg) {
-                this.matrix.messagePanel.addMessage("Error: " + msg, color = "red")
+                this.matrix.messagePanel.addMessage("Error: " + msg, "red")
                 console.log(msg);
             }.bind(this)
         );
@@ -396,7 +396,7 @@ function ModeratorDirectory(el, moderators, historyPanel) {
         this.unselectModerator();
         if (section.moderators.includes(moderator.id)) {
             this.unassignModeratorLocalForModerator(section, moderator);
-            this.matrix.messagePanel.addMessage("Success: " + moderator.first_name + " " + moderator.last_name + " was unassigned from " + section.emailcode, color = "blue");
+            this.matrix.messagePanel.addMessage("Success: " + moderator.first_name + " " + moderator.last_name + " was unassigned from " + section.emailcode, "blue");
         }
     };
 

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Moderators.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Moderators.js
@@ -5,9 +5,10 @@
  * @param moderators
  * @param matrix
  */
-function ModeratorDirectory(el, moderators) {
+function ModeratorDirectory(el, moderators, historyPanel) {
     this.el = el;
     this.moderators = moderators;
+    this.historyPanel = historyPanel || null;
     this.selectedModerator = null;
     this.selectedModeratorCell = null;
 
@@ -278,61 +279,115 @@ function ModeratorDirectory(el, moderators) {
     /**
      * Assign the selected moderator to the specified section
      * @param section: A section object
+     * @param isUndo: When true, do not record this action in session history
      */
-    this.assignModerator = function(section) {
+    this.assignModerator = function(section, isUndo) {
+        var moderator = this.selectedModerator;
         var override = this.matrix.sectionInfoPanel.override;
         this.matrix.sections.apiClient.assign_moderator(
             section.id,
-            this.selectedModerator.id,
+            moderator.id,
             override,
             function() {
-                // If successful, update moderator info
                 this.assignModeratorLocal(section);
+                if (!isUndo && this.historyPanel) {
+                    var self = this;
+                    var mod = moderator;
+                    var sid = section.id;
+                    this.historyPanel.addAction("Assigned " + mod.first_name + " " + mod.last_name + " to " + section.emailcode, function(endUndo) {
+                        self.unassignModeratorForUndo(self.matrix.sections.getById(sid), mod, endUndo);
+                    });
+                }
             }.bind(this),
             function(msg) {
-                // If unsuccessful, report the error message
                 this.matrix.messagePanel.addMessage("Error: " + msg, color = "red");
                 this.matrix.messagePanel.show();
                 console.log(msg);
             }.bind(this)
         );
-        // Reset the availability override
         this.matrix.sectionInfoPanel.override = false;
     };
 
     this.assignModeratorLocal = function(section) {
         var moderator = this.selectedModerator;
         this.unselectModerator();
+        this.assignModeratorLocalCore(section, moderator, true);
+    };
+
+    this.assignModeratorLocalCore = function(section, moderator, showMessage) {
         if (!section.moderators.includes(moderator.id)) {
             moderator.sections.push(section.id);
             section.moderators.push(moderator.id);
             section.moderator_data.push(moderator);
             $j("body").trigger("schedule-changed");
-            this.matrix.messagePanel.addMessage("Success: " + moderator.first_name + " " + moderator.last_name + " was assigned to " + section.emailcode, color = "blue")
-            // Update cell coloring
+            if (showMessage) {
+                this.matrix.messagePanel.addMessage("Success: " + moderator.first_name + " " + moderator.last_name + " was assigned to " + section.emailcode, color = "blue");
+            }
             this.matrix.updateCells();
         }
+    };
+
+    this.assignModeratorForUndo = function(section, moderator, endUndo) {
+        this.matrix.sections.apiClient.assign_moderator(
+            section.id,
+            moderator.id,
+            false,
+            function() {
+                this.assignModeratorLocalCore(section, moderator, false);
+                if (endUndo) endUndo();
+            }.bind(this),
+            function(msg) {
+                this.matrix.messagePanel.addMessage("Error: " + msg, color = "red");
+                this.matrix.messagePanel.show();
+                console.log(msg);
+                if (endUndo) endUndo();
+            }.bind(this)
+        );
+    };
+
+    this.unassignModeratorForUndo = function(section, moderator, endUndo) {
+        this.matrix.sections.apiClient.unassign_moderator(
+            section.id,
+            moderator.id,
+            function() {
+                this.unassignModeratorLocalForModerator(section, moderator);
+                if (endUndo) endUndo();
+            }.bind(this),
+            function(msg) {
+                this.matrix.messagePanel.addMessage("Error: " + msg, color = "red");
+                this.matrix.messagePanel.show();
+                console.log(msg);
+                if (endUndo) endUndo();
+            }.bind(this)
+        );
     };
 
     /**
      * Unassign the selected moderator from the specified section
      * @param section: A section object
+     * @param isUndo: When true, do not record this action in session history
      */
-    this.unassignModerator = function(section) {
+    this.unassignModerator = function(section, isUndo) {
+        var moderator = this.selectedModerator;
         this.matrix.sections.apiClient.unassign_moderator(
             section.id,
-            this.selectedModerator.id,
+            moderator.id,
             function() {
-                // If successful, update moderator info
                 this.unassignModeratorLocal(section);
+                if (!isUndo && this.historyPanel) {
+                    var self = this;
+                    var mod = moderator;
+                    var sid = section.id;
+                    this.historyPanel.addAction("Unassigned " + mod.first_name + " " + mod.last_name + " from " + section.emailcode, function(endUndo) {
+                        self.assignModeratorForUndo(self.matrix.sections.getById(sid), mod, endUndo);
+                    });
+                }
             }.bind(this),
             function(msg) {
-                // If unsuccessful, report the error message
                 this.matrix.messagePanel.addMessage("Error: " + msg, color = "red")
                 console.log(msg);
             }.bind(this)
         );
-        // Reset the availability override
         this.matrix.sectionInfoPanel.override = false;
     };
 
@@ -340,12 +395,17 @@ function ModeratorDirectory(el, moderators) {
         var moderator = this.selectedModerator;
         this.unselectModerator();
         if (section.moderators.includes(moderator.id)) {
+            this.unassignModeratorLocalForModerator(section, moderator);
+            this.matrix.messagePanel.addMessage("Success: " + moderator.first_name + " " + moderator.last_name + " was unassigned from " + section.emailcode, color = "blue");
+        }
+    };
+
+    this.unassignModeratorLocalForModerator = function(section, moderator) {
+        if (section.moderators.includes(moderator.id)) {
             moderator.sections.splice(moderator.sections.indexOf(section.id), 1);
-            section.moderators.splice(section.moderators.indexOf(moderator), 1);
+            section.moderators.splice(section.moderators.indexOf(moderator.id), 1);
             section.moderator_data.splice(section.moderator_data.indexOf(moderator), 1);
             $j("body").trigger("schedule-changed");
-            this.matrix.messagePanel.addMessage("Success: " + moderator.first_name + " " + moderator.last_name + " was unassigned from " + section.emailcode, color = "blue")
-            // Update cell coloring
             this.matrix.updateCells();
         }
     };

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Scheduler.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Scheduler.js
@@ -63,17 +63,21 @@ function Scheduler(
 
         this.rooms = data.rooms;
 
+        this.historyPanel = new HistoryPanel($j("#history-container"), $j("#clear-history"));
+
         this.sections = new Sections(data.sections,
                                      data.section_details,
                                      data.categories,
                                      data.teachers,
                                      data.moderators,
                                      data.schedule_assignments,
-                                     new ApiClient());
+                                     new ApiClient(),
+                                     this.historyPanel);
 
         if(has_moderator_module === "True"){
             this.moderatorDirectory = new ModeratorDirectory(moderatorEl,
-                                                             data.moderators);
+                                                             data.moderators,
+                                                             this.historyPanel);
         } else {
             this.moderatorDirectory = null;
         }
@@ -86,7 +90,7 @@ function Scheduler(
                                              "<strong>F1</strong>: open the 'Classes' tab<br>" +
                                              "<strong>F2</strong>: open the 'Room Filters' tab<br>" +
                                              "<strong>F3</strong>: open the 'Checks' tab<br>" +
-                                             (has_moderator_module === "True" ? "<strong>F4</strong>: open the 'Moderators' tab<br>": "") +
+                                             (has_moderator_module === "True" ? "<strong>F4</strong>: open the 'Moderators' tab<br><strong>F5</strong>: open the 'History' tab<br>" : "<strong>F4</strong>: open the 'History' tab<br>") +
                                              "<strong>/</strong>: Search for a class");
         this.sectionCommentDialog = new SectionCommentDialog(sectionDialogEl, this.sections);
         this.sectionInfoPanel = new SectionInfoPanel(sectionInfoEl,
@@ -134,9 +138,12 @@ function Scheduler(
             } else if(evt.key === 'F3') { // F3 is pressed: open the third tab (scheduling checks)
                 evt.preventDefault();
                 $j("#side-panel").tabs({active: 2});
-            } else if(evt.key === 'F4') { // F4 is pressed: open the fourth tab (moderator directory)
+            } else if(evt.key === 'F4') { // F4: moderators (if enabled) or History
                 evt.preventDefault();
                 $j("#side-panel").tabs({active: 3});
+            } else if(has_moderator_module === "True" && evt.key === 'F5') {
+                evt.preventDefault();
+                $j("#side-panel").tabs({active: 4});
             }
         }.bind(this));
 
@@ -217,18 +224,17 @@ function Scheduler(
             });
         });
 
-        // set up handler for legend button
+        // set up handler for legend button (label must match #legend visibility; do not rely on
+        // string compare — Matrix uses "Show legend" while old code expected "Show Legend".)
         $j("body").on("click", "#legend_button", function(evt, ui) {
+            evt.preventDefault();
             $j("#legend").toggle();
-            if ($j("#legend_button").html() == "Show Legend") {
-                $j("#legend_button").html("Hide Legend");
-            } else {
-                $j("#legend_button").html("Show Legend");
-            }
+            var visible = $j("#legend").is(":visible");
+            $j("#legend_button").text(visible ? "Hide legend" : "Show legend");
         });
         $j("body").on("click", "#legend", function(evt, ui) {
             $j("#legend").hide();
-            $j("#legend_button").html("Show Legend");
+            $j("#legend_button").text("Show legend");
         });
     };
 
@@ -239,6 +245,7 @@ function Scheduler(
         this.directory.render();
         if(has_moderator_module === "True") this.moderatorDirectory.render();
         this.matrix.render();
+        $j("#loadingOverlay").remove();
         this.changelogFetcher.pollForChanges(update_interval);
     };
 };

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
@@ -5,16 +5,31 @@
  *
  * @params sections_data: The raw section data
  * @params section_details_data: The AJAX section detail data
+ * @params categories_data: The raw category data for sections
  * @params teacher_data: The raw teacher data for populating the sections
+ * @params moderator_data: The raw moderator data for populating the sections
  * @params scheduleAssignments: The schedule assignments
  * @params apiClient: The object that can communicate with the server
+ * @params historyPanel: Optional HistoryPanel instance for recording actions (may be null)
  */
 function Sections(sections_data, section_details_data, categories_data, teacher_data, moderator_data, scheduleAssignments, apiClient, historyPanel) {
+    // Backwards compatibility: older call sites (e.g. tests) passed only 5 args:
+    // (sections_data, section_details_data, teacher_data, scheduleAssignments, apiClient)
+    // before categories_data, moderator_data, and historyPanel were added.
+    if (arguments.length <= 5) {
+        historyPanel      = null;
+        apiClient         = moderator_data;    // 5th arg was apiClient
+        scheduleAssignments = teacher_data;    // 4th arg was scheduleAssignments
+        teacher_data      = categories_data;   // 3rd arg was teacher_data
+        categories_data   = null;
+        moderator_data    = null;
+    }
     this.sections_data = sections_data;
-    this.categories_data = categories_data;
-    this.teacher_data = teacher_data;
-    this.scheduleAssignments = scheduleAssignments;
-    this.apiClient = apiClient;
+    this.categories_data = categories_data || null;
+    this.teacher_data = teacher_data || null;
+    this.moderator_data = moderator_data || null;
+    this.scheduleAssignments = scheduleAssignments || null;
+    this.apiClient = apiClient || null;
     this.historyPanel = historyPanel || null;
 
     // The section that is currently selected
@@ -189,7 +204,7 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
             }.bind(this),
             function(msg) {
                 this.swapSectionsLocal(revert1, revert2);
-                this.matrix.messagePanel.addMessage("Error: " + msg, color = "red");
+                this.matrix.messagePanel.addMessage("Error: " + msg, "red");
                 console.log(msg);
                 if (endUndo) endUndo();
             }.bind(this)
@@ -501,7 +516,7 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
 
         // Make sure section not locked
         if (section.schedulingLocked){
-            this.matrix.messagePanel.addMessage("Error: the specified section is locked (" + section.schedulingComment + ")! Unlock it first.", color = "red");
+            this.matrix.messagePanel.addMessage("Error: the specified section is locked (" + section.schedulingComment + ")! Unlock it first.", "red");
             this.unselectSection();
             if (onComplete) onComplete();
             return;
@@ -540,7 +555,7 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
                 this.scheduleSectionLocal(section,
                     prevSnap.room_id,
                     prevSnap.timeslots);
-                this.matrix.messagePanel.addMessage("Error: " + msg, color = "red")
+                this.matrix.messagePanel.addMessage("Error: " + msg, "red")
                 console.log(msg);
                 if (onComplete) onComplete();
             }.bind(this)
@@ -634,7 +649,7 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
         if (callback === undefined) callback = function(){};
         // Make sure section not locked
         if (section.schedulingLocked){
-            this.matrix.messagePanel.addMessage("Error: the specified section is locked (" + section.schedulingComment + ")! Unlock it first.", color = "red");
+            this.matrix.messagePanel.addMessage("Error: the specified section is locked (" + section.schedulingComment + ")! Unlock it first.", "red");
             this.unselectSection();
             if (onComplete) onComplete();
             return;
@@ -669,7 +684,7 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
             // If the server returns an error, put the class back in its original spot
             function(msg){
                 this.scheduleSectionLocal(section, old_room_id, old_schedule_timeslots);
-                this.matrix.messagePanel.addMessage("Error: " + msg, color = "red");
+                this.matrix.messagePanel.addMessage("Error: " + msg, "red");
                 console.log(msg);
                 if (onComplete) onComplete();
             }.bind(this)
@@ -802,7 +817,7 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
                         var valid = this.matrix.validateAssignment(sec, room1, new_timeslots, ignore_sections);
                         if(!valid.valid){
                             console.log(valid.reason);
-                            this.matrix.messagePanel.addMessage(valid.reason, color = "red");
+                            this.matrix.messagePanel.addMessage(valid.reason, "red");
                             this.unselectSection();
                             return;
                         }
@@ -846,7 +861,7 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
             // If there's an error, locally reschedule the sections in their old locations
             function(msg) {
                 this.swapSectionsLocal(old_assignments1, old_assignments2);
-                this.matrix.messagePanel.addMessage("Error: " + msg, color = "red");
+                this.matrix.messagePanel.addMessage("Error: " + msg, "red");
                 console.log(msg);
             }.bind(this)
         );
@@ -934,7 +949,7 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
                 // if unsuccessful, revert the comment locked status and show an error
                 section.schedulingComment = old_comment;
                 section.schedulingLocked = old_locked;
-                this.matrix.messagePanel.addMessage("Error: " + msg, color = "red");
+                this.matrix.messagePanel.addMessage("Error: " + msg, "red");
                 console.log(msg);
                 this.unselectSection();
                 if (doneCallback) doneCallback();

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
@@ -9,12 +9,13 @@
  * @params scheduleAssignments: The schedule assignments
  * @params apiClient: The object that can communicate with the server
  */
-function Sections(sections_data, section_details_data, categories_data, teacher_data, moderator_data, scheduleAssignments, apiClient) {
+function Sections(sections_data, section_details_data, categories_data, teacher_data, moderator_data, scheduleAssignments, apiClient, historyPanel) {
     this.sections_data = sections_data;
     this.categories_data = categories_data;
     this.teacher_data = teacher_data;
     this.scheduleAssignments = scheduleAssignments;
     this.apiClient = apiClient;
+    this.historyPanel = historyPanel || null;
 
     // The section that is currently selected
     this.selectedSection = null;
@@ -160,7 +161,40 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
      */
     this.bindMatrix = function(matrix) {
         this.matrix = matrix;
-    }
+    };
+
+    /**
+     * Snapshot room/timeslots for a section (for undo), before a mutating call.
+     */
+    this.snapshotAssignment = function(sectionId) {
+        var a = this.scheduleAssignments[sectionId];
+        if (!a) {
+            return { room_id: null, timeslots: [] };
+        }
+        return { room_id: a.room_id, timeslots: a.timeslots.slice() };
+    };
+
+    /**
+     * Apply a swap from saved assignment snapshots (used for undo); hits the server like swapSections.
+     */
+    this.applySwapUndo = function(target1, target2, revert1, revert2, endUndo) {
+        this.swapSectionsLocal(target1, target2);
+        this.apiClient.swap_sections(
+            target1,
+            target2,
+            false,
+            function() {
+                this.matrix.scheduler.changelogFetcher.getChanges();
+                if (endUndo) endUndo();
+            }.bind(this),
+            function(msg) {
+                this.swapSectionsLocal(revert1, revert2);
+                this.matrix.messagePanel.addMessage("Error: " + msg, color = "red");
+                console.log(msg);
+                if (endUndo) endUndo();
+            }.bind(this)
+        );
+    };
 
     /**
      * Get a section by its ID
@@ -450,9 +484,11 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
      * @param room_id: The name of the room to schedule it in
      * @param first_timeslot_id: The ID of the first timeslot to schedule the section in
      * @param callback: A function to run upon success
+     * @param isUndo: When true, do not record this action in session history
+     * @param onComplete: Optional; called after success or error (for undo completion)
      */
-    this.scheduleSection = function(section, room_id, first_timeslot_id, callback = function() {}){
-        var old_assignment = this.scheduleAssignments[section.id];
+    this.scheduleSection = function(section, room_id, first_timeslot_id, callback, isUndo, onComplete){
+        if (callback === undefined) callback = function() {};
         var schedule_timeslots = this.matrix.timeslots.
             get_timeslots_to_schedule_section(section, first_timeslot_id);
         var override = this.matrix.sectionInfoPanel.override;
@@ -469,6 +505,8 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
             return;
         }
 
+        var prevSnap = this.snapshotAssignment(section.id);
+
         // Optimistically schedule the section locally before hearing back from the server
         this.scheduleSectionLocal(section, room_id, schedule_timeslots);
         this.apiClient.schedule_section(
@@ -476,14 +514,33 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
             schedule_timeslots,
             room_id,
             override,
-            callback,
+            function() {
+                callback();
+                if (!isUndo && this.historyPanel) {
+                    var self = this;
+                    var sid = section.id;
+                    var code = section.emailcode;
+                    var undoPrev = prevSnap;
+                    this.historyPanel.addAction("Scheduled " + code, function(endUndo) {
+                        var sec = self.getById(sid);
+                        var snap = undoPrev;
+                        if (snap.room_id) {
+                            self.scheduleSection(sec, snap.room_id, snap.timeslots[0], function() {}, true, endUndo);
+                        } else {
+                            self.unscheduleSection(sec, function() {}, true, endUndo);
+                        }
+                    });
+                }
+                if (onComplete) onComplete();
+            }.bind(this),
             // If there's an error, reschedule the section in its old location
             function(msg) {
                 this.scheduleSectionLocal(section,
-                    old_assignment.room_id,
-                    old_assignment.timeslots);
+                    prevSnap.room_id,
+                    prevSnap.timeslots);
                 this.matrix.messagePanel.addMessage("Error: " + msg, color = "red")
                 console.log(msg);
+                if (onComplete) onComplete();
             }.bind(this)
         );
         // Reset the availability override
@@ -568,8 +625,11 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
      * Unschedule a section of a class.
      *
      * @param section: the section to unschedule
+     * @param isUndo: When true, do not record this action in session history
+     * @param onComplete: Optional; called after success or error (for undo completion)
      */
-    this.unscheduleSection = function(section, callback = function(){}){
+    this.unscheduleSection = function(section, callback, isUndo, onComplete){
+        if (callback === undefined) callback = function(){};
         // Make sure section not locked
         if (section.schedulingLocked){
             this.matrix.messagePanel.addMessage("Error: the specified section is locked (" + section.schedulingComment + ")! Unlock it first.", color = "red");
@@ -577,20 +637,38 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
             return;
         }
 
-        var old_assignment = this.scheduleAssignments[section.id];
-        var old_room_id = old_assignment.room_id;
-        var old_schedule_timeslots = old_assignment.timeslots;
+        var prevSnap = this.snapshotAssignment(section.id);
+        var old_room_id = prevSnap.room_id;
+        var old_schedule_timeslots = prevSnap.timeslots;
 
         // Optimistically make local changes to unschedule the class
         this.unscheduleSectionLocal(section);
         this.apiClient.unschedule_section(
             section.id,
-            callback,
+            function(){
+                callback();
+                if (!isUndo && this.historyPanel) {
+                    var self = this;
+                    var sid = section.id;
+                    var code = section.emailcode;
+                    var undoPrev = prevSnap;
+                    this.historyPanel.addAction("Unscheduled " + code, function(endUndo) {
+                        var sec = self.getById(sid);
+                        if (undoPrev.room_id) {
+                            self.scheduleSection(sec, undoPrev.room_id, undoPrev.timeslots[0], function() {}, true, endUndo);
+                        } else {
+                            endUndo();
+                        }
+                    });
+                }
+                if (onComplete) onComplete();
+            }.bind(this),
             // If the server returns an error, put the class back in its original spot
             function(msg){
                 this.scheduleSectionLocal(section, old_room_id, old_schedule_timeslots);
                 this.matrix.messagePanel.addMessage("Error: " + msg, color = "red");
                 console.log(msg);
+                if (onComplete) onComplete();
             }.bind(this)
         );
     };
@@ -604,7 +682,7 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
         this.scheduleSectionLocal(section, null, [])
     };
 
-    this.swapSections = function(section1, section2) {
+    this.swapSections = function(section1, section2, isUndo) {
         // Abort if either section is locked
         if (section1.schedulingLocked){
             this.matrix.messagePanel.addMessage("Error: the first selected section is locked (" + section1.schedulingComment + ")! Unlock it first.", color = "red");
@@ -734,6 +812,14 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
             }
         }
 
+        var undoSnap1, undoSnap2, redoSnap1, redoSnap2;
+        if (!isUndo) {
+            undoSnap1 = JSON.parse(JSON.stringify(old_assignments1));
+            undoSnap2 = JSON.parse(JSON.stringify(old_assignments2));
+            redoSnap1 = JSON.parse(JSON.stringify(new_assignments1));
+            redoSnap2 = JSON.parse(JSON.stringify(new_assignments2));
+        }
+
         var override = this.matrix.sectionInfoPanel.override;
         // Make local changes (asynchronously)
         this.swapSectionsLocal(new_assignments1, new_assignments2);
@@ -745,6 +831,14 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
             override,
             function() {
                 this.matrix.scheduler.changelogFetcher.getChanges();
+                if (!isUndo && this.historyPanel) {
+                    var self = this;
+                    var c1 = section1.emailcode;
+                    var c2 = section2.emailcode;
+                    this.historyPanel.addAction("Swapped " + c1 + " ↔ " + c2, function(endUndo) {
+                        self.applySwapUndo(undoSnap1, undoSnap2, redoSnap1, redoSnap2, endUndo);
+                    });
+                }
             }.bind(this),
             // If there's an error, locally reschedule the sections in their old locations
             function(msg) {
@@ -794,8 +888,10 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
      * @param comment: a string comment to post
      * @param locked: true if this class should be locked from scheduling
      * @param remote: true if this setComment request comes from the server and not local user
+     * @param isUndo: When true, do not record this action in session history
+     * @param doneCallback: Optional; invoked after local success or after API error (e.g. undo completion)
      */
-    this.setComment = function(section, comment, locked, remote){
+    this.setComment = function(section, comment, locked, remote, isUndo, doneCallback){
         updateCells = function() {
             var assignment = this.scheduleAssignments[section.id];
             if(assignment.room_id) {
@@ -820,6 +916,16 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
                 // if successful, update the appearance of the cells
                 updateCells();
                 this.unselectSection();
+                if (!isUndo && this.historyPanel) {
+                    var self = this;
+                    var sid = section.id;
+                    var oc = old_comment;
+                    var ol = old_locked;
+                    this.historyPanel.addAction("Updated comment/lock for " + section.emailcode, function(endUndo) {
+                        self.setComment(self.getById(sid), oc, ol, false, true, endUndo);
+                    });
+                }
+                if (doneCallback) doneCallback();
             }.bind(this), function(msg){
                 // if unsuccessful, revert the comment locked status and show an error
                 section.schedulingComment = old_comment;
@@ -827,6 +933,7 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
                 this.matrix.messagePanel.addMessage("Error: " + msg, color = "red");
                 console.log(msg);
                 this.unselectSection();
+                if (doneCallback) doneCallback();
             }.bind(this));
         } else {
             // if this is from the changelog, just update the appearance of the cells

--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/Sections.js
@@ -495,6 +495,7 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
 
         // Make sure the assignment is valid
         if (!this.matrix.validateAssignment(section, room_id, schedule_timeslots).valid){
+            if (onComplete) onComplete();
             return;
         }
 
@@ -502,6 +503,7 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
         if (section.schedulingLocked){
             this.matrix.messagePanel.addMessage("Error: the specified section is locked (" + section.schedulingComment + ")! Unlock it first.", color = "red");
             this.unselectSection();
+            if (onComplete) onComplete();
             return;
         }
 
@@ -634,6 +636,7 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
         if (section.schedulingLocked){
             this.matrix.messagePanel.addMessage("Error: the specified section is locked (" + section.schedulingComment + ")! Unlock it first.", color = "red");
             this.unselectSection();
+            if (onComplete) onComplete();
             return;
         }
 
@@ -902,6 +905,7 @@ function Sections(sections_data, section_details_data, categories_data, teacher_
         }.bind(this);
 
         if(section.schedulingComment == comment && section.schedulingLocked == locked) {
+            if (doneCallback) doneCallback();
             return;
         }
 

--- a/esp/public/media/scripts/ajaxschedulingmodule/spec/HistoryPanelSpec.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/spec/HistoryPanelSpec.js
@@ -1,0 +1,98 @@
+describe("HistoryPanel", function() {
+    var container;
+    var clearBtn;
+    var panel;
+
+    beforeEach(function() {
+        container = $j("<ul/>");
+        clearBtn = $j("<button type='button'/>");
+        panel = new HistoryPanel(container, clearBtn);
+    });
+
+    it("starts empty with a placeholder row", function() {
+        expect(container.find(".scheduler-history-empty").length).toEqual(1);
+    });
+
+    it("addAction appends an entry and increments the stack", function() {
+        panel.addAction("Test action", function(endUndo) {
+            endUndo();
+        });
+        expect(panel.items.length).toEqual(1);
+        expect(container.find(".scheduler-history-row").length).toEqual(1);
+    });
+
+    it("does not add actions while undoing", function() {
+        panel.addAction("first", function() {});
+        panel.undoing = true;
+        panel.addAction("second", function(endUndo) {
+            endUndo();
+        });
+        expect(panel.items.length).toEqual(1);
+        panel.undoing = false;
+    });
+
+    it("runUndoLatest invokes only the latest undo and clears undoing after endUndo", function() {
+        var order = [];
+        panel.addAction("older", function(endUndo) {
+            order.push("older");
+            endUndo();
+        });
+        panel.addAction("newer", function(endUndo) {
+            order.push("newer");
+            endUndo();
+        });
+        panel.runUndoLatest();
+        expect(order).toEqual(["newer"]);
+        expect(panel.items.length).toEqual(1);
+        expect(panel.undoing).toEqual(false);
+    });
+
+    it("supports multiple sequential undos without stale entry references", function() {
+        var order = [];
+        panel.addAction("a", function(endUndo) {
+            order.push("a");
+            endUndo();
+        });
+        panel.addAction("b", function(endUndo) {
+            order.push("b");
+            endUndo();
+        });
+        panel.addAction("c", function(endUndo) {
+            order.push("c");
+            endUndo();
+        });
+        panel.runUndoLatest();
+        panel.runUndoLatest();
+        panel.runUndoLatest();
+        expect(order).toEqual(["c", "b", "a"]);
+        expect(panel.items.length).toEqual(0);
+    });
+
+    it("clear removes all entries", function() {
+        panel.addAction("x", function(endUndo) {
+            endUndo();
+        });
+        panel.clear();
+        expect(panel.items.length).toEqual(0);
+        expect(container.find(".scheduler-history-empty").length).toEqual(1);
+    });
+
+    it("drops oldest entries when exceeding MAX_ITEMS", function() {
+        var i;
+        for (i = 0; i < panel.MAX_ITEMS + 3; i++) {
+            panel.addAction("n" + i, function(endUndo) {
+                endUndo();
+            });
+        }
+        expect(panel.items.length).toEqual(panel.MAX_ITEMS);
+        expect(panel.items[0].description).toEqual("n3");
+    });
+
+    it("clear button clears the panel", function() {
+        panel.addAction("y", function(endUndo) {
+            endUndo();
+        });
+        clearBtn.trigger("click");
+        expect(panel.items.length).toEqual(0);
+    });
+});

--- a/esp/public/media/styles/scheduling.css
+++ b/esp/public/media/styles/scheduling.css
@@ -274,3 +274,215 @@ button.sidetoolbar {
     text-align: center;
     background: rgba(200,200,200,0.5) url('/media/images/ajax_loader.gif') no-repeat center; /*.gif file or just div with message etc. however you like*/
 }
+
+/* --- Scheduler layout polish (matrix + session history) --- */
+
+.scheduler-matrix-workspace {
+    background: #eef1f5;
+    border-radius: 6px;
+    border: 1px solid #cfd8e3;
+    box-sizing: border-box;
+}
+
+/* Shown when the program has no timeslots and/or no classrooms */
+.scheduler-matrix-empty-state {
+    padding: 24px 28px;
+    max-width: 36em;
+    margin: 16px auto;
+    background: #fff;
+    border: 1px solid #cfd8e3;
+    border-radius: 8px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.scheduler-matrix-empty-state p {
+    margin: 0 0 12px 0;
+    line-height: 1.5;
+    color: #37474f;
+    font-size: 0.95em;
+}
+
+.scheduler-matrix-empty-hint {
+    font-size: 0.88em !important;
+    color: #546e7a !important;
+    margin-bottom: 0 !important;
+}
+
+.scheduler-matrix-empty-toolbar {
+    margin-bottom: 16px;
+    padding-bottom: 12px;
+    border-bottom: 1px solid #eceff1;
+}
+
+.scheduler-matrix-toolbar-cell {
+    padding: 8px 10px !important;
+    vertical-align: middle !important;
+    background: #f7f9fc !important;
+    border-bottom: 1px solid #cfd8e3 !important;
+}
+
+.scheduler-matrix-toolbar-btn {
+    font: inherit;
+    font-size: 0.85em;
+    padding: 0.35em 0.75em;
+    margin-right: 0.5em;
+    border-radius: 4px;
+    border: 1px solid #b0bec5;
+    background: linear-gradient(to bottom, #ffffff, #eceff1);
+    color: #263238;
+    cursor: pointer;
+}
+
+.scheduler-matrix-toolbar-btn:hover {
+    border-color: #78909c;
+    background: #fff;
+}
+
+.scheduler-admin-bar {
+    width: 100%;
+    text-align: center;
+    min-height: 36px;
+    padding: 6px 8px;
+    box-sizing: border-box;
+    background: #fff8e1;
+    border: 1px solid #ffe082;
+    border-radius: 4px;
+    margin-bottom: 6px;
+}
+
+.scheduler-danger-btn {
+    height: auto;
+    font-size: 0.8em;
+    padding: 0.4em 0.75em;
+    border-radius: 4px;
+    border: 1px solid #e65100;
+    background: #fff;
+    color: #bf360c;
+    cursor: pointer;
+}
+
+.scheduler-danger-btn:hover {
+    background: #fff3e0;
+}
+
+/* Session history tab */
+.scheduler-history-panel {
+    padding: 2px 6px 8px 2px;
+}
+
+.scheduler-history-intro {
+    font-size: 0.82em;
+    line-height: 1.45;
+    color: #455a64;
+    margin: 0 0 12px 0;
+    padding: 10px 12px;
+    background: #eceff1;
+    border-radius: 6px;
+    border-left: 4px solid #546e7a;
+}
+
+.scheduler-history-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    max-height: 42vh;
+    overflow-y: auto;
+}
+
+.scheduler-history-row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 8px 10px;
+    margin-bottom: 6px;
+    border: 1px solid #e0e0e0;
+    border-radius: 6px;
+    background: #fafafa;
+}
+
+.scheduler-history-row--latest {
+    border-color: #a5d6a7;
+    background: #e8f5e9;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+}
+
+.scheduler-history-desc {
+    flex: 1;
+    min-width: 0;
+    word-break: break-word;
+    font-size: 0.88em;
+    line-height: 1.4;
+    color: #37474f;
+}
+
+.scheduler-history-undo {
+    flex-shrink: 0;
+    font-size: 0.8em;
+    padding: 0.4em 0.75em;
+    border-radius: 4px;
+    border: 1px solid #2e7d32;
+    background: #fff;
+    color: #1b5e20;
+    cursor: pointer;
+    font-weight: 600;
+}
+
+.scheduler-history-undo:hover:not(:disabled) {
+    background: #c8e6c9;
+}
+
+.scheduler-history-undo:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+    border-color: #bdbdbd;
+    color: #757575;
+    background: #f5f5f5;
+}
+
+.scheduler-history-empty {
+    list-style: none;
+    margin: 0;
+    padding: 14px 12px;
+    text-align: center;
+    font-size: 0.88em;
+    font-style: italic;
+    color: #607d8b;
+    border: 1px dashed #cfd8dc;
+    border-radius: 8px;
+    background: #fafafa;
+}
+
+.scheduler-history-footer {
+    margin-top: 12px;
+    padding-top: 10px;
+    border-top: 1px solid #e0e0e0;
+    text-align: right;
+}
+
+.scheduler-history-clear-btn {
+    font: inherit;
+    font-size: 0.82em;
+    padding: 0.4em 0.85em;
+    border-radius: 4px;
+    border: 1px solid #90a4ae;
+    background: #fff;
+    color: #455a64;
+    cursor: pointer;
+}
+
+.scheduler-history-clear-btn:hover {
+    background: #eceff1;
+    border-color: #78909c;
+}
+
+/* Side panel tabs: slightly tighter, clearer labels */
+#side-panel.ui-tabs .ui-tabs-nav {
+    padding: 4px 4px 0;
+    border-radius: 4px 4px 0 0;
+}
+
+#side-panel.ui-tabs .ui-tabs-nav li a {
+    padding: 0.45em 0.9em;
+    font-size: 0.92em;
+}

--- a/esp/templates/SpecRunner.html
+++ b/esp/templates/SpecRunner.html
@@ -39,6 +39,7 @@
   <script type="text/javascript" src="/media/scripts/ajaxschedulingmodule/ESP/MessagePanel.js"></script>
   <script type="text/javascript" src="/media/scripts/ajaxschedulingmodule/ESP/SectionCommentDialog.js"></script>
   <script type="text/javascript" src="/media/scripts/ajaxschedulingmodule/ESP/SectionInfoPanel.js"></script>
+  <script type="text/javascript" src="/media/scripts/ajaxschedulingmodule/ESP/HistoryPanel.js"></script>
   <script type="text/javascript" src="/media/scripts/ajaxschedulingmodule/ESP/Scheduler.js"></script>
   <script type="text/javascript" src="/media/scripts/ajaxschedulingmodule/ESP/Helpers.js"></script>
   <script type="text/javascript" src="/media/scripts/ajaxschedulingmodule/ESP/ChangelogFetcher.js"></script>

--- a/esp/templates/SpecRunner.html
+++ b/esp/templates/SpecRunner.html
@@ -59,6 +59,7 @@
   <script type="text/javascript" src="/media/scripts/ajaxschedulingmodule/spec/SectionInfoPanelSpec.js"></script>
   <script type="text/javascript" src="/media/scripts/ajaxschedulingmodule/spec/SchedulerSpec.js"></script>
   <script type="text/javascript" src="/media/scripts/ajaxschedulingmodule/spec/ChangelogFetcherSpec.js"></script>
+  <script type="text/javascript" src="/media/scripts/ajaxschedulingmodule/spec/HistoryPanelSpec.js"></script>
   <script type="text/javascript" src="/media/scripts/ajaxschedulingmodule/spec/HelpersSpec.js"></script>
 
   <script type="text/javascript">

--- a/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
+++ b/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
@@ -72,9 +72,8 @@
     <td class="no-border">
       <div id="side-panel-wrapper" class="ui-widget">
 		<div class="scheduler-admin-bar">
-			<a href="ajax_clear_change_log">
-				<button type="button" id="clear_change_log" class="scheduler-danger-btn">Clear change log (all users)</button>
-			</a>
+			<a href="ajax_clear_change_log" id="clear_change_log" class="scheduler-danger-btn"
+			   onclick="return confirm('Clear the change log for all users? This will delete any unsynchronized progress.');">Clear change log (all users, deletes unsynchronized progress)</a>
 		</div>
         <div id="info-panel">
           <div id="section-info-and-message-wrapper">

--- a/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
+++ b/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
@@ -57,6 +57,7 @@
 <script type="text/javascript" src="/media/scripts/ajaxschedulingmodule/ESP/SectionCommentDialog.js"></script>
 <script type="text/javascript" src="/media/scripts/ajaxschedulingmodule/ESP/SectionInfoPanel.js"></script>
 <script type="text/javascript" src="/media/scripts/ajaxschedulingmodule/ESP/ChangelogFetcher.js"></script>
+<script type="text/javascript" src="/media/scripts/ajaxschedulingmodule/ESP/HistoryPanel.js"></script>
 <script type="text/javascript" src="/media/scripts/ajaxschedulingmodule/ESP/Scheduler.js"></script>
 <script type="text/javascript" src="/media/scripts/ajaxschedulingmodule/ESP/Main.js"></script>
 
@@ -66,13 +67,13 @@
 <table class="no-border">
   <tr>
     <td class="no-border">
-      <div id="matrix-div" class="component-div"></div>
+      <div id="matrix-div" class="component-div scheduler-matrix-workspace"></div>
     </td>
     <td class="no-border">
       <div id="side-panel-wrapper" class="ui-widget">
-		<div style =  "width: 100%; text-align: center; min-height: 30px">
-			<a href = "ajax_clear_change_log">
-				<button id = "clear_change_log" style="height: 100%;">Clear Change Log (deletes unsynchronized progress for all users!)</button>
+		<div class="scheduler-admin-bar">
+			<a href="ajax_clear_change_log">
+				<button type="button" id="clear_change_log" class="scheduler-danger-btn">Clear change log (all users)</button>
 			</a>
 		</div>
         <div id="info-panel">
@@ -90,6 +91,7 @@
             {% if has_moderator_module %}
             <li><a href="#moderators">{{ program.getModeratorTitle }}s</a></li>
             {% endif %}
+            <li><a href="#scheduler-history">History</a></li>
           </ul>
           <div id="side-panel-inner">
                 <div id="classes">
@@ -293,6 +295,13 @@
                     <div id="moderator-directory"></div>
                 </div>
                 {% endif %}
+                <div id="scheduler-history" class="scheduler-history-panel">
+                    <p class="scheduler-history-intro">Tracks this browser session only (up to 20 actions). Only the latest action can be undone. Reloading the page clears the list.</p>
+                    <ul id="history-container" class="scheduler-history-list" aria-live="polite"></ul>
+                    <div class="scheduler-history-footer">
+                        <button type="button" id="clear-history" class="scheduler-history-clear-btn">Clear session history</button>
+                    </div>
+                </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Description

Adds a History panel with Undo functionality to the AJAX Scheduler.

This introduces a new `HistoryPanel` module that tracks recent user actions (session-scoped) and allows precise undo using snapshot-based state restoration. Undo actions trigger the same API calls as normal operations, ensuring backend consistency and proper validation.

The history is capped (20 entries) and avoids recursive logging using an `isUndo` flag.

## Related Issue

Closes #464

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## AI Disclosure

Used AI assistance for refining approach and improving code clarity.

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced
