### PR TITLE
feat(printables): allow sorting student schedules by first class time (#843)

### DIFF
--- a/esp/esp/program/modules/handlers/programprintables.py
+++ b/esp/esp/program/modules/handlers/programprintables.py
@@ -1255,6 +1255,20 @@ class ProgramPrintables(ProgramModuleObj):
             classes_by_student[user_id].sort(
                 key=lambda cls: (cls.start_time_prefetchable(), cls.title()))
 
+        if request.GET.get('sort') == 'first_class':
+            from datetime import datetime
+            def first_class_sort_key(student):
+                student_classes = classes_by_student[student.id]
+                if not student_classes:
+                    return (datetime.max, student.last_name or '', student.first_name or '')
+                start_time = student_classes[0].start_time_prefetchable()
+                # If start_time is somehow None, handle it to avoid TypeError in sorting
+                if start_time is None:
+                    return (datetime.max, student.last_name or '', student.first_name or '')
+                return (start_time, student.last_name or '', student.first_name or '')
+
+            students.sort(key=first_class_sort_key)
+
         times_compulsory = Event.objects.filter(program=prog, event_type__description='Compulsory').order_by('start')
         for t in times_compulsory:
             t.friendly_times = [t.pretty_time()]

--- a/esp/public/media/scripts/program/modules/printoptions.js
+++ b/esp/public/media/scripts/program/modules/printoptions.js
@@ -1,7 +1,13 @@
 $j(function () {
-    $j("#student_format").on("change", function (){
+    $j("#student_format, #student_sort").on("change", function (){
         // Get user-selected options
-        var url = "./studentschedules/" + $j("#student_format").val() + "/?recipient_type=Student&base_list=enrolled";
+        var format = $j("#student_format").val() || "pdf";
+        var url = "./studentschedules/" + format + "/?recipient_type=Student&base_list=enrolled";
+        
+        var sortValue = $j("#student_sort").val();
+        if (sortValue && sortValue !== "name") {
+            url += "&sort=" + sortValue;
+        }
         
         // Update href
         $j("#student_schedules a").attr('href', url);

--- a/esp/templates/program/modules/programprintables/options.html
+++ b/esp/templates/program/modules/programprintables/options.html
@@ -48,6 +48,17 @@ Please select from options below.
                 </option>
             </select>
         </div>
+        <div>
+            <div>Sort by:</div>
+            <select id="student_sort">
+                <option value="name" selected>
+                    Name
+                </option>
+                <option value="first_class">
+                    First Class Time
+                </option>
+            </select>
+        </div>
         <div class="module_button" id="student_schedules">
             <a href="./studentschedules/pdf/?recipient_type=Student&base_list=enrolled" title="Generate Student Schedules">
                 <button type="button" class="module_link_large">


### PR DESCRIPTION
**Resolves #843**

**Description:**
This PR adds functionality to sort the printed student schedules by the student's earliest class start time, rather than restricting it to the default alphabetical name sort. This is highly beneficial for organizations that perform student check-ins sorted by their first class of the day.

**Changes Added:**
* **Frontend:** Added a "Sort by" dropdown to the Program Printables options page (`options.html`) underneath the schedule format dropdown, allowing administrators to pick between "Name" and "First Class Time".
* * **Javascript:** Updated `printoptions.js` to listen for changes to the new sort dropdown. If "First Class Time" is selected, a `&sort=first_class` parameter is appended to the schedule generation URL.
* * **Backend:** Modified the core schedule parsing logic in `programprintables.py` (`get_student_schedules`). It now parses the URL arguments for `sort=first_class`. When requested, it computes a custom sort key that finds the earliest cached start time block across all of an individual's scheduled classes and re-orders the returned student schedule list accordingly.
**CI Note:** The `ThemesTest.testEditor` failure is a pre-existing flaky test related to LESS CSS compilation in the CI environment. It is unrelated to the changes in this PR.