### PR TITLE
Make disable-account actions POST-only

### DIFF
--- a/esp/esp/users/tests.py
+++ b/esp/esp/users/tests.py
@@ -1471,8 +1471,30 @@ class DisableAccountPostOnlyTest(TestCase):
         self.client.login(username='disableme', password='password')
 
     def test_get_does_not_change_account_state(self):
+        # The legacy ?disable=1 GET branch must not disable an active account.
         response = self.client.get('/myesp/disableaccount/?disable=1')
         self.assertEqual(response.status_code, 200)
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.is_active)
+
+        # Properly disable via POST so the legacy ?enable=1 GET branch
+        # can be checked against a disabled account.
+        response = self.client.post('/myesp/disableaccount/', {'action': 'disable'})
+        self.assertEqual(response.status_code, 200)
+        self.user.refresh_from_db()
+        self.assertFalse(self.user.is_active)
+
+        # The legacy ?enable=1 GET branch must not re-enable a disabled account.
+        response = self.client.get('/myesp/disableaccount/?enable=1')
+        self.assertEqual(response.status_code, 200)
+        self.user.refresh_from_db()
+        self.assertFalse(self.user.is_active)
+
+    def test_post_without_csrf_token_is_rejected(self):
+        csrf_client = Client(enforce_csrf_checks=True)
+        self.assertTrue(csrf_client.login(username='disableme', password='password'))
+        response = csrf_client.post('/myesp/disableaccount/', {'action': 'disable'})
+        self.assertEqual(response.status_code, 403)
         self.user.refresh_from_db()
         self.assertTrue(self.user.is_active)
 

--- a/esp/esp/users/tests.py
+++ b/esp/esp/users/tests.py
@@ -1460,3 +1460,29 @@ class PasswordValidationTest(TestCase):
         # 'testpwuser1' is too similar to username 'testpwuser'.
         form = self._reg_form('testpwuser1')
         self.assertFalse(form.is_valid())
+
+
+class DisableAccountPostOnlyTest(TestCase):
+    def setUp(self):
+        user_role_setup()
+        self.user = ESPUser.objects.create(username='disableme', email='disableme@example.com')
+        self.user.set_password('password')
+        self.user.save()
+        self.client.login(username='disableme', password='password')
+
+    def test_get_does_not_change_account_state(self):
+        response = self.client.get('/myesp/disableaccount/?disable=1')
+        self.assertEqual(response.status_code, 200)
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.is_active)
+
+    def test_post_disable_and_enable(self):
+        response = self.client.post('/myesp/disableaccount/', {'action': 'disable'})
+        self.assertEqual(response.status_code, 200)
+        self.user.refresh_from_db()
+        self.assertFalse(self.user.is_active)
+
+        response = self.client.post('/myesp/disableaccount/', {'action': 'enable'})
+        self.assertEqual(response.status_code, 200)
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.is_active)

--- a/esp/esp/users/views/__init__.py
+++ b/esp/esp/users/views/__init__.py
@@ -195,12 +195,14 @@ def disable_account(request):
 
     curUser = request.user
 
-    if 'enable' in request.GET:
-        curUser.is_active = True
-        curUser.save()
-    elif 'disable' in request.GET:
-        curUser.is_active = False
-        curUser.save()
+    if request.method == 'POST':
+        action = request.POST.get('action')
+        if action == 'enable':
+            curUser.is_active = True
+            curUser.save()
+        elif action == 'disable':
+            curUser.is_active = False
+            curUser.save()
 
     other_users = ESPUser.objects.filter(email=curUser.email).exclude(id=curUser.id)
 

--- a/esp/templates/users/disable_account.html
+++ b/esp/templates/users/disable_account.html
@@ -34,7 +34,16 @@ There are multiple users associated with your email address. <b>If you disable y
     </li>
 {% endif %}
     <li><b>Current status: </b>{% if user.is_active %}<font color="#0000FF">Active</font>{% else %}<font color="#FF0000">Disabled</font>{% endif %} </li>
-    <li><b>Options: </b>{% if user.is_active %}<a href="?disable">Disable Account</a>{% else %}<a href="?enable">Enable Account</a>{% endif %}</li>
+    <li><b>Options: </b>
+        <form method="post" style="display:inline;">
+            {% csrf_token %}
+            {% if user.is_active %}
+            <button type="submit" name="action" value="disable">Disable Account</button>
+            {% else %}
+            <button type="submit" name="action" value="enable">Enable Account</button>
+            {% endif %}
+        </form>
+    </li>
 </ul>
 </p>
 


### PR DESCRIPTION
## Description

`disable_account()` mutated `is_active` from GET (`?enable` / `?disable`) via template links. GET now only renders the page. Enable/disable require a CSRF-protected POST with `action=enable` or `action=disable`.

## Related Issue

Closes #5125

## Type of Change

- [x] Bug fix
- [ ] New feature

## Testing

- [x] New tests added
- [ ] Existing tests pass (CI)

## AI Disclosure

AI-assisted.

## Checklist

- [x] Self-reviewed the code