### PR TITLE
Fix missing authorization check in ajaxstudentattendance

### DIFF
--- a/esp/esp/program/modules/handlers/teacherclassregmodule.py
+++ b/esp/esp/program/modules/handlers/teacherclassregmodule.py
@@ -371,6 +371,9 @@ class TeacherClassRegModule(ProgramModuleObj):
                     json_data['error'] = 'Section with ID %s not found!' % request.POST['secid']
                 else:
                     section = sections[0]
+                    if not (request.user.canEdit(section.parent_class) or request.user.canMod(section)):
+                        json_data['error'] = 'You do not have permission to modify attendance for this section.'
+                        return HttpResponse(json.dumps(json_data), content_type='text/json')
                     json_data['secid'] = section.id
                     if request.POST.get('undo', 'false').lower() == 'true':
                         srs = StudentRegistration.valid_objects().filter(user = student, section = section, relationship = attended)

--- a/esp/esp/program/modules/tests/teacherclassregmodule.py
+++ b/esp/esp/program/modules/tests/teacherclassregmodule.py
@@ -41,7 +41,7 @@ from esp.cal.models import Event
 from esp.program.tests import ProgramFrameworkTest
 from esp.program.modules.base import ProgramModule, ProgramModuleObj
 from esp.program.class_status import ClassStatus
-from esp.program.models import ClassSubject, RegistrationType
+from esp.program.models import ClassSubject, RegistrationType, StudentRegistration
 from esp.program.setup import prepare_program, commit_program
 from esp.program.forms import ProgramCreationForm
 from esp.resources.models import ResourceType, ResourceRequest
@@ -328,3 +328,72 @@ class TeacherClassRegTest(ProgramFrameworkTest):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'no valid class meeting timeslots or durations are available')
+    @transaction.atomic
+    def test_ajaxstudentattendance_rejects_unrelated_teacher(self):
+        """A teacher with no relationship to a section must not be able to
+        mutate its attendance/enrollment via ajaxstudentattendance.
+
+        Regression test for missing object-level authorization: the view is
+        guarded by @needs_teacher (a global role check), but unlike its sibling
+        views (section_attendance, section_students, class_students) it never
+        verifies canEdit()/canMod() on the target section.
+        """
+        attacker = self.teacher
+        victim_cls = random.choice(self.other_teacher1.getTaughtClasses())
+        victim_section = victim_cls.get_sections()[0]
+        student = self.students[0]
+
+        # Precondition: attacker genuinely lacks rights to the section
+        self.assertNotIn(attacker, victim_cls.get_teachers())
+        self.assertFalse(attacker.canEdit(victim_section.parent_class),
+                         "Test setup invalid: attacker can edit victim class")
+        self.assertFalse(attacker.canMod(victim_section),
+                         "Test setup invalid: attacker can moderate victim section")
+
+        attended = RegistrationType.objects.get_or_create(
+            name='Attended', category='student')[0]
+        self.assertFalse(
+            StudentRegistration.valid_objects().filter(
+                user=student, section=victim_section, relationship=attended
+            ).exists())
+
+        # Exploit: POST as attacker against the victim's secid
+        self.assertTrue(
+            self.client.login(username=attacker.username, password='password'),
+            "Couldn't log in as attacker %s" % attacker.username)
+
+        url = '%sajaxstudentattendance' % self.program.get_teach_url()
+        response = self.client.post(url, {
+            'student': student.username,
+            'secid': victim_section.id,
+        })
+
+        self.assertEqual(response.status_code, 200)
+        payload = json.loads(response.content)
+
+        # Desired (post-fix) behaviour: mutation refused, student NOT attended
+        self.assertFalse(
+            StudentRegistration.valid_objects().filter(
+                user=student, section=victim_section, relationship=attended
+            ).exists(),
+            "SECURITY: unrelated teacher was able to mark a student as "
+            "attending a section they do not teach (secid=%s). Response: %r"
+            % (victim_section.id, payload))
+
+    @transaction.atomic
+    def test_section_students_rejects_unrelated_teacher(self):
+        """Control: the sibling view section_students DOES enforce the check,
+        confirming the expected authorization model for this module."""
+        attacker = self.teacher
+        victim_cls = random.choice(self.other_teacher1.getTaughtClasses())
+        victim_section = victim_cls.get_sections()[0]
+
+        self.assertFalse(attacker.canEdit(victim_section.parent_class))
+        self.assertFalse(attacker.canMod(victim_section))
+
+        self.assertTrue(
+            self.client.login(username=attacker.username, password='password'))
+        url = '%ssection_students' % self.program.get_teach_url()
+        response = self.client.post(url, {'secid': victim_section.id})
+        self.assertContains(response, 'do not have privileges to edit', status_code=200)
+


### PR DESCRIPTION
Reported privately to web-team@learningu.org; Will asked me to open a PR.

## Problem

`ajaxstudentattendance` in `teacherclassregmodule.py` is guarded by `@needs_teacher`, which is a global role check (`request.user.isTeacher()` takes no program or section argument). The view then operates on a section taken directly from `request.POST['secid']` with no object-level authorization. Any account with the site-wide Teacher role could mark attendance, enroll students, unenroll them from conflicting sections, and delete check-in records for any section of any program.

The sibling views in the same module (`section_attendance`, `section_students`, `class_students`) all guard the target section with `canEdit()`/`canMod()`. This view was missing that check.

## Fix

Add the same `canEdit()/canMod()` check before any mutation, returning the view's existing JSON error shape on failure. Admins are unaffected, since both methods fall back to `isAdmin`.

## Tests

- `test_ajaxstudentattendance_rejects_unrelated_teacher` — a teacher with no relationship to a section (verified via `canEdit`/`canMod` both False) is refused. Failed before the fix, passes after.
- `test_section_students_rejects_unrelated_teacher` — control confirming the sibling view already enforces the check.

Full `teacherclassregmodule` suite passes (11 tests). Verified on Django 5.2.16, Docker dev setup.

Closes #5978