### PR TITLE
Fix duplicate test collection in program/modules/tests

### DIFF
--- a/esp/esp/program/modules/tests/conftest.py
+++ b/esp/esp/program/modules/tests/conftest.py
@@ -7,8 +7,11 @@ standard test_*.py convention. Django's test runner discovers TestCase
 subclasses regardless of filename, but pytest only collects files that
 match the python_files patterns in pytest.ini.
 
-The pytest_collect_file hook below explicitly collects all .py files in
-this directory so pytest finds the same tests as manage.py test.
+The pytest_collect_file hook below explicitly collects the non-standard
+named .py files in this directory so pytest finds the same tests as
+manage.py test. Files matching pytest's built-in python_files pattern
+(test_*.py) are intentionally excluded here since pytest collects those
+natively, avoiding double-collection.
 """
 import pytest
 from pathlib import Path
@@ -18,9 +21,12 @@ _THIS_DIR = Path(__file__).parent
 
 def pytest_collect_file(parent, file_path):
     """
-    Collect .py files in this directory even though they don't follow the
-    test_*.py naming convention. Scoped to this directory only to avoid
-    accidentally collecting non-test .py files elsewhere in the project.
+    Collect non-standard named .py files in this directory (e.g.
+    programprintables.py, studentreg.py) that pytest would otherwise miss.
+
+    Skips test_*.py files — pytest's built-in collection handles those.
+    Scoped to this directory only to avoid accidentally collecting non-test
+    .py files elsewhere in the project.
     """
     # ajaxstudentreg.py imports django_selenium which is not installed.
     # It must be skipped at collection time to avoid a ModuleNotFoundError.
@@ -30,5 +36,6 @@ def pytest_collect_file(parent, file_path):
         and file_path.parent == _THIS_DIR
         and file_path.name not in _SKIP
         and not file_path.name.startswith(".")
+        and not file_path.name.startswith("test_")
     ):
         return pytest.Module.from_parent(parent, path=file_path)

--- a/esp/esp/program/modules/tests_modules.py
+++ b/esp/esp/program/modules/tests_modules.py
@@ -1,1 +1,0 @@
-from esp.program.modules.tests import *


### PR DESCRIPTION
## Description

Every test under `esp/program/modules/tests/` was being collected 2–3× by pytest because three routes all pointed to the same tests:

- The `conftest.py` hook collected **all** `.py` files, including `test_*.py` ones
- `tests_modules.py` (`from esp.program.modules.tests import *`) matched pytest's `tests_*.py` pattern, re-exporting every test class a second time
- pytest's built-in collection **also** picked up `test_*.py` files independently

**Two changes fix this:**

1. **Deleted `tests_modules.py`** — a single-line wildcard re-export with no other importers. Removing it eliminates one collection route entirely.

2. **Updated `conftest.py` hook** — added `and not file_path.name.startswith("test_")` so the hook only collects the non-standard named files like `programprintables.py` and `studentreg.py`. The `test_*.py` files are left to pytest's built-in collection, which already handles them.

After this fix, every test file is collected exactly once.

## Related Issue

Closes #5820

## Type of Change

- [x] Bug fix

## Testing

- [x] Existing tests pass
- [x] Manually verified

## AI Disclosure

Used Kiro (AI coding assistant) to help verify this implementation.

## Checklist

- [x] Self-reviewed the code
- [x] No new warnings or errors introduced
