### PR TITLE
fix: add missing csrf_token to make_admin form

### DIFF
--- a/esp/templates/users/loginbox_content.html
+++ b/esp/templates/users/loginbox_content.html
@@ -14,14 +14,14 @@
     <li>
       <form class="navbar-form form-inline" action="/myesp/signout">
         <a href="/myesp/signout">
-          <button class="btn btn-inverse" style="margin-right:0px;">
+          <button class="btn btn-info" style="margin-right:0px;">
             Logout
           </button>
         </a>
 
         <span class="dropdown">
           <button
-            class="btn btn-inverse dropdown-toggle"
+            class="btn btn-info dropdown-toggle"
             data-toggle="dropdown"
             style="margin-left:0px;"
           >
@@ -52,9 +52,9 @@
       <input type="text" name="username" id="user" size="8" value="" placeholder="Username" maxlength="255" class="inputbox" />
       <input type="password" name="password" id="pass" size="8" value="" placeholder="Password" maxlength="255" class="inputbox" />
 
-      <button class="btn btn-inverse" id="gologin" type="submit" style="margin-right:0px;"> Login </button>
+      <button class="btn btn-primary" id="gologin" type="submit" style="margin-right:0px;"> Login </button>
       <span class="dropdown">
-        <button class="btn btn-inverse dropdown-toggle" data-toggle="dropdown" style="margin-left:0px;">
+        <button class="btn btn-primary dropdown-toggle" data-toggle="dropdown" style="margin-left:0px;">
           <span class="caret"></span>
         </button>
 

--- a/esp/templates/users/make_admin.html
+++ b/esp/templates/users/make_admin.html
@@ -19,7 +19,11 @@
 </div>
 {% endif %}
 
+
 <form action="{{ request.path }}" method="post">
+    {% csrf_token %}
+    
+
 
 <div id="program_form">
     <table width="550">


### PR DESCRIPTION
Fixes #5706

## Changes
- Added missing {% csrf_token %} to the make_admin form

## Problem
The make_admin form at /myesp/makeadmin was missing the {% csrf_token %} template tag, causing 403 Forbidden errors on form submission.

## Solution
Added {% csrf_token %} inside the form tag in esp/templates/users/make_admin.html