### PR TITLE
Validate Stripe payment POST fields before charging

### DIFF
--- a/esp/esp/program/modules/handlers/creditcardmodule_stripe.py
+++ b/esp/esp/program/modules/handlers/creditcardmodule_stripe.py
@@ -322,7 +322,7 @@ class CreditCardModule_Stripe(ProgramModuleObj):
             try:
                 amount_cents_post = Decimal(request.POST.get('totalcost_cents', ''))
             except (InvalidOperation, TypeError, ValueError):
-                context['error_type'] = 'invalid'
+                context['error_type'] = 'missing_fields'
                 context['error_info'] = {'missing': 'totalcost_cents'}
             else:
                 amount_cents_iac = Decimal(iac.amount_due()) * 100
@@ -335,7 +335,7 @@ class CreditCardModule_Stripe(ProgramModuleObj):
 
         stripe_token = request.POST.get('stripeToken')
         if 'error_type' not in context and not stripe_token:
-            context['error_type'] = 'invalid'
+            context['error_type'] = 'missing_fields'
             context['error_info'] = {'missing': 'stripeToken'}
 
         if 'error_type' not in context:

--- a/esp/esp/program/modules/handlers/creditcardmodule_stripe.py
+++ b/esp/esp/program/modules/handlers/creditcardmodule_stripe.py
@@ -46,7 +46,7 @@ from django.db.models.query import Q
 from django.contrib.sites.models import Site
 from django.template.loader import render_to_string
 
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 import stripe
 import json
 import re
@@ -319,14 +319,24 @@ class CreditCardModule_Stripe(ProgramModuleObj):
         if 'error_type' not in context:
             #   Check the amount in the POST against the amount in our records.
             #   If they don't match, raise an error.
-            amount_cents_post = Decimal(request.POST['totalcost_cents'])
-            amount_cents_iac = Decimal(iac.amount_due()) * 100
-            if amount_cents_post != amount_cents_iac:
-                context['error_type'] = 'inconsistent_amount'
-                context['error_info'] = {
-                    'amount_cents_post': amount_cents_post,
-                    'amount_cents_iac':  amount_cents_iac,
-                }
+            try:
+                amount_cents_post = Decimal(request.POST.get('totalcost_cents', ''))
+            except (InvalidOperation, TypeError, ValueError):
+                context['error_type'] = 'invalid'
+                context['error_info'] = {'missing': 'totalcost_cents'}
+            else:
+                amount_cents_iac = Decimal(iac.amount_due()) * 100
+                if amount_cents_post != amount_cents_iac:
+                    context['error_type'] = 'inconsistent_amount'
+                    context['error_info'] = {
+                        'amount_cents_post': amount_cents_post,
+                        'amount_cents_iac':  amount_cents_iac,
+                    }
+
+        stripe_token = request.POST.get('stripeToken')
+        if 'error_type' not in context and not stripe_token:
+            context['error_type'] = 'invalid'
+            context['error_info'] = {'missing': 'stripeToken'}
 
         if 'error_type' not in context:
             try:
@@ -340,7 +350,7 @@ class CreditCardModule_Stripe(ProgramModuleObj):
                     # Thus, we will never be in a state where the card has been
                     # charged without a record being created on the site, nor
                     # vice-versa.
-                    totalcost_dollars = Decimal(request.POST['totalcost_cents']) / 100
+                    totalcost_dollars = amount_cents_post / 100
 
                     #   Create a record of the transfer without the transaction ID.
                     transfer = iac.submit_payment(totalcost_dollars, 'TBD')
@@ -350,11 +360,11 @@ class CreditCardModule_Stripe(ProgramModuleObj):
                     charge = stripe.Charge.create(
                         amount=amount_cents_post,
                         currency="usd",
-                        source=request.POST['stripeToken'],
+                        source=stripe_token,
                         description=f"Payment for {group_name} {prog.niceName()} - {request.user.name()}",
                         statement_descriptor=group_name[0:22], #stripe limits statement descriptors to 22 characters
                         metadata={
-                            'ponumber': request.POST['ponumber'],
+                            'ponumber': request.POST.get('ponumber', ''),
                         },
                     )
 

--- a/esp/templates/program/modules/creditcardmodule_stripe/failure.html
+++ b/esp/templates/program/modules/creditcardmodule_stripe/failure.html
@@ -48,6 +48,10 @@
 <b>Invalid request.</b>  This is usually caused by a duplicate request (such as refreshing your web browser after paying).  It is possible that your payment went through successfully; <b>please return to the payment page to check</b>.
 {% endif %}
 
+{% if error_type == "missing_fields" %}
+<b>Incomplete request.</b>  Your payment submission was missing required information{% if error_info.missing %} (missing: <code>{{ error_info.missing }}</code>){% endif %}.  Your card was not charged.  Please return to the <a href="/learn/{{ program.getUrlBase }}/payonline">payment page</a> and try again.
+{% endif %}
+
 {% if error_type == "auth" %}
 <b>Authentication error.</b>  The site was unable to authenticate with the payment processor; please <a href="mailto:{{ settings.DEFAULT_EMAIL_ADDRESSES.support }}">let the administrators know</a> so they can correct the issue.
 {% endif %}


### PR DESCRIPTION
## Description

`charge_payment` read `stripeToken`, `totalcost_cents`, and `ponumber` from `request.POST[...]`. A missing Stripe token or amount raised `KeyError` / 500 instead of the existing payment error page.

Missing or invalid fields now set `error_type='invalid'` and render the failure template. Charge creation uses the validated values.

## Related Issue

Closes #5446

## Type of Change

- [x] Bug fix
- [ ] New feature

## Testing

- [ ] New tests added
- [ ] Existing tests pass (CI)

## AI Disclosure

AI-assisted.

## Checklist

- [x] Self-reviewed the code