### PR TITLE
Add default seq ordering for custom form models

### DIFF
--- a/esp/esp/customforms/models.py
+++ b/esp/esp/customforms/models.py
@@ -64,11 +64,11 @@ class Field(models.Model):
     help_text = models.TextField(blank=True)
     required = models.BooleanField(default=False)
 
-    def __str__(self):
-        return f'{self.label}'
-
     class Meta:
         ordering = ['seq']
+
+    def __str__(self):
+        return f'{self.label}'
 
     def set_attribute(self, atype, value):
         from esp.customforms.models import Attribute

--- a/esp/esp/customforms/models.py
+++ b/esp/esp/customforms/models.py
@@ -37,6 +37,9 @@ class Page(models.Model):
     form = models.ForeignKey(Form, on_delete=models.CASCADE)
     seq = models.IntegerField(default=-1)
 
+    class Meta:
+        ordering = ['seq']
+
     def __str__(self):
         return f'Page {self.seq} of {self.form.title}'
 
@@ -45,6 +48,9 @@ class Section(models.Model):
     title = models.CharField(max_length=40)
     description = models.CharField(max_length=140, blank=True)
     seq = models.IntegerField()
+
+    class Meta:
+        ordering = ['seq']
 
     def __str__(self):
         return f'Sec. {self.seq}: {self.title}'
@@ -60,6 +66,9 @@ class Field(models.Model):
 
     def __str__(self):
         return f'{self.label}'
+
+    class Meta:
+        ordering = ['seq']
 
     def set_attribute(self, atype, value):
         from esp.customforms.models import Attribute

--- a/esp/esp/customforms/tests.py
+++ b/esp/esp/customforms/tests.py
@@ -858,3 +858,10 @@ class FormOwnershipAccessTest(TestCase):
             {'form_id': 999999, 'question_name': self.question_name},
         )
         self.assertEqual(response.status_code, 404)
+
+
+class CustomFormModelOrderingTest(TestCase):
+    def test_page_section_field_default_order_is_seq(self):
+        self.assertEqual(Page._meta.ordering, ['seq'])
+        self.assertEqual(Section._meta.ordering, ['seq'])
+        self.assertEqual(Field._meta.ordering, ['seq'])


### PR DESCRIPTION
## Description

`Page`, `Section`, and `Field` store order in `seq` but had no model `Meta.ordering`, so querysets could come back in nondeterministic order.

Each model now has `ordering = ['seq']`.

## Related Issue

Closes #5190

## Type of Change

- [x] Bug fix
- [ ] New feature

## Testing

- [x] New tests added
- [ ] Existing tests pass (CI)

## AI Disclosure

AI-assisted.

## Checklist

- [x] Self-reviewed the code