### PR TITLE
[Accessibility]: Add missing <label> elements to form controls in Custom Form Creation page.

### DIFF
--- a/esp/public/media/scripts/custom_form.js
+++ b/esp/public/media/scripts/custom_form.js
@@ -265,7 +265,7 @@ $j(document).ready(function() {
     if(edit_form != -1){
         $j("#base_form").val(edit_form).trigger("change");
         createFromBase();
-        $j("#create_text").html("Modifying existing form:");
+        $j("#create_text").text("Modifying existing form:");
         $j("#base_form").prop('disabled', true);
         $j("#create_from_base").hide();
         $j("#id_modify").prop('checked', true).trigger("change");

--- a/esp/templates/customforms/index.html
+++ b/esp/templates/customforms/index.html
@@ -47,7 +47,7 @@
             <p><label for="input_suc_url">Redirect URL for successful completion</label></p>
             <input type="text" id="input_suc_url" size="30"/>
             <p><label for="id_anonymous">Anonymous Form</label> <input type='checkbox' id='id_anonymous'/></p>
-            <label for="base_form"><p id="create_text">Create from existing form:</p></label>
+            <label for="base_form" id="create_text">Create from existing form:</label>
             <select id="base_form">
                 <option value="-1">None</option>
                 {% for form in form_list %}

--- a/esp/templates/customforms/index.html
+++ b/esp/templates/customforms/index.html
@@ -109,9 +109,9 @@
 
             <div id="field_properties">
 
-                <label for="id_question" class="toolboxText">Field label</label>
+                <p class="toolboxText"><label for="id_question">Field label</label></p>
                 <textarea name="question" id="id_question" rows=4 cols=30 maxlength=200></textarea>
-                <label for="id_instructions" class="toolboxText">Instructions for user</label>
+                <p class="toolboxText"><label for="id_instructions">Instructions for user</label></p>
                 <textarea name="instructions" id="id_instructions" rows=4 cols=30></textarea>
                 <p class="toolboxText"><label for="id_required">Required</label>&nbsp;
                     <input type="checkbox" id="id_required" name="required" /><br/><br/></p>

--- a/esp/templates/customforms/index.html
+++ b/esp/templates/customforms/index.html
@@ -39,15 +39,15 @@
     <div id="form_toolbox">
         <h3 id="header_information"><a href='#'>Form information</a></h3>
         <div id="form_information">
-            <label for="input_form_title">Form Title</label> <input type='text' id='input_form_title' size='30' value='Form Title'/>
-            <label for="input_form_description">Description</label>
+            <p><label for="input_form_title">Form Title</label></p> <input type='text' id='input_form_title' size='30' value='Form Title'/>
+            <p><label for="input_form_description">Description</label></p>
             <textarea rows='3' cols='30' id='input_form_description'></textarea>
-            <label for="input_form_sucmsg">Message on Success</label>
+            <p><label for="input_form_sucmsg">Message on Success</label></p>
             <textarea rows='3' cols='30' id='input_form_sucmsg'></textarea>
-            <label for="input_suc_url">Redirect URL for successful completion</label>
+            <p><label for="input_suc_url">Redirect URL for successful completion</label></p>
             <input type="text" id="input_suc_url" size="30"/>
             <p><label for="id_anonymous">Anonymous Form</label> <input type='checkbox' id='id_anonymous'/></p>
-            <label for="base_form" id="create_text">Create from existing form:</label>
+            <p id="create_text"><label for="base_form">Create from existing form:</label></p>
             <select id="base_form">
                 <option value="-1">None</option>
                 {% for form in form_list %}
@@ -93,13 +93,13 @@
                     <p>These fields will modify existing values in the database, or create new ones. Please select how you want
                         this to happen.
                     </p>
-                    <label for="main_cat_spec">Modification method:</label>
+                    <p><label for="main_cat_spec">Modification method:</label></p>
                     <select id="main_cat_spec">
                         <option value="automatic">Automatic</option>
                         <option value="particular">Choose particular instance to modify</option>
                     </select>
                     <br/>
-                    <label for="cat_instance_sel">Instance:</label>
+                    <p><label for="cat_instance_sel">Instance:</label></p>
                     <select id="cat_instance_sel">
                     </select>
                     <br/>
@@ -132,7 +132,7 @@
                 <option value="Student">Students</option>
             </select></p>
             <p><input type="checkbox" id="id_prog_belong" /><label for="id_prog_belong"> Belonging to program</label></p>
-            <label for="id_perm_program">Program:</label>
+            <p><label for="id_perm_program">Program:</label></p>
             <select id="id_perm_program">
                 <option value="-1">None</option>
                 {% for prog in prog_list %}
@@ -141,7 +141,7 @@
             </select>
             <br/>
             <div>
-                <label for="id_sub_perm">Filter</label>
+                <p><label for="id_sub_perm">Filter</label></p>
                 <select id="id_sub_perm">
                 </select>
             </div>

--- a/esp/templates/customforms/index.html
+++ b/esp/templates/customforms/index.html
@@ -35,7 +35,7 @@
             </div>
         </div>
     </div>
-        
+
     <div id="form_toolbox">
         <h3 id="header_information"><a href='#'>Form information</a></h3>
         <div id="form_information">
@@ -47,24 +47,24 @@
             <label for="input_suc_url">Redirect URL for successful completion</label>
             <input type="text" id="input_suc_url" size="30"/>
             <p><label for="id_anonymous">Anonymous Form</label> <input type='checkbox' id='id_anonymous'/></p>
-            <p id="create_text">Create from existing form:</p>
-            <select id="base_form" aria-label="Create from existing form">
+            <label for="base_form" id="create_text">Create from existing form:</label>
+            <select id="base_form">
                 <option value="-1">None</option>
                 {% for form in form_list %}
                     <option value="{{form.id}}">{{form.title}}</option>
-                {% endfor %}	
+                {% endfor %}
             </select>
             <button type="button" id="create_from_base" hidden type="button" onclick="createFromBase()">Create from previous form</button>
             <p id="create_from_base_error" hidden style="color: red;"></p>
-            <div id="id_modify_wrapper" hidden><p>Modify this form <input type="checkbox" id="id_modify"/></p>
+            <div id="id_modify_wrapper" hidden><p><label for="id_modify">Modify this form</label> <input type="checkbox" id="id_modify"/></p>
             <p>(Please check this off <b>only</b> if you want to modify this form. If you just want to create a form that
                 resembles this one, leave this unchecked.)</p>
-            </div> 		
+            </div>
         </div>
-            
+
         <h3 id="header_fields"><a href='#'>Fields</a></h3>
         <div id="toolbox_content">
-        
+
             <div id="field_selector">
                 <br/>
                 <table border="0">
@@ -85,7 +85,7 @@
                             <select id="elem_selector">
                             </select>
                         </td>
-                    </tr>		
+                    </tr>
                 </table>
                 <br/>
                 <div id="cat_spec_options">
@@ -93,20 +93,22 @@
                     <p>These fields will modify existing values in the database, or create new ones. Please select how you want
                         this to happen.
                     </p>
-                    <select id="main_cat_spec" aria-label="Field instance mode">
+                    <label for="main_cat_spec">Modification method:</label>
+                    <select id="main_cat_spec">
                         <option value="automatic">Automatic</option>
                         <option value="particular">Choose particular instance to modify</option>
                     </select>
                     <br/>
-                    <select id="cat_instance_sel" aria-label="Choose instance">
+                    <label for="cat_instance_sel">Instance:</label>
+                    <select id="cat_instance_sel">
                     </select>
-                    <br/>				
+                    <br/>
                 </div>
-                                        
+
             </div>
-            
+
             <div id="field_properties">
-                
+
                 <label for="id_question" class="toolboxText">Field label</label>
                 <textarea name="question" id="id_question" rows=4 cols=30 maxlength=200></textarea>
                 <label for="id_instructions" class="toolboxText">Instructions for user</label>
@@ -116,70 +118,70 @@
                 <form id="elem_properties">
                     <div id="multi_options"></div>
                 </form>
-                <div id="other_options"></div>		
+                <div id="other_options"></div>
                 <button type="button" id="button_add" value="Add to Form"/>Add Field to Form</button>
             </div>
-            
+
         </div>
         <h3><a href='#'>Form Permissions</a></h3>
         <div>
-            <p><label for="id_main_perm">Restrict to -</label>
+            <p><label for="id_main_perm">Restrict to</label>
             <select id="id_main_perm">
                 <option value="none">None</option>
                 <option value="Teacher">Teachers</option>
                 <option value="Student">Students</option>
             </select></p>
             <p><input type="checkbox" id="id_prog_belong" /><label for="id_prog_belong"> Belonging to program</label></p>
-            <select id="id_perm_program" aria-label="Program">
+            <label for="id_perm_program">Program:</label>
+            <select id="id_perm_program">
                 <option value="-1">None</option>
                 {% for prog in prog_list %}
                     <option value="{{ prog.id }}">{{ prog.niceName }}</option>
                 {% endfor %}
             </select>
-            <br/>	
+            <br/>
             <div>
-                <p>Filter</p>
+                <label for="id_sub_perm">Filter</label>
                 <select id="id_sub_perm">
-                </select>		
+                </select>
             </div>
         </div>
-        
+
         <h3><a href='#'>Link to a Program or Course</a></h3>
         <div>
-            <p>Link to -
-            <select id="links_id_main">	
+            <p><label for="links_id_main">Link to</label>
+            <select id="links_id_main">
             </select>
             </p>
-            
-            <p>Specify -
+
+            <p><label for="links_id_specify">Specify</label>
             <select id="links_id_specify">
                 <option value="userdef">Let user pick</option>
                 <option value="particular">Particular Instance</option>
             </select>
             </p>
-            
-            <p>Pick -
+
+            <p><label for="links_id_pick">Pick</label>
             <select id="links_id_pick">
             </select>
             </p>
 
-            <p>User type -
+            <p><label for="links_id_tl">User type</label>
             <select id="links_id_tl">
                 <option value="learn">Students</option>
                 <option value="teach">Teachers</option>
             </select>
             </p>
 
-            <p>Module -
+            <p><label for="links_id_module">Module</label>
             <select id="links_id_module">
             </select>
             </p>
             <p id="links_id_module_help_text" hidden style="color: red;"></p>
-        </div>	
-            
+        </div>
+
         <input type="button" id="submit" value="Create Form"/>
         <p id="submit_error" hidden style="color: red;"></p>
     </div>
 </div>
 {% endblock %}
-

--- a/esp/templates/customforms/index.html
+++ b/esp/templates/customforms/index.html
@@ -47,14 +47,14 @@
             <p><label for="input_suc_url">Redirect URL for successful completion</label></p>
             <input type="text" id="input_suc_url" size="30"/>
             <p><label for="id_anonymous">Anonymous Form</label> <input type='checkbox' id='id_anonymous'/></p>
-            <p id="create_text"><label for="base_form">Create from existing form:</label></p>
+            <label for="base_form"><p id="create_text">Create from existing form:</p></label>
             <select id="base_form">
                 <option value="-1">None</option>
                 {% for form in form_list %}
                     <option value="{{form.id}}">{{form.title}}</option>
                 {% endfor %}
             </select>
-            <button type="button" id="create_from_base" hidden type="button" onclick="createFromBase()">Create from previous form</button>
+            <button type="button" id="create_from_base" hidden onclick="createFromBase()">Create from previous form</button>
             <p id="create_from_base_error" hidden style="color: red;"></p>
             <div id="id_modify_wrapper" hidden><p><label for="id_modify">Modify this form</label> <input type="checkbox" id="id_modify"/></p>
             <p>(Please check this off <b>only</b> if you want to modify this form. If you just want to create a form that
@@ -119,7 +119,7 @@
                     <div id="multi_options"></div>
                 </form>
                 <div id="other_options"></div>
-                <button type="button" id="button_add" value="Add to Form"/>Add Field to Form</button>
+                <button type="button" id="button_add" value="Add to Form">Add Field to Form</button>
             </div>
 
         </div>


### PR DESCRIPTION
Replaces descriptive <p> tags with properly associated <label for="..."> elements for all <textarea>, <select>, and <input> controls on the Custom Form Creation page, addressing WCAG 2.1 SC 1.3.1 and 4.1.2. JS .parent() relationships and dynamic element IDs are preserved.

## Description

<!-- Brief summary of the changes and their purpose. -->

## Related Issue

<!-- Link the relevant issue. Use "Closes #123" to auto-close on merge. -->

Closes #4484 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manually verified

## AI Disclosure

<!-- If you used AI tools for any part of this pull request, please disclose this here -->

## Checklist

- [ ] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [ ] No new warnings or errors introduced
