### PR TITLE
Phase 2(Week 2): Add time-filtering to getModules() for non-admins (Issue #4935)

### DIFF
--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -1266,7 +1266,11 @@ class Program(models.Model, CustomFormsLinkModel):
 
     def getModules(self, user = None, tl = None, old_prog = None):
         """ Gets modules for this program, optionally attaching a user. """
-        modules = self.getModules_cached(tl, old_prog)
+        modules = list(self.getModules_cached(tl, old_prog))
+
+        if user and not user.isAdmin(self):
+            modules = [m for m in modules if m.is_valid()]
+
         if user:
             for module in modules:
                 module.user = user

--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -1265,7 +1265,7 @@ class Program(models.Model, CustomFormsLinkModel):
     getModules_cached.depend_on_row('modules.StudentClassRegModuleInfo', lambda modinfo: {'self': modinfo.program})
 
     def getModules(self, user = None, tl = None, old_prog = None):
-        """ Gets modules for this program, optionally attaching a user. """
+        """ Gets modules for this program, optionally attaching a user. Only open modules are included for non-admins. """
         modules = list(self.getModules_cached(tl, old_prog))
 
         if user and not user.isAdmin(self):

--- a/esp/esp/program/modules/tests/test_module_time_filtering.py
+++ b/esp/esp/program/modules/tests/test_module_time_filtering.py
@@ -1,0 +1,111 @@
+"""Tests for the time-filtering behaviour added to Program.getModules().
+
+Verifies that non-admin users only see modules whose ``start_date`` /
+``end_date`` window includes the current moment, while admins and
+internal callers (user=None) bypass the filter entirely.
+"""
+
+from datetime import datetime, timedelta
+
+from esp.program.models import ProgramModule
+from esp.program.modules.base import ProgramModuleObj
+from esp.program.tests import ProgramFrameworkTest
+
+
+class TestModuleTimeFiltering(ProgramFrameworkTest):
+    def setUp(self):
+        super().setUp()
+
+        self.student = self.students[0]
+        self.admin = self.admins[0]
+
+        now = datetime.now()
+        self.past = now - timedelta(days=1)
+        self.future = now + timedelta(days=1)
+
+        # ProgramFrameworkTest provisions ProgramModule rows and links
+        # them via the M2M, but ProgramModuleObj rows are created
+        # lazily by getFromProgModule().  Mirror the pattern used by
+        # test_expirable_module.py to force creation.
+        mod = ProgramModule.objects.filter(
+            id__in=self.program.program_modules.values_list(
+                'id', flat=True
+            )
+        ).first()
+        self.pmo = ProgramModuleObj.getFromProgModule(
+            self.program, mod
+        )
+
+    # -- helpers -----------------------------------------------------------
+
+    def _module_ids(self, user):
+        """Return set of ProgramModuleObj PKs from getModules()."""
+        return {m.id for m in self.program.getModules(user=user)}
+
+    # -- student visibility ------------------------------------------------
+
+    def test_active_module_visible_to_student(self):
+        """Module inside its time window is visible to students."""
+        self.pmo.start_date = self.past
+        self.pmo.end_date = self.future
+        self.pmo.save()
+
+        self.assertIn(self.pmo.id, self._module_ids(self.student))
+
+    def test_null_dates_module_visible_to_student(self):
+        """Module with no dates (always valid) is visible to students."""
+        self.pmo.start_date = None
+        self.pmo.end_date = None
+        self.pmo.save()
+
+        self.assertIn(self.pmo.id, self._module_ids(self.student))
+
+    def test_expired_module_hidden_from_student(self):
+        """Module whose end_date has passed is hidden from students."""
+        self.pmo.start_date = None
+        self.pmo.end_date = self.past
+        self.pmo.save()
+
+        self.assertNotIn(self.pmo.id, self._module_ids(self.student))
+
+    def test_future_module_hidden_from_student(self):
+        """Module whose start_date is in the future is hidden."""
+        self.pmo.start_date = self.future
+        self.pmo.end_date = None
+        self.pmo.save()
+
+        self.assertNotIn(self.pmo.id, self._module_ids(self.student))
+
+    # -- admin visibility --------------------------------------------------
+
+    def test_expired_module_visible_to_admin(self):
+        """Admins bypass time filtering and see expired modules."""
+        self.pmo.start_date = None
+        self.pmo.end_date = self.past
+        self.pmo.save()
+
+        self.assertIn(self.pmo.id, self._module_ids(self.admin))
+
+    def test_future_module_visible_to_admin(self):
+        """Admins bypass time filtering and see future modules."""
+        self.pmo.start_date = self.future
+        self.pmo.end_date = None
+        self.pmo.save()
+
+        self.assertIn(self.pmo.id, self._module_ids(self.admin))
+
+    # -- internal / no-user visibility -------------------------------------
+
+    def test_no_user_returns_all_modules(self):
+        """Internal calls (user=None) bypass filtering entirely."""
+        self.pmo.start_date = None
+        self.pmo.end_date = self.past
+        self.pmo.save()
+
+        self.assertIn(self.pmo.id, self._module_ids(None))
+
+        self.pmo.start_date = self.future
+        self.pmo.end_date = None
+        self.pmo.save()
+
+        self.assertIn(self.pmo.id, self._module_ids(None))


### PR DESCRIPTION
### Description
Addresses #4935 by implementing Phase 2 of the Module Management Timeline UI. This update enforces the `start_date` and `end_date` boundary logic on the backend so that expired or upcoming modules are hidden from students and teachers in the dashboard, but remain fully visible to administrators.

### Changes
* **Time-Aware Filtering:** Updated the `getModules()` function in `esp/esp/program/models/__init__.py` to filter modules using `m.is_valid()`. 
* **Role-Based Bypass:** Included an explicit `user.isAdmin(self)` check so that administrators completely bypass the time constraints and can always see all modules to manage them.
* **Cache Safety:** Cast the `django-argcache` result to a new `list()` before filtering to ensure the shared global cache array isn't accidentally mutated.
* **Unit Testing:** Added a comprehensive test suite (`test_module_time_filtering.py`) that tests boundary scenarios across student, admin, and system roles for past, future, and active program modules.

### Related Issue
Fixes #4935

### Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

### Testing

- [x] Existing tests pass
- [x] New tests added (if applicable)
- [x] Manually verified

### AI Disclosure
AI was used for suggestions only.

### Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced
