### PR TITLE
Fix the program modules form field

### DIFF
--- a/esp/public/media/scripts/program/modules/modulequestions.js
+++ b/esp/public/media/scripts/program/modules/modulequestions.js
@@ -50,13 +50,13 @@ function modulesToQuestions() {
     // check if ALL the modules associated with a given question are selected
     // if so, check that box
     for (var i=0; i < questions.length; i++) {
-        var q = questions[i];
-        var qvalslist = q.firstChild.firstChild.value.split(",");
+        var q = $j(questions[i]);
+        var qvalslist = q.find("input[type='checkbox']").val().split(",");
         var include = true;
-        if (qvalslist.length == 0) {
+        if (qvalslist.length == 1 && qvalslist[0] == "") {
             alert("The following question is associated with zero modules! "
                   + "Please contact web support.\n"
-                  + q.textContent);
+                  + q.text().trim());
         }
         else {
             for (var j=0; j < qvalslist.length; j++) {


### PR DESCRIPTION
This fixes the program modules field in the program settings form. It broke because the structure of forms changed in Django 5. Now we use jQuery instead of brittle Javascript pathing to get the correct elements.