### PR TITLE
Fix #4818: Add HTML5 required attributes for login form validation

### DIFF
--- a/esp/esp/themes/theme_data/bigpicture/templates/users/loginbox_content.html
+++ b/esp/esp/themes/theme_data/bigpicture/templates/users/loginbox_content.html
@@ -1,4 +1,4 @@
-{# TODO(benkraft): This isn't that different from the non-theme one, dedupe #}
+﻿{# TODO(benkraft): This isn't that different from the non-theme one, dedupe #}
 <div id="loginbox">
 
   <div class="logged_in">
@@ -26,8 +26,8 @@
   <div class="not_logged_in">
     <form name="loginform" id="loginform" method="post" action="/myesp/login/" class="navbar-form form-inline">
       <input type="hidden" name="next" value="{{ request.path }}" />
-      <input type="text" name="username" id="user" size="8" value="" placeholder="Username" maxlength="255" class="inputbox" />
-      <input type="password" name="password" id="pass" size="8" value="" placeholder="Password" maxlength="255" class="inputbox" />
+      <input type="text" name="username" required id="user" size="8" value="" placeholder="Username" maxlength="255" class="inputbox" />
+      <input type="password" name="password" required id="pass" size="8" value="" placeholder="Password" maxlength="255" class="inputbox" />
 
       <button class="btn" id="gologin" type="submit">Login</button>
       <span class="dropdown">

--- a/esp/esp/themes/theme_data/circles/templates/users/loginbox_content.html
+++ b/esp/esp/themes/theme_data/circles/templates/users/loginbox_content.html
@@ -1,4 +1,4 @@
-<div id="loginbox">
+﻿<div id="loginbox">
 <table align="center" class="loginform" cellspacing="0" cellpadding="5">
 <tr><td>
 
@@ -66,13 +66,13 @@
     <table border="0" cellpadding="0" cellspacing="0" summary=" ">
       <tr>
         <td><div class="divformcol1"><label for="user">User name:</label></div></td>
-        <td><div class="divformcol2"><input type="text" name="username" id="user" size="8" value="" maxlength="255" class="inputbox input-small" /></div></td>
+        <td><div class="divformcol2"><input type="text" name="username" required id="user" size="8" value="" maxlength="255" class="inputbox input-small" /></div></td>
 
         <td><div class="divformcol3"></div></td>
       </tr>
       <tr>
         <td><div class="divformcol1"><label for="pass">Password:</label></div></td>
-        <td><div class="divformcol2"><input type="password" name="password" id="pass" size="8" value="" maxlength="255" class="inputbox input-small" /></div></td>
+        <td><div class="divformcol2"><input type="password" name="password" required id="pass" size="8" value="" maxlength="255" class="inputbox input-small" /></div></td>
         <td style="vertical-align: top;"><div class="divformcol3"><button class="btn btn-secondary" id="gologin" type="submit" style="margin-left:5px;"></button></div></td>
       </tr>
       <tr>

--- a/esp/esp/themes/theme_data/droplets/templates/users/loginbox_content.html
+++ b/esp/esp/themes/theme_data/droplets/templates/users/loginbox_content.html
@@ -1,4 +1,4 @@
-{% if login_result %}
+﻿{% if login_result %}
   <div class="navbar-text text-light w-100 px-3">{{ login_result }}</div>
 {% endif %}
 
@@ -23,9 +23,9 @@
   <li class="nav-item d-flex align-items-center flex-wrap">
     <form name="loginform" id="loginform" method="post" action="/myesp/login/" class="form-inline navbar-form my-1">
       <label class="visually-hidden" for="user">Username</label>
-      <input type="text" name="username" id="user" size="8" value="" placeholder="Username" maxlength="255" class="form-control form-control-sm inputbox me-1" />
+      <input type="text" name="username" required id="user" size="8" value="" placeholder="Username" maxlength="255" class="form-control form-control-sm inputbox me-1" />
       <label class="visually-hidden" for="pass">Password</label>
-      <input type="password" name="password" id="pass" size="8" value="" placeholder="Password" maxlength="255" class="form-control form-control-sm inputbox me-1" />
+      <input type="password" name="password" required id="pass" size="8" value="" placeholder="Password" maxlength="255" class="form-control form-control-sm inputbox me-1" />
       <button class="btn btn-secondary btn-sm" id="gologin" type="submit">Login</button>
     </form>
   </li>

--- a/esp/esp/themes/theme_data/floaty/templates/users/loginbox_content.html
+++ b/esp/esp/themes/theme_data/floaty/templates/users/loginbox_content.html
@@ -1,4 +1,4 @@
-{# Floaty: compact login UI for the right-hand .box area (not navbar-nav) #}
+﻿{# Floaty: compact login UI for the right-hand .box area (not navbar-nav) #}
 <div id="loginbox">
 
   <div class="logged_in">
@@ -27,8 +27,8 @@
   <div class="not_logged_in">
     <form name="loginform" id="loginform" method="post" action="/myesp/login/" class="navbar-form form-inline">
       <input type="hidden" name="next" value="{{ request.path }}" />
-      <input type="text" name="username" id="user" size="8" value="" placeholder="Username" maxlength="255" class="inputbox" />
-      <input type="password" name="password" id="pass" size="8" value="" placeholder="Password" maxlength="255" class="inputbox" />
+      <input type="text" name="username" required id="user" size="8" value="" placeholder="Username" maxlength="255" class="inputbox" />
+      <input type="password" name="password" required id="pass" size="8" value="" placeholder="Password" maxlength="255" class="inputbox" />
 
       <button class="btn" id="gologin" type="submit">Login</button>
       <span class="dropdown">

--- a/esp/templates/users/loginbox_content.html
+++ b/esp/templates/users/loginbox_content.html
@@ -1,4 +1,4 @@
-<div id="loginbox">
+﻿<div id="loginbox">
 
   {% if login_result %}
     <div class="navbar">{{ login_result }}</div>
@@ -50,9 +50,9 @@
     <form name="loginform" id="loginform" method="post" action="{% url 'login' %}" class="navbar-form form-inline">
       <!-- input type="hidden" name="next" value={-{ request.path }}" / -->
       <label class="visually-hidden" for="user">Username</label>
-      <input type="text" name="username" id="user" size="8" value="" placeholder="Username" maxlength="255" class="inputbox" />
+      <input type="text" name="username" required id="user" size="8" value="" placeholder="Username" maxlength="255" class="inputbox" />
       <label class="visually-hidden" for="pass">Password</label>
-      <input type="password" name="password" id="pass" size="8" value="" placeholder="Password" maxlength="255" class="inputbox" />
+      <input type="password" name="password" required id="pass" size="8" value="" placeholder="Password" maxlength="255" class="inputbox" />
 
       <button class="btn btn-primary" id="gologin" type="submit" style="margin-right:0px;"> Login </button>
       <span class="dropdown">


### PR DESCRIPTION
## Description
Added native HTML5 `required` attributes to the username and password input fields within the login form template (`loginbox_content.html`). This ensures client-side validation catches empty submissions instantly, preventing redundant backend hits.

## Related Issue
Closes #4818

## Type of Change
- [x] Bug fix / UI refinement

## Testing
- [x] Manually verified locally