### PR TITLE
Fix Formstack APIError string conversion on Python 3

### DIFF
--- a/esp/esp/formstack/api.py
+++ b/esp/esp/formstack/api.py
@@ -120,4 +120,5 @@ class Formstack(object):
 
 class APIError(Exception):
     def __str__(self):
-        return f'Formstack API error: {self.message}'
+        msg = self.args[0] if self.args else ''
+        return f'Formstack API error: {msg}'

--- a/esp/esp/formstack/tests.py
+++ b/esp/esp/formstack/tests.py
@@ -1,46 +1,11 @@
-"""
-Tests for esp.formstack.objects
-Source: esp/esp/formstack/objects.py
+from django.test import SimpleTestCase
 
-Tests FormstackForm and FormstackSubmission objects.
-"""
-from unittest.mock import MagicMock, patch
-
-from esp.formstack.objects import FormstackForm, FormstackSubmission
-from esp.tests.util import CacheFlushTestCase as TestCase
+from esp.formstack.api import APIError
 
 
-class FormstackFormTest(TestCase):
-    def test_init(self):
-        form = FormstackForm(12345)
-        self.assertEqual(form.id, 12345)
-        self.assertIsNone(form.name)
-        self.assertIsNone(form.formstack)
+class APIErrorTests(SimpleTestCase):
+    def test_str_includes_message(self):
+        self.assertEqual(str(APIError('Invalid API key')), 'Formstack API error: Invalid API key')
 
-    def test_init_with_formstack(self):
-        mock_fs = MagicMock()
-        form = FormstackForm(99, formstack=mock_fs)
-        self.assertEqual(form.formstack, mock_fs)
-
-    def test_str(self):
-        form = FormstackForm(42)
-        self.assertEqual(str(form), '42')
-
-    def test_repr(self):
-        form = FormstackForm(42)
-        self.assertEqual(repr(form), '<FormstackForm: 42>')
-
-
-class FormstackSubmissionTest(TestCase):
-    def test_init(self):
-        sub = FormstackSubmission(100)
-        self.assertEqual(sub.id, 100)
-        self.assertIsNone(sub.formstack)
-
-    def test_str(self):
-        sub = FormstackSubmission(200)
-        self.assertEqual(str(sub), '200')
-
-    def test_repr(self):
-        sub = FormstackSubmission(200)
-        self.assertEqual(repr(sub), '<FormstackSubmission: 200>')
+    def test_str_without_args(self):
+        self.assertEqual(str(APIError()), 'Formstack API error: ')

--- a/esp/esp/formstack/tests.py
+++ b/esp/esp/formstack/tests.py
@@ -1,6 +1,52 @@
+"""
+Tests for esp.formstack.objects
+Source: esp/esp/formstack/objects.py
+
+Tests FormstackForm and FormstackSubmission objects.
+"""
+from unittest.mock import MagicMock, patch
+
 from django.test import SimpleTestCase
 
 from esp.formstack.api import APIError
+from esp.formstack.objects import FormstackForm, FormstackSubmission
+from esp.tests.util import CacheFlushTestCase as TestCase
+
+
+class FormstackFormTest(TestCase):
+    def test_init(self):
+        form = FormstackForm(12345)
+        self.assertEqual(form.id, 12345)
+        self.assertIsNone(form.name)
+        self.assertIsNone(form.formstack)
+
+    def test_init_with_formstack(self):
+        mock_fs = MagicMock()
+        form = FormstackForm(99, formstack=mock_fs)
+        self.assertEqual(form.formstack, mock_fs)
+
+    def test_str(self):
+        form = FormstackForm(42)
+        self.assertEqual(str(form), '42')
+
+    def test_repr(self):
+        form = FormstackForm(42)
+        self.assertEqual(repr(form), '<FormstackForm: 42>')
+
+
+class FormstackSubmissionTest(TestCase):
+    def test_init(self):
+        sub = FormstackSubmission(100)
+        self.assertEqual(sub.id, 100)
+        self.assertIsNone(sub.formstack)
+
+    def test_str(self):
+        sub = FormstackSubmission(200)
+        self.assertEqual(str(sub), '200')
+
+    def test_repr(self):
+        sub = FormstackSubmission(200)
+        self.assertEqual(repr(sub), '<FormstackSubmission: 200>')
 
 
 class APIErrorTests(SimpleTestCase):


### PR DESCRIPTION
## Description

`APIError.__str__` used `self.message`, which does not exist on Python 3 `Exception`. Printing or logging the error raised `AttributeError` instead of the API message.

It now reads `self.args[0]`.

## Related Issue

Closes #4717

## Type of Change

- [x] Bug fix
- [ ] New feature

## Testing

- [x] New tests added
- [ ] Existing tests pass (CI)

## AI Disclosure

AI-assisted.

## Checklist

- [x] Self-reviewed the code