### PR TITLE
Initial module permissions and dates configuration in new program form (Issue #5916)

### DIFF
--- a/esp/esp/program/modules/base.py
+++ b/esp/esp/program/modules/base.py
@@ -314,12 +314,20 @@ class ProgramModuleObj(ExpirableModel):
                     if not perm_types and hasattr(handler_cls, 'get_permission_types'):
                         perm_types = handler_cls.get_permission_types(handler_cls)
                     if perm_types:
-                        from esp.users.models import Permission
-                        perm = Permission.objects.filter(
+                        role_by_module_type = {'learn': 'Student', 'teach': 'Teacher', 'volunteer': 'Volunteer'}
+                        role_name = role_by_module_type.get(getattr(mod, 'module_type', ''))
+                        if role_name:
+                            perm_types = [pt for pt in perm_types if pt.startswith(role_name)] or perm_types
+                        group = Group.objects.filter(name=role_name).first() if role_name else None
+                        perm_qs = Permission.objects.filter(
                             program=prog,
                             permission_type__in=perm_types,
-                            user__isnull=True
-                        ).first()
+                            user__isnull=True,
+                            user_filter__isnull=True,
+                        )
+                        if group:
+                            perm_qs = perm_qs.filter(role=group)
+                        perm = perm_qs.order_by('id').first()
                         if perm:
                             BaseModule.start_date = perm.start_date
                             BaseModule.end_date = perm.end_date

--- a/esp/esp/program/modules/base.py
+++ b/esp/esp/program/modules/base.py
@@ -302,9 +302,29 @@ class ProgramModuleObj(ExpirableModel):
                 BaseModule.seq = old_pmo[0].seq
                 BaseModule.required = old_pmo[0].required
                 BaseModule.required_label = old_pmo[0].required_label
+                BaseModule.start_date = old_pmo[0].start_date
+                BaseModule.end_date = old_pmo[0].end_date
             else:
                 BaseModule.seq = mod.seq
                 BaseModule.required = mod.required
+                # Populate initial start_date and end_date from program permission records
+                try:
+                    handler_cls = mod.getPythonClass()
+                    perm_types = getattr(handler_cls, 'permission_types', ())
+                    if not perm_types and hasattr(handler_cls, 'get_permission_types'):
+                        perm_types = handler_cls.get_permission_types(handler_cls)
+                    if perm_types:
+                        from esp.users.models import Permission
+                        perm = Permission.objects.filter(
+                            program=prog,
+                            permission_type__in=perm_types,
+                            user__isnull=True
+                        ).first()
+                        if perm:
+                            BaseModule.start_date = perm.start_date
+                            BaseModule.end_date = perm.end_date
+                except Exception:
+                    pass
             BaseModule.save()
 
         elif len(BaseModuleList) > 1:

--- a/esp/esp/program/modules/tests/test_student_reg_phase_zero.py
+++ b/esp/esp/program/modules/tests/test_student_reg_phase_zero.py
@@ -101,10 +101,10 @@ class StudentRegPhaseZeroTestCase(ProgramFrameworkTest):
         Tag.setTag('student_lottery_run', target=self.program, value='False')
         self._login_student()
 
-        # Ensure the student does not already have broad student permissions (e.g. Student/All)
+        # Ensure the student does not already have broad student permissions (e.g. Student/All) or Student/PhaseZero
         Permission.objects.filter(
             role__name='Student',
-            permission_type='Student/All',
+            permission_type__in=['Student/All', 'Student/PhaseZero'],
             program=self.program,
         ).delete()
 

--- a/esp/esp/program/setup.py
+++ b/esp/esp/program/setup.py
@@ -47,14 +47,52 @@ def prepare_program(program, data):
     perms = []
     modules = []
 
-    perms += [('Student/All', None, data['student_reg_start'], data['student_reg_end'])] #it is recursive
-    perms += [('Student/Profile', None, data['student_reg_start'], None)]
-    perms += [('Teacher/All', None, data['teacher_reg_start'], data['teacher_reg_end'])]
-    perms += [('Teacher/Classes/View', None, data['teacher_reg_start'], None)]
-    perms += [('Teacher/MainPage', None, data['teacher_reg_start'], None)]
-    perms += [('Teacher/Profile', None, data['teacher_reg_start'], None)]
+    perms += [('Student/All', None, data.get('student_reg_start'), data.get('student_reg_end'))] #it is recursive
+    perms += [('Student/Profile', None, data.get('student_reg_start'), None)]
+    perms += [('Teacher/All', None, data.get('teacher_reg_start'), data.get('teacher_reg_end'))]
+    perms += [('Teacher/Classes/View', None, data.get('teacher_reg_start'), None)]
+    perms += [('Teacher/MainPage', None, data.get('teacher_reg_start'), None)]
+    perms += [('Teacher/Profile', None, data.get('teacher_reg_start'), None)]
 
-    modules += [(i.admin_title, i.id) for i in data['program_modules']]
+    existing_perm_types = {p[0] for p in perms}
+
+    for pm in data.get('program_modules', []):
+        try:
+            handler_cls = pm.getPythonClass()
+        except Exception:
+            handler_cls = None
+
+        if handler_cls:
+            perm_types = ()
+            if hasattr(handler_cls, 'get_permission_types'):
+                try:
+                    perm_types = handler_cls.get_permission_types(handler_cls)
+                except Exception:
+                    perm_types = getattr(handler_cls, 'permission_types', ())
+            else:
+                perm_types = getattr(handler_cls, 'permission_types', ())
+
+            for perm_type in perm_types:
+                if perm_type in existing_perm_types:
+                    continue
+
+                if perm_type.startswith('Student') or getattr(pm, 'module_type', '') == 'learn':
+                    start_date = data.get('student_reg_start')
+                    end_date = data.get('student_reg_end')
+                elif perm_type.startswith('Teacher') or getattr(pm, 'module_type', '') == 'teach':
+                    start_date = data.get('teacher_reg_start')
+                    end_date = data.get('teacher_reg_end')
+                elif perm_type.startswith('Volunteer') or getattr(pm, 'module_type', '') == 'volunteer':
+                    start_date = data.get('teacher_reg_start') or data.get('student_reg_start')
+                    end_date = data.get('teacher_reg_end') or data.get('student_reg_end')
+                else:
+                    start_date = data.get('student_reg_start')
+                    end_date = data.get('student_reg_end')
+
+                perms.append((perm_type, None, start_date, end_date))
+                existing_perm_types.add(perm_type)
+
+    modules += [(i.admin_title, i.id) for i in data.get('program_modules', [])]
 
     return perms, modules
 
@@ -75,6 +113,9 @@ def commit_program(prog, perms, cost=0, sibling_discount=None):
             new_perm.role=Group.objects.get(name="Student")
         elif tup[1] is None and tup[0].startswith("Teacher"):
             new_perm.role=Group.objects.get(name="Teacher")
+        elif tup[1] is None and tup[0].startswith("Volunteer"):
+            group, _ = Group.objects.get_or_create(name="Volunteer")
+            new_perm.role = group
         else:
             raise ESPError('Invalid permission/deadline: `{}`'.format(tup[1]))
         new_perm.save()

--- a/esp/esp/program/tests.py
+++ b/esp/esp/program/tests.py
@@ -2439,6 +2439,9 @@ class NewProgramModulePermissionsTest(TestCase):
         from esp.users.models import Permission
         from datetime import datetime
 
+        from esp.tests.util import user_role_setup
+        user_role_setup()
+
         student_start = datetime(2026, 9, 1, 0, 0)
         student_end = datetime(2026, 11, 1, 0, 0)
         teacher_start = datetime(2026, 8, 1, 0, 0)
@@ -2458,8 +2461,9 @@ class NewProgramModulePermissionsTest(TestCase):
             name='Test Perm Program',
             url='TestPerm/2026',
             grade_min=7,
-            grade_max=12
+            grade_max=12,
         )
+        program.program_modules.set(all_modules)
 
         perms, modules = prepare_program(program, data)
         commit_program(program, perms)
@@ -2483,11 +2487,9 @@ class NewProgramModulePermissionsTest(TestCase):
 
         # Verify ProgramModuleObj instances created for program inherit dates
         program.getModules()
-        student_cls_pm = ProgramModule.objects.filter(handler='StudentClassRegModule').first()
-        if student_cls_pm:
-            from esp.program.modules.base import ProgramModuleObj
-            pmo = ProgramModuleObj.objects.filter(program=program, module=student_cls_pm).first()
-            if pmo:
-                self.assertEqual(pmo.start_date, student_start)
-                self.assertEqual(pmo.end_date, student_end)
+        student_cls_pm = ProgramModule.objects.get(handler='StudentClassRegModule')
+        from esp.program.modules.base import ProgramModuleObj
+        pmo = ProgramModuleObj.objects.get(program=program, module=student_cls_pm)
+        self.assertEqual(pmo.start_date, student_start)
+        self.assertEqual(pmo.end_date, student_end)
 

--- a/esp/esp/program/tests.py
+++ b/esp/esp/program/tests.py
@@ -2428,3 +2428,66 @@ class SubmitTransactionRequiresPostTest(TestCase):
     def test_get_returns_405(self):
         response = self.client.get(reverse('manage_submit_transaction'))
         self.assertEqual(response.status_code, 405)
+
+
+class NewProgramModulePermissionsTest(TestCase):
+    """Tests that prepare_program sets initial start/end dates for permissions of enabled modules."""
+
+    def test_new_program_sets_module_permissions_and_dates(self):
+        from esp.program.models import Program, ProgramModule
+        from esp.program.setup import prepare_program, commit_program
+        from esp.users.models import Permission
+        from datetime import datetime
+
+        student_start = datetime(2026, 9, 1, 0, 0)
+        student_end = datetime(2026, 11, 1, 0, 0)
+        teacher_start = datetime(2026, 8, 1, 0, 0)
+        teacher_end = datetime(2026, 10, 1, 0, 0)
+
+        all_modules = list(ProgramModule.objects.all())
+
+        data = {
+            'student_reg_start': student_start,
+            'student_reg_end': student_end,
+            'teacher_reg_start': teacher_start,
+            'teacher_reg_end': teacher_end,
+            'program_modules': all_modules,
+        }
+
+        program = Program.objects.create(
+            name='Test Perm Program',
+            url='TestPerm/2026',
+            grade_min=7,
+            grade_max=12
+        )
+
+        perms, modules = prepare_program(program, data)
+        commit_program(program, perms)
+
+        # Verify Student/Classes permission exists and matches student dates
+        student_cls_perm = Permission.objects.filter(program=program, permission_type='Student/Classes').first()
+        self.assertIsNotNone(student_cls_perm)
+        self.assertEqual(student_cls_perm.start_date, student_start)
+        self.assertEqual(student_cls_perm.end_date, student_end)
+
+        # Verify Teacher/Classes/All permission exists and matches teacher dates
+        teacher_cls_perm = Permission.objects.filter(program=program, permission_type='Teacher/Classes/All').first()
+        self.assertIsNotNone(teacher_cls_perm)
+        self.assertEqual(teacher_cls_perm.start_date, teacher_start)
+        self.assertEqual(teacher_cls_perm.end_date, teacher_end)
+
+        # Verify Volunteer/Signup permission exists and has start_date set
+        volunteer_perm = Permission.objects.filter(program=program, permission_type='Volunteer/Signup').first()
+        self.assertIsNotNone(volunteer_perm)
+        self.assertIsNotNone(volunteer_perm.start_date)
+
+        # Verify ProgramModuleObj instances created for program inherit dates
+        program.getModules()
+        student_cls_pm = ProgramModule.objects.filter(handler='StudentClassRegModule').first()
+        if student_cls_pm:
+            from esp.program.modules.base import ProgramModuleObj
+            pmo = ProgramModuleObj.objects.filter(program=program, module=student_cls_pm).first()
+            if pmo:
+                self.assertEqual(pmo.start_date, student_start)
+                self.assertEqual(pmo.end_date, student_end)
+


### PR DESCRIPTION
Description:
Configures the new program creation form to automatically set initial start and end dates for permissions associated with all enabled program modules. Now that module permissions are associated across program modules, this PR ensures that whenever an administrator creates a program and enables modules, initial permissions for Student, Teacher, and Volunteer roles automatically inherit the start and end dates configured during program setup.

Changes

- Automatic Permission Generation — Updated `prepare_program()` in `setup.py` to inspect enabled `program_modules`, retrieve their `permission_types`, and populate start and end dates for Student, Teacher, and Volunteer permissions based on form input.
- Volunteer Group Handling — Added support for `Volunteer` role group creation in `commit_program()` in `setup.py`.
- Module Date Inheritance — Updated `ProgramModuleObj.getFromProgModule()` in `base.py` so newly created `ProgramModuleObj` instances inherit `start_date` and `end_date` from program permission records.
- Test Suite Updates — Added `NewProgramModulePermissionsTest` in `tests.py` to verify permission creation, date assignment, and module date inheritance.

Related Issue
Resolves #5916

Type of Change

 [x] New feature
 [ ] Bug fix (non-breaking change which fixes an issue)
 [ ] Refactoring (no functional changes, no api changes)

Testing

 [x] Existing tests pass
 [x] New tests added
 [x] Manually verified

AI Disclosure
AI used for suggestions only.

Checklist

 [x] Self-reviewed
 [x] Documentation updated
 [x] No new warnings or errors
