### PR TITLE
Bulk fix caching dependencies

### DIFF
--- a/docs/dev/cache.rst
+++ b/docs/dev/cache.rst
@@ -198,6 +198,144 @@ although in this case the correct response is to do nothing.)
                                             'self': resource.user})
 
 
+Writing cache dependencies
+--------------------------
+
+Getting the dependencies right is the hard part of using ``@cache_function``.
+Too few dependencies and the site serves stale data, too many and the cache
+is thrown away so often it stops helping.
+
+A checklist
+~~~~~~~~~~~
+
+#. List every model, field, and relation the function body reads. This includes
+   anything reached through a property or a helper it calls.
+#. Declare a dependency for each one.
+#. Choose a key set: which of the function's *arguments* does this change
+   affect?
+#. If the key set names only some of the arguments, add a matching token.
+#. Ideally, write a test that asserts invalidation happens, *and* one that
+   asserts an unrelated key survives.
+
+A key set without a token does nothing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This is the trap that catches people most often. Writing a scoped key set is
+not enough::
+
+    # getFullClasses_pretty(self, program) -- two arguments
+    getFullClasses_pretty.depend_on_row('program.ClassSubject',
+                                        lambda cls: {'program': cls.parent_program})
+
+The key set names ``program`` but not ``self``, so it identifies a *set* of
+cache entries rather than one entry. argcache needs a ``Token`` to delete a set
+like that. Without one it falls back to the token every cache has (the one
+that deletes everything) and the key set has no effect at all.
+
+Declare the token explicitly::
+
+    getFullClasses_pretty.get_or_create_token(('program',))
+
+The exception is a key set that names *every* argument. That identifies exactly
+one entry, so argcache deletes it directly and no token is needed. This is why
+``timeslots(prog)`` works with just ``{'prog': ...}`` and no token, while
+``ajax_lunch_timeslots_cached(self, prog)`` needs a ``('prog',)`` token.
+
+Each key set needs its own token
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Tokens cover key sets, not functions. A cache with one dependency keyed on
+``{'self': ...}`` and another keyed on ``{'program': ...}`` needs *two* tokens.
+A single ``('self', 'program')`` token covers neither, because it describes key
+sets that specify both at once.
+
+``depend_on_model`` dumps the whole cache
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``depend_on_model(Model)`` with no key set discards every entry in the cache
+whenever any row of that model changes. That is sometimes correct: global
+configuration models such as ``ProgramModule``, ``RegistrationType`` and
+``ClassFlagType`` have no per-program rows, so any change really can affect
+every program.
+
+It is wrong when the model *does* map to something the cache is keyed on. Use
+``depend_on_row`` with a selector instead::
+
+    getTimeSlotList.depend_on_row('cal.Event',
+                                  lambda e: {'self': e.program} if e.program_id else {})
+
+Note that one wildcard dependency undoes the scoping of every other dependency
+on the same cache. A cache is only as narrowly invalidated as its loosest
+dependency.
+
+Many-to-many changes do not trigger depend_on_row/depend_on_model
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If the cached value depends on a many-to-many relation, you need ``depend_on_m2m``::
+
+    catalog_cached.depend_on_m2m('program.ClassSubject', 'teachers',
+                                 lambda subj, teacher: {'program': subj.parent_program})
+
+This is easy to miss because the relation is often read indirectly. The catalog
+orders classes by their sections' meeting times, so rescheduling a class would otherwise change
+the catalog without invalidating it's cache.
+
+Selectors must not raise
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+argcache does not guard against exceptions in selectors. Where a selector
+traverses relations that might be missing, catch broadly and return ``{}``:
+over-invalidating costs a rebuild, under-invalidating serves wrong data.
+
+Nullable foreign keys need a fallback
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``Event.program`` and ``ResourceType.program`` are nullable. Returning
+``{'prog': None}`` produces a key that matches nothing, so the real entries are
+never invalidated. Fall back to ``{}`` instead::
+
+    lambda e: {'prog': e.program} if e.program_id else {}
+
+Prefer depend_on_cache over repeating yourself
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If your function calls another cached function, depend on that cache rather than
+re-declaring its dependencies. The coverage is transitive and stays correct when
+the inner function changes. ``jsondatamodule.sections`` does this for
+``get_teachers``, ``friendly_times`` and ``_get_capacity``.
+
+Time-based caches need no dependencies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``@cache_function_for(seconds)`` expires on a timer and ignores dependencies
+entirely. Bounded staleness is the design, so do not add dependencies to one.
+
+Testing invalidation
+~~~~~~~~~~~~~~~~~~~~
+
+Cached functions accept ``cache_only=True``, which returns ``None`` on a miss.
+That is the hook for asserting on cache state directly, rather than trying to
+construct a value that visibly changes::
+
+    program.getTimeSlotList()                                    # warm
+    assert program.getTimeSlotList(cache_only=True) is not None
+    Event.objects.create(program=program, ...)
+    assert program.getTimeSlotList(cache_only=True) is None      # invalidated
+
+Always assert both directions. A test that only checks "the cache was cleared"
+passes just as well against a wildcard dependency, so it cannot tell you whether
+your scoping works. Warm two programs, write to one, and assert the other
+survives. Then confirm the test actually fails without your change -- a
+dependency test that passes either way is telling you nothing.
+
+For views decorated with ``@cached_module_view`` the cache object hangs off the
+wrapper, but the attribute path depends on the other decorators: some are
+reached as ``view.cached_function``, others as ``view.method.cached_function``.
+Follow whatever the function's own dependency declarations use.
+
+See ``esp/esp/program/tests_cache_scoping.py`` and
+``esp/esp/program/tests_m2m_cache_deps.py`` for worked examples.
+
 The Memcached Backend
 ---------------------
 

--- a/docs/dev/cache.rst
+++ b/docs/dev/cache.rst
@@ -278,7 +278,7 @@ If the cached value depends on a many-to-many relation, you need ``depend_on_m2m
 
 This is easy to miss because the relation is often read indirectly. The catalog
 orders classes by their sections' meeting times, so rescheduling a class would otherwise change
-the catalog without invalidating it's cache.
+the catalog without invalidating its cache.
 
 Selectors must not raise
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/esp/esp/customforms/DynamicForm.py
+++ b/esp/esp/customforms/DynamicForm.py
@@ -490,6 +490,7 @@ class FormHandler:
             else:
                 field_dict[field['id']]['attributes'].update({field['attribute__attr_type']: field['attribute__value']})
         return master_struct
+    _getFormMetadata.get_or_create_token(('form',))
     _getFormMetadata.depend_on_row('customforms.Field', lambda field: {'form': field.form})
     _getFormMetadata.depend_on_row('customforms.Attribute', lambda attr: {'form': attr.field.form})
     _getFormMetadata.depend_on_row('customforms.Section', lambda section: {'form': section.page.form})

--- a/esp/esp/customforms/DynamicModel.py
+++ b/esp/esp/customforms/DynamicModel.py
@@ -108,6 +108,7 @@ class DynamicModelHandler:
         """
         self.fields = Field.objects.filter(form=form).values_list('id', 'field_type')
         return self.fields
+    _getFieldsForForm.get_or_create_token(('form',))
     _getFieldsForForm.depend_on_row('customforms.Field', lambda field: {'form': field.form})
 
     def _getModelField(self, field_type):

--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -995,7 +995,8 @@ class Program(models.Model, CustomFormsLinkModel):
             return list(self.getTimeSlots(exclude_types=[]))
         else:
             return list(self.getTimeSlots())
-    getTimeSlotList.depend_on_model('cal.Event')
+    getTimeSlotList.get_or_create_token(('self',))
+    getTimeSlotList.depend_on_row('cal.Event', lambda e: {'self': e.program} if e.program_id else {})
 
     def total_duration(self):
         """ Returns the total length of the events in this program, as a timedelta object. """
@@ -1131,7 +1132,9 @@ class Program(models.Model, CustomFormsLinkModel):
             Q_filters = Q(program=self)
 
         return ResourceType.objects.filter(Q_filters).exclude(id__in=[t.id for t in exclude_types]).order_by('priority_default')
-    getResourceTypes.depend_on_model('resources.ResourceType')
+    getResourceTypes.get_or_create_token(('self',))
+    getResourceTypes.depend_on_row('resources.ResourceType',
+                                   lambda rt: {'self': rt.program} if rt.program_id else {})
     getResourceTypes.depend_on_model('tagdict.Tag')
 
     def getResources(self):

--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -1271,6 +1271,7 @@ class Program(models.Model, CustomFormsLinkModel):
 
         modules.sort(key=lambda m: m.seq)
         return modules
+    getModules_cached.get_or_create_token(('self',))
     getModules_cached.depend_on_row('program.Program', lambda prog: {'self': prog})
     getModules_cached.depend_on_model('program.ProgramModule')
     getModules_cached.depend_on_m2m('program.Program', 'program_modules', lambda program, module: {'self': program})
@@ -1297,6 +1298,7 @@ class Program(models.Model, CustomFormsLinkModel):
     def hasModule(self, name):
         """ Tests whether a program has the given module enabled, cachedly. name should be a module name, like 'AvailabilityModule'. """
         return self.program_modules.filter(handler=name).exists()
+    hasModule.get_or_create_token(('self',))
     hasModule.depend_on_row('program.Program', lambda prog: {'self': prog})
     hasModule.depend_on_model('program.ProgramModule')
     hasModule.depend_on_row('modules.ProgramModuleObj', lambda module: {'self': module.program})
@@ -1473,6 +1475,7 @@ class Program(models.Model, CustomFormsLinkModel):
     def by_prog_inst(cls, program, instance):
         prog_inst = Program.objects.select_related().get(url=f'{program}/{instance}')
         return prog_inst
+    by_prog_inst.get_or_create_token(('program',))
     by_prog_inst.depend_on_row('program.Program', lambda prog: {'program': prog})
     by_prog_inst = classmethod(by_prog_inst)
 
@@ -1702,6 +1705,7 @@ class RegistrationProfile(models.Model):
     # We can fall back to the user's latest profile from another program when a
     # program-specific profile does not exist, so cache invalidation must depend
     # on any profile for the user (not just the exact (user, program) pair).
+    getLastForProgram.get_or_create_token(('user',))
     getLastForProgram.depend_on_row('program.RegistrationProfile', lambda rp: {'user': rp.user})
     getLastForProgram.depend_on_row('users.StudentInfo', lambda si: {'user': si.user})
     getLastForProgram = staticmethod(getLastForProgram)

--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -1273,6 +1273,7 @@ class Program(models.Model, CustomFormsLinkModel):
         return modules
     getModules_cached.depend_on_row('program.Program', lambda prog: {'self': prog})
     getModules_cached.depend_on_model('program.ProgramModule')
+    getModules_cached.depend_on_m2m('program.Program', 'program_modules', lambda program, module: {'self': program})
     getModules_cached.depend_on_row('modules.ProgramModuleObj', lambda mod: {'self': mod.program})
     # I've only included the module extensions we still seem to use.
     # Feel free to adjust. -ageng 2010-10-23

--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -1478,8 +1478,7 @@ class Program(models.Model, CustomFormsLinkModel):
     def by_prog_inst(cls, program, instance):
         prog_inst = Program.objects.select_related().get(url=f'{program}/{instance}')
         return prog_inst
-    by_prog_inst.get_or_create_token(('program',))
-    by_prog_inst.depend_on_row('program.Program', lambda prog: {'program': prog})
+    by_prog_inst.depend_on_row('program.Program', lambda prog: {})
     by_prog_inst = classmethod(by_prog_inst)
 
     def _sibling_discount_get(self):

--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -1419,6 +1419,10 @@ class Program(models.Model, CustomFormsLinkModel):
     #   Update cache whenever a class is approved, a student is marked as attending, a teacher or student changes their profile, or a volunteer offer is changed
     getShirtInfo.depend_on_row('program.ClassSubject', lambda cls: {'self': cls.parent_program})
     getShirtInfo.depend_on_row('users.Record', lambda record: {'self': record.program}, lambda record: record.event and record.event.name == 'attended')
+    getShirtInfo.depend_on_m2m('program.ClassSubject', 'teachers',
+                               lambda cls, teacher: {'self': cls.parent_program})
+    getShirtInfo.depend_on_row('program.ClassSection',
+                               lambda sec: {'self': sec.parent_class.parent_program})
     getShirtInfo.depend_on_model('users.TeacherInfo')
     getShirtInfo.depend_on_model('users.StudentInfo')
     getShirtInfo.depend_on_model('program.VolunteerOffer')

--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -1638,7 +1638,8 @@ class ClassSubject(models.Model, CustomFormsLinkModel):
         return result
     get_section.get_or_create_token(('self',))
     get_section.depend_on_row('program.ClassSection', lambda cs: {'self': cs.parent_class})
-    get_section.depend_on_m2m('program.ClassSection', 'meeting_times', lambda cs, ev: {'self': cs})
+    get_section.depend_on_m2m('program.ClassSection', 'meeting_times',
+                              lambda cs, ev: {'self': cs.parent_class})
 
     def default_section(self, create=True):
         """ Return the first section that was created for this class. """

--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -648,6 +648,7 @@ class ClassSection(models.Model):
             return False
         else:
             return True
+    sufficient_length.get_or_create_token(('self',))
     sufficient_length.depend_on_m2m('program.ClassSection', 'meeting_times', lambda sec, event: {'self': sec})
 
 
@@ -1061,6 +1062,7 @@ class ClassSection(models.Model):
         if verbs == ['Enrolled']:
             return self.enrolled_students
         return self.students(verbs).count()
+    num_students.get_or_create_token(('self',))
     num_students.depend_on_row('program.StudentRegistration', lambda reg: {'self': reg.section})
 
     @cache_function
@@ -1334,6 +1336,7 @@ class ClassSection(models.Model):
                         in Event.collapse(events, tol=datetime.timedelta(minutes=15))]
 
         return txtTimes
+    friendly_times.get_or_create_token(('self',))
     friendly_times.depend_on_m2m('program.ClassSection', 'meeting_times', lambda cs, ev: {'self': cs})
 
     def friendly_times_with_date(self, raw=False):
@@ -1633,6 +1636,7 @@ class ClassSubject(models.Model, CustomFormsLinkModel):
             result = self.default_section()
 
         return result
+    get_section.get_or_create_token(('self',))
     get_section.depend_on_row('program.ClassSection', lambda cs: {'self': cs.parent_class})
     get_section.depend_on_m2m('program.ClassSection', 'meeting_times', lambda cs, ev: {'self': cs})
 

--- a/esp/esp/program/models/class_.py
+++ b/esp/esp/program/models/class_.py
@@ -507,6 +507,8 @@ class ClassSection(models.Model):
     _get_capacity.depend_on_row('resources.ResourceRequest', lambda r: {'self': r.target})
     _get_capacity.depend_on_row('resources.ResourceAssignment', lambda r: {'self': r.target})
     _get_capacity.depend_on_model('modules.StudentClassRegModuleInfo')
+    _get_capacity.depend_on_m2m('program.ClassSubject', 'allowable_class_size_ranges',
+                                lambda subj, csr: {})
 
 
     capacity = property(_get_capacity)

--- a/esp/esp/program/models/flags.py
+++ b/esp/esp/program/models/flags.py
@@ -81,6 +81,7 @@ class ClassFlagType(models.Model):
         if teacher:
             base = base.filter(show_to_teacher=True)
         return base
+    get_flag_types.get_or_create_token(('program',))
     get_flag_types.depend_on_model('program.ClassFlagType')
     get_flag_types.depend_on_m2m('program.Program', 'flag_types', lambda prog, flag_type: {'program': prog})
     get_flag_types = classmethod(get_flag_types)

--- a/esp/esp/program/modules/handlers/ajaxschedulingmodule.py
+++ b/esp/esp/program/modules/handlers/ajaxschedulingmodule.py
@@ -371,9 +371,12 @@ class AJAXSchedulingModule(ProgramModuleObj):
         response = HttpResponse(content_type="application/json")
         json.dump(data, response)
         return response
-    ajax_lunch_timeslots_cached.depend_on_model('cal.Event')
-    ajax_lunch_timeslots_cached.depend_on_model('program.ClassSection')
-    ajax_lunch_timeslots_cached.depend_on_model('program.ClassSubject')
+    ajax_lunch_timeslots_cached.depend_on_row('cal.Event',
+                                              lambda e: {'prog': e.program} if e.program_id else {})
+    ajax_lunch_timeslots_cached.depend_on_row('program.ClassSection',
+                                              lambda sec: {'prog': sec.parent_class.parent_program})
+    ajax_lunch_timeslots_cached.depend_on_row('program.ClassSubject',
+                                              lambda cls: {'prog': cls.parent_program})
     ajax_lunch_timeslots_cached.depend_on_model('program.ClassCategories')
     ajax_lunch_timeslots_cached.depend_on_m2m('program.ClassSection', 'meeting_times', lambda sec, event: {'prog': sec.parent_class.parent_program})
 

--- a/esp/esp/program/modules/handlers/ajaxschedulingmodule.py
+++ b/esp/esp/program/modules/handlers/ajaxschedulingmodule.py
@@ -371,6 +371,7 @@ class AJAXSchedulingModule(ProgramModuleObj):
         response = HttpResponse(content_type="application/json")
         json.dump(data, response)
         return response
+    ajax_lunch_timeslots_cached.get_or_create_token(('prog',))
     ajax_lunch_timeslots_cached.depend_on_row('cal.Event',
                                               lambda e: {'prog': e.program} if e.program_id else {})
     ajax_lunch_timeslots_cached.depend_on_row('program.ClassSection',

--- a/esp/esp/program/modules/handlers/bigboardmodule.py
+++ b/esp/esp/program/modules/handlers/bigboardmodule.py
@@ -268,6 +268,8 @@ class BigBoardModule(ProgramModuleObj):
     popular_classes.depend_on_row(StudentRegistration, lambda sr: {'prog': sr.section.parent_class.parent_program},
                                                        filter = lambda sr: (sr.relationship.name.startswith("Priority") or sr.relationship.name == "Enrolled"))
     popular_classes.depend_on_row(StudentSubjectInterest, lambda ssi: {'prog': ssi.subject.parent_program})
+    popular_classes.depend_on_m2m(ClassSection, 'meeting_times',
+                                  lambda sec, event: {'prog': sec.parent_class.parent_program})
 
     @cache_function_for(105)
     def times_medical(self, prog):

--- a/esp/esp/program/modules/handlers/bigboardmodule.py
+++ b/esp/esp/program/modules/handlers/bigboardmodule.py
@@ -265,6 +265,7 @@ class BigBoardModule(ProgramModuleObj):
                     series.append(sec_dict)
                 popular_classes.append((description, series))
         return popular_classes
+    popular_classes.get_or_create_token(('prog',))
     popular_classes.depend_on_row(StudentRegistration, lambda sr: {'prog': sr.section.parent_class.parent_program},
                                                        filter = lambda sr: (sr.relationship.name.startswith("Priority") or sr.relationship.name == "Enrolled"))
     popular_classes.depend_on_row(StudentSubjectInterest, lambda ssi: {'prog': ssi.subject.parent_program})

--- a/esp/esp/program/modules/handlers/jsondatamodule.py
+++ b/esp/esp/program/modules/handlers/jsondatamodule.py
@@ -368,7 +368,8 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
     sections.cached_function.depend_on_row(ClassSection, lambda sec: {'prog': sec.parent_class.parent_program})
     sections.cached_function.depend_on_m2m(ClassSection, 'moderators', lambda sec, moderator: {'prog': sec.parent_class.parent_program})
     sections.cached_function.depend_on_row(ClassSubject, lambda subj: {'prog': subj.parent_program})
-    sections.cached_function.depend_on_model(UserAvailability)
+    sections.cached_function.depend_on_row(UserAvailability,
+        lambda ua: {'prog': ua.event.program} if ua.event.program_id else {})
     # Put this import here rather than at the toplevel, because wildcard messes things up
     from argcache.key_set import wildcard
     sections.cached_function.depend_on_cache(ClassSubject.get_teachers, lambda self=wildcard, **kwargs: {'prog': self.parent_program})
@@ -445,8 +446,12 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
 
         return {'sections': sections, 'teachers': teachers}
     sections_admin.method.cached_function.depend_on_cache(sections.cached_function, lambda extra=wildcard, prog=wildcard, **kwargs: {'prog': prog, 'extra': extra})
-    sections_admin.method.cached_function.depend_on_model(ResourceRequest)
-    sections_admin.method.cached_function.depend_on_model(ClassFlag)
+    sections_admin.method.cached_function.get_or_create_token(('prog',))
+    sections_admin.method.cached_function.depend_on_row(ResourceRequest,
+        lambda rr: {'prog': rr.target.parent_class.parent_program} if rr.target_id
+              else {'prog': rr.target_subj.parent_program} if rr.target_subj_id else {})
+    sections_admin.method.cached_function.depend_on_row(ClassFlag,
+        lambda cf: {'prog': cf.subject.parent_program})
 
     @aux_call
     @json_response({
@@ -482,7 +487,8 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
 
         return {'timeslot_sections': section_ids,
                 'timeslot_subjects': subject_ids}
-    classes_timeslot.cached_function.depend_on_model(Event)
+    classes_timeslot.cached_function.get_or_create_token(('prog',))
+    classes_timeslot.cached_function.depend_on_row(Event, lambda e: {'prog': e.program} if e.program_id else {})
     classes_timeslot.cached_function.depend_on_m2m(ClassSection, 'meeting_times', lambda sec, event: {'prog': sec.parent_class.parent_program, 'extra': str(event.id)})
 
     @aux_call
@@ -690,8 +696,10 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
         }
 
         return {return_key: [return_dict]}
-    class_info.cached_function.depend_on_model(ClassSubject)
-    class_info.cached_function.depend_on_model(ClassSection)
+    class_info.cached_function.get_or_create_token(('prog',))
+    class_info.cached_function.depend_on_row(ClassSubject, lambda cls: {'prog': cls.parent_program})
+    class_info.cached_function.depend_on_row(ClassSection,
+        lambda sec: {'prog': sec.parent_class.parent_program})
 
     @aux_call
     @no_auth

--- a/esp/esp/program/modules/handlers/jsondatamodule.py
+++ b/esp/esp/program/modules/handlers/jsondatamodule.py
@@ -200,7 +200,8 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
                                                     lambda rec: {'prog': rec.program})
     moderators.method.cached_function.depend_on_m2m(ModeratorRecord, 'class_categories',
                                                     lambda rec, cat: {'prog': rec.program})
-    moderators.method.cached_function.depend_on_model(UserAvailability)
+    moderators.method.cached_function.depend_on_row(UserAvailability,
+        lambda ua: {'prog': ua.event.program} if ua.event.program_id else {})
 
     @aux_call
     @json_response()

--- a/esp/esp/program/modules/handlers/jsondatamodule.py
+++ b/esp/esp/program/modules/handlers/jsondatamodule.py
@@ -282,7 +282,7 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
             timeslots[i]['end'] = timeslots[i]['end'].timetuple()[:6]
 
         return {'timeslots': timeslots}
-    timeslots.cached_function.depend_on_model(Event)
+    timeslots.cached_function.depend_on_row(Event, lambda e: {'prog': e.program} if e.program_id else {})
     timeslots.cached_function.depend_on_m2m(ClassSection, 'meeting_times', lambda sec, event: {'prog': sec.parent_class.parent_program})
 
     @aux_call
@@ -878,6 +878,8 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
         return moderator_list
     mod_nums.depend_on_row(ModeratorRecord, lambda mr: {'prog': mr.program})
     mod_nums.depend_on_m2m(ClassSection, 'moderators', lambda sec, moderator: {'prog': sec.parent_class.parent_program})
+    mod_nums.depend_on_m2m(ClassSection, 'meeting_times',
+                           lambda sec, event: {'prog': sec.parent_class.parent_program})
     mod_nums.depend_on_model(Tag)
     mod_nums = staticmethod(mod_nums)
 

--- a/esp/esp/program/modules/handlers/jsondatamodule.py
+++ b/esp/esp/program/modules/handlers/jsondatamodule.py
@@ -196,7 +196,10 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
             m['availability'] = avail_lookup.get(m['id'], [])
         return {'moderators': moderator_list}
     moderators.method.cached_function.depend_on_m2m(ClassSection, 'moderators', lambda sec, moderator: {'prog': sec.parent_class.parent_program})
-    moderators.method.cached_function.depend_on_model(ModeratorRecord)
+    moderators.method.cached_function.depend_on_row(ModeratorRecord,
+                                                    lambda rec: {'prog': rec.program})
+    moderators.method.cached_function.depend_on_m2m(ModeratorRecord, 'class_categories',
+                                                    lambda rec, cat: {'prog': rec.program})
     moderators.method.cached_function.depend_on_model(UserAvailability)
 
     @aux_call

--- a/esp/esp/program/modules/handlers/jsondatamodule.py
+++ b/esp/esp/program/modules/handlers/jsondatamodule.py
@@ -562,6 +562,7 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
             teacher['availability'] = avail_lookup.get(teacher['id'], [])
 
         return {'classes': classes, 'teachers': teachers, 'moderators': moderators}
+    class_subjects.cached_function.get_or_create_token(('prog',))
     class_subjects.cached_function.depend_on_row(ClassSubject, lambda cls: {'prog': cls.parent_program})
     class_subjects.cached_function.depend_on_cache(ClassSubject.get_teachers, lambda cls=wildcard, **kwargs: {'prog': cls.parent_program})
     class_subjects.cached_function.depend_on_model('tagdict.Tag')

--- a/esp/esp/program/modules/handlers/jsondatamodule.py
+++ b/esp/esp/program/modules/handlers/jsondatamodule.py
@@ -364,6 +364,7 @@ class JSONDataModule(ProgramModuleObj, CoreModule):
             teacher['availability'] = avail_lookup.get(teacher['id'], [])
 
         return {'sections': sections, 'teachers': teachers}
+    sections.cached_function.get_or_create_token(('prog',))
     sections.cached_function.depend_on_row(ClassSection, lambda sec: {'prog': sec.parent_class.parent_program})
     sections.cached_function.depend_on_m2m(ClassSection, 'moderators', lambda sec, moderator: {'prog': sec.parent_class.parent_program})
     sections.cached_function.depend_on_row(ClassSubject, lambda subj: {'prog': subj.parent_program})

--- a/esp/esp/program/modules/handlers/studentregcore.py
+++ b/esp/esp/program/modules/handlers/studentregcore.py
@@ -82,6 +82,7 @@ class StudentRegCore(ProgramModuleObj, CoreModule):
         """ Whether the user has paid for this program.  """
         iac = IndividualAccountingController(self.program, user)
         return (iac.has_paid())
+    have_paid.get_or_create_token(('user',))
     have_paid.depend_on_row('accounting.Transfer', lambda transfer: {'user': transfer.user})
     have_paid.depend_on_row('program.SplashInfo', lambda splashinfo: {'user': splashinfo.student})
     have_paid.depend_on_row('accounting.FinancialAidGrant', lambda grant: {'user': grant.request.user})

--- a/esp/esp/program/tests_cache_scoping.py
+++ b/esp/esp/program/tests_cache_scoping.py
@@ -235,3 +235,56 @@ class FullClassesEnrolmentDepTest(TwoProgramCacheTest):
 
         self.assertIsNone(self.cached(self.program),
                           "a capacity change must invalidate the entry")
+
+
+class TagCacheScopeTest(ProgramFrameworkTest):
+    """_getTag(cls, key, default, target) is keyed by (key, target) but had no
+    matching token, so any tag write dumped every cached tag lookup."""
+
+    def setUp(self):
+        super().setUp(num_students=0, num_teachers=0, classes_per_teacher=0)
+        from esp.tagdict.models import Tag
+        self.Tag = Tag
+        Tag.setTag('cache_scope_a', value='1')
+        Tag.setTag('cache_scope_b', value='1')
+
+    def cached(self, key):
+        return self.Tag._getTag(key, cache_only=True)
+
+    def test_writing_one_tag_spares_other_tags(self):
+        self.Tag._getTag('cache_scope_a')
+        self.Tag._getTag('cache_scope_b')
+        self.assertIsNotNone(self.cached('cache_scope_a'))
+        self.assertIsNotNone(self.cached('cache_scope_b'))
+
+        self.Tag.setTag('cache_scope_a', value='2')
+
+        self.assertIsNone(self.cached('cache_scope_a'),
+                          "the written tag should be invalidated")
+        self.assertIsNotNone(self.cached('cache_scope_b'),
+                             "an unrelated tag's lookup should survive")
+
+
+class NumStudentsCacheScopeTest(ProgramFrameworkTest):
+    """num_students(self, verbs) is keyed by section; without a token any
+    registration dumped the count for every section."""
+
+    def setUp(self):
+        super().setUp(num_students=1, num_teachers=2, classes_per_teacher=1,
+                      sections_per_class=1)
+        secs = [c.sections.first() for c in
+                ClassSubject.objects.filter(parent_program=self.program)]
+        self.sec_a, self.sec_b = secs[0], secs[1]
+
+    def test_enrolling_in_one_section_spares_the_other(self):
+        self.sec_a.num_students()
+        self.sec_b.num_students()
+        self.assertIsNotNone(self.sec_a.num_students(cache_only=True))
+        self.assertIsNotNone(self.sec_b.num_students(cache_only=True))
+
+        self.sec_a.preregister_student(self.students[0], overridefull=True)
+
+        self.assertIsNone(self.sec_a.num_students(cache_only=True),
+                          "the enrolled section's count should be invalidated")
+        self.assertIsNotNone(self.sec_b.num_students(cache_only=True),
+                             "an unrelated section's count should survive")

--- a/esp/esp/program/tests_cache_scoping.py
+++ b/esp/esp/program/tests_cache_scoping.py
@@ -288,3 +288,68 @@ class NumStudentsCacheScopeTest(ProgramFrameworkTest):
                           "the enrolled section's count should be invalidated")
         self.assertIsNotNone(self.sec_b.num_students(cache_only=True),
                              "an unrelated section's count should survive")
+
+
+class WildcardScopingTest(TwoProgramCacheTest):
+    """Caches whose depend_on_model wildcards were narrowed to the program that
+    actually changed.  Each model reached here has a real path to a Program."""
+
+    def test_getTimeSlotList_scoped_by_program(self):
+        self.program.getTimeSlotList()
+        self.program_b.getTimeSlotList()
+        self.assertIsNotNone(self.program.getTimeSlotList(cache_only=True))
+        self.assertIsNotNone(self.program_b.getTimeSlotList(cache_only=True))
+
+        Event.objects.create(
+            program=self.program, event_type=self.event_type,
+            start=datetime(2222, 7, 12, 9, 0), end=datetime(2222, 7, 12, 10, 0),
+            name='A slot', short_description='a', description='slot in A')
+
+        self.assertIsNone(self.program.getTimeSlotList(cache_only=True))
+        self.assertIsNotNone(self.program_b.getTimeSlotList(cache_only=True),
+                             "program B's timeslot list should survive")
+
+    def test_getTimeSlotList_global_event_still_dumps_everything(self):
+        """Event.program is nullable; a global event must invalidate broadly."""
+        self.program.getTimeSlotList()
+        self.program_b.getTimeSlotList()
+
+        Event.objects.create(
+            program=None, event_type=self.event_type,
+            start=datetime(2222, 7, 13, 9, 0), end=datetime(2222, 7, 13, 10, 0),
+            name='global', short_description='g', description='global event')
+
+        self.assertIsNone(self.program.getTimeSlotList(cache_only=True))
+        self.assertIsNone(self.program_b.getTimeSlotList(cache_only=True))
+
+    def test_getResourceTypes_scoped_by_program(self):
+        from esp.resources.models import ResourceType
+        self.program.getResourceTypes()
+        self.program_b.getResourceTypes()
+        self.assertIsNotNone(self.program.getResourceTypes(cache_only=True))
+        self.assertIsNotNone(self.program_b.getResourceTypes(cache_only=True))
+
+        ResourceType.objects.create(name='Projector A', program=self.program)
+
+        self.assertIsNone(self.program.getResourceTypes(cache_only=True))
+        self.assertIsNotNone(self.program_b.getResourceTypes(cache_only=True),
+                             "program B's resource types should survive")
+
+    def test_classes_timeslot_scoped_by_program(self):
+        from esp.program.modules.handlers.jsondatamodule import JSONDataModule
+        cf = JSONDataModule.classes_timeslot.cached_function
+        #   `extra` is a timeslot id, so each program is keyed on its own slot.
+        ts_a = str(self.timeslots[0].id)
+        ts_b = str(self.program_b.getTimeSlots()[0].id)
+        cf(ts_a, self.program); cf(ts_b, self.program_b)
+        self.assertIsNotNone(cf(ts_a, self.program, cache_only=True))
+        self.assertIsNotNone(cf(ts_b, self.program_b, cache_only=True))
+
+        Event.objects.create(
+            program=self.program, event_type=self.event_type,
+            start=datetime(2222, 7, 14, 9, 0), end=datetime(2222, 7, 14, 10, 0),
+            name='A slot 2', short_description='a2', description='another slot in A')
+
+        self.assertIsNone(cf(ts_a, self.program, cache_only=True))
+        self.assertIsNotNone(cf(ts_b, self.program_b, cache_only=True),
+                             "program B's classes_timeslot should survive")

--- a/esp/esp/program/tests_cache_scoping.py
+++ b/esp/esp/program/tests_cache_scoping.py
@@ -1,0 +1,237 @@
+"""Tests that per-program caches are not dumped wholesale by unrelated writes.
+
+Each test warms the cache for two independent programs, writes to one, and
+asserts the other survives.  Paired with an assertion that the written-to
+program *was* invalidated, so over-scoping fails too.
+"""
+
+from datetime import datetime, timedelta
+
+from esp.cal.models import Event
+from esp.program.models import ClassSubject
+from esp.program.modules.handlers.jsondatamodule import JSONDataModule
+from esp.program.tests import ProgramFrameworkTest
+from esp.tests.factories import make_class, make_program
+
+
+class TwoProgramCacheTest(ProgramFrameworkTest):
+    def setUp(self, **kwargs):
+        kwargs.setdefault('num_students', 0)
+        kwargs.setdefault('num_teachers', 1)
+        kwargs.setdefault('classes_per_teacher', 1)
+        kwargs.setdefault('sections_per_class', 1)
+        super().setUp(**kwargs)
+        self.program_b = make_program(
+            instance_name='2224_Summer', instance_label='Summer 2224',
+            categories=self.categories, admins=self.admins,
+            modules=self.settings['modules'],
+        )
+        self.class_b = make_class(program=self.program_b, teacher=self.teachers[0],
+                                  title='B class', category=self.categories[0],
+                                  sections=1, accept=True)
+
+    def a_class_in(self, program):
+        return ClassSubject.objects.filter(parent_program=program).first()
+
+
+class GetFullClassesPrettyScopeTest(TwoProgramCacheTest):
+    """getFullClasses_pretty(self, program) was dumped for every user and every
+    program whenever any ClassSubject was saved."""
+
+    def cached(self, program):
+        return self.teachers[0].getFullClasses_pretty(program, cache_only=True)
+
+    def test_editing_one_program_spares_the_other(self):
+        self.teachers[0].getFullClasses_pretty(self.program)
+        self.teachers[0].getFullClasses_pretty(self.program_b)
+        self.assertIsNotNone(self.cached(self.program))
+        self.assertIsNotNone(self.cached(self.program_b))
+
+        cls = self.a_class_in(self.program)
+        cls.title = 'Retitled'
+        cls.save()
+
+        self.assertIsNone(self.cached(self.program),
+                          "the edited program's entry should be invalidated")
+        self.assertIsNotNone(self.cached(self.program_b),
+                             "an unrelated program's entry should survive")
+
+    def test_adding_a_teacher_still_invalidates(self):
+        """The old wildcard covered class edits but not teacher m2m edits."""
+        self.teachers[0].getFullClasses_pretty(self.program)
+        self.assertIsNotNone(self.cached(self.program))
+
+        self.a_class_in(self.program).makeTeacher(self.teachers[0])
+        #   re-adding is a no-op for the relation, so use a real change
+        self.a_class_in(self.program).removeTeacher(self.teachers[0])
+        self.assertIsNone(self.cached(self.program),
+                          "a teacher change must invalidate the entry")
+
+
+class TimeslotsJsonScopeTest(TwoProgramCacheTest):
+    """jsondatamodule.timeslots(prog) depended on cal.Event globally."""
+
+    def cached(self, program):
+        return JSONDataModule.timeslots.cached_function(program, cache_only=True)
+
+    def test_event_change_spares_the_other_program(self):
+        JSONDataModule.timeslots.cached_function(self.program)
+        JSONDataModule.timeslots.cached_function(self.program_b)
+        self.assertIsNotNone(self.cached(self.program))
+        self.assertIsNotNone(self.cached(self.program_b))
+
+        #   A new timeslot in program A only.
+        Event.objects.create(
+            program=self.program, event_type=self.event_type,
+            start=datetime(2222, 7, 10, 9, 0),
+            end=datetime(2222, 7, 10, 10, 0),
+            name='A extra slot', short_description='extra',
+            description='extra slot in program A')
+
+        self.assertIsNone(self.cached(self.program),
+                          "program A's timeslots should be invalidated")
+        self.assertIsNotNone(self.cached(self.program_b),
+                             "program B's timeslots should survive")
+
+    def test_program_less_event_still_invalidates_everything(self):
+        """Event.program is nullable; those fall back to a full dump."""
+        JSONDataModule.timeslots.cached_function(self.program)
+        JSONDataModule.timeslots.cached_function(self.program_b)
+
+        Event.objects.create(
+            program=None, event_type=self.event_type,
+            start=datetime(2222, 7, 11, 9, 0),
+            end=datetime(2222, 7, 11, 10, 0),
+            name='global slot', short_description='global',
+            description='event with no program')
+
+        self.assertIsNone(self.cached(self.program))
+        self.assertIsNone(self.cached(self.program_b))
+
+
+class AjaxLunchTimeslotsScopeTest(TwoProgramCacheTest):
+    """ajax_lunch_timeslots_cached(prog) depended on Event, ClassSection,
+    ClassSubject and ClassCategories globally."""
+
+    def setUp(self):
+        super().setUp()
+        self.mod_a = self.program.getModule('AJAXSchedulingModule')
+        self.mod_b = self.program_b.getModule('AJAXSchedulingModule')
+
+    def test_class_edit_spares_the_other_program(self):
+        self.mod_a.ajax_lunch_timeslots_cached(self.program)
+        self.mod_b.ajax_lunch_timeslots_cached(self.program_b)
+        self.assertIsNotNone(
+            self.mod_a.ajax_lunch_timeslots_cached(self.program, cache_only=True))
+        self.assertIsNotNone(
+            self.mod_b.ajax_lunch_timeslots_cached(self.program_b, cache_only=True))
+
+        cls = self.a_class_in(self.program)
+        cls.title = 'Retitled again'
+        cls.save()
+
+        self.assertIsNone(
+            self.mod_a.ajax_lunch_timeslots_cached(self.program, cache_only=True),
+            "program A's lunch timeslots should be invalidated")
+        self.assertIsNotNone(
+            self.mod_b.ajax_lunch_timeslots_cached(self.program_b, cache_only=True),
+            "program B's lunch timeslots should survive")
+
+
+class TokenBackedScopingTest(TwoProgramCacheTest):
+    """Caches whose key_sets name only some of their parameters need a matching
+    token; without one argcache falls back to dumping the whole cache, so the
+    key_set is decorative.  These assert the tokens are doing their job."""
+
+    def setUp(self):
+        super().setUp(num_students=1)
+        self.teacher = self.teachers[0]
+        self.class_b.makeTeacher(self.teacher)
+
+    def test_getTaughtClassesFromProgram_is_scoped_by_program(self):
+        self.teacher.getTaughtClassesFromProgram(self.program)
+        self.teacher.getTaughtClassesFromProgram(self.program_b)
+        self.assertIsNotNone(
+            self.teacher.getTaughtClassesFromProgram(self.program, cache_only=True))
+        self.assertIsNotNone(
+            self.teacher.getTaughtClassesFromProgram(self.program_b, cache_only=True))
+
+        cls = self.a_class_in(self.program)
+        cls.title = 'Retitled for scoping'
+        cls.save()
+
+        self.assertIsNone(
+            self.teacher.getTaughtClassesFromProgram(self.program, cache_only=True),
+            "the edited program's entry should be invalidated")
+        self.assertIsNotNone(
+            self.teacher.getTaughtClassesFromProgram(self.program_b, cache_only=True),
+            "an unrelated program's entry should survive")
+
+    def test_getFirstClassTime_is_scoped_by_program(self):
+        student = self.students[0]
+        sec_a = self.a_class_in(self.program).sections.first()
+        sec_b = self.class_b.sections.first()
+        sec_a.meeting_times.add(self.timeslots[0])
+        #   B needs a meeting time too, or getFirstClassTime returns None there
+        #   and a cached None is indistinguishable from a cache miss.
+        sec_b.meeting_times.add(self.program_b.getTimeSlots()[0])
+        sec_a.preregister_student(student, overridefull=True)
+        sec_b.preregister_student(student, overridefull=True)
+
+        student.getFirstClassTime(self.program)
+        student.getFirstClassTime(self.program_b)
+        self.assertIsNotNone(student.getFirstClassTime(self.program, cache_only=True))
+        self.assertIsNotNone(student.getFirstClassTime(self.program_b, cache_only=True))
+
+        #   Reschedule in program A only.
+        sec_a.meeting_times.add(self.timeslots[1])
+
+        self.assertIsNone(student.getFirstClassTime(self.program, cache_only=True),
+                          "program A's entry should be invalidated")
+        self.assertIsNotNone(student.getFirstClassTime(self.program_b, cache_only=True),
+                             "program B's entry should survive")
+
+
+class FullClassesEnrolmentDepTest(TwoProgramCacheTest):
+    """getFullClasses_pretty calls is_nearly_full(), which compares
+    num_students() against capacity scaled by the nearly_full_threshold tag.
+    None of those were covered by its class-level dependencies."""
+
+    def setUp(self):
+        super().setUp(num_students=2)
+        self.teacher = self.teachers[0]
+        self.section = self.a_class_in(self.program).sections.first()
+        self.section.meeting_times.add(self.timeslots[0])
+
+    def cached(self, program):
+        return self.teacher.getFullClasses_pretty(program, cache_only=True)
+
+    def test_enrolment_invalidates(self):
+        self.teacher.getFullClasses_pretty(self.program)
+        self.assertIsNotNone(self.cached(self.program))
+
+        self.section.preregister_student(self.students[0], overridefull=True)
+
+        self.assertIsNone(self.cached(self.program),
+                          "enrolling a student must invalidate the entry")
+
+    def test_enrolment_in_one_program_spares_the_other(self):
+        self.teacher.getFullClasses_pretty(self.program)
+        self.teacher.getFullClasses_pretty(self.program_b)
+        self.assertIsNotNone(self.cached(self.program_b))
+
+        self.section.preregister_student(self.students[0], overridefull=True)
+
+        self.assertIsNone(self.cached(self.program))
+        self.assertIsNotNone(self.cached(self.program_b),
+                             "an unrelated program's entry should survive")
+
+    def test_capacity_change_invalidates(self):
+        self.teacher.getFullClasses_pretty(self.program)
+        self.assertIsNotNone(self.cached(self.program))
+
+        self.section.max_class_capacity = (self.section.max_class_capacity or 0) + 5
+        self.section.save()
+
+        self.assertIsNone(self.cached(self.program),
+                          "a capacity change must invalidate the entry")

--- a/esp/esp/program/tests_m2m_cache_deps.py
+++ b/esp/esp/program/tests_m2m_cache_deps.py
@@ -222,3 +222,36 @@ class ModeratorCacheDepTest(ProgramFrameworkTest):
         self.assertIsNone(
             JSONDataModule.moderators.method.cached_function(self.program, cache_only=True),
             "a moderator category change must invalidate the moderators payload")
+
+
+class ModeratorsAvailabilityScopeTest(ProgramFrameworkTest):
+    """moderators(prog) reads each moderator's availability; that dependency
+    used to be a wildcard, undoing the scoping of the other three."""
+
+    def setUp(self):
+        super().setUp(num_students=0, num_teachers=1, classes_per_teacher=1,
+                      sections_per_class=1)
+        from esp.tests.factories import make_program
+        self.program_b = make_program(
+            instance_name='2225_Summer', instance_label='Summer 2225',
+            categories=self.categories, admins=self.admins,
+            modules=self.settings['modules'])
+
+    def test_availability_change_spares_the_other_program(self):
+        from esp.program.modules.handlers.jsondatamodule import JSONDataModule
+        from esp.users.models import UserAvailability
+        from django.contrib.auth.models import Group
+
+        cf = JSONDataModule.moderators.method.cached_function
+        cf(self.program); cf(self.program_b)
+        self.assertIsNotNone(cf(self.program, cache_only=True))
+        self.assertIsNotNone(cf(self.program_b, cache_only=True))
+
+        UserAvailability.objects.create(
+            user=self.teachers[0], event=self.timeslots[0],
+            role=Group.objects.get_or_create(name='Teacher')[0])
+
+        self.assertIsNone(cf(self.program, cache_only=True),
+                          "program A's moderators payload should be invalidated")
+        self.assertIsNotNone(cf(self.program_b, cache_only=True),
+                             "program B's moderators payload should survive")

--- a/esp/esp/program/tests_m2m_cache_deps.py
+++ b/esp/esp/program/tests_m2m_cache_deps.py
@@ -139,3 +139,45 @@ class PopularClassesCacheDepTest(ProgramFrameworkTest):
         self.assertIsNone(
             self.module.popular_classes(self.program, cache_only=True),
             "popular_classes cache survived a reschedule")
+
+
+class ShirtInfoAndModNumsCacheDepTest(ProgramFrameworkTest):
+    """getShirtInfo and mod_nums read prog.teachers(), which TeacherClassRegModule
+    builds from the ClassSubject.teachers m2m and section statuses, and mod_nums
+    additionally aggregates Count('meeting_times')."""
+
+    def setUp(self):
+        super().setUp(num_students=0, num_teachers=2, classes_per_teacher=1,
+                      sections_per_class=1)
+        self.cls = ClassSubject.objects.filter(parent_program=self.program).first()
+        self.section = self.cls.sections.first()
+        self.json_module = self.program.getModule('JSONDataModule')
+
+    def test_getShirtInfo_follows_teacher_changes(self):
+        self.program.getShirtInfo()
+        self.assertIsNotNone(self.program.getShirtInfo(cache_only=True))
+
+        self.cls.makeTeacher(self.teachers[1])
+
+        self.assertIsNone(self.program.getShirtInfo(cache_only=True),
+                          "adding a teacher must invalidate getShirtInfo")
+
+    def test_getShirtInfo_follows_section_changes(self):
+        self.program.getShirtInfo()
+        self.assertIsNotNone(self.program.getShirtInfo(cache_only=True))
+
+        self.section.status = 5
+        self.section.save()
+
+        self.assertIsNone(self.program.getShirtInfo(cache_only=True),
+                          "a section status change must invalidate getShirtInfo")
+
+    def test_mod_nums_follows_rescheduling(self):
+        from esp.program.modules.handlers.jsondatamodule import JSONDataModule
+        JSONDataModule.mod_nums(self.program)
+        self.assertIsNotNone(JSONDataModule.mod_nums(self.program, cache_only=True))
+
+        self.section.meeting_times.add(self.timeslots[0])
+
+        self.assertIsNone(JSONDataModule.mod_nums(self.program, cache_only=True),
+                          "rescheduling must invalidate mod_nums")

--- a/esp/esp/program/tests_m2m_cache_deps.py
+++ b/esp/esp/program/tests_m2m_cache_deps.py
@@ -181,3 +181,44 @@ class ShirtInfoAndModNumsCacheDepTest(ProgramFrameworkTest):
 
         self.assertIsNone(JSONDataModule.mod_nums(self.program, cache_only=True),
                           "rescheduling must invalidate mod_nums")
+
+
+class ModeratorCacheDepTest(ProgramFrameworkTest):
+    """Moderator-facing caches read m2m data that post_save cannot see."""
+
+    def setUp(self):
+        super().setUp(num_students=0, num_teachers=1, classes_per_teacher=1,
+                      sections_per_class=1)
+        self.moderator = self.teachers[0]
+        self.section = ClassSubject.objects.filter(
+            parent_program=self.program).first().sections.first()
+        self.section.moderators.add(self.moderator)
+
+    def test_moderating_sections_follows_rescheduling(self):
+        """Results are ordered by Min('meeting_times__start')."""
+        self.moderator.getModeratingSectionsFromProgram(self.program)
+        self.assertIsNotNone(
+            self.moderator.getModeratingSectionsFromProgram(self.program, cache_only=True))
+
+        self.section.meeting_times.add(self.timeslots[0])
+
+        self.assertIsNone(
+            self.moderator.getModeratingSectionsFromProgram(self.program, cache_only=True),
+            "rescheduling must invalidate the moderating-sections cache")
+
+    def test_moderators_json_follows_category_changes(self):
+        """The payload includes rec.class_categories, an m2m on ModeratorRecord."""
+        from esp.program.models import ModeratorRecord
+        from esp.program.modules.handlers.jsondatamodule import JSONDataModule
+
+        rec = ModeratorRecord.objects.create(user=self.moderator, program=self.program,
+                                             will_moderate=True, num_slots=1)
+        JSONDataModule.moderators.method.cached_function(self.program)
+        self.assertIsNotNone(
+            JSONDataModule.moderators.method.cached_function(self.program, cache_only=True))
+
+        rec.class_categories.add(self.categories[0])
+
+        self.assertIsNone(
+            JSONDataModule.moderators.method.cached_function(self.program, cache_only=True),
+            "a moderator category change must invalidate the moderators payload")

--- a/esp/esp/program/tests_m2m_cache_deps.py
+++ b/esp/esp/program/tests_m2m_cache_deps.py
@@ -1,0 +1,141 @@
+"""Tests for cached functions that read m2m data.
+
+An m2m edit does not fire post_save on either end, so a cache that reads an m2m
+relation needs an explicit depend_on_m2m.  Each test below drives a real m2m
+edit and asserts the cache noticed.
+"""
+
+from datetime import datetime, timedelta
+
+from esp.cal.models import Event
+from esp.program.models import ClassSubject, ProgramModule
+from esp.program.tests import ProgramFrameworkTest
+from esp.users.models import ESPUser
+
+
+class MeetingTimesCacheDepTest(ProgramFrameworkTest):
+    """meeting_times feeds getFirstClassTime and popular_classes."""
+
+    def setUp(self):
+        super().setUp(num_students=1, num_teachers=1, classes_per_teacher=1,
+                      sections_per_class=1)
+        self.student = self.students[0]
+        self.section = ClassSubject.objects.filter(
+            parent_program=self.program).first().sections.first()
+        self.spare_slot = Event.objects.create(
+            program=self.program, event_type=self.event_type,
+            start=datetime(2222, 7, 9, 9, 0),
+            end=datetime(2222, 7, 9, 9, 0) + timedelta(hours=1),
+            name='spare slot', short_description='spare',
+            description='spare slot for m2m cache tests')
+
+    def enroll(self):
+        self.section.preregister_student(self.student, overridefull=True)
+
+    def test_getFirstClassTime_follows_rescheduling(self):
+        """getFirstClassTime reads the section's meeting_times, so a reschedule
+        must change its answer rather than serving the cached time."""
+        self.section.meeting_times.clear()
+        self.section.meeting_times.add(self.timeslots[1])
+        self.enroll()
+
+        first = self.student.getFirstClassTime(self.program)
+        self.assertEqual(first, self.timeslots[1])
+
+        #   Move the section earlier; the cached answer must not survive.
+        self.section.meeting_times.clear()
+        self.section.meeting_times.add(self.timeslots[0])
+
+        self.assertEqual(self.student.getFirstClassTime(self.program),
+                         self.timeslots[0],
+                         "getFirstClassTime served a stale meeting time")
+
+    def test_getFirstClassTime_follows_added_time(self):
+        self.section.meeting_times.clear()
+        self.section.meeting_times.add(self.timeslots[2])
+        self.enroll()
+        self.assertEqual(self.student.getFirstClassTime(self.program),
+                         self.timeslots[2])
+
+        self.section.meeting_times.add(self.timeslots[0])
+        self.assertEqual(self.student.getFirstClassTime(self.program),
+                         self.timeslots[0],
+                         "getFirstClassTime ignored a newly added earlier time")
+
+
+class ProgramModulesCacheDepTest(ProgramFrameworkTest):
+    """program_modules feeds getModules_cached."""
+
+    def setUp(self):
+        super().setUp(num_students=0, num_teachers=0, classes_per_teacher=0)
+
+    def test_getModules_cached_follows_module_changes(self):
+        before = len(self.program.getModules_cached())
+        self.assertGreater(before, 0)
+
+        removed = self.program.program_modules.first()
+        self.program.program_modules.remove(removed)
+
+        self.assertEqual(len(self.program.getModules_cached()), before - 1,
+                         "getModules_cached served a stale module list")
+
+    def test_getModules_cached_follows_module_addition(self):
+        removed = self.program.program_modules.first()
+        self.program.program_modules.remove(removed)
+        after_removal = len(self.program.getModules_cached())
+
+        self.program.program_modules.add(removed)
+        self.assertEqual(len(self.program.getModules_cached()), after_removal + 1,
+                         "getModules_cached ignored a re-added module")
+
+
+class AllowableClassSizeRangesCacheDepTest(ProgramFrameworkTest):
+    """allowable_class_size_ranges feeds ClassSection.capacity."""
+
+    def setUp(self):
+        super().setUp(num_students=0, num_teachers=1, classes_per_teacher=1,
+                      sections_per_class=1)
+        self.cls = ClassSubject.objects.filter(parent_program=self.program).first()
+        self.section = self.cls.sections.first()
+        self.section.meeting_times.add(self.timeslots[0])
+
+    def test_capacity_cache_is_dropped_when_size_ranges_change(self):
+        """capacity reads parent_class.allowable_class_size_ranges, so editing
+        that m2m must drop the cached value.  Asserted on the cache directly
+        because the resulting number depends on room assignments."""
+        from esp.program.models.class_ import ClassSizeRange
+
+        self.section.capacity                                   # warm
+        self.assertIsNotNone(self.section._get_capacity(cache_only=True),
+                             "capacity should be cached after first access")
+
+        rng = ClassSizeRange.objects.create(range_min=1, range_max=99,
+                                            program=self.program)
+        self.cls.allowable_class_size_ranges.add(rng)
+
+        self.assertIsNone(self.section._get_capacity(cache_only=True),
+                          "capacity cache survived a size-range change")
+
+
+class PopularClassesCacheDepTest(ProgramFrameworkTest):
+    """meeting_times feeds BigBoardModule.popular_classes."""
+
+    def setUp(self):
+        super().setUp(num_students=1, num_teachers=1, classes_per_teacher=1,
+                      sections_per_class=1)
+        self.module = self.program.getModule('BigBoardModule')
+        self.section = ClassSubject.objects.filter(
+            parent_program=self.program).first().sections.first()
+
+    def test_popular_classes_cache_is_dropped_when_rescheduled(self):
+        """popular_classes includes each section's meeting times."""
+        self.module.popular_classes(self.program)               # warm
+        self.assertIsNotNone(
+            self.module.popular_classes(self.program, cache_only=True),
+            "popular_classes should be cached after first call")
+
+        self.section.meeting_times.add(self.timeslots[0])
+
+        self.assertIsNone(
+            self.module.popular_classes(self.program, cache_only=True),
+            "popular_classes cache survived a reschedule")

