### PR TITLE
Improve README setup instructions for first-time contributors

### DIFF
--- a/README1.md
+++ b/README1.md
@@ -1,0 +1,52 @@
++ ## 🚀 Getting Started
++
++ Follow these steps to set up the project locally:
++
++ ### 1. Clone the repository
++ ```bash
++ git clone https://github.com/learning-unlimited/ESP-Website.git
++ cd ESP-Website
++ ```
++
++ ### 2. Create a virtual environment
++ ```bash
++ python -m venv venv
++ source venv/bin/activate   # On Windows: venv\Scripts\activate
++ ```
++
++ ### 3. Install dependencies
++ ```bash
++ pip install -r requirements.txt
++ ```
++
++ ### 4. Run migrations
++ ```bash
++ python manage.py migrate
++ ```
++
++ ### 5. Start the development server
++ ```bash
++ python manage.py runserver
++ ```
++
++ ---
++
++ ## ⚠️ Common Issues
++
++ **Error: Module not found**
++ → Ensure virtual environment is activated
++
++ **Error: Database issues**
++ → Run:
++ ```bash
++ python manage.py migrate
++ ```
++
++ ---
++
++ ## 🤝 Contributing
++
++ 1. Fork the repository
++ 2. Create a new branch (`git checkout -b feature-name`)
++ 3. Commit your changes
++ 4. Push and open a PR


### PR DESCRIPTION
Title: Improve README setup instructions for first-time contributors

Description:

While setting up the project locally, I found that the README could be improved for better clarity, especially for first-time contributors.

Current issues:

* Missing or unclear step-by-step setup instructions
* No clear separation between backend and frontend setup (if applicable)
* Lack of troubleshooting guidance

Expected improvement:

* Add a clear “Getting Started” section
* Step-by-step setup instructions
* Common errors and fixes

Proposed solution:

* Update README with structured setup steps
* Add commands for installation and running the server
* Include a troubleshooting section

This would make onboarding much easier for new contributors.
