### PR TITLE
Fix #5793: seed_dummy_data now includes all choosable=1 modules

### DIFF
--- a/esp/esp/program/management/commands/seed_dummy_data.py
+++ b/esp/esp/program/management/commands/seed_dummy_data.py
@@ -295,7 +295,10 @@ class Command(BaseCommand):
             module_dotted_name = f'esp.program.modules.handlers.{mod_name}'
             try:
                 mod = importlib.import_module(module_dotted_name)
-            except Exception:
+            except Exception as e:
+                self.stdout.write(self.style.WARNING(
+                    f'  Skipping handler module {module_dotted_name}: {e!r}'
+                ))
                 continue
             for _name, cls in inspect.getmembers(mod, inspect.isclass):
                 # Only consider classes actually defined in this handler file,
@@ -310,15 +313,20 @@ class Command(BaseCommand):
                     continue
                 try:
                     all_props = cls.module_properties_autopopulated()
-                except Exception:
+                except Exception as e:
+                    self.stdout.write(self.style.WARNING(
+                        f'  Skipping module_properties for {module_dotted_name}.{cls.__name__}: {e!r}'
+                    ))
                     continue
                 for props in all_props:
                     if props.get('choosable') == 1:
-                        ProgramModule.objects.get_or_create(
+                        ProgramModule.objects.update_or_create(
                             handler=props['handler'],
                             module_type=props['module_type'],
                             defaults=dict(
                                 admin_title=props.get('admin_title', props['handler']),
+                                link_title=props.get('link_title'),
+                                inline_template=props.get('inline_template'),
                                 seq=props.get('seq', 200),
                                 required=props.get('required', False),
                                 choosable=1,

--- a/esp/esp/program/management/commands/seed_dummy_data.py
+++ b/esp/esp/program/management/commands/seed_dummy_data.py
@@ -285,6 +285,45 @@ class Command(BaseCommand):
             defaults=dict(admin_title='Teacher Profile Editor',
                           seq=0, required=True, choosable=1))
 
+        # Supplement with all other choosable=1 modules from the handlers directory
+        from esp.program.modules import handlers as handlers_pkg
+        import importlib
+        import pkgutil
+        import inspect
+
+        for _, mod_name, _ in pkgutil.iter_modules(handlers_pkg.__path__):
+            module_dotted_name = f'esp.program.modules.handlers.{mod_name}'
+            try:
+                mod = importlib.import_module(module_dotted_name)
+            except Exception:
+                continue
+            for _name, cls in inspect.getmembers(mod, inspect.isclass):
+                # Only consider classes actually defined in this handler file,
+                # not ones that happen to be imported into it.
+                if cls.__module__ != module_dotted_name:
+                    continue
+                try:
+                    is_handler = issubclass(cls, ProgramModuleObj) and cls is not ProgramModuleObj
+                except TypeError:
+                    continue
+                if not is_handler:
+                    continue
+                try:
+                    all_props = cls.module_properties_autopopulated()
+                except Exception:
+                    continue
+                for props in all_props:
+                    if props.get('choosable') == 1:
+                        ProgramModule.objects.get_or_create(
+                            handler=props['handler'],
+                            module_type=props['module_type'],
+                            defaults=dict(
+                                admin_title=props.get('admin_title', props['handler']),
+                                seq=props.get('seq', 200),
+                                required=props.get('required', False),
+                                choosable=1,
+                            ))
+
         for name in ['yes/no', 'rating', 'open response', 'multiple choice']:
             QuestionType.objects.get_or_create(name=name)
 
@@ -332,33 +371,6 @@ class Command(BaseCommand):
     # ── programs ──────────────────────────────────────────────────────────────
 
     def _create_programs(self):
-        all_module_handlers = [
-            # Core
-            'StudentRegCore', 'TeacherRegCore', 'AdminCore',
-            'OnsiteCore', 'VolunteerSignup', 'VolunteerManage',
-            'RegProfileModule', 'JSONDataModule',
-            # Student registration
-            'StudentClassRegModule', 'StudentRegConfirm',
-            'StudentAcknowledgementModule', 'StudentSurveyModule',
-            'LotteryStudentRegModule', 'LotteryFrontendModule',
-            'FinancialAidAppModule', 'StudentExtracosts', 'DonationModule',
-            'CreditCardModule_Stripe', 'StudentOnsite',
-            # Teacher registration
-            'TeacherClassRegModule', 'TeacherBioModule',
-            'AvailabilityModule', 'TeacherSurveyModule',
-            'TeacherAcknowledgementModule', 'TeacherPreviewModule',
-            'TeacherOnsite', 'TeacherEventsModule',
-            # Admin
-            'AdminClass', 'AdminVitals', 'AdminMaterials',
-            'ResourceModule', 'SchedulingCheckModule',
-            'ProgramPrintables', 'SurveyManagement',
-            'CommModule', 'NameTagModule',
-            'BigBoardModule', 'TeacherBigBoardModule', 'BatchClassRegModule',
-            'OnSiteCheckinModule', 'OnSiteCheckoutModule',
-            'OnSiteClassList', 'OnSiteAttendance',
-            'UnenrollModule', 'ClassSearchModule',
-            'TeacherCheckinModule', 'FinAidApproveModule',
-        ]
         programs = []
         for spec in [
             dict(name='Splash Dev', url='SplashDev/2026', grade_min=7,  grade_max=12),
@@ -373,14 +385,14 @@ class Command(BaseCommand):
                     director_cc_email='', director_confidential_email='',
                     program_size_max=200, program_allow_waitlist=True,
                 ))
-            modules_qs = ProgramModule.objects.filter(handler__in=all_module_handlers)
+            modules_qs = ProgramModule.objects.filter(choosable=1)
 
             if created:
                 program.class_categories.set(ClassCategories.objects.all())
                 program.program_modules.set(modules_qs)
 
                 # Seed ProgramModuleObj instances so the program has active modules
-                for pm in ProgramModule.objects.filter(handler__in=all_module_handlers):
+                for pm in modules_qs:
                     ProgramModuleObj.objects.get_or_create(
                         program=program,
                         module=pm,


### PR DESCRIPTION
### Description
Addresses the bug in `seed_dummy_data` where the management command only seeded a hard-coded subset of modules. This update dynamically auto-discovers all modules with `choosable=1`, ensuring that the dummy data generator stays in sync with the codebase as new handlers are added, completely resolving #5793.

### Changes
- **Module Auto-Discovery**: Updated `_seed_lookup_data` in `esp/esp/program/management/commands/seed_dummy_data.py` to use `pkgutil` and `inspect` to iterate over all handlers in `esp.program.modules.handlers`. It evaluates `module_properties_autopopulated()` and automatically seeds a `ProgramModule` record for any module where `choosable=1`.
- **Dynamic Program Seeding**: Removed the massive, hard-coded `all_module_handlers` array in `_create_programs`. 
- **Queryset Standardization**: Replaced manual filtering loops with a unified `ProgramModule.objects.filter(choosable=1)` queryset. This guarantees that dummy programs like `Splash Dev` and `Spark Dev` are correctly assigned all available choosable modules and receive their corresponding `ProgramModuleObj` rows.

### Related Issue
Fixes #5793

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

### Testing
- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

### AI Disclosure
AI was used for suggestions only.

### Checklist
- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced
