### PR TITLE
Fix HTTP 500 error in AdminReviewApps for students without applications

### DIFF
--- a/esp/esp/program/modules/handlers/adminreviewapps.py
+++ b/esp/esp/program/modules/handlers/adminreviewapps.py
@@ -179,7 +179,6 @@ class AdminReviewApps(ProgramModuleObj):
             student.app = student.studentapplication_set.get(program = self.program)
         except StudentApplication.DoesNotExist:
             student.app = None
-            assert False, student.studentapplication_set.all()[0].__dict__
             raise ESPError('Error: Student did not apply. Student is automatically rejected.', log=False)
 
         return render_to_response(self.baseDir()+'app_popup.html', request, {'class': cls, 'student': student, 'program': prog})


### PR DESCRIPTION
### Description

When an administrator attempted to view an application for a student who had not applied to the selected program, the server returned a 500 Internal Server Error instead of a user-friendly message.

This was caused by a leftover debugging statement in the StudentApplication.DoesNotExist exception handler:
```
except StudentApplication.DoesNotExist:
    student.app = None
    assert False, student.studentapplication_set.all()[0].__dict__  # ← debug artifact
    raise ESPError('Error: Student did not apply...', log=False)    # ← never reached
```

The assert False unconditionally raised an AssertionError, preventing the intended ESPError from ever executing. If the student had zero applications across all programs, .all()[0] would additionally raise an IndexError.

### Fix
Removed the assert False debugging line so the exception handler works as originally intended:

```
except StudentApplication.DoesNotExist:
    student.app = None
    raise ESPError('Error: Student did not apply. Student is automatically rejected.', log=False)
```

### Impact
Admins now see a friendly error message instead of a server crash
No functional behavior changes for students who have valid applications
No new logic introduced — purely removes dead/broken debugging code

### Testing
Navigate to the Admin Application Review module for a program
Access view_app for a student who has not submitted a StudentApplication for that program
Should now display the ESPError message instead of crashing

Closes #5679 