### PR TITLE
fix(customforms): ensure atomic DB operations in ComboForm.done

### DIFF
--- a/esp/esp/customforms/DynamicForm.py
+++ b/esp/esp/customforms/DynamicForm.py
@@ -5,6 +5,8 @@ from django.utils.safestring import mark_safe
 from form_utils.forms import BetterForm
 from collections import OrderedDict
 from django.db import transaction
+import logging
+logger = logging.getLogger(__name__)
 from formtools.wizard.views import SessionWizardView
 from django.core.files.storage import FileSystemStorage
 from django.shortcuts import redirect, HttpResponse
@@ -407,9 +409,7 @@ class ComboForm(SessionWizardView):
                     try:
                         new_instance = v['model'].objects.create(**v['data'])
                         v['instance'] = new_instance
-                    except Exception as e:
-                        import logging
-                        logger = logging.getLogger(__name__)
+                    except Exception:
                         logger.exception(f"Failed to create linked model {v['model'].__name__}")
                         raise
                 if v['instance'] is not None:

--- a/esp/esp/customforms/DynamicForm.py
+++ b/esp/esp/customforms/DynamicForm.py
@@ -4,6 +4,7 @@ from django.forms.models import fields_for_model
 from django.utils.safestring import mark_safe
 from form_utils.forms import BetterForm
 from collections import OrderedDict
+from django.db import transaction
 from formtools.wizard.views import SessionWizardView
 from django.core.files.storage import FileSystemStorage
 from django.shortcuts import redirect, HttpResponse
@@ -395,34 +396,38 @@ class ComboForm(SessionWizardView):
 
         # Create/update instances corresponding to link fields
         # Also, populate 'data' with foreign-keys that need to be inserted into the response table
-        for k, v in link_models_cache.items():
-            if v['instance'] is not None:
-                # TODO-> the following update won't work for fk fields.
-                v['instance'].__dict__.update(v['data'])
-                v['instance'].save()
-                curr_instance = v['instance']
-            else:
-                try:
-                    new_instance = v['model'].objects.create(**v['data'])
-                except Exception:
-                    # show some error message
-                    pass
-            if v['instance'] is not None:
-                data[f'link_{v["model"].__name__}'] = v['instance']
+        with transaction.atomic():
+            for k, v in link_models_cache.items():
+                if v['instance'] is not None:
+                    # TODO-> the following update won't work for fk fields.
+                    v['instance'].__dict__.update(v['data'])
+                    v['instance'].save()
+                    curr_instance = v['instance']
+                else:
+                    try:
+                        new_instance = v['model'].objects.create(**v['data'])
+                        v['instance'] = new_instance
+                    except Exception as e:
+                        import logging
+                        logger = logging.getLogger(__name__)
+                        logger.exception(f"Failed to create linked model {v['model'].__name__}")
+                        raise
+                if v['instance'] is not None:
+                    data[f'link_{v["model"].__name__}'] = v['instance']
 
-        # Saving response
-        initial_keys = list(data.keys())
-        for key in initial_keys:
-            #   Check that we didn't already handle this value as a linked field
-            if key.split('_')[0] in cf_cache.link_fields:
-                del data[key]
-            #   Check that this value didn't come from a dummy field
-            if key.split('_')[0] == 'question' and generic_fields[fields[int(key.split('_')[1])]]['typeMap'] == DummyField:
-                del data[key]
-        # Delete old response(s) if not anonymous (we only want one response per user)
-        if not self.form.anonymous:
-            dynModel.objects.filter(user=self.curr_request.user).delete()
-        dynModel.objects.create(**data)
+            # Saving response
+            initial_keys = list(data.keys())
+            for key in initial_keys:
+                #   Check that we didn't already handle this value as a linked field
+                if key.split('_')[0] in cf_cache.link_fields:
+                    del data[key]
+                #   Check that this value didn't come from a dummy field
+                if key.split('_')[0] == 'question' and generic_fields[fields[int(key.split('_')[1])]]['typeMap'] == DummyField:
+                    del data[key]
+            # Delete old response(s) if not anonymous (we only want one response per user)
+            if not self.form.anonymous:
+                dynModel.objects.filter(user=self.curr_request.user).delete()
+            dynModel.objects.create(**data)
         return HttpResponseRedirect(kwargs.get('redirect_url', f'/customforms/success/{self.form.id}/'))
 
     def render_to_response(self, context):

--- a/esp/esp/customforms/tests.py
+++ b/esp/esp/customforms/tests.py
@@ -212,6 +212,61 @@ class CustomFormsTest(TestCase):
             if entry[0] in ['user_id', 'user_display', 'user_email', 'username']:
                 continue
             self.assertTrue(entry[0] in responses_corrected)
+    def test_comboform_done_transaction_rollback(self):
+        """ Test that a linked model creation failure rolls back the entire transaction. """
+        from unittest.mock import patch
+        from esp.users.models import ContactInfo
+        import json
+
+        self.client.login(username=self.admin.username, password='password')
+
+        form_data = {
+            'title': 'Test Rollback Form',
+            'perms': '',
+            'link_id': -1,
+            'success_url': '/formsuccess.html',
+            'success_message': 'Thank you!',
+            'anonymous': False,
+            'pages': [{
+                'parent_id': -1,
+                'sections': [{
+                    'fields': [
+                        {'data': {'field_type': 'ContactInfo_e_mail', 'question_text': 'Your Email', 'seq': 0, 'required': True, 'parent_id': -1, 'attrs':{}, 'help_text': ''}},
+                        {'data': {'field_type': 'TeacherInfo_bio', 'question_text': 'Your Bio', 'seq': 1, 'required': True, 'parent_id': -1, 'attrs':{}, 'help_text': ''}},
+                    ],
+                'data': {'help_text': '', 'question_text': '', 'seq': 0}
+                }],
+                'seq': 0
+            }],
+            'link_type': '-1',
+            'desc': 'Test'
+        }
+
+        response = self.client.post("/customforms/submit/", json.dumps(form_data), content_type='application/json', HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        self.assertEqual(response.status_code, 200)
+
+        forms = Form.objects.filter(title='Test Rollback Form')
+        self.assertTrue(forms.exists())
+        form = forms[0]
+        fields = form.field_set.all()
+        email_field = fields.get(label='Your Email')
+        bio_field = fields.get(label='Your Bio')
+
+        self.client.login(username=self.student.username, password='password')
+
+        post_dict = {'combo_form-current_step': '0'}
+        post_dict[f'question_{email_field.id}'] = 'test@example.com'
+        post_dict[f'question_{bio_field.id}'] = 'Some bio'
+
+        initial_contact_count = ContactInfo.objects.filter(user=self.student).count()
+
+        with patch('esp.users.models.TeacherInfo.objects.create', side_effect=Exception("Simulated DB failure")):
+            with self.assertRaises(Exception) as cm:
+                self.client.post(f"/customforms/view/{form.id}/", post_dict)
+            self.assertEqual(str(cm.exception), "Simulated DB failure")
+
+        final_contact_count = ContactInfo.objects.filter(user=self.student).count()
+        self.assertEqual(initial_contact_count, final_contact_count, "ContactInfo was not rolled back!")
 
 
 class LandingViewTest(TestCase):


### PR DESCRIPTION
## Description

Wraps database write operations in `ComboForm.done` inside a `transaction.atomic()` block to ensure atomicity and prevent partial database writes if an error occurs. Replaces silent exception handling (which previously swallowed errors) with proper logging and re-raising to prevent hidden failures and improve debuggability.

## Related Issue

Closes #5194

## Type of Change

- [x] Bug fix

## Testing

- [x] Existing tests pass
- [x] Manually verified
