### PR TITLE
Validate query parameters before integer conversion to prevent 500 er…

### DIFF
--- a/esp/program/modules/program_printables.py
+++ b/esp/program/modules/program_printables.py
@@ -1,0 +1,8 @@
+from django.http import HttpResponseBadRequest
+
+userid = request.GET.get("userid")
+
+if not userid or not str(userid).isdigit():
+    return HttpResponseBadRequest("Invalid userid")
+
+userid = int(userid)


### PR DESCRIPTION
Validate query parameters before integer conversion

Adds checks to prevent ValueError when invalid values are passed
in query parameters, returning a 400 response instead of 500.

 Fixes #5752