### PR TITLE
Don't reset is_unique on Resource re-save (#5976)

### DIFF
--- a/esp/esp/resources/models.py
+++ b/esp/esp/resources/models.py
@@ -192,9 +192,6 @@ class Resource(models.Model):
             new_group = ResourceGroup.objects.create()
             self.res_group = new_group
             self.is_unique = True
-        else:
-            self.is_unique = False
-
         super().save(*args, **kwargs)
 
     # I'd love to kill this, but since it's set as the __sub__, it's hard to
@@ -347,6 +344,7 @@ class Resource(models.Model):
         else:
             collision = ResourceAssignment.objects.filter(resource=self)
             return collision.exists()
+
 
     def has_unreturned_prior_assignment(self, timeslot, ignore_section=None):
         """Check if any identical resource (same name and type) in an earlier

--- a/esp/esp/resources/tests.py
+++ b/esp/esp/resources/tests.py
@@ -199,3 +199,39 @@ class FloatingResourceAvailabilityTest(TestCase):
         # Assign to different section in timeslot2 — should raise
         with self.assertRaises(ESPError_Log):
             self.res_ts2.assign_to_section(other_section)
+    def test_is_unique_survives_resave(self):
+        """is_unique must not be flipped by an unrelated later save (issue #5976)."""
+        rt = ResourceType.get_or_create('Projector')
+        r = Resource.objects.create(
+            name='proj-resave', res_type=rt, event=self.timeslot1)
+        # Standalone resource: gets its own group and is marked unique.
+        self.assertTrue(r.is_unique)
+        group_id = r.res_group_id
+
+        # An unrelated edit must not change is_unique or the group.
+        r.name = 'proj-resave-renamed'
+        r.save()
+        self.assertTrue(r.is_unique,
+                        "is_unique was cleared by an unrelated re-save")
+        self.assertEqual(r.res_group_id, group_id)
+
+        # Confirm it persisted, not just the in-memory object.
+        self.assertTrue(Resource.objects.get(pk=r.pk).is_unique)
+
+    def test_is_unique_false_for_resource_in_existing_group(self):
+        """A resource attached to an existing group stays non-unique across saves."""
+        classroom_type = ResourceType.get_or_create('Classroom')
+        room = Resource.objects.create(
+            name='Room Z', res_type=classroom_type, event=self.timeslot1)
+        self.assertTrue(room.is_unique)
+
+        furn_type = ResourceType.get_or_create('Whiteboard')
+        furn = Resource(name='wb-z', res_type=furn_type, event=self.timeslot1)
+        furn.res_group = room.res_group
+        furn.save()
+        self.assertFalse(furn.is_unique)
+
+        # A later save must not spuriously flip it.
+        furn.name = 'wb-z-renamed'
+        furn.save()
+        self.assertFalse(furn.is_unique)


### PR DESCRIPTION
## Description

`Resource.save()` set `is_unique` based on whether `res_group` was null, which forced it to `True` on creation and `False` on every later save. Because the first save assigns `res_group`, any later save (a rename, an admin save) took the `else` branch and cleared the flag. That disabled the floating-resource return check (#4211) and dropped the resource from `getFloatingResources()`.

This sets `is_unique = True` only when creating the resource's group at initial creation, and leaves it untouched on later saves. Per @willgearty's guidance in the issue, `is_unique` stays a stored field.

Verified against all Resource-creation paths — classrooms and floating equipment (created standalone, correctly get `True`), furnishings (attached to an existing group, keep the `False` default), and program import — so there's no regression in how new resources are marked.

## Related Issue

Closes #5976

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing
- [x] Existing tests pass
- [x] New tests added (if applicable)
- [x] Manually verified

Full `esp.resources` suite passes (13 tests), including the existing `FloatingResourceAvailabilityTest` cases. Added two regression tests: `test_is_unique_survives_resave` (the flag is not cleared by an unrelated re-save) and `test_is_unique_false_for_resource_in_existing_group`.

## AI Disclosure

I used an AI assistant as a research aid while investigating this issue. All changes were written, reviewed, tested, and verified by me in a local dev environment, and I understand and stand behind the fix.

## Checklist
- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced