### PR TITLE
Move commonly used links to featured Admin Portal categories

### DIFF
--- a/esp/esp/program/modules/base.py
+++ b/esp/esp/program/modules/base.py
@@ -340,7 +340,13 @@ class ProgramModuleObj(ExpirableModel):
                                        'ListGenModule', 'ResourceModule', 'CommModule',
                                        'VolunteerManage', 'ClassFlagModule', 'ProgramPrintables',
                                        'AJAXSchedulingModule', 'NameTagModule', 'TeacherEventsManageModule',
-                                       'SurveyManagement']
+                                       'SurveyManagement', 'ClassSearchModule', 'SchedulingCheckModule',
+                                       'CheckAvailabilityModule', 'BatchClassRegModule', 'BigBoardModule',
+                                       'TeacherBigBoardModule', 'LotteryFrontendModule', 'GroupTextModule',
+                                       'DeactivationModule', 'UserGroupModule', 'UserRecordsModule',
+                                       'MapGenModule', 'LineItemsModule', 'AccountingModule',
+                                       'CreditCardViewer', 'FinAidApproveModule', 'AdminTestingModule',
+                                       'StudentRegPhaseZeroManage', 'AdmissionsDashboard', 'AdminReviewApps']
     def isOnSiteFeatured(self):
         """Don't display in the long list of additional modules if it's already featured
         in the main portion of the admin portal"""

--- a/esp/esp/program/modules/handlers/admincore.py
+++ b/esp/esp/program/modules/handlers/admincore.py
@@ -108,16 +108,16 @@ class AdminCore(ProgramModuleObj, CoreModule):
         base = program.getUrlBase()
         # Map view names to (title, category, keywords) for admin dashboard search.
         entries = {
-            "main": ("Admin Portal", "Configure", ["dashboard", "admin", "home"]),
-            "settings": ("Program Settings", "Configure", ["settings", "program", "registration", "options"]),
-            "tags": ("Tag Settings", "Configure", ["tags", "advanced", "experts", "settings"]),
-            "dashboard": ("Dashboard", "Logistics", ["classes", "stats", "overview", "enrollment", "logistics"]),
-            "registrationtype_management": ("Student Registration Types", "Configure", ["registration", "types", "student", "sections", "schedule"]),
-            "lunch_constraints": ("Lunch Constraints", "Configure", ["lunch", "constraints", "schedule", "availability"]),
-            "deadline_management": ("Deadlines", "Configure", ["registration", "open", "close", "dates", "deadlines"]),
-            "deadlines": ("Deadlines", "Configure", ["registration", "open", "close", "dates", "deadlines"]),
-            "surveys": ("Surveys", "Configure", ["survey", "feedback", "student survey", "teacher survey"]),
-            "modules": ("Manage Modules", "Configure", ["modules", "required", "sequence", "student registration", "teacher registration"]),
+            "main": ("Admin Portal", "Program Management and Settings", ["dashboard", "admin", "home"]),
+            "settings": ("Program Settings", "Program Management and Settings", ["settings", "program", "registration", "options"]),
+            "tags": ("Tag Settings", "Program Management and Settings", ["tags", "advanced", "experts", "settings"]),
+            "dashboard": ("Dashboard", "Class Management and Scheduling", ["classes", "stats", "overview", "enrollment", "logistics"]),
+            "registrationtype_management": ("Student Registration Types", "Registration", ["registration", "types", "student", "sections", "schedule"]),
+            "lunch_constraints": ("Lunch Constraints", "Registration", ["lunch", "constraints", "schedule", "availability"]),
+            "deadline_management": ("Deadlines", "Registration", ["registration", "open", "close", "dates", "deadlines"]),
+            "deadlines": ("Deadlines", "Registration", ["registration", "open", "close", "dates", "deadlines"]),
+            "surveys": ("Surveys", "Program Management and Settings", ["survey", "feedback", "student survey", "teacher survey"]),
+            "modules": ("Manage Modules", "Program Management and Settings", ["modules", "required", "sequence", "student registration", "teacher registration"]),
         }
         if view_name not in entries:
             return None

--- a/esp/esp/program/modules/handlers/adminmaterials.py
+++ b/esp/esp/program/modules/handlers/adminmaterials.py
@@ -61,9 +61,9 @@ class AdminMaterials(ProgramModuleObj):
         return AdminSearchEntry(
             id="manage_get_materials",
             url="/manage/%s/get_materials" % base,
-            title="Documents",
-            category="Logistics",
-            keywords=["documents", "files", "upload", "download", "materials"],
+            title="Administrative Materials",
+            category="Program Management and Settings",
+            keywords=["materials", "resources", "files", "upload", "download"],
         )
 
     @main_call

--- a/esp/esp/program/modules/handlers/ajaxschedulingmodule.py
+++ b/esp/esp/program/modules/handlers/ajaxschedulingmodule.py
@@ -70,9 +70,9 @@ class AJAXSchedulingModule(ProgramModuleObj):
         return AdminSearchEntry(
             id="manage_ajax_scheduling",
             url="/manage/%s/ajax_scheduling" % base,
-            title="Scheduling",
-            category="Logistics",
-            keywords=["schedule", "rooms", "times", "ajax", "scheduling"],
+            title="AJAX Scheduling module",
+            category="Class Management and Scheduling",
+            keywords=["scheduling", "ajax", "rooms", "times"],
         )
 
     def prepare(self, context={}):

--- a/esp/esp/program/modules/handlers/commmodule.py
+++ b/esp/esp/program/modules/handlers/commmodule.py
@@ -131,9 +131,9 @@ class CommModule(ProgramModuleObj):
         return AdminSearchEntry(
             id="manage_commpanel",
             url="/manage/%s/commpanel" % base,
-            title="Email (Communications Panel)",
-            category="Coordinate",
-            keywords=["email", "communications", "commpanel", "messages"],
+            title="Communications Panel",
+            category="Participants and Communication",
+            keywords=["communications", "emails", "send", "messages"],
         )
 
     @staticmethod

--- a/esp/esp/program/modules/handlers/lineitemsmodule.py
+++ b/esp/esp/program/modules/handlers/lineitemsmodule.py
@@ -61,7 +61,7 @@ class LineItemsModule(ProgramModuleObj, CoreModule):
             id="manage_lineitems",
             url="/manage/%s/lineitems" % base,
             title="Line Items Management",
-            category="Configure",
+            category="Participants and Communication",
             keywords=["line items", "extra costs", "fees", "payments", "accounting"],
         )
 

--- a/esp/esp/program/modules/handlers/listgenmodule.py
+++ b/esp/esp/program/modules/handlers/listgenmodule.py
@@ -313,9 +313,9 @@ class ListGenModule(ProgramModuleObj):
         return AdminSearchEntry(
             id="manage_selectList",
             url="/manage/%s/selectList" % base,
-            title="Arbitrary User List",
-            category="Coordinate",
-            keywords=["user list", "search users", "export", "mailing list"],
+            title="Arbitrary List Generator",
+            category="Participants and Communication",
+            keywords=["list", "lists", "generation", "query", "selectList", "mailing list"],
         )
 
     @aux_call

--- a/esp/esp/program/modules/handlers/resourcemodule.py
+++ b/esp/esp/program/modules/handlers/resourcemodule.py
@@ -78,9 +78,9 @@ class ResourceModule(ProgramModuleObj):
         return AdminSearchEntry(
             id="manage_resources",
             url="/manage/%s/resources" % base,
-            title="Resources",
-            category="Configure",
-            keywords=["rooms", "classrooms", "spaces", "timeslots", "resources"],
+            title="Classroom Resources Management",
+            category="Class Management and Scheduling",
+            keywords=["resources", "projectors", "classrooms", "spaces", "timeslots", "resources"],
         )
 
     """

--- a/esp/esp/program/modules/handlers/teachereventsmanagemodule.py
+++ b/esp/esp/program/modules/handlers/teachereventsmanagemodule.py
@@ -70,9 +70,9 @@ class TeacherEventsManageModule(ProgramModuleObj):
         return AdminSearchEntry(
             id="manage_teacher_events",
             url="/manage/%s/teacher_events" % base,
-            title="Teacher Training / Interviews",
-            category="Configure",
-            keywords=["teacher", "training", "interviews", "events"],
+            title="Teacher Events",
+            category="Registration",
+            keywords=["events", "onsite", "interviews", "training"],
         )
 
     @main_call

--- a/esp/esp/program/modules/handlers/volunteermanage.py
+++ b/esp/esp/program/modules/handlers/volunteermanage.py
@@ -67,9 +67,9 @@ class VolunteerManage(ProgramModuleObj):
         return AdminSearchEntry(
             id="manage_volunteering",
             url="/manage/%s/volunteering" % base,
-            title="Volunteers",
-            category="Logistics",
-            keywords=["volunteers", "shifts", "signups"],
+            title="Volunteering Management",
+            category="Registration",
+            keywords=["volunteer", "help", "signup", "volunteering"],
         )
 
     """

--- a/esp/templates/program/modules/admincore/directory.html
+++ b/esp/templates/program/modules/admincore/directory.html
@@ -283,6 +283,9 @@
                 {% if manage_tags %}
                 <a href="/manage/{{ program.getUrlBase }}/tags" title="miscellaneous settings, for experts only" class="dashboard-btn"><i class="bi bi-gear"></i> Tags</a>
                 {% endif %}
+                {% if manage_admin_testing %}
+                <a href="/manage/{{ program.getUrlBase }}/admin_testing" title="testing mode" class="dashboard-btn"><i class="bi bi-tools"></i> Testing Mode</a>
+                {% endif %}
                 {% if onsite_main %}
                 <a href="/onsite/{{ program.getUrlBase }}/main" class="dashboard-btn"><i class="bi bi-house"></i> Onsite Main</a>
                 {% endif %}
@@ -301,6 +304,30 @@
                 {% if manage_ajax_scheduling %}
                 <a href="/manage/{{ program.getUrlBase }}/ajax_scheduling" title="assign rooms and times" class="dashboard-btn"><i class="bi bi-calendar"></i> Scheduling</a>
                 {% endif %}
+                {% if manage_classsearch %}
+                <a href="/manage/{{ program.getUrlBase }}/classsearch" title="search for classes" class="dashboard-btn"><i class="bi bi-search"></i> Class Search</a>
+                {% endif %}
+                {% if manage_scheduling_checks %}
+                <a href="/manage/{{ program.getUrlBase }}/scheduling_checks" title="run scheduling diagnostics" class="dashboard-btn"><i class="bi bi-check-square"></i> Scheduling Checks</a>
+                {% endif %}
+                {% if manage_edit_availability %}
+                <a href="/manage/{{ program.getUrlBase }}/edit_availability" title="check teacher availability" class="dashboard-btn"><i class="bi bi-calendar-check"></i> Availability</a>
+                {% endif %}
+                {% if manage_batchclassreg %}
+                <a href="/manage/{{ program.getUrlBase }}/batchclassreg" title="batch register students to a class" class="dashboard-btn"><i class="bi bi-person-lines-fill"></i> Batch Reg</a>
+                {% endif %}
+                {% if manage_bigboard %}
+                <a href="/manage/{{ program.getUrlBase }}/bigboard" title="live student registration board" class="dashboard-btn"><i class="bi bi-display"></i> Student BigBoard</a>
+                {% endif %}
+                {% if manage_teacherbigboard %}
+                <a href="/manage/{{ program.getUrlBase }}/teacherbigboard" title="live teacher registration board" class="dashboard-btn"><i class="bi bi-display"></i> Teacher BigBoard</a>
+                {% endif %}
+                {% if manage_lottery %}
+                <a href="/manage/{{ program.getUrlBase }}/lottery" title="run the lottery assignment thing" class="dashboard-btn"><i class="bi bi-dice-5"></i> Lottery</a>
+                {% endif %}
+                {% if manage_classflags %}
+                <a href="/manage/{{ program.getUrlBase }}/classflags" title="manage class flags" class="dashboard-btn"><i class="bi bi-flag"></i> Class Flags</a>
+                {% endif %}
                 {% if learn_catalog %}
                 <a href="/learn/{{ program.getUrlBase }}/catalog" class="dashboard-btn"><i class="bi bi-book"></i> Catalog</a>
                 {% endif %}
@@ -310,6 +337,15 @@
         <button class="collapsible-btn">Registration <span class="dropdown-icon text-muted">&#9660;</span></button>
         <div class="collapsible-content">
             <div class="pill-grid" style="padding: 15px 0 5px 0;">
+                {% if manage_phasezero %}
+                <a href="/manage/{{ program.getUrlBase }}/phasezero" title="manage program lottery" class="dashboard-btn"><i class="bi bi-0-circle"></i> Phase Zero</a>
+                {% endif %}
+                {% if manage_admissions %}
+                <a href="/manage/{{ program.getUrlBase }}/admissions" title="admissions dashboard" class="dashboard-btn"><i class="bi bi-person-check"></i> Admissions</a>
+                {% endif %}
+                {% if manage_review_students %}
+                <a href="/manage/{{ program.getUrlBase }}/review_students" title="application review for admin" class="dashboard-btn"><i class="bi bi-journal-check"></i> Review Apps</a>
+                {% endif %}
                 {% if manage_deadlines %}
                 <a href="/manage/{{ program.getUrlBase }}/deadlines" title="open/close registration" class="dashboard-btn"><i class="bi bi-clock"></i> Deadlines</a>
                 {% endif %}
@@ -345,6 +381,33 @@
                 {% endif %}
                 {% if manage_selectList %}
                 <a href="/manage/{{ program.getUrlBase }}/selectList" title="get a list of users" class="dashboard-btn"><i class="bi bi-card-list"></i> Arbitrary User List</a>
+                {% endif %}
+                {% if manage_grouptextpanel %}
+                <a href="/manage/{{ program.getUrlBase }}/grouptextpanel" title="group text panel" class="dashboard-btn"><i class="bi bi-phone"></i> Texts</a>
+                {% endif %}
+                {% if manage_deactivate %}
+                <a href="/manage/{{ program.getUrlBase }}/deactivate" title="mass deactivate users" class="dashboard-btn"><i class="bi bi-person-x"></i> Deactivate Users</a>
+                {% endif %}
+                {% if manage_usergroup %}
+                <a href="/manage/{{ program.getUrlBase }}/usergroup" title="manage user groups" class="dashboard-btn"><i class="bi bi-people"></i> User Groups</a>
+                {% endif %}
+                {% if manage_userrecords %}
+                <a href="/manage/{{ program.getUrlBase }}/userrecords" title="manage user records" class="dashboard-btn"><i class="bi bi-file-person"></i> User Records</a>
+                {% endif %}
+                {% if manage_usermap %}
+                <a href="/manage/{{ program.getUrlBase }}/usermap" title="generate map of users" class="dashboard-btn"><i class="bi bi-map"></i> User Map</a>
+                {% endif %}
+                {% if manage_lineitems %}
+                <a href="/manage/{{ program.getUrlBase }}/lineitems" title="line items management" class="dashboard-btn"><i class="bi bi-list-check"></i> Line Items</a>
+                {% endif %}
+                {% if manage_accounting %}
+                <a href="/manage/{{ program.getUrlBase }}/accounting" title="accounting" class="dashboard-btn"><i class="bi bi-calculator"></i> Accounting</a>
+                {% endif %}
+                {% if manage_viewpay %}
+                <a href="/manage/{{ program.getUrlBase }}/viewpay" title="view credit card transactions" class="dashboard-btn"><i class="bi bi-credit-card"></i> Transactions</a>
+                {% endif %}
+                {% if manage_finaidapprove %}
+                <a href="/manage/{{ program.getUrlBase }}/finaidapprove" title="approve financial aid requests" class="dashboard-btn"><i class="bi bi-bank"></i> Financial Aid</a>
                 {% endif %}
                 {% if manage_refund %}
                 <a href="/accounting/refund?program={{ program.id }}" class="dashboard-btn"><i class="bi bi-currency-dollar"></i> Refunds</a>


### PR DESCRIPTION
## Description

This PR moves commonly used administrative modules out of the overwhelming "Additional Modules" section at the bottom of the portal and into the structured, featured collapsible categories (e.g., Class Management and Scheduling, Registration, Participants and Communication).

It also updates relevant admin search categories to better align with the new dashboard organization. For the finance-related modules (`LineItemsModule`, `AccountingModule`, `CreditCardViewer`, `FinAidApproveModule`), they have been grouped under "Participants and Communication" for now, but this can easily be adjusted if a dedicated Finance section is preferred.

## Related Issue

Closes #5826

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

<img width="774" height="826" alt="dashboard_screenshot" src="https://github.com/user-attachments/assets/b8f982da-64f7-439d-a493-f98875bacc7a" />

## AI Disclosure

Code debugging, category organization, and this PR description were generated with the assistance of an AI coding agent.

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced