### PR TITLE
Fix CSRF failure page program context propagation (#5746)

### DIFF
--- a/esp/esp/web/views/csrf.py
+++ b/esp/esp/web/views/csrf.py
@@ -23,17 +23,15 @@ def csrf_failure(request, reason=""):
         from esp.utils.web import render_to_response
         from esp.program.models import Program
 
-        prog_re = r'^/?[-A-Za-z0-9_ ]+/([-A-Za-z0-9_ ]+)/([-A-Za-z0-9_ ]+)'
-        match = re.match(prog_re, request.path)
         prog = None
-        if match:
-            one, two = match.groups()
-            try:
-                prog = Program.by_prog_inst(one, two)
-            except Program.DoesNotExist:
-                prog = None
-
+        path_parts = request.path.lstrip('/').split('/')
+        if len(path_parts) >= 3:
+            program_url = '/'.join(path_parts[1:3])
+            prog = Program.objects.filter(url=program_url).first()
+        
         c['prog'] = prog
+        if prog:
+            request.program = prog
 
         response = render_to_response('403_csrf_failure.html', request, c)
         # render_to_response() hands back an unrendered TemplateResponse, whose


### PR DESCRIPTION
## Description

This PR fixes a bug where the CSRF failure page (`403_csrf_failure.html`) failed to properly render program-specific headers and themes.

The CSRF failure handler in `esp/esp/web/views/csrf.py` previously attempted to parse the URL using a fragile regular expression, but it failed to integrate with the global context processor logic, resulting in the failure page falling back to generic non-program branding.

This PR replaces the regex with a clean URL split and a direct `Program.objects.filter(url=...)` lookup. Most importantly, it attaches the resolved `prog` to `request.program`, ensuring that global context processors seamlessly pick it up and pass `{{ program }}` to the base templates.

## Related Issue

Closes #5746 

<img width="613" height="485" alt="Screenshot from 2026-08-30 17-16-40" src="https://github.com/user-attachments/assets/355b87f1-7145-400d-8a53-dde13479b369" />
