### PR TITLE
Fix stale filterid value in deactivationmodule.py

### DIFF
--- a/esp/esp/program/modules/handlers/deactivationmodule.py
+++ b/esp/esp/program/modules/handlers/deactivationmodule.py
@@ -64,7 +64,11 @@ class DeactivationModule(ProgramModuleObj):
             raise ESPError()('You must confirm that you want to deactivate these users.')
 
         # get the filter to use and text message to send from the request; this is set in grouptextpanel form
-        filterObj = PersistentQueryFilter.objects.get(id=request.GET['filterid'])
+        try:
+            filterObj = PersistentQueryFilter.objects.get(id=request.GET['filterid'])
+        except PersistentQueryFilter.DoesNotExist:
+            raise ESPError()('The selected filter no longer exists. Please go back and reselect a valid user group.')
+
         users = filterObj.getList(ESPUser)
 
         if not users:


### PR DESCRIPTION
## Description

Implements defensive handling for `PersistentQueryFilter` lookups within the `DeactivationModule`. 

Previously, `deactivatefinal()` performed a direct `objects.get()` lookup using the `filterid` from the request. If the filter was deleted, expired, or tampered with between the search and confirmation steps, the application would raise an uncaught `PersistentQueryFilter.DoesNotExist` exception, resulting in a 500 Internal Server Error. 

This change wraps the lookup in a `try...except` block, catching the specific `DoesNotExist` exception and raising a user-friendly `ESPError`. This ensures the administrative action fails gracefully with a clear message rather than a raw server crash.

## Related Issue

Closes #5683

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added
- [x] Manually verified

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (N/A)
- [x] No new warnings or errors introduced