### PR TITLE
Fix crashing of BatchClassRegModule on stale or invalid filterid in batchclassregfinal()

### DIFF
--- a/esp/esp/program/modules/handlers/batchclassregmodule.py
+++ b/esp/esp/program/modules/handlers/batchclassregmodule.py
@@ -99,9 +99,12 @@ class BatchClassRegModule(ProgramModuleObj):
         except (ClassSection.DoesNotExist, ValueError):
             raise ESPError()('Invalid class section selected')
 
-        filterObj = PersistentQueryFilter.objects.get(id=request.GET['filterid'])
+        try:
+            filterObj = PersistentQueryFilter.objects.get(id=request.GET['filterid'])
+        except (PersistentQueryFilter.DoesNotExist, ValueError):
+            raise ESPError()('Selected Filter is either invalid or available no more')
+        
         override_full = 'override_full' in request.POST
-
         result = self.batch_register(filterObj, section, override_full)
 
         context = {

--- a/esp/esp/program/modules/handlers/batchclassregmodule.py
+++ b/esp/esp/program/modules/handlers/batchclassregmodule.py
@@ -102,7 +102,7 @@ class BatchClassRegModule(ProgramModuleObj):
         try:
             filterObj = PersistentQueryFilter.objects.get(id=request.GET['filterid'])
         except (PersistentQueryFilter.DoesNotExist, ValueError):
-            raise ESPError()('Selected Filter is either not valid or available no more')
+            raise ESPError()('Selected filter is invalid or no longer available.')
         
         override_full = 'override_full' in request.POST
         result = self.batch_register(filterObj, section, override_full)

--- a/esp/esp/program/modules/handlers/batchclassregmodule.py
+++ b/esp/esp/program/modules/handlers/batchclassregmodule.py
@@ -102,7 +102,7 @@ class BatchClassRegModule(ProgramModuleObj):
         try:
             filterObj = PersistentQueryFilter.objects.get(id=request.GET['filterid'])
         except (PersistentQueryFilter.DoesNotExist, ValueError):
-            raise ESPError()('Selected Filter is either invalid or available no more')
+            raise ESPError()('Selected Filter is either not valid or available no more')
         
         override_full = 'override_full' in request.POST
         result = self.batch_register(filterObj, section, override_full)

--- a/esp/esp/program/modules/tests/batchclassregmodule.py
+++ b/esp/esp/program/modules/tests/batchclassregmodule.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from unittest.mock import patch
 
 from django.db.models import Q
-
+from esp.middleware import ESPError
 from esp.program.models import ClassSection
 from esp.program.modules.base import ProgramModule, ProgramModuleObj
 from esp.program.tests import ProgramFrameworkTest
@@ -137,3 +137,25 @@ class BatchClassRegModuleTest(ProgramFrameworkTest):
             )
         self.assertEqual(result['fail_count'], 1)
         self.assertEqual(result['results'][0]['status'], 'full')
+
+    def test_batchclassregfinal_invalid_filterid(self):
+        """Passing an invalid or missing filterid to batchclassregfinal raises ESPError cleanly."""
+        section = ClassSection.objects.filter(
+            parent_class__parent_program=self.program,
+            status__gte=10
+        ).first()
+        if section is None:
+            self.skipTest("No accepted sections in test program")
+        self.client.login(username='admin', password='password')
+
+        errorMessage = 'Selected Filter is either invalid or available no more'
+        
+        # testing with a non-existing integer filter ID
+        url = '/manage/' + self.program.url + '/batchclassregfinal?filterid=999999'
+        with self.assertRaisesMessage(ESPError, errorMessage):
+            self.client.post(url, {'section_id': section.id})
+
+        # test with filter ID which is not a number, which triggers ValueError branch
+        url_bad_type = '/manage/' + self.program.url + '/batchclassregfinal?filterid=abc'
+        with self.assertRaisesMessage(ESPError, errorMessage):
+            self.client.post(url_bad_type, {'section_id': section.id})

