### PR TITLE
Fix: handle missing or invalid filterid in GroupTextModule gracefully…

### DIFF
--- a/esp/esp/program/modules/handlers/grouptextmodule.py
+++ b/esp/esp/program/modules/handlers/grouptextmodule.py
@@ -102,7 +102,11 @@ class GroupTextModule(ProgramModuleObj):
             return render_to_response(self.baseDir() + 'not_configured.html', request, {})
 
         # get the filter to use and text message to send from the request; this is set in grouptextpanel form
-        filterObj = PersistentQueryFilter.objects.get(id=request.GET['filterid'])
+        filter_id = request.GET.get('filterid')
+        try:
+            filterObj = PersistentQueryFilter.objects.get(id=filter_id)
+        except (PersistentQueryFilter.DoesNotExist, ValueError, TypeError):
+            raise ESPError()('The requested query filter is invalid or no longer exists.')
         message = request.POST['message']
         override = False
         if 'text-override' in request.POST:


### PR DESCRIPTION

## Description

Refactored `GroupTextModule.grouptextfinal()` to handle missing, invalid, or deleted `filterid` query parameters gracefully. Previously, accessing `request.GET['filterid']` directly and querying `PersistentQueryFilter.objects.get()` without exception handling caused 500 Unhandled Server Errors when given an invalid ID or when a filter was deleted. Added a `try-except` block covering `DoesNotExist`, `ValueError`, and `TypeError` to raise a user-friendly `ESPError` instead.

## Related Issue

Closes #5475

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## AI Disclosure

I used Gemini (Google AI) to assist with analyzing the issue, reviewing exception handling patterns, and drafting this pull request description.

## Checklist

- [x] Self-reviewed the code
- [x] Updated documentation (if needed)
- [x] No new warnings or errors introduced