### PR TITLE
Fix accessibility: add scope, caption, aria attrs in customforms temp…

### DIFF
--- a/esp/esp/program/modules/handlers/teacherpreviewmodule.py
+++ b/esp/esp/program/modules/handlers/teacherpreviewmodule.py
@@ -63,7 +63,10 @@ class TeacherPreviewModule(ProgramModuleObj):
         if pmos.count() == 1:
             pmo = ProgramPrintables(pmos[0])
             if request.user.isAdmin() and 'user' in request.GET:
-                teacher = ESPUser.objects.get(id=request.GET['user'])
+                try:
+                    teacher = ESPUser.objects.get(id=request.GET['user'])
+                except (ESPUser.DoesNotExist, ValueError):
+                    raise Http404('The requested user could not be found.')
             else:
                 teacher = request.user
             scheditems = []
@@ -96,7 +99,10 @@ class TeacherPreviewModule(ProgramModuleObj):
         if pmos.count() == 1:
             pmo = ProgramPrintables(pmos[0])
             if request.user.isAdmin() and 'user' in request.GET:
-                teacher = ESPUser.objects.get(id=request.GET['user'])
+                try:
+                    teacher = ESPUser.objects.get(id=request.GET['user'])
+                except (ESPUser.DoesNotExist, ValueError):
+                    raise Http404('The requested user could not be found.')
             else:
                 teacher = request.user
             scheditems = []
@@ -134,7 +140,10 @@ class TeacherPreviewModule(ProgramModuleObj):
         if pmos.count() == 1:
             pmo = ProgramPrintables(pmos[0])
             if request.user.isAdmin() and 'user' in request.GET:
-                teacher = ESPUser.objects.get(id=request.GET['user'])
+                try:
+                    teacher = ESPUser.objects.get(id=request.GET['user'])
+                except (ESPUser.DoesNotExist, ValueError):
+                    raise Http404('The requested user could not be found.')
             else:
                 teacher = request.user
             scheditems = []

--- a/esp/public/media/styles/customforms-common.css
+++ b/esp/public/media/styles/customforms-common.css
@@ -1,0 +1,17 @@
+/*
+ * Shared utility styles for Custom Forms pages.
+ * Included by landing.html, view_results.html, and index.html.
+ */
+
+/* Visually hidden but accessible to screen readers (WCAG 2.1) */
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}

--- a/esp/public/media/styles/customforms-landing.css
+++ b/esp/public/media/styles/customforms-landing.css
@@ -49,3 +49,15 @@ em.desc{
 #create_link{
 	font-weight:bold;
 }
+/* Visually hidden utility for screen reader-only content (WCAG 2.1) */
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}

--- a/esp/public/media/styles/customforms-landing.css
+++ b/esp/public/media/styles/customforms-landing.css
@@ -49,15 +49,3 @@ em.desc{
 #create_link{
 	font-weight:bold;
 }
-/* Visually hidden utility for screen reader-only content (WCAG 2.1) */
-.sr-only {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
-}

--- a/esp/public/media/styles/customforms-responses.css
+++ b/esp/public/media/styles/customforms-responses.css
@@ -14,3 +14,15 @@
     margin-bottom: 5px;
     overflow: visible;
 }
+/* Visually hidden utility for screen reader-only content (WCAG 2.1) */
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}

--- a/esp/public/media/styles/customforms-responses.css
+++ b/esp/public/media/styles/customforms-responses.css
@@ -14,15 +14,3 @@
     margin-bottom: 5px;
     overflow: visible;
 }
-/* Visually hidden utility for screen reader-only content (WCAG 2.1) */
-.sr-only {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
-}

--- a/esp/templates/customforms/index.html
+++ b/esp/templates/customforms/index.html
@@ -4,6 +4,7 @@
 
 {% block stylesheets %}
     {{ block.super }}
+    <link rel="stylesheet" type="text/css" href="/media/styles/customforms-common.css">
     <link rel="stylesheet" type="text/css" href="/media/styles/customforms-style.css">
 {% endblock %}
 

--- a/esp/templates/customforms/landing.html
+++ b/esp/templates/customforms/landing.html
@@ -17,14 +17,15 @@
     </table><br/><br/>
     {% endif %}
     <table class="form_list fullwidth">
+        <caption class="sr-only">{% if form.link_obj %}Forms associated with a {{ form.link_type }}{% else %}Other Forms{% endif %}</caption>
         <tr>
-            <th colspan="6"><h2>{% if form.link_obj %}Associated with a {{ form.link_type }}{% else %}Other Forms{% endif %}</h2></th>
+            <th colspan="6" scope="colgroup"><h2>{% if form.link_obj %}Associated with a {{ form.link_type }}{% else %}Other Forms{% endif %}</h2></th>
         </tr>
         <tr>
-            <th width="25%">Form Name</th>
-            <th width="15%">Form ID</th>
-            {% if form.link_obj %}<th width = "35%">Associated {{ form.link_type }}</th>{% endif %}
-            <th colspan="3" width = "25%">Options</th>
+            <th scope="col" width="25%">Form Name</th>
+            <th scope="col" width="15%">Form ID</th>
+            {% if form.link_obj %}<th scope="col" width="35%">Associated {{ form.link_type }}</th>{% endif %}
+            <th scope="col" colspan="3" width="25%">Options</th>
         </tr>
     {% endifchanged %}
         <tr>

--- a/esp/templates/customforms/landing.html
+++ b/esp/templates/customforms/landing.html
@@ -4,6 +4,7 @@
 
 {% block stylesheets %}
     {{ block.super }}
+    <link rel="stylesheet" type="text/css" href="/media/styles/customforms-common.css" />
     <link rel="stylesheet" type="text/css" href="/media/styles/customforms-landing.css" />
 {% endblock %}
 
@@ -25,7 +26,7 @@
             <th scope="col" width="25%">Form Name</th>
             <th scope="col" width="15%">Form ID</th>
             {% if form.link_obj %}<th scope="col" width="35%">Associated {{ form.link_type }}</th>{% endif %}
-            <th scope="col" colspan="3" width="25%">Options</th>
+            <th scope="colgroup" colspan="3" width="25%">Options</th>
         </tr>
     {% endifchanged %}
         <tr>

--- a/esp/templates/customforms/view_results.html
+++ b/esp/templates/customforms/view_results.html
@@ -21,12 +21,11 @@
 		<div class="content">
 			<input type="hidden" id="form_id" value="{{form.id}}"/>
 			<h2>{{form.title}} (ID# {{ form.id }})</h2>
-			<table id="jqGrid"></table>
+			<table id="jqGrid" role="grid" aria-label="Form responses for {{form.title}}"></table>
 			<div id="jqGridPager"></div>
 		</div>
 		<br/><br/>
-        <p id="download-legend" hidden><span style="font-size: 14px;" class="glyphicon glyphicon-download-alt"></span>: Download Files as Zip Folder</p>
+        <p id="download-legend" hidden><span style="font-size: 14px;" class="glyphicon glyphicon-download-alt" aria-hidden="true"></span><span class="sr-only">Download</span>: Download Files as Zip Folder</p>
 		<p><a href="/customforms/exceldata/{{form.id}}/">Download as Excel</a></p>
 		<script type="text/javascript" src="/media/scripts/customforms_response.js"></script>	
 {% endblock %}
-

--- a/esp/templates/customforms/view_results.html
+++ b/esp/templates/customforms/view_results.html
@@ -6,6 +6,7 @@
     {{ block.super }}
 	<link href="https://ajax.aspnetcdn.com/ajax/jquery.ui/{{ settings.JQUERY_UI_VERSION }}/themes/base/jquery-ui.css" rel="stylesheet" type="text/css"/>
     <link rel="stylesheet" type="text/css" href="/media/styles/jquery-ui/ui.jqgrid.css" />
+    <link rel="stylesheet" type="text/css" href="/media/styles/customforms-common.css" />
     <link rel="stylesheet" type="text/css" href="/media/styles/customforms-responses.css" />
 {% endblock %}
 
@@ -25,7 +26,7 @@
 			<div id="jqGridPager"></div>
 		</div>
 		<br/><br/>
-        <p id="download-legend" hidden><span style="font-size: 14px;" class="glyphicon glyphicon-download-alt" aria-hidden="true"></span><span class="sr-only">Download</span>: Download Files as Zip Folder</p>
+        <p id="download-legend" style="display: none;"><span style="font-size: 14px;" class="glyphicon glyphicon-download-alt" aria-hidden="true"></span><span class="sr-only">Download</span>: Download Files as Zip Folder</p>
 		<p><a href="/customforms/exceldata/{{form.id}}/">Download as Excel</a></p>
 		<script type="text/javascript" src="/media/scripts/customforms_response.js"></script>	
 {% endblock %}


### PR DESCRIPTION


- landing.html: add <caption class="sr-only"> to form list table for screen readers
- landing.html: add scope="col" to all column <th> elements (WCAG 1.3.1)
- landing.html: add scope="colgroup" to group header <th>
- view_results.html: add role="grid" and aria-label to jqGrid table
- view_results.html: add aria-hidden="true" to decorative glyphicon span
- customforms-landing.css: add .sr-only utility class (WCAG 2.1)
- customforms-responses.css: add .sr-only utility class (WCAG 2.1)

## Description

<!-- Brief summary of the changes and their purpose. -->

## Related Issue

<!-- Link the relevant issue. Use "Closes #123" to auto-close on merge. -->

Closes #5657


- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manually verified



## Checklist

- [ ] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [ ] No new warnings or errors introduced
