### PR TITLE
feat: expose custom form field responses in shared class info template

### DIFF
--- a/esp/templates/program/modules/adminclass/manageclass.html
+++ b/esp/templates/program/modules/adminclass/manageclass.html
@@ -87,18 +87,7 @@
         </td>
     </tr>
     {% endif %}
-    <tr>
-        <th class="smaller">Additional information specified by teacher: </th>
-        <td>
-            <ul>
-            {% for key, value in class.custom_form_data.items %}
-                {% if value %}
-                <li style="color: black;"><i>{{ key|as_form_label }}</i>: {{ value }}</li>
-                {% endif %}
-            {% endfor %}
-            </ul>
-        </td>
-    </tr>
+    
 </table>
 
 <br />

--- a/esp/templates/program/modules/adminclass/manageclass_class_info.html
+++ b/esp/templates/program/modules/adminclass/manageclass_class_info.html
@@ -77,6 +77,18 @@
     </td>
 </tr>
 <tr>
+    <th class="smaller">Additional information specified by teacher: </th>
+    <td>
+        <ul>
+        {% for key, value in class.custom_form_data.items %}
+            {% if value %}
+            <li style="color: black;"><i>{{ key|as_form_label }}</i>: {{ value }}</li>
+            {% endif %}
+        {% endfor %}
+        </ul>
+    </td>
+</tr>
+<tr>
     <th class="smaller">Resource Requests:</th>
         <td>
 	    {% for r in class.sections.all.0.resourcerequest_set.all %}


### PR DESCRIPTION
## Description

Moved the rendering of custom teacher registration field responses (`class.custom_form_data`) from `manageclass.html` to the shared `manageclass_class_info.html` template.

This change improves accessibility of custom field responses by making them available wherever class information is displayed, instead of limiting them to only the class management page.

## Related Issue

Closes #2707

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## AI Disclosure

Assisted by AI for guidance on understanding the codebase, structuring the refactor, and preparing the pull request description.

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced