### PR TITLE
Fix Stripe charge_payment POST validation for missing and invalid amount inputs #5446

### DIFF
--- a/esp/esp/program/modules/handlers/creditcardmodule_stripe.py
+++ b/esp/esp/program/modules/handlers/creditcardmodule_stripe.py
@@ -305,6 +305,10 @@ class CreditCardModule_Stripe(ProgramModuleObj):
                 context['error_type'] = 'invalid_amount'
                 context['error_info'] = {'totalcost_cents': raw_totalcost_cents}
 
+        if 'error_type' not in context and amount_cents_post <= 0:
+            context['error_type'] = 'invalid_amount'
+            context['error_info'] = {'totalcost_cents': raw_totalcost_cents}
+
         #   Set Stripe key based on settings.  Also require the API version
         #   which our code is designed for.
         stripe.api_key = self.settings['secret_key']

--- a/esp/esp/program/modules/handlers/creditcardmodule_stripe.py
+++ b/esp/esp/program/modules/handlers/creditcardmodule_stripe.py
@@ -45,7 +45,7 @@ from django.db.models.query import Q
 from django.contrib.sites.models import Site
 from django.template.loader import render_to_string
 
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 import stripe
 import json
 import re
@@ -265,6 +265,8 @@ class CreditCardModule_Stripe(ProgramModuleObj):
         context = {'postdata': request.POST.copy()}
 
         group_name = Tag.getTag('full_group_name') or '%s %s' % (settings.INSTITUTION_NAME, settings.ORGANIZATION_SHORT_NAME)
+        stripe_token = request.POST.get('stripeToken')
+        raw_totalcost_cents = request.POST.get('totalcost_cents')
 
         iac = IndividualAccountingController(self.program, request.user)
 
@@ -285,6 +287,24 @@ class CreditCardModule_Stripe(ProgramModuleObj):
                 if form.amount:
                     iac.set_preference('Donation to Learning Unlimited', 1, amount=form.amount)
 
+        if not stripe_token or raw_totalcost_cents in (None, ''):
+            context['error_type'] = 'missing_post_data'
+            context['error_info'] = {
+                'missing_fields': [
+                    field for field, value in (
+                        ('stripeToken', stripe_token),
+                        ('totalcost_cents', raw_totalcost_cents),
+                    ) if not value
+                ],
+            }
+
+        if 'error_type' not in context:
+            try:
+                amount_cents_post = Decimal(raw_totalcost_cents)
+            except (TypeError, InvalidOperation):
+                context['error_type'] = 'invalid_amount'
+                context['error_info'] = {'totalcost_cents': raw_totalcost_cents}
+
         #   Set Stripe key based on settings.  Also require the API version
         #   which our code is designed for.
         stripe.api_key = self.settings['secret_key']
@@ -292,7 +312,7 @@ class CreditCardModule_Stripe(ProgramModuleObj):
         # v1.12.2.
         stripe.api_version = '2014-03-13'
 
-        if request.POST.get('ponumber', '') != iac.get_id():
+        if 'error_type' not in context and request.POST.get('ponumber', '') != iac.get_id():
             #   If we received a payment for the wrong PO:
             #   This is not a Python exception, but an error nonetheless.
             context['error_type'] = 'inconsistent_po'
@@ -301,7 +321,6 @@ class CreditCardModule_Stripe(ProgramModuleObj):
         if 'error_type' not in context:
             #   Check the amount in the POST against the amount in our records.
             #   If they don't match, raise an error.
-            amount_cents_post = Decimal(request.POST['totalcost_cents'])
             amount_cents_iac = Decimal(iac.amount_due()) * 100
             if amount_cents_post != amount_cents_iac:
                 context['error_type'] = 'inconsistent_amount'
@@ -322,7 +341,7 @@ class CreditCardModule_Stripe(ProgramModuleObj):
                     # Thus, we will never be in a state where the card has been
                     # charged without a record being created on the site, nor
                     # vice-versa.
-                    totalcost_dollars = Decimal(request.POST['totalcost_cents']) / 100
+                    totalcost_dollars = amount_cents_post / 100
 
                     #   Create a record of the transfer without the transaction ID.
                     transfer = iac.submit_payment(totalcost_dollars, 'TBD')
@@ -332,11 +351,11 @@ class CreditCardModule_Stripe(ProgramModuleObj):
                     charge = stripe.Charge.create(
                         amount=amount_cents_post,
                         currency="usd",
-                        card=request.POST['stripeToken'],
+                        card=stripe_token,
                         description="Payment for %s %s - %s" % (group_name, prog.niceName(), request.user.name()),
                         statement_descriptor=group_name[0:22], #stripe limits statement descriptors to 22 characters
                         metadata={
-                            'ponumber': request.POST['ponumber'],
+                            'ponumber': request.POST.get('ponumber', ''),
                         },
                     )
 

--- a/esp/esp/program/modules/handlers/creditcardmodule_stripe.py
+++ b/esp/esp/program/modules/handlers/creditcardmodule_stripe.py
@@ -299,11 +299,11 @@ class CreditCardModule_Stripe(ProgramModuleObj):
             }
 
         if 'error_type' not in context:
-            try:
-                amount_cents_post = Decimal(raw_totalcost_cents)
-            except (TypeError, InvalidOperation):
+            if not isinstance(raw_totalcost_cents, basestring) or not raw_totalcost_cents.isdigit():
                 context['error_type'] = 'invalid_amount'
                 context['error_info'] = {'totalcost_cents': raw_totalcost_cents}
+            else:
+                amount_cents_post = int(raw_totalcost_cents)
 
         if 'error_type' not in context and amount_cents_post <= 0:
             context['error_type'] = 'invalid_amount'
@@ -325,7 +325,7 @@ class CreditCardModule_Stripe(ProgramModuleObj):
         if 'error_type' not in context:
             #   Check the amount in the POST against the amount in our records.
             #   If they don't match, raise an error.
-            amount_cents_iac = Decimal(iac.amount_due()) * 100
+            amount_cents_iac = int(Decimal(iac.amount_due()) * 100)
             if amount_cents_post != amount_cents_iac:
                 context['error_type'] = 'inconsistent_amount'
                 context['error_info'] = {

--- a/esp/esp/program/modules/handlers/tests/test_creditcardmodule_stripe.py
+++ b/esp/esp/program/modules/handlers/tests/test_creditcardmodule_stripe.py
@@ -59,3 +59,15 @@ class CreditCardStripeChargePaymentTests(SimpleTestCase):
 
         self.assertEqual(response, 'failure-response')
         self.module.send_error_email.assert_called_once()
+
+    def test_zero_totalcost_cents_returns_failure(self):
+        response = self._call({'ponumber': 'PO-1', 'stripeToken': 'tok_test_123', 'totalcost_cents': '0'})
+
+        self.assertEqual(response, 'failure-response')
+        self.module.send_error_email.assert_called_once()
+
+    def test_invalid_totalcost_cents_returns_failure(self):
+        response = self._call({'ponumber': 'PO-1', 'stripeToken': 'tok_test_123', 'totalcost_cents': 'abc'})
+
+        self.assertEqual(response, 'failure-response')
+        self.module.send_error_email.assert_called_once()

--- a/esp/esp/program/modules/handlers/tests/test_creditcardmodule_stripe.py
+++ b/esp/esp/program/modules/handlers/tests/test_creditcardmodule_stripe.py
@@ -1,0 +1,61 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from django.test import RequestFactory, SimpleTestCase
+
+from esp.program.modules.handlers import creditcardmodule_stripe as cc_module
+from esp.program.modules.handlers.creditcardmodule_stripe import CreditCardModule_Stripe
+
+
+class CreditCardStripeChargePaymentTests(SimpleTestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.module = SimpleNamespace(
+            program=SimpleNamespace(),
+            check_setup=Mock(return_value=True),
+            settings={'secret_key': 'sk_test_123'},
+            line_item_type=Mock(return_value=SimpleNamespace()),
+            send_error_email=Mock(),
+            baseDir=Mock(return_value='program/modules/creditcardmodule_stripe/'),
+        )
+        self.user = SimpleNamespace(id=42, name=Mock(return_value='Test User'))
+        self.program = SimpleNamespace(niceName=Mock(return_value='Test Program'))
+
+    def _call(self, post_data):
+        request = self.factory.post('/learn/test/charge_payment', post_data)
+        request.user = self.user
+
+        fake_iac = SimpleNamespace(
+            get_preferences=Mock(return_value=[]),
+            set_preference=Mock(),
+            get_id=Mock(return_value='PO-1'),
+            amount_due=Mock(return_value=0),
+            submit_payment=Mock(),
+        )
+        fake_form = SimpleNamespace(is_valid=Mock(return_value=False), amount=None)
+
+        charge_payment = getattr(
+            CreditCardModule_Stripe.charge_payment,
+            'method',
+            CreditCardModule_Stripe.charge_payment,
+        )
+
+        with patch('esp.program.modules.handlers.creditcardmodule_stripe.IndividualAccountingController', return_value=fake_iac), \
+             patch('esp.program.modules.handlers.creditcardmodule_stripe.DonationModule.get_form', return_value=fake_form), \
+             patch('esp.program.modules.handlers.creditcardmodule_stripe.Tag.getTag', return_value=None), \
+             patch('esp.program.modules.handlers.creditcardmodule_stripe.render_to_response', return_value='failure-response'), \
+             patch.object(cc_module.settings, 'INSTITUTION_NAME', 'Institute', create=True), \
+             patch.object(cc_module.settings, 'ORGANIZATION_SHORT_NAME', 'Org', create=True):
+            return charge_payment(self.module, request, None, None, None, None, None, self.program)
+
+    def test_missing_stripe_token_returns_failure(self):
+        response = self._call({'ponumber': 'PO-1', 'totalcost_cents': '5000'})
+
+        self.assertEqual(response, 'failure-response')
+        self.module.send_error_email.assert_called_once()
+
+    def test_missing_totalcost_cents_returns_failure(self):
+        response = self._call({'ponumber': 'PO-1', 'stripeToken': 'tok_test_123'})
+
+        self.assertEqual(response, 'failure-response')
+        self.module.send_error_email.assert_called_once()


### PR DESCRIPTION
This PR fixes issue #5446 by hardening the Stripe payment POST handling in creditcardmodule_stripe.py.

Why this is needed:
Previously, missing stripeToken or missing totalcost_cents could trigger unhandled server errors instead of the normal payment failure flow. This change ensures these cases are handled safely and consistently.

What changed:

Added early validation for missing required POST fields (stripeToken and totalcost_cents).

Replaced unsafe direct POST access in the payment path with safely validated values so missing fields no longer raise unhandled KeyError exceptions.

Added amount validation to reject malformed and non-positive values for totalcost_cents:

Non-numeric values are treated as invalid_amount.

Zero or negative values are treated as invalid_amount.

Preserved the existing failure behavior:

The user is safely shown the failure page.

An admin error email is sent through send_error_email.

Related Issue
Closes #5446
Supersedes #[5712] 

Type of Change
[x] Bug fix

[ ] New feature

[ ] Breaking change

[ ] Documentation update

[ ] Refactor / cleanup

[ ] CI/CD or build change

Testing
[x] Existing tests pass

[x] New tests added

Added regression tests in test_creditcardmodule_stripe.py covering: missing stripeToken, missing totalcost_cents, zero totalcost_cents, and non-numeric totalcost_cents.

[x] Manually verified

Result: 4 tests passed successfully in Docker.

Command used: docker compose exec web python manage.py test esp.program.modules.handlers.tests.test_creditcardmodule_stripe

AI Disclosure
Drafted with the assistance of AI (Gemini).

Checklist
[x] Self-reviewed the code

[ ] Updated documentation (if needed)

[x] No new warnings or errors introduced

<img width="1444" height="398" alt="Screenshot 2026-04-11 232318" src="https://github.com/user-attachments/assets/cc114fdd-6fd0-4d14-8e0a-59e4ee2858c9" />

"A big thanks to @SuyashJain17 and @RITVIKKAMASETTY for guiding me to the perfect solution and helping me raise this PR!"

