### PR TITLE
Improve test coverage for AJAX changelog unschedule entries

### DIFF
--- a/esp/esp/program/modules/tests/ajaxschedulingmodule.py
+++ b/esp/esp/program/modules/tests/ajaxschedulingmodule.py
@@ -189,7 +189,11 @@ class AJAXSchedulingModuleTest(AJAXSchedulingModuleTestBase):
         changelog_response = self.client.get(self.changelog_url, {'last_fetched_index': 1 })
         changelog = json.loads(changelog_response.content)["changelog"]
         self.assertTrue(len(changelog) == 1, "Change log did not contain the unscheduled class: " + str(changelog))
-        #TODO:  more detailed testing here
+        entry = changelog[0]
+        self.assertEqual(entry['id'], section.id, "Changelog entry has wrong class section ID")
+        self.assertTrue(entry['is_scheduling'], "Changelog entry should be a scheduling entry")
+        self.assertEqual(entry['timeslots'], [], "Timeslots should be empty for an unscheduled class")
+        self.assertEqual(entry['room_name'], "", "Room name should be empty for an unscheduled class")
 
     def testChangeLogFailedScheduling(self):
         #change log should not include failed scheduling of classes


### PR DESCRIPTION
## Summary

This PR resolves #5717 by strengthening `testChangeLogUnscheduledClasses` in `esp/esp/program/modules/tests/ajaxschedulingmodule.py`.

The test previously only checked that one changelog entry existed after unscheduling a class. It now also verifies that the entry content correctly represents an unschedule action.

## Changes made

- Assert that the changelog entry matches the unscheduled section ID
- Assert that the entry is still marked as a scheduling entry
- Assert that `timeslots` is an empty list for an unscheduled class
- Assert that `room_name` is an empty string for an unscheduled class

## Why this helps

This closes the coverage gap described in #5717 and makes the test catch future regressions where an unschedule action might be logged incorrectly.

## Testing

I attempted to run the targeted test locally with:

```bash
python -m pytest esp\esp\program\modules\tests\ajaxschedulingmodule.py -k testChangeLogUnscheduledClasses
