### PR TITLE
REFACTOR(BaseESPUser): Replace the cmp comparison logic with python3 compatible logic.

### DIFF
--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -335,33 +335,32 @@ class BaseESPUser(object):
         """
         return ESPUser.email_sendto_address(self.email, self.name())
 
-    def __cmp__(self, other):
-        if other is None:
-            return 1
-        # two anonymous users are equal
-        if isinstance(self, AnonymousESPUser) and isinstance(other, AnonymousESPUser):
-            return 0
-        # otherwise, rank the signed-in user higher
-        elif isinstance(other, AnonymousESPUser):
-            return 1
-        elif isinstance(self, AnonymousESPUser):
-            return -1
-        lastname = cmp(self.last_name.upper(), other.last_name.upper())
-        if lastname == 0:
-           return cmp(self.first_name.upper(), other.first_name.upper())
-        return lastname
+    def _get_sort_key(self):
+        not_anon = not isinstance(self, AnonymousESPUser)
+        # safe fallback to empty string if user is anonymous or normal user with last_name or first_name as None
+        last_name = getattr(self, 'last_name', '') or ''
+        first_name = getattr(self, 'first_name', '') or ''
+        return (not_anon, last_name.upper(), first_name.upper())
+
     def __lt__(self, other):
-        return self.__cmp__(other) < 0
-    def __gt__(self, other):
-        return self.__cmp__(other) > 0
-    def __eq__(self, other):
-        return self.__cmp__(other) == 0
+        if not isinstance(other, BaseESPUser):
+            return NotImplemented
+        return self._get_sort_key() < other._get_sort_key()
+
     def __le__(self, other):
-        return self.__cmp__(other) <= 0
+        if not isinstance(other, BaseESPUser):
+            return NotImplemented
+        return self._get_sort_key() <= other._get_sort_key()
+
+    def __gt__(self, other):
+        if not isinstance(other, BaseESPUser):
+            return NotImplemented
+        return self._get_sort_key() > other._get_sort_key()
+
     def __ge__(self, other):
-        return self.__cmp__(other) >= 0
-    def __ne__(self, other):
-        return self.__cmp__(other) != 0
+        if not isinstance(other, BaseESPUser):
+            return NotImplemented
+        return self._get_sort_key() >= other._get_sort_key()
 
     def getLastProfile(self):
         # caching is handled in RegistrationProfile.getLastProfile

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -365,33 +365,32 @@ class BaseESPUser(object):
         """
         return ESPUser.email_sendto_address(self.email, self.name())
 
-    def __cmp__(self, other):
-        if other is None:
-            return 1
-        # two anonymous users are equal
-        if isinstance(self, AnonymousESPUser) and isinstance(other, AnonymousESPUser):
-            return 0
-        # otherwise, rank the signed-in user higher
-        elif isinstance(other, AnonymousESPUser):
-            return 1
-        elif isinstance(self, AnonymousESPUser):
-            return -1
-        lastname = cmp(self.last_name.upper(), other.last_name.upper())
-        if lastname == 0:
-           return cmp(self.first_name.upper(), other.first_name.upper())
-        return lastname
+    def _get_sort_key(self):
+        not_anon = not isinstance(self, AnonymousESPUser)
+        # safe fallback to empty string if user is anonymous or normal user with last_name or first_name as None
+        last_name = getattr(self, 'last_name', '') or ''
+        first_name = getattr(self, 'first_name', '') or ''
+        return (not_anon, last_name.upper(), first_name.upper())
+
     def __lt__(self, other):
-        return self.__cmp__(other) < 0
-    def __gt__(self, other):
-        return self.__cmp__(other) > 0
-    def __eq__(self, other):
-        return self.__cmp__(other) == 0
+        if not isinstance(other, BaseESPUser):
+            return NotImplemented
+        return self._get_sort_key() < other._get_sort_key()
+
     def __le__(self, other):
-        return self.__cmp__(other) <= 0
+        if not isinstance(other, BaseESPUser):
+            return NotImplemented
+        return self._get_sort_key() <= other._get_sort_key()
+
+    def __gt__(self, other):
+        if not isinstance(other, BaseESPUser):
+            return NotImplemented
+        return self._get_sort_key() > other._get_sort_key()
+
     def __ge__(self, other):
-        return self.__cmp__(other) >= 0
-    def __ne__(self, other):
-        return self.__cmp__(other) != 0
+        if not isinstance(other, BaseESPUser):
+            return NotImplemented
+        return self._get_sort_key() >= other._get_sort_key()
 
     def getLastProfile(self):
         # caching is handled in RegistrationProfile.getLastProfile

--- a/esp/esp/users/tests.py
+++ b/esp/esp/users/tests.py
@@ -17,7 +17,7 @@ from esp.tagdict.models import Tag
 from esp.tests.util import CacheFlushTestCase as TestCase, user_role_setup
 from esp.users.forms.user_reg import ValidHostEmailField
 from esp.users.forms.user_profile import StudentProfileForm
-from esp.users.models import User, ESPUser, UserForwarder, StudentInfo, Permission, Record, RecordType
+from esp.users.models import User, ESPUser, AnonymousESPUser, UserForwarder, StudentInfo, Permission, Record, RecordType
 
 class ESPUserTest(TestCase):
     def setUp(self):
@@ -138,6 +138,41 @@ class ESPUserTest(TestCase):
                                 f"Token check failed for username: {username}")
             finally:
                 user.delete()
