### PR TITLE
Fix CSRF failure view path parsing and pass program context

### DIFF
--- a/esp/esp/web/views/csrf.py
+++ b/esp/esp/web/views/csrf.py
@@ -23,16 +23,17 @@ def csrf_failure(request, reason=""):
         from esp.utils.web import render_to_response
         from esp.program.models import Program
 
-        prog_re = r'^[-A-Za-z0-9_ ]+/([-A-Za-z0-9_ ]+)/([-A-Za-z0-9_ ]+)'
+        prog_re = r'^/?[-A-Za-z0-9_ ]+/([-A-Za-z0-9_ ]+)/([-A-Za-z0-9_ ]+)'
         match = re.match(prog_re, request.path)
+        prog = None
         if match:
             one, two = match.groups()
             try:
                 prog = Program.by_prog_inst(one, two)
             except Program.DoesNotExist:
                 prog = None
-        else:
-            prog = None
+
+        c['prog'] = prog
 
         response = render_to_response('403_csrf_failure.html', request, c)
         response = HttpResponseForbidden(str(response.content, encoding='UTF-8'),


### PR DESCRIPTION
## Description

This PR fixes an issue in csrf.py where the view wasn't picking up the program from the URL during a CSRF failure.

I just tweaked the prog_re regex to handle the leading / in request.path, and made sure the prog object actually gets added to the context dict c.

Just a heads-up based on the issue discussion: prog isn't actually being used in 403_csrf_failure.html right now. I left the template alone, but the backend is wired up correctly now if someone wants to use it later!

## Related Issue

Closes #5692

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## AI Disclosure

Used AI assistance to help review the code changes and validate the approach.

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced