### PR TITLE
Fix duplicate error messages and improve required field indication for heard_about

### DIFF
--- a/esp/esp/users/forms/user_profile.py
+++ b/esp/esp/users/forms/user_profile.py
@@ -171,7 +171,7 @@ class StudentInfoForm(FormUnrestrictedOtherUser):
     dob = forms.DateField(widget=SplitDateWidget(min_year=datetime.now().year-20))
     studentrep = forms.BooleanField(required=False)
     studentrep_expl = forms.CharField(required=False)
-    heard_about = DropdownOtherField(required=False, widget=DropdownOtherWidget(choices=list(zip(HEARD_ABOUT_ESP_CHOICES, HEARD_ABOUT_ESP_CHOICES))))#forms.CharField(required=False)
+    heard_about = DropdownOtherField(required=True, widget=DropdownOtherWidget(choices=list(zip(HEARD_ABOUT_ESP_CHOICES, HEARD_ABOUT_ESP_CHOICES))))#forms.CharField(required=False)
     shirt_size = forms.ChoiceField(choices=[], required=False)
     shirt_type = forms.ChoiceField(choices=[], required=False)
     food_preference = forms.ChoiceField(choices=[], required=False)

--- a/esp/esp/users/forms/user_profile.py
+++ b/esp/esp/users/forms/user_profile.py
@@ -171,7 +171,7 @@ class StudentInfoForm(FormUnrestrictedOtherUser):
     dob = forms.DateField(widget=SplitDateWidget(min_year=datetime.now().year-20))
     studentrep = forms.BooleanField(required=False)
     studentrep_expl = forms.CharField(required=False)
-    heard_about = DropdownOtherField(required=True, widget=DropdownOtherWidget(choices=list(zip(HEARD_ABOUT_ESP_CHOICES, HEARD_ABOUT_ESP_CHOICES))))#forms.CharField(required=False)
+    heard_about = DropdownOtherField(required=False, widget=DropdownOtherWidget(choices=list(zip(HEARD_ABOUT_ESP_CHOICES, HEARD_ABOUT_ESP_CHOICES))))#forms.CharField(required=False)
     shirt_size = forms.ChoiceField(choices=[], required=False)
     shirt_type = forms.ChoiceField(choices=[], required=False)
     food_preference = forms.ChoiceField(choices=[], required=False)

--- a/esp/templates/users/profiles/studentinfo.html
+++ b/esp/templates/users/profiles/studentinfo.html
@@ -1,8 +1,5 @@
 <!-- Begin Student Info Portion -->
 <h3>Additional Student Information</h3>
-
-{{ form.errors }}
-
 {% if not user.getGrade or form.allow_change_grade_level %}
 <div class="alert">
 <button type="button" class="close" data-dismiss="alert">x</button>
@@ -99,7 +96,7 @@ Your grade level will update automatically every August.
 
 {% if form.heard_about %}
 <div class="control-group">
-    <label for="id_heardofesp" class="control-label">How did you hear of this program?
+    <label for="id_heardofesp" class="control-label">How did you hear of this program? <font color="red">*</font>
     </label>
     <div class="controls controls-row">
     <span style="font-size: 0.8em; font-style: italic;">(If you select "Other," please explain in the lower box.)</span><br />

--- a/esp/templates/users/profiles/studentinfo.html
+++ b/esp/templates/users/profiles/studentinfo.html
@@ -96,7 +96,7 @@ Your grade level will update automatically every August.
 
 {% if form.heard_about %}
 <div class="control-group">
-    <label for="{{ form.heard_about.id_for_label }}" class="control-label">How did you hear of this program?
+    <label for="{{ form.heard_about.id_for_label }}" class="control-label">How did you hear of this program? <font color="red">*</font>
     </label>
     <div class="controls controls-row">
     <span style="font-size: 0.8em; font-style: italic;">(If you select "Other," please explain in the lower box.)</span><br />

--- a/esp/templates/users/profiles/studentinfo.html
+++ b/esp/templates/users/profiles/studentinfo.html
@@ -96,7 +96,7 @@ Your grade level will update automatically every August.
 
 {% if form.heard_about %}
 <div class="control-group">
-    <label for="id_heardofesp" class="control-label">How did you hear of this program? <font color="red">*</font>
+    <label for="{{ form.heard_about.id_for_label }}" class="control-label">How did you hear of this program?
     </label>
     <div class="controls controls-row">
     <span style="font-size: 0.8em; font-style: italic;">(If you select "Other," please explain in the lower box.)</span><br />

--- a/esp/templates/users/profiles/studentinfo.html
+++ b/esp/templates/users/profiles/studentinfo.html
@@ -96,7 +96,7 @@ Your grade level will update automatically every August.
 
 {% if form.heard_about %}
 <div class="control-group">
-    <label for="{{ form.heard_about.id_for_label }}" class="control-label">How did you hear of this program? <font color="red">*</font>
+    <label for="{{ form.heard_about.id_for_label }}" class="control-label">(Optional) How did you hear of this program?
     </label>
     <div class="controls controls-row">
     <span style="font-size: 0.8em; font-style: italic;">(If you select "Other," please explain in the lower box.)</span><br />


### PR DESCRIPTION
Removed form.errors to prevent duplicate error messages. 
Added a red asterisk to the "heard_about" field to indicate it may be required. 
Improves UI clarity and avoids repeated validation messages.

Closes #278