### PR TITLE
Apply the custom form ownership check to the metadata endpoint too

### DIFF
--- a/esp/esp/customforms/tests.py
+++ b/esp/esp/customforms/tests.py
@@ -859,6 +859,56 @@ class FormOwnershipAccessTest(TestCase):
         )
         self.assertEqual(response.status_code, 404)
 
+    def test_owner_can_get_metadata(self):
+        self.client.login(username='owner_teacher', password='password')
+        response = self.client.get(
+            '/customforms/metadata/',
+            {'form_id': self.form.id},
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['title'], 'Ownership Test Form')
+
+    def test_nonowner_teacher_cannot_get_metadata(self):
+        """The form builder's 'create from existing form' dropdown only lists
+        forms you created, but the endpoint behind it used to serve any form
+        to any teacher who asked for it by id."""
+        self.client.login(username='other_teacher', password='password')
+        response = self.client.get(
+            '/customforms/metadata/',
+            {'form_id': self.form.id},
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_admin_can_get_any_metadata(self):
+        self.client.login(username='owner_admin', password='password')
+        response = self.client.get(
+            '/customforms/metadata/',
+            {'form_id': self.form.id},
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_metadata_nonexistent_form_does_not_500(self):
+        self.client.login(username='owner_teacher', password='password')
+        response = self.client.get(
+            '/customforms/metadata/',
+            {'form_id': 999999},
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('message', response.json())
+
+    def test_metadata_missing_form_id_does_not_500(self):
+        self.client.login(username='owner_teacher', password='password')
+        response = self.client.get(
+            '/customforms/metadata/',
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('message', response.json())
+
 
 class CustomFormModelOrderingTest(TestCase):
     def test_page_section_field_default_order_is_seq(self):

--- a/esp/esp/customforms/views.py
+++ b/esp/esp/customforms/views.py
@@ -447,9 +447,13 @@ def getRebuildData(request):
         if request.method == 'GET':
             try:
                 form_id = int(request.GET['form_id'])
-            except ValueError:
-                return HttpResponse(status=400)
-            form = Form.objects.get(pk=form_id)
+                form = Form.objects.get(pk=form_id)
+            except (KeyError, ValueError, Form.DoesNotExist):
+                # The form builder reads .message off the error response, so
+                # keep the body JSON rather than returning a bare 400.
+                return HttpResponse(json.dumps({'message': 'No such form.'}), status=400)
+            if not request.user.isAdministrator() and not request.user.is_morphed(request) and form.created_by_id != request.user.id:
+                raise Http403('You do not have permission to view this form.')
             fh = FormHandler(form=form, request=request)
             try:
                 return HttpResponse(json.dumps(fh.rebuildData()))

--- a/esp/esp/customforms/views.py
+++ b/esp/esp/customforms/views.py
@@ -450,15 +450,15 @@ def getRebuildData(request):
                 form = Form.objects.get(pk=form_id)
             except (KeyError, ValueError, Form.DoesNotExist):
                 # The form builder reads .message off the error response, so
-                # keep the body JSON rather than returning a bare 400.
-                return HttpResponse(json.dumps({'message': 'No such form.'}), status=400)
+                # this needs to be JSON rather than a bare 400.
+                return JsonResponse({'message': 'No such form.'}, status=400)
             if not request.user.isAdministrator() and not request.user.is_morphed(request) and form.created_by_id != request.user.id:
                 raise Http403('You do not have permission to view this form.')
             fh = FormHandler(form=form, request=request)
             try:
-                return HttpResponse(json.dumps(fh.rebuildData()))
+                return JsonResponse(fh.rebuildData())
             except Exception as err:
-                return HttpResponse(json.dumps({'message': str(err)}), status=400)
+                return JsonResponse({'message': str(err)}, status=400)
     return HttpResponse(status=400)
 
 @user_passes_test(test_func)


### PR DESCRIPTION
## Description

PR #4583 added an object-level ownership check to the customforms views that take a `form_id`. It covered four of them. `getRebuildData` — the view behind `/customforms/metadata/` — takes a `form_id` the same way and was left out, so any teacher could pull back the full structure of any other teacher's form: title, description, the `perms` string, and every question label on it.

The project already treats these as private everywhere else. `formBuilder()` filters the "Create from existing form" dropdown to `created_by=request.user` for non-admins, so the UI never shows you someone else's form. Only the endpoint behind that dropdown disagreed. This applies the same check the other four use, so admins and morphed users are unaffected.

The same view also had two ways to 500: a missing `form_id` raised `MultiValueDictKeyError`, and an unknown id raised `Form.DoesNotExist` from a lookup sitting outside the `try`. Both now return the JSON error body the front end expects — `custom_form.js` reads `error.responseJSON.message` off the failure, so returning a plain 404 page here would make the form builder throw while handling the error.

## Related Issue

Closes #5985

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [ ] Existing tests pass
- [x] New tests added (if applicable)
- [x] Manually verified

Five cases added to `FormOwnershipAccessTest`, alongside the ones #4583 wrote for the other four endpoints: owner 200, unrelated teacher 403, admin 200, unknown id 400, missing `form_id` 400.

`test_nonowner_teacher_cannot_get_metadata` is the regression guard — on main it returns 200 with the other teacher's form.

Reproduced by hand first, with two teacher accounts in the Docker dev environment: as the second teacher the builder's dropdown correctly offers nothing, `/responses/<id>/` and `/exceldata/<id>/` both 403, and `/metadata/?form_id=<id>` returned 200 with the first teacher's title, description, `perms` and every question label. Screenshots are on #5985.

I couldn't get a local suite run in before opening this — my Docker engine is wedged at the moment — so I'm leaning on CI for the full run and will follow up if anything goes red.

## AI Disclosure
I reproduced the bug and reviewed the change myself.

## Checklist


- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced

---
##screenshots


<img width="957" height="860" alt="Screenshot 2026-09-06 185449" src="https://github.com/user-attachments/assets/96d201c0-e7fd-4c6c-a3cb-1d9548397102" />

Is `created_by` the right owner test? Forms can be linked to a Program, and it seems arguable that an admin of that program should reach a form attached to it. I matched the existing pattern to keep this consistent and reviewable, but if the intended rule is "creator OR admin of the linked program" then all five endpoints are currently too strict, and that's worth doing deliberately as its own change.

That condition is now spelled out five times in one file. Happy to follow up by pulling it onto the model as something like `form.can_be_viewed_by(user)` if you'd want that.


