### PR TITLE
fix: add missing csrf_token to make_admin form

### DIFF
--- a/esp/templates/users/make_admin.html
+++ b/esp/templates/users/make_admin.html
@@ -19,7 +19,11 @@
 </div>
 {% endif %}
 
+
 <form action="{{ request.path }}" method="post">
+    {% csrf_token %}
+    
+
 
 <div id="program_form">
     <table width="550">


### PR DESCRIPTION
Fixes #5706

## Changes
- Added missing {% csrf_token %} to the make_admin form

## Problem
The make_admin form at /myesp/makeadmin was missing the {% csrf_token %} template tag, causing 403 Forbidden errors on form submission.

## Solution
Added {% csrf_token %} inside the form tag in esp/templates/users/make_admin.html