### PR TITLE
Fix TypeError on /archives/teachers/ and /archives/programs/

### DIFF
--- a/docs/dev/walkthroughs/esp/esp/web-README.MD
+++ b/docs/dev/walkthroughs/esp/esp/web-README.MD
@@ -97,8 +97,8 @@
 | `filter_archive` | Function | `views/archives.py` | Applies a list of `ArchiveFilter` objects as Django ORM filters to an `ArchiveClass` queryset. |
 | `title_heading` | Function | `views/archives.py` | Returns the first character of a title string for use as a jump-to heading, or `'[No Title]'` if empty. |
 | `archive_classes` | Function | `views/archives.py` | Renders a filterable, sortable, paginated list of historical `ArchiveClass` records. |
-| `archive_teachers` | Function | `views/archives.py` | Stub: sets `selection`, `category`, `options` in context and renders `program/archives.html` — **crashes with `TypeError`** when called via `archives()` because the dispatcher passes more positional arguments than this function accepts. |
-| `archive_programs` | Function | `views/archives.py` | Stub: same signature mismatch as `archive_teachers` — also crashes with `TypeError`. |
+| `archive_teachers` | Function | `views/archives.py` | Stub: sets `selection`, `category`, `options` in context and renders `program/archives.html`. Accepts unused `sortorder=None` so `archives()` can pass sort params without crashing. |
+| `archive_programs` | Function | `views/archives.py` | Stub: same signature as `archive_teachers` — renders the archives template for the programs selection. |
 | `archive_handlers` | Dict | `views/archives.py` | Maps the strings `'classes'`, `'teachers'`, `'programs'` to their respective view functions; used by `archives()` in `main.py`. |
 
 ### Views — `views/navBar.py`
@@ -211,8 +211,6 @@
 - **`profile_editor` dynamically imports the form class by string name.** The role string (e.g. `'teacher'`) maps to a form class name (e.g. `'UserContactForm'`) via `ESPUser.getAllUserTypes()`. If you add a new user role, you must add a corresponding entry there *and* create the matching form in `esp.users.forms.user_profile`, otherwise `profile_editor` will throw a `ValueError` (from `list.index()` on the unknown role string) or an `AttributeError` (from `getattr` on a missing form class) at runtime.
 
 - **`bio_user` deliberately excludes classes whose end time is in the future.** This is a documented privacy decision: the course catalog for a not-yet-run program may not be public yet, so exposing class titles on the bio page would leak information. See the comment in [views/bio.py](views/bio.py).
-
-- **`archive_teachers` and `archive_programs` crash on every call.** The dispatcher `archives()` in `main.py` always calls `archive_handlers[selection](request, category, options, sortparams)` with 4 positional arguments, but `archive_teachers(request, category, options)` and `archive_programs(request, category, options)` only accept 3. Any request to `/archives/teachers/` or `/archives/programs/` will raise `TypeError`. `archive_classes` is thCodebase commit: HEADe only handler that is both implemented and callable.
 
 - **Old bio URLs permanently redirect.** Both `bio` and `bio_edit` detect "old URL" patterns (non-`teach` tl prefix, or first/last/num format) and issue `HttpResponsePermanentRedirect`. A `TODO` comment in [views/bio.py](views/bio.py) indicates these redirects were expected to be removed, but are still present.
 

--- a/esp/esp/web/tests_archives.py
+++ b/esp/esp/web/tests_archives.py
@@ -27,6 +27,7 @@ from esp.web.views.archives import (
     archive_teachers,
     archive_programs,
 )
+from esp.web.views.main import archives
 from esp.program.models import ArchiveClass
 
 
@@ -295,6 +296,13 @@ class ArchiveTeachersViewTest(TestCase):
         response = archive_teachers(request, None, None)
         self.assertEqual(response.status_code, 200)
 
+    def test_dispatcher_passes_sortparams(self):
+        """archives() always forwards sortparams; handlers must accept it."""
+        request = self.factory.get('/archives/teachers/')
+        request.user = AnonymousUser()
+        response = archives(request, 'teachers')
+        self.assertEqual(response.status_code, 200)
+
     def test_with_category_options(self):
         request = self.factory.get('/archives/teachers/year/2023/')
         request.user = AnonymousUser()
@@ -315,6 +323,13 @@ class ArchiveProgramsViewTest(TestCase):
         request = self.factory.get('/archives/programs/')
         request.user = AnonymousUser()
         response = archive_programs(request, None, None)
+        self.assertEqual(response.status_code, 200)
+
+    def test_dispatcher_passes_sortparams(self):
+        """archives() always forwards sortparams; handlers must accept it."""
+        request = self.factory.get('/archives/programs/')
+        request.user = AnonymousUser()
+        response = archives(request, 'programs')
         self.assertEqual(response.status_code, 200)
 
     def test_with_category_options(self):

--- a/esp/esp/web/views/archives.py
+++ b/esp/esp/web/views/archives.py
@@ -207,14 +207,14 @@ def archive_classes(request, category, options, sortorder = None):
 
     return render_to_response('program/archives.html', request, context)
 
-def archive_teachers(request, category, options):
+def archive_teachers(request, category, options, sortorder=None):
     context = {'selection': 'Teachers'}
     context['category'] = category
     context['options'] = options
 
     return render_to_response('program/archives.html', request, context)
 
-def archive_programs(request, category, options):
+def archive_programs(request, category, options, sortorder=None):
     context = {'selection': 'Programs'}
     context['category'] = category
     context['options'] = options


### PR DESCRIPTION
## Summary
- `/archives/teachers/` and `/archives/programs/` 500 on live sites (for example https://esp.mit.edu/archives/teachers/) because `archives()` always passes `sortparams` and those handlers did not accept it.
- Give `archive_teachers` and `archive_programs` the same optional `sortorder=None` argument as `archive_classes`.
- Add dispatcher tests so a future signature mismatch fails in CI instead of only on the URL.

## Test plan
- [ ] Hit `/archives/teachers/` and `/archives/programs/` locally; both should return 200 (stub pages), not a 500.
- [ ] Confirm `/archives/classes/` still works.
- [ ] Run `pytest esp/web/tests_archives.py` (or the project equivalent in Docker).

Closes #5974. 