### PR TITLE
Fix: Hide navbar login form on login page to avoid duplicate UI

### DIFF
--- a/esp/templates/navbar.html
+++ b/esp/templates/navbar.html
@@ -15,7 +15,9 @@
 	</ul>
 	<ul class="nav pull-right">
 	  <li>
-	    {% include "users/loginbox_content.html" %} 
+	    {% if "/accounts/login" not in request.path %}
+    {% include "users/loginbox_content.html" %}
+{% endif %}
 	  </li>
 	</ul>
       </div>


### PR DESCRIPTION
This PR fixes the issue where two login interfaces were displayed simultaneously on the login page.

## Description

Added conditional rendering to hide the navbar login form when the user is on the `/accounts/login/` page. This prevents duplicate login interfaces and improves the overall user experience.

## Related Issue

Closes #<your-issue-number>

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation update
* [ ] Refactor / cleanup
* [ ] CI/CD or build change

## Testing

* [x] Existing tests pass
* [ ] New tests added (not required for this fix)
* [x] Manually verified

Tested locally:

* `/accounts/login/` → only main login form is visible
* Other pages → navbar login form is displayed correctly

## AI Disclosure

Used AI assistance to help understand the issue and structure the fix, but the implementation and testing were done manually.

## Checklist

* [x] Self-reviewed the code
* [ ] Updated documentation (not required)
* [x] No new warnings or errors introduced
Closes #4998