### PR TITLE
Fix test docstring referencing removed code

### DIFF
--- a/esp/esp/program/controllers/test_classreg_controller.py
+++ b/esp/esp/program/controllers/test_classreg_controller.py
@@ -8,7 +8,7 @@ is caught even if the view returns HTTP 200.
 Test classes:
   - GetCustomFieldsTest:       tag-driven custom field loading (CacheFlushTestCase)
   - SetClassDataTest:          field routing, custom field separation,
-                               section_ key exclusion, is-not regression guard
+                               section_ key exclusion
   - TeacherTimeTest:           teacher_has_time() and require_teacher_has_time()
   - UpdateClassSectionsTest:   section count creation, reduction, duration propagation
 """
@@ -158,15 +158,11 @@ class SetClassDataTest(ClassregControllerTestBase):
 
     def test_section_prefixed_field_excluded_from_cls_dict(self):
         """
-        Regression guard for the is-not identity comparison bug.
-
         Fields starting with 'section_' must NOT be written to cls.__dict__.
-        The original code used `k[:8] is not 'section_'` (identity comparison).
-        In Python 3, string interning is not guaranteed for sliced strings —
-        this can evaluate to True even when k starts with 'section_', silently
-        writing form fields to cls.__dict__. The fix (`!=` value comparison) is
-        already in place. This test documents correct behaviour and prevents
-        future regression.
+
+        set_class_data() routes these to section-level handling instead of
+        the class itself; this test guards against a future edit letting
+        them leak into cls.__dict__ as ordinary class attributes.
         """
         cls = self._make_saved_class()
         form = self._make_mock_form({


### PR DESCRIPTION
## Description

One of the test docstrings in `test_classreg_controller.py` (added in #5840) talked about a bug in code that isn't there anymore, a string comparison using `is not` instead of `!=`. That code was already fixed before this test file existed, so the docstring was just describing something nobody reading it could actually go check.

Rewrote it to say what the test actually checks now: fields starting with `section_` don't get written into `cls.__dict__`. Fixed the same kind of line in the file's top docstring too.

No test logic changed, just the comments.

## Related Issue

Refs #3780

## Type of Change

- [x] Documentation update

## Testing

- [x] Existing tests pass (`pytest esp/program/controllers/test_classreg_controller.py`, 22 passed)
- [x] flake8 clean
