### PR TITLE
Fix empty bullet in navbar by skipping empty entries

### DIFF
--- a/esp/templates/inclusion/web/navbar_left.html
+++ b/esp/templates/inclusion/web/navbar_left.html
@@ -2,6 +2,7 @@
   <!-- secondary nav -->
   <ul id="submenu">
   {% for nav_entry in navbar_list.entries %}
+    {% if nav_entry.entry.makeTitle %}
     <li class="divsecondarynavlink {% if nav_entry.entry.indent %}indent{% endif %}">
       {% if nav_entry.entry.is_link %}
         <a href="{{ nav_entry.entry.makeUrl }}"
@@ -9,10 +10,12 @@
           {{ nav_entry.entry.makeTitle }}
         </a>
       {% else %}
-          {{ nav_entry.entry.makeTitle }}
+        {{ nav_entry.entry.makeTitle }}
       {% endif %}
-   </li>
+    </li>
+    {% endif %}
   {% endfor %}
+
   {% if navbar_list.category %}
   {% with navbar_list.category as cat %}
   <li class="navbar-manage admin">


### PR DESCRIPTION
## Description

Fixed the empty bullet appearing in the secondary navbar.

The issue was caused because empty navbar entries were still generating empty `<li>` elements in the HTML. Since the `<li>` existed without any content, the browser displayed an unwanted bullet.

This change adds a condition in the Django template to render navbar list items only when `makeTitle` exists, preventing empty `<li>` elements from being created.

## Related Issue

Closes #5689

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## AI Disclosure

Used AI assistance for debugging guidance and understanding the issue. The final code changes were reviewed and applied manually.

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced