### PR TITLE
Fix mid-scroll staleness in onsite class list (#116)

### DIFF
--- a/esp/esp/program/modules/handlers/onsiteclasslist.py
+++ b/esp/esp/program/modules/handlers/onsiteclasslist.py
@@ -386,6 +386,14 @@ class OnSiteClassList(ProgramModuleObj):
         return self.classList_base(request, tl, one, two, module, extra, prog, template_name='classlist.html')
 
     @aux_call
+    @needs_onsite
+    def classlist_fragment(self, request, tl, one, two, module, extra, prog):
+        """ Returns just the scrolling class-list fragment (no page chrome), for
+            AJAX refreshing of the classList scroller mid-scroll without a full
+            page reload.  See issue #116. """
+        return self.classList_base(request, tl, one, two, module, extra, prog, template_name='allclass_fragment.html')
+
+    @aux_call
     @needs_student_in_grade
     def classlist_public(self, request, tl, one, two, module, extra, prog):
         return self.classList_base(request, tl, one, two, module, extra, prog, options={}, template_name='allclass_fragment.html')

--- a/esp/esp/program/modules/handlers/tests/test_onsiteclasslist.py
+++ b/esp/esp/program/modules/handlers/tests/test_onsiteclasslist.py
@@ -842,7 +842,7 @@ class ClassListFragmentAuthorizationTests(CacheFlushTestCase):
         )
         module.classList_base = types.MethodType(OnSiteClassList.classList_base, module)
         return wrapped_fn(module, request, 'onsite', None, None, None, None, self.program)
-    
+
     def test_anonymous_user_redirected(self):
         """An unauthenticated request must be redirected to the login page."""
         from django.contrib.auth.models import AnonymousUser

--- a/esp/esp/program/modules/handlers/tests/test_onsiteclasslist.py
+++ b/esp/esp/program/modules/handlers/tests/test_onsiteclasslist.py
@@ -714,6 +714,161 @@ class OnsiteAuthorizationTests(CacheFlushTestCase):
         resp = self._call_catalog_status(self.admin)
         self.assertEqual(resp.status_code, 200)
         self.assertIn('application/json', resp.get('Content-Type', ''))
+
+
+class ClassListMidScrollRefreshTests(ProgramFrameworkTest):
+    """The scrolling onsite class list should refresh its data once per lap
+    (issue #116), not just once every full page reload cycle (issue #318),
+    so a long list doesn't sit stale for several minutes while it scrolls.
+    """
+
+    def setUp(self):
+        super().setUp(
+            num_timeslots=2,
+            num_teachers=2,
+            classes_per_teacher=1,
+            sections_per_class=1,
+            num_rooms=2,
+            num_students=0,
+        )
+        self.factory = RequestFactory()
+        self.admin = self.admins[0]
+
+    def _render(self, template_name='classlist.html', options=None):
+        options = options or {'refresh': '30', 'scrollspeed': '1'}
+        request = self.factory.get('/onsite/classlist', options)
+        request.user = self.admin
+        module = SimpleNamespace(
+            program=self.program,
+            baseDir=lambda: 'program/modules/onsiteclasslist/'
+        )
+        resp = OnSiteClassList.classList_base(
+            module,
+            request,
+            'onsite',
+            None,
+            None,
+            None,
+            None,
+            self.program,
+            options=options,
+            template_name=template_name,
+        )
+        resp.render()
+        return resp.content.decode()
+
+    def test_prefetch_and_swap_js_present(self):
+        """classlist.html must define the background prefetch and the
+        reset()-time swap that keeps data fresh across laps."""
+        content = self._render()
+        self.assertIn('prefetch_fragment', content)
+        self.assertIn('pending_html', content)
+        self.assertIn('fragment_url', content)
+
+    def test_swap_happens_before_dom_scan_in_reset(self):
+        """The pending fragment must be swapped into the DOM, and the next
+        fetch kicked off, before reset() re-scans .category/.start_time —
+        otherwise the freshly-swapped headers wouldn't be picked up."""
+        content = self._render()
+
+        swap_index = content.index('pending_html !== null')
+        prefetch_call_index = content.index(
+            'prefetch_fragment();', content.index('function reset()')
+        )
+        rescan_index = content.index('categories = $j(".category")')
+
+        self.assertLess(swap_index, rescan_index)
+        self.assertLess(prefetch_call_index, rescan_index)
+
+    def test_fragment_url_targets_classlist_fragment_endpoint(self):
+        """The prefetch must hit the fragment-only endpoint, not the full
+        classList page (which would re-fetch page chrome every lap)."""
+        content = self._render()
+        self.assertIn('/classlist_fragment', content)
+
+    def test_fragment_view_returns_fragment_only(self):
+        """classlist_fragment must render allclass_fragment.html, not the
+        full classlist.html page with its <head>/<script> chrome."""
+        content = self._render(template_name='allclass_fragment.html')
+        self.assertNotIn('<head>', content)
+        self.assertNotIn('prefetch_fragment', content)
+
+
+class ClassListFragmentAuthorizationTests(CacheFlushTestCase):
+    """The new classlist_fragment endpoint must be gated by @needs_onsite,
+    the same as the full classList page, not left open to any logged-in user.
+    """
+
+    def setUp(self):
+        super().setUp()
+        user_role_setup()
+
+        self.student = ESPUser.objects.create_user(
+            username='fragment_test_student',
+            password='password',
+            email='fragment_student@test.com',
+            first_name='Fragment',
+            last_name='Student',
+        )
+        self.student.makeRole('Student')
+
+        self.admin = ESPUser.objects.create_user(
+            username='fragment_test_admin',
+            password='password',
+            email='fragment_admin@test.com',
+            first_name='Fragment',
+            last_name='Admin',
+        )
+        self.admin.makeRole('Administrator')
+
+        self.program = Program.objects.create(
+            name='Fragment Auth Test Program',
+            url='fragmentauthtest/2222',
+            grade_min=7,
+            grade_max=12,
+        )
+
+        self.factory = RequestFactory()
+
+    def _call_classlist_fragment(self, user):
+        import types
+        request = self.factory.get('/onsite/%s/classlist_fragment' % self.program.url)
+        request.user = user
+        request.session = self.client.session
+        wrapped_fn = OnSiteClassList.classlist_fragment
+        module = SimpleNamespace(
+            program=self.program,
+            baseDir=lambda: 'program/modules/onsiteclasslist/'
+        )
+        module.classList_base = types.MethodType(OnSiteClassList.classList_base, module)
+        return wrapped_fn(module, request, 'onsite', None, None, None, None, self.program)
+    
+    def test_anonymous_user_redirected(self):
+        """An unauthenticated request must be redirected to the login page."""
+        from django.contrib.auth.models import AnonymousUser
+        anonymous = AnonymousUser()
+        resp = self._call_classlist_fragment(anonymous)
+        self.assertEqual(resp.status_code, 302)
+        location = resp.get('Location', '')
+        self.assertIn('login', location)
+
+    def test_student_denied(self):
+        """A student must not get the fragment content back.
+        needs_onsite renders errors/program/notonsite.html when access is
+        denied, so the response won't contain the fragment's markers.
+        """
+        resp = self._call_classlist_fragment(self.student)
+        if hasattr(resp, 'render'):
+            resp.render()
+        self.assertNotIn('scroller', resp.content.decode())
+
+    def test_admin_gets_200(self):
+        """A user in the Administrator group must pass the guard and get
+        the fragment content back."""
+        resp = self._call_classlist_fragment(self.admin)
+        self.assertEqual(resp.status_code, 200)
+
+
 class SchedulePdfTests(SimpleTestCase):
     """Regression tests for schedule_pdf early failure cases and success path."""
 

--- a/esp/templates/program/modules/onsiteclasslist/classlist.html
+++ b/esp/templates/program/modules/onsiteclasslist/classlist.html
@@ -15,6 +15,25 @@ next_start_time = 0;
 var page_load_time = Date.now();
 var refresh_interval_ms = {{ refresh }} * 1000;
 
+//   Mid-scroll data refresh (issue #116): fetch a fresh copy of the class-list
+//   fragment in the background during each lap, and swap it in right at the
+//   reset() seam, where the old content has just scrolled fully out of view.
+//   This keeps the data from going stale over a long scroll cycle, without
+//   causing a visible jump the way a mid-scroll page reload would.
+var pending_html = null;
+var fetch_in_progress = false;
+var fragment_url = window.location.pathname.replace(/\/classList\/?$/, "/classlist_fragment") + window.location.search;
+
+function prefetch_fragment() {
+    if (fetch_in_progress) return;
+    fetch_in_progress = true;
+    $j.get(fragment_url, function(data) {
+        pending_html = data;
+    }).always(function() {
+        fetch_in_progress = false;
+    });
+}
+
 function setElementStyleById(id, propertyName, propertyValue) {
     if (!document.getElementById) return;
     var el = document.getElementById(id);
@@ -74,6 +93,16 @@ function reset()
 {
     if (interval_handle != -1)
         clearInterval(interval_handle);
+
+    if (pending_html !== null) {
+        document.getElementById("scroller_top").innerHTML = pending_html;
+        document.getElementById("scroller_bottom").innerHTML = pending_html;
+        pending_html = null;
+    }
+    //   Kick off the fetch for the *next* lap now, so it has this whole lap
+    //   to complete before it's needed.
+    prefetch_fragment();
+
     categories = $j(".category");
     start_times = $j(".start_time");
     next_category = 0;


### PR DESCRIPTION
Fixes #116

## Problem

The onsite class list scroller (used at front-desk/registration kiosks) only
refreshes its data on a full page reload. #318 fixed the scroller from
yanking itself mid-scroll by moving the reload to happen at the end of a
scroll cycle instead of interrupting it — but the underlying class data is
still whatever was fetched at the last page load. For a long list of
classes, one lap through the scroller can take close to the full refresh
interval, so the back half of the list can be showing stale enrollment
numbers for most of the cycle, especially while registration is actively
underway.

## Fix

`reset()` already has a natural "seam" once per lap: the moment
`#scroller_top` has fully scrolled out of view and the loop restarts from
the top. That's the one point where swapping in new content is invisible
to whoever's watching the screen.

This PR:

- Adds a new `classlist_fragment` aux_call (mirrors the existing
  `classlist_public` aux_call, but gated by `@needs_onsite` instead of
  `@needs_student_in_grade` so it's usable from the kiosk session). It
  returns just the scrolling fragment (`allclass_fragment.html`), not the
  full page.
- In `classlist.html`, prefetches the next lap's fragment in the background
  during each scroll cycle, then swaps it into both `#scroller_top` and
  `#scroller_bottom` exactly at the `reset()` seam, before headers/times are
  re-scanned.
- Keeps the existing `location.reload()` path, but now purely as an
  infrequent fallback (e.g. to guard against long-running-session memory
  growth), not as the primary way data gets refreshed.

The swap works even if the list's length changes between fetches, since
`scroll()` already recomputes `#scroller_bottom`'s position from
`elt1.offsetHeight` on every tick — a longer or shorter fragment realigns
itself automatically instead of leaving a gap or overlap.

## Testing

Added two test classes to `test_onsiteclasslist.py`:

- `ClassListMidScrollRefreshTests` — checks the prefetch/swap JS is present,
  that the swap and prefetch happen before `reset()` re-scans
  `.category`/`.start_time` (ordering matters for fresh headers to be
  picked up), that `fragment_url` points at `/classlist_fragment` and not
  the full page, and that `classlist_fragment` returns fragment-only
  content (no `<head>`, no page JS).
- `ClassListFragmentAuthorizationTests` — mirrors the existing
  `OnsiteAuthorizationTests` pattern, confirming `classlist_fragment` is
  gated the same way the rest of the onsite module is (anonymous →
  redirected, student → denied, admin → 200).

Locally:
- `pytest esp/program/modules/handlers -v` → 65 passed
- `flake8 esp/esp/program/modules/handlers/onsiteclasslist.py esp/esp/program/modules/handlers/tests/test_onsiteclasslist.py` → clean

## Notes for reviewers

This follows up on feedback from a previous PR of mine, which correctly
addressed #318 but didn't fully resolve #116. Happy to adjust the fallback
reload interval or make it a configurable option (similar to the existing
`onsite_classlist_min_refresh` tag) if that's preferred over hardcoding it.