--- a/esp/esp/qsd/models.py
+++ b/esp/esp/qsd/models.py
@@ -69,6 +69,7 @@ class QSDManager(models.Manager):
             return self.filter(url=url).select_related().latest('create_date')
         except QuasiStaticData.DoesNotExist:
             return None
+    get_by_url.get_or_create_token(('url',))
     get_by_url.depend_on_row('qsd.QuasiStaticData', lambda qsd: {'url': qsd.url})
 
     @cache_function
@@ -94,6 +95,7 @@ class QSDManager(models.Manager):
             content = '\n'.join(content)
             qsd_obj.content = content
         return qsd_obj
+    get_by_url_else_init.get_or_create_token(('url',))
     get_by_url_else_init.depend_on_row('qsd.QuasiStaticData', lambda qsd: {'url': qsd.url})
 
     def __str__(self):

--- a/esp/esp/resources/models.py
+++ b/esp/esp/resources/models.py
@@ -338,6 +338,8 @@ class Resource(models.Model):
             return ~Q(test_resource.is_taken(True))
         else:
             return not test_resource.is_taken(False)
+    is_available.get_or_create_token(('self',))
+    is_available.get_or_create_token(('timeslot',))
     is_available.depend_on_row('resources.ResourceAssignment', lambda instance: {'self': instance.resource})
     is_available.depend_on_row('cal.Event', lambda instance: {'timeslot': instance})
 

--- a/esp/esp/resources/models.py
+++ b/esp/esp/resources/models.py
@@ -340,7 +340,7 @@ class Resource(models.Model):
             return not test_resource.is_taken(False)
     is_available.get_or_create_token(('self',))
     is_available.depend_on_row('resources.ResourceAssignment', lambda instance: {'self': instance.resource})
-    is_available.depend_on_row('cal.Event', lambda instance: {'timeslot': instance})
+    is_available.depend_on_row('cal.Event', lambda instance: {})
 
     def is_taken(self, QObjects=False):
         if QObjects:

--- a/esp/esp/resources/models.py
+++ b/esp/esp/resources/models.py
@@ -339,7 +339,6 @@ class Resource(models.Model):
         else:
             return not test_resource.is_taken(False)
     is_available.get_or_create_token(('self',))
-    is_available.get_or_create_token(('timeslot',))
     is_available.depend_on_row('resources.ResourceAssignment', lambda instance: {'self': instance.resource})
     is_available.depend_on_row('cal.Event', lambda instance: {'timeslot': instance})
 

--- a/esp/esp/tagdict/models.py
+++ b/esp/esp/tagdict/models.py
@@ -119,6 +119,7 @@ class Tag(models.Model):
             if 'does not exist' in err or 'no such table' in err:
                 return default
             raise
+    _getTag.get_or_create_token(('key', 'target',))
     _getTag.depend_on_row('tagdict.Tag', lambda tag: {'key': tag.key, 'target': tag.target})
     _getTag = classmethod(_getTag)
 

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -616,7 +616,7 @@ class BaseESPUser(object):
             classes = classes.exclude(status=ClassStatus.CANCELLED)
         return classes
     getTaughtClassesAll.get_or_create_token(('self',))
-    getTaughtClassesAll.depend_on_row('program.ClassSubject', lambda cls: {'self': cls})
+    getTaughtClassesAll.depend_on_row('program.ClassSubject', lambda cls: {})
     getTaughtClassesAll.depend_on_m2m('program.ClassSubject', 'teachers', lambda cls, teacher: {'self': teacher})
 
     @cache_function
@@ -775,7 +775,7 @@ class BaseESPUser(object):
     getAvailableTimes.get_or_create_token(('self', 'program', 'ignore_classes',))
     getAvailableTimes.depend_on_cache(getTaughtSectionsFromProgram,
             lambda self=wildcard, program=wildcard, **kwargs:
-                 {'self':self, 'program':program, 'ignore_classes':True})
+                 {'self':self, 'program':program, 'ignore_classes':False})
     getAvailableTimes.depend_on_m2m('program.ClassSubject', 'teachers', lambda cls, teacher: {'self': teacher, 'program': cls.parent_program})
     getAvailableTimes.depend_on_m2m('program.ClassSection', 'moderators', lambda sec, moderator: {'self': moderator, 'program': sec.parent_program})
     getAvailableTimes.depend_on_m2m('program.ClassSection', 'meeting_times', lambda sec, event: {'program': sec.parent_program})

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -885,6 +885,8 @@ class BaseESPUser(object):
             else:
                 return sections[0].meeting_times.order_by('start')[0]
     getFirstClassTime.depend_on_row('program.StudentRegistration', lambda reg: {'self': reg.user})
+    getFirstClassTime.depend_on_m2m('program.ClassSection', 'meeting_times',
+                                    lambda sec, event: {'program': sec.parent_class.parent_program})
 
     def can_skip_phase_zero(self, program):
         return Permission.user_has_perm(self, 'OverridePhaseZero', program)

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -566,7 +566,11 @@ class BaseESPUser(object):
             raise ESPError("getModeratingSectionsFromProgram expects a Program, not a `" + str(type(program)) + "'.")
         else:
             return self.moderating_sections.filter(parent_class__parent_program = program).annotate(start_time = Min('meeting_times__start')).order_by('start_time')
+    getModeratingSectionsFromProgram.get_or_create_token(('self',))
+    getModeratingSectionsFromProgram.get_or_create_token(('program',))
     getModeratingSectionsFromProgram.depend_on_m2m('program.ClassSection', 'moderators', lambda sec, moderator: {'self': moderator})
+    getModeratingSectionsFromProgram.depend_on_m2m('program.ClassSection', 'meeting_times',
+                                                   lambda sec, event: {'program': sec.parent_class.parent_program})
     getModeratingSectionsFromProgram.depend_on_row('program.ClassSection', lambda instance: {'program': instance.parent_program})
 
     def getModeratingTimesFromProgram(self, program, exclude = []):

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -652,6 +652,7 @@ class BaseESPUser(object):
         if not include_cancelled:
             sections = sections.exclude(status=ClassStatus.CANCELLED)
         return sections
+    getTaughtSectionsAll.get_or_create_token(('self',))
     getTaughtSectionsAll.depend_on_model('program.ClassSection')
     getTaughtSectionsAll.depend_on_cache(getTaughtClassesAll, lambda self=wildcard, **kwargs:
                                                               {'self':self})
@@ -667,6 +668,7 @@ class BaseESPUser(object):
             sections = sections.exclude(status=ClassStatus.CANCELLED)
         return sections
     getTaughtSectionsFromProgram.get_or_create_token(('program',))
+    getTaughtSectionsFromProgram.get_or_create_token(('self', 'program',))
     getTaughtSectionsFromProgram.depend_on_row('program.ClassSection', lambda instance: {'program': instance.parent_program})
     getTaughtSectionsFromProgram.depend_on_cache(getTaughtClassesFromProgram, lambda self=wildcard, program=wildcard, **kwargs:
                                                                               {'self':self, 'program':program})
@@ -769,6 +771,8 @@ class BaseESPUser(object):
 
         return list(valid_events)
     getAvailableTimes.get_or_create_token(('self', 'program',))
+    getAvailableTimes.get_or_create_token(('program',))
+    getAvailableTimes.get_or_create_token(('self', 'program', 'ignore_classes',))
     getAvailableTimes.depend_on_cache(getTaughtSectionsFromProgram,
             lambda self=wildcard, program=wildcard, **kwargs:
                  {'self':self, 'program':program, 'ignore_classes':True})

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -614,7 +614,16 @@ class BaseESPUser(object):
     def getFullClasses_pretty(self, program):
         full_classes = [cls for cls in self.getTaughtClassesFromProgram(program) if cls.is_nearly_full()]
         return "\n".join([cls.emailcode()+": "+cls.title for cls in full_classes])
-    getFullClasses_pretty.depend_on_model('program.ClassSubject') # should filter by teachers... eh.
+    getFullClasses_pretty.depend_on_m2m('program.ClassSubject', 'teachers',
+                                        lambda cls, teacher: {'self': teacher})
+    getFullClasses_pretty.depend_on_row('program.ClassSubject',
+                                        lambda cls: {'program': cls.parent_program})
+    getFullClasses_pretty.depend_on_row('program.StudentRegistration',
+                                        lambda reg: {'program': reg.section.parent_class.parent_program})
+    getFullClasses_pretty.depend_on_row('program.ClassSection',
+                                        lambda sec: {'program': sec.parent_class.parent_program})
+    getFullClasses_pretty.depend_on_row('tagdict.Tag', lambda tag: {},
+                                        lambda tag: tag.key == 'nearly_full_threshold')
 
     def getTaughtSections(self, program = None, include_rejected = False, include_cancelled = True):
         if program is None:

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -554,6 +554,8 @@ class BaseESPUser(object):
             if not include_cancelled:
                 classes = classes.exclude(status=ClassStatus.CANCELLED)
             return classes
+    getTaughtClassesFromProgram.get_or_create_token(('self',))
+    getTaughtClassesFromProgram.get_or_create_token(('program',))
     getTaughtClassesFromProgram.depend_on_m2m('program.ClassSubject', 'teachers', lambda cls, teacher: {'self': teacher})
     getTaughtClassesFromProgram.depend_on_row('program.ClassSubject', lambda cls: {'program': cls.parent_program}) # TODO: auto-row-thing...
 
@@ -595,6 +597,8 @@ class BaseESPUser(object):
             if not include_cancelled:
                 sections = sections.exclude(status=ClassStatus.CANCELLED)
             return self.moderating_sections.filter(parent_class__parent_program = program) | sections
+    getTaughtOrModeratingSectionsFromProgram.get_or_create_token(('self',))
+    getTaughtOrModeratingSectionsFromProgram.get_or_create_token(('program',))
     getTaughtOrModeratingSectionsFromProgram.depend_on_m2m('program.ClassSection', 'moderators', lambda sec, moderator: {'self': moderator})
     getTaughtOrModeratingSectionsFromProgram.depend_on_m2m('program.ClassSubject', 'teachers', lambda sec, teacher: {'self': teacher})
     getTaughtOrModeratingSectionsFromProgram.depend_on_row('program.ClassSection', lambda instance: {'program': instance.parent_program})
@@ -607,6 +611,7 @@ class BaseESPUser(object):
         if not include_cancelled:
             classes = classes.exclude(status=ClassStatus.CANCELLED)
         return classes
+    getTaughtClassesAll.get_or_create_token(('self',))
     getTaughtClassesAll.depend_on_row('program.ClassSubject', lambda cls: {'self': cls})
     getTaughtClassesAll.depend_on_m2m('program.ClassSubject', 'teachers', lambda cls, teacher: {'self': teacher})
 
@@ -614,6 +619,8 @@ class BaseESPUser(object):
     def getFullClasses_pretty(self, program):
         full_classes = [cls for cls in self.getTaughtClassesFromProgram(program) if cls.is_nearly_full()]
         return "\n".join([cls.emailcode()+": "+cls.title for cls in full_classes])
+    getFullClasses_pretty.get_or_create_token(('self',))
+    getFullClasses_pretty.get_or_create_token(('program',))
     getFullClasses_pretty.depend_on_m2m('program.ClassSubject', 'teachers',
                                         lambda cls, teacher: {'self': teacher})
     getFullClasses_pretty.depend_on_row('program.ClassSubject',
@@ -872,6 +879,7 @@ class BaseESPUser(object):
         for sec in result:
             sec._timeslot_ids = sec.timeslot_ids()
         return result
+    getEnrolledSectionsFromProgram.get_or_create_token(('self',))
     getEnrolledSectionsFromProgram.depend_on_row('program.StudentRegistration', lambda reg: {'self': reg.user})
     getEnrolledSectionsFromProgram.depend_on_cache('program.ClassSection.timeslot_ids', lambda self=wildcard, **kwargs: {})
 
@@ -893,6 +901,8 @@ class BaseESPUser(object):
                 return None
             else:
                 return sections[0].meeting_times.order_by('start')[0]
+    getFirstClassTime.get_or_create_token(('self',))
+    getFirstClassTime.get_or_create_token(('program',))
     getFirstClassTime.depend_on_row('program.StudentRegistration', lambda reg: {'self': reg.user})
     getFirstClassTime.depend_on_m2m('program.ClassSection', 'meeting_times',
                                     lambda sec, event: {'program': sec.parent_class.parent_program})
@@ -948,6 +958,7 @@ class BaseESPUser(object):
     def appliedFinancialAid(self, program):
         return self.financialaidrequest_set.all().filter(program=program, done=True).exists()
     #   Invalidate cache when any of the user's financial aid requests are changed
+    appliedFinancialAid.get_or_create_token(('self',))
     appliedFinancialAid.depend_on_row('program.FinancialAidRequest', lambda fr: {'self': fr.user})
     appliedFinancialAid.depend_on_row('accounting.FinancialAidGrant', lambda fr: {'self': fr.request.user})
 
@@ -959,6 +970,7 @@ class BaseESPUser(object):
             return True
         else:
             return False
+    hasFinancialAid.get_or_create_token(('self',))
     hasFinancialAid.depend_on_row('program.FinancialAidRequest', lambda fr: {'self': fr.user})
 
     def isOnsite(self, program=None):


### PR DESCRIPTION
After I discovered #5959, I used Claude Code to audit our entire codebase for other caching inconsistencies (several iterations to make sure nothing was missed). This is the result. It does a mix of the following:

- adds missing cache dependencies (e.g., `depend_on_row`, `depend_on_m2m`)
- narrows dependencies scope with lambda filters (e.g., `depend_on_model` -> `depend_on_row`)
- narrows cache key scope (if not all of the arguments to a cached function are tied to dependencies, you need to add `get_or_create_token` for each single or combination of arguments used in dependencies)
- adds tests covering some of the above (Claude Code confirmed each set of tests worked by running them with and without the related cache dependency changes)
- adds more documentation for future contributors to hopefully prevent these pitfalls in the future