--- a/esp/esp/program/modules/tests/batchclassregmodule.py
+++ b/esp/esp/program/modules/tests/batchclassregmodule.py
@@ -152,10 +152,15 @@ class BatchClassRegModuleTest(ProgramFrameworkTest):
         
         # testing with a non-existing integer filter ID
         url = '/manage/' + self.program.url + '/batchclassregfinal?filterid=999999'
-        with self.assertRaisesMessage(ESPError, errorMessage):
+        with self.assertRaisesMessage(ESPError(), errorMessage):
             self.client.post(url, {'section_id': section.id})
-
+            
         # test with filter ID which is not a number, which triggers ValueError branch
         url_bad_type = '/manage/' + self.program.url + '/batchclassregfinal?filterid=abc'
-        with self.assertRaisesMessage(ESPError, errorMessage):
+        with self.assertRaisesMessage(ESPError(), errorMessage):
             self.client.post(url_bad_type, {'section_id': section.id})
+            
+        # test with missing filter ID
+        url_missing = '/manage/' + self.program.url + '/batchclassregfinal'
+        with self.assertRaisesMessage(ESPError, errorMessage):
+            self.client.post(url_missing, {'section_id': section.id})

--- a/esp/esp/program/modules/tests/batchclassregmodule.py
+++ b/esp/esp/program/modules/tests/batchclassregmodule.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from unittest.mock import patch
 
 from django.db.models import Q
-from esp.middleware import ESPError
+from esp.middleware import ESPError, ESPError_Log
 from esp.program.models import ClassSection
 from esp.program.modules.base import ProgramModule, ProgramModuleObj
 from esp.program.tests import ProgramFrameworkTest
@@ -148,19 +148,19 @@ class BatchClassRegModuleTest(ProgramFrameworkTest):
             self.skipTest("No accepted sections in test program")
         self.client.login(username='admin', password='password')
 
-        errorMessage = 'Selected Filter is either invalid or available no more'
+        errorMessage = 'Selected filter is invalid or no longer available.'
         
-        # testing with a non-existing integer filter ID
+        # Test with a non-existing integer filter ID (tests the ObjectDoesNotExist branch)
         url = '/manage/' + self.program.url + '/batchclassregfinal?filterid=999999'
-        with self.assertRaisesMessage(ESPError(), errorMessage):
+        with self.assertRaisesMessage(ESPError_Log, errorMessage):
             self.client.post(url, {'section_id': section.id})
             
-        # test with filter ID which is not a number, which triggers ValueError branch
+        # Test with a filter ID that is not a number (tests the ValueError branch)
         url_bad_type = '/manage/' + self.program.url + '/batchclassregfinal?filterid=abc'
-        with self.assertRaisesMessage(ESPError(), errorMessage):
+        with self.assertRaisesMessage(ESPError_Log, errorMessage):
             self.client.post(url_bad_type, {'section_id': section.id})
             
-        # test with missing filter ID
+        # Test missing filter ID entirely (tests the early request validation)
         url_missing = '/manage/' + self.program.url + '/batchclassregfinal'
-        with self.assertRaisesMessage(ESPError, errorMessage):
+        with self.assertRaisesMessage(ESPError_Log, 'Filter and/or section has not been properly set'):
             self.client.post(url_missing, {'section_id': section.id})


### PR DESCRIPTION
## Description
Fixed a server error crash in the batch class registration process `batchclassregfinal`. If the passed filter id in the URL query was either stale, deleted, or altered, the direct database lookup using `PersistentQueryFilter.objects.get()` method raised an unhandled `DoesNotExist` exception.
This patch is done by a try and except clause for catching any errors caused by non-existing PersistentQueryFilter objects or incorrect ID types like the non-numeric ones or etc. In such cases, it now returns a user-friendly ESPError object with the following message: *"Selected Filter is either invalid or available no more"*.
A new automatic test case `test_batchclassregfinal_invalid_filterid` has also been implemented to detect all invalid scenarios.

## Related Issue
Closes #5733 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [x] New tests added (if applicable)
- [ ] Manually verified

## AI Disclosure

Gemini 3.1 Pro for better Understanding of Bug

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced
