### PR TITLE
Clarify comment fetching of confirmed user-program pairs

### DIFF
--- a/esp/esp/program/statistics.py
+++ b/esp/esp/program/statistics.py
@@ -262,7 +262,8 @@ def repeats(form, programs, students, profiles, result_dict=None):
     #   For each student, find out what other programs they registered for and bin by quantity in each program type.
     #   Uses a single bulk query instead of per-student loops.
 
-    #   Fetch all confirmed (user_id, program_type) pairs in one query
+     #   Fetch all confirmed (user_id, program_url) pairs in one query,
+    #   then derive program_type from the url below
     confirmed_pairs = (
         Record.objects.filter(
             user__in=students,


### PR DESCRIPTION


## Description
Updated the comment above the `confirmed_pairs` query in `repeats()` (esp/esp/program/statistics.py) to accurately reflect that the query fetches `(user_id, program_url)` pairs and that `program_type` is derived from the URL afterward, rather than fetched directly. This was flagged in Copilot's review of PR #5871.

## Related Issue
Closes #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing
- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified


## Checklist
- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced