### PR TITLE
fix(middleware): guard against missing request.session in process_response

### DIFF
--- a/esp/esp/middleware/espauthmiddleware.py
+++ b/esp/esp/middleware/espauthmiddleware.py
@@ -79,7 +79,8 @@ class ESPAuthMiddleware(AuthenticationMiddleware):
         ## the no_set_cookies early-return so that cacheable views (decorated with
         ## @disable_csrf_cookie_update) also benefit from the workaround.
         ## -- aseering 11/1/2010, moved before no_set_cookies check
-        request.session.accessed = request.session.modified
+        if hasattr(request, 'session'):
+            request.session.accessed = request.session.modified
 
         ## This gets set if we're not supposed to modify the cookie
         if getattr(response, 'no_set_cookies', False):
@@ -105,10 +106,9 @@ class ESPAuthMiddleware(AuthenticationMiddleware):
                     "%a, %d-%b-%Y %H:%M:%S GMT"
                 )
             ret_title = ''
-            try:
-                ret_title = request.session['user_morph']['retTitle']
-            except KeyError:
-                pass
+            ret_title = ''
+            if hasattr(request, 'session'):
+                ret_title = request.session.get('user_morph', {}).get('retTitle', '')
 
             # URL-encode some data since cookies don't like funny characters. They
             # make the chocolate chips nervous.

--- a/esp/esp/tests/test_middleware.py
+++ b/esp/esp/tests/test_middleware.py
@@ -94,3 +94,30 @@ class ESPAuthMiddlewareProcessResponseTest(TestCase):
         self.assertIn('cur_username', cookie_names)
         self.assertIn('cur_userid', cookie_names)
         self.assertIn('cur_email', cookie_names)
+
+    def test_process_response_without_session_attribute_anonymous(self):
+        """Should handle requests without session attribute for anonymous users without error."""
+        request = self.factory.get('/')
+        request._cached_user = AnonymousESPUser()
+        request.COOKIES = {}
+        response = HttpResponse()
+        result = self.middleware.process_response(request, response)
+        self.assertIs(result, response)
+
+    def test_process_response_without_session_attribute_authenticated(self):
+        """Should handle requests without session attribute for authenticated users without error."""
+        user = ESPUser.objects.create_user(
+            username='nosessionuser',
+            password='password',
+            email='nosession@test.com',
+            first_name='NoSession',
+            last_name='User',
+        )
+        request = self.factory.get('/')
+        request._cached_user = user
+        request.COOKIES = {}
+        request.encoding = None
+        response = HttpResponse()
+        result = self.middleware.process_response(request, response)
+        self.assertIs(result, response)
+        self.assertIn('cur_username', result.cookies.keys())


### PR DESCRIPTION
### Description
This pull request addresses #5967, resolving an `AttributeError: 'WSGIRequest' object has no attribute 'session'` that occurs when requests lack a `session` attribute during the `process_response` lifecycle (e.g., requests handled before `SessionMiddleware` executes or custom error responses).

### Key Changes
* Added defensive `hasattr(request, 'session')` guard before setting `request.session.accessed = request.session.modified`.
* Safely handled `request.session` retrieval when extracting `user_morph` data to prevent `AttributeError`.
* Added comprehensive unit tests in `esp/esp/tests/test_middleware.py` covering both anonymous and authenticated requests that lack a `session` attribute.

### Related Issue
Closes #5967

### Checklist
- [x] Code strictly contains functional changes without unrelated edits.
- [x] Unit tests added and verified.
- [x] All CI checks passing.