+
+    def test_sort_key_normal_user_greater_than_anon(self):
+        anon_user = AnonymousESPUser()
+        user = ESPUser(username="t", first_name="Smith", last_name="Michael")
+        self.assertGreater(user, anon_user)
+
+    def test_sort_key_alphabetical_order(self):
+        user_m = ESPUser(username="t1", first_name="Smith", last_name="Michael")
+        user_z = ESPUser(username="t2", first_name="Adam", last_name="Zebra")
+        self.assertLess(user_m, user_z)
+
+    def test_sort_key_same_last_name(self):
+        user_s = ESPUser(username="t1", first_name="Smith", last_name="Michael")
+        user_a = ESPUser(username="t2", first_name="Adam", last_name="Michael")
+        self.assertLess(user_a, user_s)
+
+    def test_sort_key_none_name_same_sort_position(self):
+        user1 = ESPUser(username="t1", first_name=None, last_name=None)
+        user2 = ESPUser(username="t2", first_name="", last_name="")
+        self.assertFalse(user1 < user2)
+        self.assertFalse(user2 < user1)
+
+    def test_sort_key_case_insensitive_same_sort_position(self):
+        user_lower = ESPUser(username="t1", first_name="smith", last_name="michael")
+        user_upper = ESPUser(username="t2", first_name="Smith", last_name="Michael")
+        self.assertFalse(user_lower < user_upper)
+        self.assertFalse(user_upper < user_lower)
+
+    def test_sort_key_compare_with_non_user(self):
+        user = ESPUser(username="t", first_name="Smith", last_name="Michael")
+        self.assertFalse(user == "string") # Django Model.__eq__ returns False, does not raise
+        with self.assertRaises(TypeError): # ordering operators raise TypeError for non-BaseESPUser
+            _ = user > "string"
+        with self.assertRaises(TypeError):
+            _ = user < "string"
 
 class PasswordRecoveryTest(TestCase):
     """Test password recovery using Django's built-in token generator.

--- a/esp/esp/users/tests.py
+++ b/esp/esp/users/tests.py
@@ -29,7 +29,7 @@ from esp.users.models import (
     PersistentQueryFilter,
 )
 from esp.users.forms.user_profile import StudentProfileForm
-from esp.users.models import User, ESPUser, UserForwarder, StudentInfo, Permission, Record, RecordType, DBList
+from esp.users.models import User, ESPUser, AnonymousESPUser, UserForwarder, StudentInfo, Permission, Record, RecordType, DBList
 
 class ESPUserTest(TestCase):
     def setUp(self):
@@ -163,6 +163,41 @@ class ESPUserTest(TestCase):
         refreshed = DBList(key='all-users', QObject=Q(id__gt=0)).count()
 
         self.assertEqual(refreshed, baseline + 1)
+
+    def test_sort_key_normal_user_greater_than_anon(self):
+        anon_user = AnonymousESPUser()
+        user = ESPUser(username="t", first_name="Smith", last_name="Michael")
+        self.assertGreater(user, anon_user)
+
+    def test_sort_key_alphabetical_order(self):
+        user_m = ESPUser(username="t1", first_name="Smith", last_name="Michael")
+        user_z = ESPUser(username="t2", first_name="Adam", last_name="Zebra")
+        self.assertLess(user_m, user_z)
+
+    def test_sort_key_same_last_name(self):
+        user_s = ESPUser(username="t1", first_name="Smith", last_name="Michael")
+        user_a = ESPUser(username="t2", first_name="Adam", last_name="Michael")
+        self.assertLess(user_a, user_s)
+
+    def test_sort_key_none_name_same_sort_position(self):
+        user1 = ESPUser(username="t1", first_name=None, last_name=None)
+        user2 = ESPUser(username="t2", first_name="", last_name="")
+        self.assertFalse(user1 < user2)
+        self.assertFalse(user2 < user1)
+
+    def test_sort_key_case_insensitive_same_sort_position(self):
+        user_lower = ESPUser(username="t1", first_name="smith", last_name="michael")
+        user_upper = ESPUser(username="t2", first_name="Smith", last_name="Michael")
+        self.assertFalse(user_lower < user_upper)
+        self.assertFalse(user_upper < user_lower)
+
+    def test_sort_key_compare_with_non_user(self):
+        user = ESPUser(username="t", first_name="Smith", last_name="Michael")
+        self.assertFalse(user == "string") # Django Model.__eq__ returns False, does not raise
+        with self.assertRaises(TypeError): # ordering operators raise TypeError for non-BaseESPUser
+            _ = user > "string"
+        with self.assertRaises(TypeError):
+            _ = user < "string"
 
 class PasswordRecoveryTest(TestCase):
     """Test password recovery using Django's built-in token generator.


### PR DESCRIPTION
## Description

<!-- Brief summary of the changes and their purpose. -->
- Replace the usage of `__cmp__` magic method and `cmp` function for comparison in `BaseESPUser` class with modern comparison magic methods that are python3 compliant (`__lt__`, etc.).
- Fix the Legacy bug of having separate behavior in equality & hashing (names-based equality and PK-based hashing).
- Add regression tests covering all known edge cases and scenarios for the `_get_sort_key` function.

## Related Issue

<!-- Link the relevant issue. Use "Closes #123" to auto-close on merge. -->

Closes #5701

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [x] New tests added (if applicable)
- [x] Manually verified

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced
