### PR TITLE
Fix statistics page FieldError on program_type (#5431)

### DIFF
--- a/esp/esp/program/statistics.py
+++ b/esp/esp/program/statistics.py
@@ -268,12 +268,13 @@ def repeats(form, programs, students, profiles, result_dict=None):
             user__in=students,
             event__name='reg_confirmed',
         )
-        .values_list('user_id', 'program__program_type')
+        .values_list('user_id', 'program__url')
     )
 
     #   Group by user: count how many programs of each type they confirmed
     user_type_counts = defaultdict(Counter)
-    for user_id, program_type in confirmed_pairs:
+    for user_id, program_url in confirmed_pairs:
+        program_type = program_url.split('/')[0] if program_url else program_url
         user_type_counts[user_id][program_type] += 1
 
     #   Bin students by their (program_type, count) signature

--- a/esp/esp/program/statistics.py
+++ b/esp/esp/program/statistics.py
@@ -262,7 +262,7 @@ def repeats(form, programs, students, profiles, result_dict=None):
     #   For each student, find out what other programs they registered for and bin by quantity in each program type.
     #   Uses a single bulk query instead of per-student loops.
 
-   #   Fetch all confirmed (user_id, program_url) pairs in one query,
+    #   Fetch all confirmed (user_id, program_url) pairs in one query,
     #   then derive program_type from the url below
     confirmed_pairs = (
         Record.objects.filter(

--- a/esp/esp/program/statistics.py
+++ b/esp/esp/program/statistics.py
@@ -262,7 +262,8 @@ def repeats(form, programs, students, profiles, result_dict=None):
     #   For each student, find out what other programs they registered for and bin by quantity in each program type.
     #   Uses a single bulk query instead of per-student loops.
 
-    #   Fetch all confirmed (user_id, program_type) pairs in one query
+   #   Fetch all confirmed (user_id, program_url) pairs in one query,
+    #   then derive program_type from the url below
     confirmed_pairs = (
         Record.objects.filter(
             user__in=students,

--- a/esp/esp/program/test_statistics.py
+++ b/esp/esp/program/test_statistics.py
@@ -377,13 +377,7 @@ class StartRegTest(StatisticsTestBase):
 # ===========================================================================
 
 class RepeatsTest(StatisticsTestBase):
-    """Tests for statistics.repeats().
-
-    NOTE: repeats() references 'program__program_type' (statistics.py L258),
-    but the Program model has no ``program_type`` field.  Every call therefore
-    raises ``django.core.exceptions.FieldError``.  These tests document the
-    pre-existing bug so it does not silently break the rest of the suite.
-    """
+    """Tests for statistics.repeats()."""
 
     def _call(self, students=None, profiles=None, rd=None):
         if students is None:
@@ -395,24 +389,20 @@ class RepeatsTest(StatisticsTestBase):
         return repeats(_form(), self.programs, students, profiles, rd), rd
 
     def test_returns_string(self):
-        from django.core.exceptions import FieldError
-        with self.assertRaises(FieldError):
-            self._call()
+        result, _ = self._call()
+        self.assertIsInstance(result, str)
 
     def test_result_dict_has_repeat_data(self):
-        from django.core.exceptions import FieldError
-        with self.assertRaises(FieldError):
-            self._call(rd={})
+        _, rd = self._call(rd={})
+        self.assertIn("repeat_data", rd)
 
     def test_repeat_data_is_list(self):
-        from django.core.exceptions import FieldError
-        with self.assertRaises(FieldError):
-            self._call(rd={})
+        _, rd = self._call(rd={})
+        self.assertIsInstance(rd["repeat_data"], list)
 
     def test_empty_students_gives_empty_repeat_data(self):
-        from django.core.exceptions import FieldError
-        with self.assertRaises(FieldError):
-            self._call(students=self.empty_users, profiles=self.empty_profiles, rd={})
+        _, rd = self._call(students=self.empty_users, profiles=self.empty_profiles, rd={})
+        self.assertEqual(rd["repeat_data"], [])
 
     def test_repeats_logic_flow(self):
         mock_data = [

--- a/esp/esp/program/test_statistics.py
+++ b/esp/esp/program/test_statistics.py
@@ -406,10 +406,10 @@ class RepeatsTest(StatisticsTestBase):
 
     def test_repeats_logic_flow(self):
         mock_data = [
-            (1, "Science"),
-            (1, "Science"),
-            (1, "Math"),
-            (2, "Math"),
+            (1, "Science/123"),
+            (1, "Science/123"),
+            (1, "Math/456"),
+            (2, "Math/456"),
         ]
 
         with patch('esp.users.models.Record.objects.filter') as mock_filter:


### PR DESCRIPTION
## Description
The statistics page (`/manage/statistics`) threw a `django.core.exceptions.FieldError`
when running the "What other programs have the students attended?" query. This was
caused by PR #4037, which changed the query in `repeats()` to filter/fetch using
`program__program_type`. However, `program_type` is a Python `@property` on the
`Program` model (`self.url.split('/')[0]`), not an actual database field, so it
cannot be used in a `values_list()`/`filter()` ORM lookup.

This PR fetches `program__url` (a real database field) instead, and derives
`program_type` in Python from the URL, matching the exact logic used by the
`Program.program_type` property. Updated the corresponding tests in
`test_statistics.py` to assert correct behavior instead of the previously
expected `FieldError`.

## Related Issue
Closes #5431

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing
- [x] Existing tests pass
- [x] New tests added (if applicable)
- [ ] Manually verified

## Checklist
- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced