### PR TITLE
Add a functionality to kick students only enrolled in lunch #1169

### DIFF
--- a/esp/esp/program/modules/handlers/studentclassregmodule.py
+++ b/esp/esp/program/modules/handlers/studentclassregmodule.py
@@ -180,12 +180,14 @@ class StudentClassRegModule(ProgramModuleObj):
         past_enrolled_users = ESPUser.objects.filter(Enrolled & Past).values('id').distinct()
         Q_enrolled_past = Q(id__in=past_enrolled_users)
         Q_enrolled = Enrolled & Par & Unexpired
+        Q_enrolled_non_lunch = Q_enrolled & ~Q(studentregistration__section__parent_class__category__category='Lunch')
         Q_attended_past_temp = Q(record__event__name= "attended", record__program__in=past_programs)
         past_attended_users = ESPUser.objects.filter(Q_attended_past_temp).values('id').distinct()
         Q_attended_past = Q(id__in=past_attended_users)
 
         qobjects = {
             'enrolled': Q_enrolled,
+            'enrolled_non_lunch': Q_enrolled_non_lunch,
             'classreg': Q_classreg,
             'enrolled_past': Q_enrolled_past,
             'attended_past': Q_attended_past
@@ -207,6 +209,7 @@ class StudentClassRegModule(ProgramModuleObj):
 
         return {'classreg': """Students who signed up for at least one class""",
                 'enrolled': """Students who are enrolled in at least one class""",
+            'enrolled_non_lunch': """Students who are enrolled in at least one non-lunch class""",
                 'enrolled_past': """Students who have enrolled in a past program""",
                 'attended_past': """Students who have attended a past program"""}
 

--- a/esp/esp/program/modules/tests/programprintables.py
+++ b/esp/esp/program/modules/tests/programprintables.py
@@ -109,10 +109,10 @@ class ProgramPrintablesModuleTest(ProgramFrameworkTest):
         self.assertContains(response, '<div class="classtitle">', count=len(self.program.classes()))
 
     def testSchedules(self):
-        response = self.get_response('studentschedules/log', 'students', 'enrolled')
+        response = self.get_response('studentschedules/log', 'students', 'enrolled_non_lunch')
         print(response)
         #   Check that our Latex->PDF schedule generation code runs without error
-        response = self.get_response('studentschedules', 'students', 'enrolled')
+        response = self.get_response('studentschedules', 'students', 'enrolled_non_lunch')
 
         #   Check that the output is an actual PDF file
         print((response['Content-Type']))

--- a/esp/esp/program/modules/tests/studentregmodules.py
+++ b/esp/esp/program/modules/tests/studentregmodules.py
@@ -362,7 +362,7 @@ class StudentLunchSelectionTest(ProgramFrameworkTest):
             title='Lunch Period', category=self.lunch_category, grade_min=7, grade_max=12,
             parent_program=self.program, class_size_max=100, class_info='Lunch break')
         self.lunch_class.accept()
-        section = self.lunch_class.add_section(duration=1.0)
+        section = self.lunch_class.add_section(duration=50 / 60.0)
         if self.program.getTimeSlots():
             section.meeting_times.add(self.program.getTimeSlots()[0])
         RecordType.objects.get_or_create(name='lunch_selected')
@@ -451,9 +451,44 @@ class StudentClassRegModuleTest(ProgramFrameworkTest):
         module = self.program.getModule('StudentClassRegModule')
         students = module.students(QObject=False)
         self.assertIn('enrolled', students)
+        self.assertIn('enrolled_non_lunch', students)
         self.assertIn('classreg', students)
 
     def test_student_desc(self):
         module = self.program.getModule('StudentClassRegModule')
         desc = module.studentDesc()
         self.assertIn('enrolled', desc)
+        self.assertIn('enrolled_non_lunch', desc)
+
+    def test_enrolled_non_lunch_excludes_lunch_only_students(self):
+        module = self.program.getModule('StudentClassRegModule')
+
+        lunch_category, _ = ClassCategories.objects.get_or_create(category='Lunch', symbol='L')
+        lunch_class = ClassSubject.objects.create(
+            title='Lunch Period',
+            category=lunch_category,
+            grade_min=7,
+            grade_max=12,
+            parent_program=self.program,
+            class_size_max=100,
+            class_info='Lunch break',
+        )
+        lunch_class.makeTeacher(self.teachers[0])
+        lunch_class.accept()
+        lunch_section = lunch_class.add_section(duration=50 / 60.0)
+        if self.program.getTimeSlots():
+            lunch_section.meeting_times.add(self.program.getTimeSlots()[0])
+
+        regular_section = self.program.sections().exclude(parent_class__category__category='Lunch').first()
+        self.assertIsNotNone(regular_section, 'Expected at least one non-lunch section in the test program')
+
+        lunch_only_student = self.students[0]
+        regular_student = self.students[1]
+
+        lunch_section.preregister_student(lunch_only_student, fast_force_create=True)
+        regular_section.preregister_student(regular_student, fast_force_create=True)
+
+        students = module.students(QObject=False)
+        self.assertIn('enrolled_non_lunch', students)
+        self.assertNotIn(lunch_only_student, students['enrolled_non_lunch'])
+        self.assertIn(regular_student, students['enrolled_non_lunch'])

--- a/esp/templates/program/modules/programprintables/options.html
+++ b/esp/templates/program/modules/programprintables/options.html
@@ -49,7 +49,7 @@ Please select from options below.
             </select>
         </div>
         <div class="module_button" id="student_schedules">
-            <a href="./studentschedules/pdf/?recipient_type=Student&base_list=enrolled" title="Generate Student Schedules">
+            <a href="./studentschedules/pdf/?recipient_type=Student&base_list=enrolled_non_lunch" title="Generate Student Schedules">
                 <button type="button" class="module_link_large">
                     <div class="module_link_main"><i class="glyphicon glyphicon-list-alt"></i> Generate Student Schedules</div>
                 </button>
@@ -63,7 +63,7 @@ Please select from options below.
             </a>
         </div>
         <div class="module_button">
-            <a href="./flatstudentschedules?recipient_type=Student&base_list=enrolled" title="Flat Student Schedules">
+            <a href="./flatstudentschedules?recipient_type=Student&base_list=enrolled_non_lunch" title="Flat Student Schedules">
                 <button type="button" class="module_link_large">
                     <div class="module_link_main"><i class="glyphicon glyphicon-th"></i> Flat Student Schedules</div>
                 </button>


### PR DESCRIPTION
## Description

**PR Description**

This PR is to prevent schedule printing for lunch-only students by introducing a dedicated non-lunch student filter and wiring student schedule printables to use it.

**What Changed**

1. Added new student list filter: enrolled_non_lunch  
- File: studentclassregmodule.py  
- Added query:
  - enrolled_non_lunch = enrolled AND NOT category Lunch
- Added to student list map:
  - studentclassregmodule.py
- Added human-readable description:
  - studentclassregmodule.py

2. Updated printables links to use enrolled_non_lunch for student schedules  
- File: options.html  
  - Generate Student Schedules now uses base_list=enrolled_non_lunch
- File: options.html  
  - Flat Student Schedules now uses base_list=enrolled_non_lunch

**How It Works**

- Previously, student schedules used base_list=enrolled, which includes students enrolled only in Lunch.
- Now, student schedule printables use base_list=enrolled_non_lunch, which excludes sections whose class category is Lunch.
- Result: students with only Lunch registrations are excluded from student schedule printables, while students enrolled in at least one non-Lunch class are included.

**Tests Added/Updated**

1. Added regression coverage for filter behavior  
- File: studentregmodules.py  
- New test: test_enrolled_non_lunch_excludes_lunch_only_students
  - Creates Lunch-only enrollment for one student and non-Lunch enrollment for another
  - Verifies Lunch-only student is excluded from enrolled_non_lunch
  - Verifies non-Lunch-enrolled student is included

2. Updated existing schedules test to use new filter  
- File: programprintables.py  
- testSchedules now requests student schedules with base_list=enrolled_non_lunch and verifies PDF generation still works.

3. Minor test stabilization in lunch setup duration  
- File: studentregmodules.py  
- Adjusted duration setup to match expected test conventions.

**Validation Performed**

- Targeted regression test passed:
  - StudentClassRegModuleTest.test_enrolled_non_lunch_excludes_lunch_only_students
- Printable schedules test passed:
  - ProgramPrintablesModuleTest.testSchedules
 
**Screen Shots**
<img width="501" height="133" alt="image" src="https://github.com/user-attachments/assets/aa619285-67a2-41fb-84ec-4e79ddde81d0" />

<img width="1039" height="529" alt="image" src="https://github.com/user-attachments/assets/6ba79878-c983-4a20-bec1-a4ed38f53c4c" />


Closes #1169 

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [ ] Existing tests pass
- [X] New tests added (if applicable)
- [X] Manually verified

## Checklist

- [X] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [X] No new warnings or errors introduced
