### PR TITLE
Revert form rendering to Django 4 style

### DIFF
--- a/esp/esp/django_settings.py
+++ b/esp/esp/django_settings.py
@@ -201,7 +201,7 @@ TEMPLATES = [
     },
 ]
 
-FORM_RENDERER = 'django.forms.renderers.TemplatesSetting'
+FORM_RENDERER = 'esp.utils.forms.TableFormRenderer'
 
 # Set MIDDLEWARE_LOCAL in local_settings.py to configure this
 MIDDLEWARE_GLOBAL = [

--- a/esp/esp/utils/forms.py
+++ b/esp/esp/utils/forms.py
@@ -34,9 +34,14 @@ Learning Unlimited, Inc.
 """
 
 from django import forms
+from django.forms.renderers import TemplatesSetting
 
 from esp.tagdict.models import Tag
 from esp.utils.widgets import DummyWidget
+
+class TableFormRenderer(TemplatesSetting):
+    form_template_name = "django/forms/table.html"
+    formset_template_name = "django/forms/formsets/table.html"
 
 class SizedCharField(forms.CharField):
     """ Just like CharField, but you can set the width of the text widget. """


### PR DESCRIPTION
This reverts form rendering to the Django 4 default style of using tables (the default in Django 5 uses `div`s). This fixes, for example, the rendering of the forms on the resources page. Any uses of `{{ form }}` should now behave like they did in Django 4 and earlier, and any uses of `{{ form.as_table }}` or other specific renderers should still work.