### PR TITLE
Add search filter to admin class list page

### DIFF
--- a/esp/templates/program/modules/adminclass/listclasses.html
+++ b/esp/templates/program/modules/adminclass/listclasses.html
@@ -29,6 +29,54 @@ json_data = {};
   // Start the AJAX request to get the class data and display it
   json_fetch(["class_subjects"], fillClasses, json_data, function() { alert("Error loading class data"); });
 
+  // Class list search filter
+  function filterClassRows() {
+    var $tbody = $j('#classes_anchor');
+
+    // fillClasses() rebuilds the tbody's contents on load, which can wipe
+    // out our "no results" row, so re-create it here if it's missing.
+    var $noResultsRow = $j('#no_results_row');
+    if ($noResultsRow.length === 0) {
+      $noResultsRow = $j(
+        '<tr id="no_results_row" style="display: none;">' +
+        '<td colspan="7"><em>No classes match your search.</em></td>' +
+        '</tr>'
+      );
+      $tbody.append($noResultsRow);
+    }
+
+    var filter = $j('#classSearch').val().trim().toLowerCase();
+    var visibleCount = 0;
+
+    $tbody.children('tr').not('#no_results_row').each(function() {
+      var rowText = $j(this).text().toLowerCase();
+      var matches = rowText.indexOf(filter) !== -1;
+      $j(this).toggle(matches);
+      if (matches) { visibleCount++; }
+    });
+
+    $noResultsRow.toggle(visibleCount === 0);
+  }
+
+  $j(document).ready(function() {
+    $j('#classSearch').on('input', filterClassRows);
+
+    // Re-apply filter when classes finish loading via AJAX (json_fetch
+    // replaces the tbody contents asynchronously after this script runs).
+    // Debounced so a batch of row insertions only triggers one filter pass.
+    if (window.MutationObserver) {
+      var filterDebounceTimer;
+      var debouncedFilter = function() {
+        clearTimeout(filterDebounceTimer);
+        filterDebounceTimer = setTimeout(filterClassRows, 50);
+      };
+      var classesObserver = new MutationObserver(debouncedFilter);
+      classesObserver.observe(document.getElementById('classes_anchor'), {
+        childList: true,
+        subtree: false
+      });
+    }
+  });
 /* ]]> */
 </script>
 
@@ -66,6 +114,13 @@ json_data = {};
           </li>
         </ul>
       </p>
+
+      <div class="dashboard_search">
+        <label for="classSearch">Search classes:</label>
+        <input type="search" id="classSearch" class="form-control"
+               placeholder="Search by title, teacher, code..."
+               aria-label="Search classes by title, teacher, or code" />
+      </div>
     </div>
 
     <div id="battlescreen">

--- a/esp/templates/program/modules/adminclass/listclasses.html
+++ b/esp/templates/program/modules/adminclass/listclasses.html
@@ -33,14 +33,23 @@ json_data = {};
   function filterClassRows() {
     var $tbody = $j('#classes_anchor');
 
+    // While the initial AJAX fetch is still in progress, the only row
+    // present is the "Loading classes..." placeholder. Skip filtering so
+    // it stays visible instead of being hidden or replaced by a
+    // misleading "no results" message before real data arrives.
+    if ($j('#loading_row').length > 0) {
+      return;
+    }
+
     // fillClasses() rebuilds the tbody's contents on load, which can wipe
     // out our "no results" row, so re-create it here if it's missing.
+    // The table has 5 columns normally, 6 when TeacherModeratorModule is
+    // enabled, so compute the colspan instead of hard-coding it.
     var $noResultsRow = $j('#no_results_row');
     if ($noResultsRow.length === 0) {
-      $noResultsRow = $j(
-        '<tr id="no_results_row" style="display: none;">' +
-        '<td colspan="7"><em>No classes match your search.</em></td>' +
-        '</tr>'
+      var colspan = (has_moderator_module === "True") ? 6 : 5;
+      $noResultsRow = $j('<tr/>', { id: 'no_results_row', style: 'display: none;' }).append(
+        $j('<td/>', { colspan: colspan }).append($j('<em/>').text('No classes match your search.'))
       );
       $tbody.append($noResultsRow);
     }
@@ -49,7 +58,11 @@ json_data = {};
     var visibleCount = 0;
 
     $tbody.children('tr').not('#no_results_row').each(function() {
-      var rowText = $j(this).text().toLowerCase();
+      // Exclude the Management Options column (last cell) from the
+      // searchable text, since it only contains button labels
+      // (Delete/Edit/Manage/Status) that would otherwise match on
+      // common words and hide unrelated rows.
+      var rowText = $j(this).find('td').not(':last').text().toLowerCase();
       var matches = rowText.indexOf(filter) !== -1;
       $j(this).toggle(matches);
       if (matches) { visibleCount++; }
@@ -146,7 +159,7 @@ json_data = {};
       </tr>
     </thead>
     <tbody id="classes_anchor">
-      <tr>
+      <tr id="loading_row">
         <td colspan="7">Loading classes...</td>
       </tr>
     </tbody>


### PR DESCRIPTION
## Description

Adds a live search filter above the admin "Manage Classes" table so administrators can quickly narrow down classes by title, teacher, or code as they type, without needing to scroll through the full list.

## Related Issue

<!-- Link the relevant issue. Use "Closes #123" to auto-close on merge. -->

Closes #5469

## Type of Change

- [x] New feature

## Testing

- [x] Manually verified

<img width="1280" height="762" alt="Screenshot 2026-09-04 at 7 41 30 AM" src="https://github.com/user-attachments/assets/adede726-0d5d-4b8d-9a38-40e8d188d7b1" />


Manually verified in a local Docker developer environment with a test program containing 8 sample classes:

- Filtering by title, class code, and teacher name too
<img width="500" height="99" alt="Screenshot 2026-09-04 at 8 58 32 AM" src="https://github.com/user-attachments/assets/b6548c5d-ec2b-4ba2-a2be-8d1c0abb5bd2" />

<img width="500" height="105" alt="Screenshot 2026-09-04 at 8 59 43 AM" src="https://github.com/user-attachments/assets/b6d944c9-4213-4794-9931-2095460c299f" />

- Case-insensitive matching (e.g. "PyTHon" matches "Intro to Python Programming")
<img width="500" height="107" alt="Screenshot 2026-09-04 at 9 01 12 AM" src="https://github.com/user-attachments/assets/af4c1a4e-d4d1-45c5-82d6-6baef4aae5d2" />

- A query with no matches shows the "no results" message instead of an empty table
<img width="500" height="89" alt="Screenshot 2026-09-04 at 9 02 20 AM" src="https://github.com/user-attachments/assets/eaa29d79-7db2-4aa5-90e0-32038d0f2a52" />


- Clearing the search box restores all rows, Verified no JS console errors while typing.

> No automated JS test harness exists for this template in the current codebase, so no new tests were added; happy to add coverage if there's a preferred pattern to follow.

## AI Disclosure

AI assisted

## Checklist

- [x] Self-reviewed the code
- [x] No new warnings or errors introduced
