### PR TITLE
Phase 1(Week 1): Make ProgramModuleObj inherit from ExpirableModel (#2895)

### DIFF
--- a/esp/esp/program/modules/base.py
+++ b/esp/esp/program/modules/base.py
@@ -69,6 +69,8 @@ class CoreModule(object):
     pass
 
 class ProgramModuleObj(ExpirableModel):
+    start_date = models.DateTimeField(blank=True, null=True, default=None,
+                                      help_text="If blank, has always started.")
     program  = models.ForeignKey(Program, on_delete=models.CASCADE)
     module   = models.ForeignKey(ProgramModule, on_delete=models.CASCADE)
     seq      = models.IntegerField()

--- a/esp/esp/program/modules/base.py
+++ b/esp/esp/program/modules/base.py
@@ -44,6 +44,7 @@ from django.utils.safestring import mark_safe
 
 from esp.program.models import Program, ProgramModule
 from esp.users.models import ESPUser, Permission
+from esp.utils.expirable_model import ExpirableModel
 from esp.utils.web import render_to_response
 from argcache import cache_function
 from django.http import HttpResponseRedirect, Http404
@@ -67,7 +68,7 @@ class CoreModule(object):
     """
     pass
 
-class ProgramModuleObj(models.Model):
+class ProgramModuleObj(ExpirableModel):
     program  = models.ForeignKey(Program, on_delete=models.CASCADE)
     module   = models.ForeignKey(ProgramModule, on_delete=models.CASCADE)
     seq      = models.IntegerField()

--- a/esp/esp/program/modules/migrations/0054_programmoduleobj_expirable.py
+++ b/esp/esp/program/modules/migrations/0054_programmoduleobj_expirable.py
@@ -33,16 +33,6 @@ class Migration(migrations.Migration):
                 help_text='If blank, has always started.',
             ),
         ),
-        migrations.AlterField(
-            model_name='programmoduleobj',
-            name='start_date',
-            field=models.DateTimeField(
-                blank=True,
-                null=True,
-                default=datetime.datetime.now,
-                help_text='If blank, has always started.',
-            ),
-        ),
         migrations.AddField(
             model_name='programmoduleobj',
             name='end_date',

--- a/esp/esp/program/modules/migrations/0054_programmoduleobj_expirable.py
+++ b/esp/esp/program/modules/migrations/0054_programmoduleobj_expirable.py
@@ -1,0 +1,46 @@
+"""Add start_date and end_date to ProgramModuleObj.
+
+ProgramModuleObj now inherits from ExpirableModel.  We hand-write this
+migration instead of auto-generating it so that **existing rows receive
+NULL** for both columns (i.e. "always active / no expiry").
+
+ExpirableModel defines ``start_date`` with ``default=datetime.now``.
+An auto-generated migration would back-fill every existing module with
+today's timestamp, which would break backward compatibility.  By
+explicitly setting ``default=None`` here, Django's AddField populates
+existing rows with NULL, which ``ExpirableModel.is_valid()`` treats as
+"has always been valid".
+"""
+
+import datetime
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('modules', '0053_delete_mailinglabels'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='programmoduleobj',
+            name='start_date',
+            field=models.DateTimeField(
+                blank=True,
+                null=True,
+                default=None,
+                help_text='If blank, has always started.',
+            ),
+        ),
+        migrations.AddField(
+            model_name='programmoduleobj',
+            name='end_date',
+            field=models.DateTimeField(
+                blank=True,
+                null=True,
+                default=None,
+                help_text='If blank, never ends.',
+            ),
+        ),
+    ]

--- a/esp/esp/program/modules/migrations/0054_programmoduleobj_expirable.py
+++ b/esp/esp/program/modules/migrations/0054_programmoduleobj_expirable.py
@@ -33,6 +33,16 @@ class Migration(migrations.Migration):
                 help_text='If blank, has always started.',
             ),
         ),
+        migrations.AlterField(
+            model_name='programmoduleobj',
+            name='start_date',
+            field=models.DateTimeField(
+                blank=True,
+                null=True,
+                default=datetime.datetime.now,
+                help_text='If blank, has always started.',
+            ),
+        ),
         migrations.AddField(
             model_name='programmoduleobj',
             name='end_date',

--- a/esp/esp/program/modules/tests/test_expirable_module.py
+++ b/esp/esp/program/modules/tests/test_expirable_module.py
@@ -1,0 +1,98 @@
+"""Tests for the ExpirableModel integration on ProgramModuleObj.
+
+Verifies that ``ProgramModuleObj`` correctly inherits temporal behaviour
+(``start_date`` / ``end_date``, ``is_valid()``, ``valid_objects()``)
+from ``ExpirableModel`` after the Phase-1 migration.
+"""
+
+from datetime import datetime, timedelta
+
+from esp.program.models import ProgramModule
+from esp.program.modules.base import ProgramModuleObj
+from esp.program.tests import ProgramFrameworkTest
+
+
+class ProgramModuleObjExpirableTest(ProgramFrameworkTest):
+    """Verify that ProgramModuleObj temporal fields work correctly."""
+
+    def setUp(self):
+        super().setUp()
+        # Create a few modules for the program so we can test them
+        modules = ProgramModule.objects.all()[:3]
+        self.pmo = ProgramModuleObj.getFromProgModule(self.program, modules[0])
+        self.pmo2 = ProgramModuleObj.getFromProgModule(self.program, modules[1])
+        self.pmo3 = ProgramModuleObj.getFromProgModule(self.program, modules[2])
+
+    # ------------------------------------------------------------------
+    # is_valid() tests
+    # ------------------------------------------------------------------
+
+    def test_null_dates_is_valid(self):
+        """A module with no start/end date is always considered valid."""
+        self.pmo.start_date = None
+        self.pmo.end_date = None
+        self.pmo.save()
+        self.assertTrue(self.pmo.is_valid())
+
+    def test_future_start_is_invalid(self):
+        """A module whose start_date is in the future is not yet valid."""
+        self.pmo.start_date = datetime.now() + timedelta(days=30)
+        self.pmo.end_date = None
+        self.pmo.save()
+        self.assertFalse(self.pmo.is_valid())
+
+    def test_past_end_is_invalid(self):
+        """A module whose end_date is in the past is no longer valid."""
+        self.pmo.start_date = None
+        self.pmo.end_date = datetime.now() - timedelta(days=1)
+        self.pmo.save()
+        self.assertFalse(self.pmo.is_valid())
+
+    def test_active_window_is_valid(self):
+        """A module currently between its start and end date is valid."""
+        self.pmo.start_date = datetime.now() - timedelta(days=1)
+        self.pmo.end_date = datetime.now() + timedelta(days=30)
+        self.pmo.save()
+        self.assertTrue(self.pmo.is_valid())
+
+    # ------------------------------------------------------------------
+    # valid_objects() queryset test
+    # ------------------------------------------------------------------
+
+    def test_valid_objects_filters_correctly(self):
+        """valid_objects() should exclude expired and future modules."""
+        all_pmos = [self.pmo, self.pmo2, self.pmo3]
+
+        # Make the first module expired
+        expired = all_pmos[0]
+        expired.end_date = datetime.now() - timedelta(days=1)
+        expired.start_date = None
+        expired.save()
+
+        # Make the second module future
+        future = all_pmos[1]
+        future.start_date = datetime.now() + timedelta(days=30)
+        future.end_date = None
+        future.save()
+
+        # Ensure the rest have null dates (always valid)
+        for pmo in all_pmos[2:]:
+            pmo.start_date = None
+            pmo.end_date = None
+            pmo.save()
+
+        valid_ids = set(
+            ProgramModuleObj.valid_objects()
+            .filter(program=self.program)
+            .values_list('id', flat=True)
+        )
+
+        self.assertNotIn(expired.id, valid_ids,
+                         "Expired module should not appear in valid_objects()")
+        self.assertNotIn(future.id, valid_ids,
+                         "Future module should not appear in valid_objects()")
+
+        # All remaining modules should be valid
+        for pmo in all_pmos[2:]:
+            self.assertIn(pmo.id, valid_ids,
+                          f"Module {pmo.id} with null dates should be in valid_objects()")


### PR DESCRIPTION
**Description**
Partially addresses #2895 by implementing Phase 1 of the Module Management Timeline UI, making program modules time-aware.

**Changes**
* **`ProgramModuleObj` Subclassing:** Modified `base.py` so that `ProgramModuleObj` inherits from `ExpirableModel` rather than `models.Model`, giving all program modules native `start_date`, `end_date`, `is_valid()`, and `valid_objects()` support.
* **Safe Database Migration:** Hand-wrote the `0054_programmoduleobj_expirable` migration to override the default `datetime.now` backfill behavior. Existing records receive `NULL` (interpreted as "always active / no expiry"), keeping full backward compatibility for historical program data.
* **Unit Testing:** Added a new unit test suite (`test_expirable_module.py`) covering temporal boundary behavior across `NULL` dates, past dates, future dates, and active windows at both the instance level and SQL queryset filtering level.

**Related Issue**
Partially addresses #2895

**Type of Change**
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

**Testing**
- [x] Existing tests pass
- [x] New tests added (if applicable)
- [x] Manually verified

**AI Disclosure**
AI was used for suggestions only.

**Checklist**
- [x] Self-reviewed the code
- [x] Updated documentation (if needed)
- [x] No new warnings or errors introduced