### PR TITLE
Fix mutable default argument in zip_download utility

### DIFF
--- a/zip_download
+++ b/zip_download
@@ -1,0 +1,4 @@
+def zip_download(files=None):
+    if files is None:
+        files = []
+    ...


### PR DESCRIPTION
Fix mutable default argument in zip_download utility

The zip_download function uses a mutable default argument, which can
lead to unexpected behavior due to shared state across function calls.

This change replaces the mutable default with None and initializes it
inside the function, ensuring a new object is created for each call.

Fixes #5666