### PR TITLE
fix invalid escape sequences

### DIFF
--- a/esp/esp/users/tests.py
+++ b/esp/esp/users/tests.py
@@ -502,7 +502,7 @@ class AccountCreationTest(TestCase):
         self.assertEqual(mail.outbox[0].to[0], u.email)
         #note: will break if the activation email is changed too much
         import re
-        match = re.search("\?username=(?P<user>[^&]*)&key=(?P<key>\d+)", mail.outbox[0].body)
+        match = re.search(r"\?username=(?P<user>[^&]*)&key=(?P<key>\d+)", mail.outbox[0].body)
         self.assertEqual(match.group("user"), u.username)
         self.assertEqual(match.group("key"), u.password.rsplit("_")[-1])
 

--- a/esp/useful_scripts/code_relicensing.py
+++ b/esp/useful_scripts/code_relicensing.py
@@ -118,7 +118,7 @@ for fn in filenames:
                     print('  Copyright contents follow')
                     print(copyright_text)
 
-                    result = re.search('Copyright \(c\) ([-0-9]+)', copyright_text)
+                    result = re.search(r'Copyright \(c\) ([-0-9]+)', copyright_text)
                     if result:
                         print('  Copyright date search yielded %s' % result.groups()[0])
 


### PR DESCRIPTION
## Description

fix invalid escape sequence warnings that are showing up in the unit tests, for example

```
/home/runner/work/ESP-Website/ESP-Website/esp/esp/users/tests.py:505: SyntaxWarning: invalid escape sequence '\?'
    match = re.search("\?username=(?P<user>[^&]*)&key=(?P<key>\d+)", mail.outbox[0].body)
```

The warnings no longer show up in the execution of the unit tests on this PR.

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [X] Manually verified

## Checklist

- [X] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [X] No new warnings or errors introduced
