### PR TITLE
Cache a test database for CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,9 +81,7 @@ jobs:
       id: apt-action
       run: |
         PKGS=$(cat esp/packages_base.txt | grep -v '^memcached' | grep -v '^postgres' | grep -v '^libpq-dev' | grep -v '^.*pip' | tr '\n' ' ')
-        # pg_dump/pg_restore/createdb for the test-database seeding step. The
-        # postgresql server package stays filtered out; this job uses a service
-        # container for that.
+        # pg_dump/pg_restore/createdb for the test-database seeding step
         PKGS="$PKGS postgresql-client"
         echo "packages=$PKGS" >> $GITHUB_OUTPUT
     - name: Cache apt packages
@@ -102,27 +100,16 @@ jobs:
     - name: Get PostgreSQL major version
       id: pgver
       # Keys the dump cache below, so upgrading the postgres service image
-      # cannot restore a dump taken against a different major version. Read
-      # from the running service rather than the image tag, so there is no
-      # second place to keep in sync. A failed probe yields 'unknown', which
-      # still forms a valid key and only costs a rebuild.
+      # cannot restore a dump taken against a different major version.
       run: |
         major=$(PGPASSWORD=testpassword psql -h localhost -U testuser -d test_django \
                 -tAc "SELECT current_setting('server_version_num')::int / 10000" 2>/dev/null || echo unknown)
         echo "major=${major:-unknown}" >> $GITHUB_OUTPUT
-    # Exact key only, deliberately: with restore-keys an older dump would be
-    # restored and then saved back under the new key, so it would never catch
-    # up with the migrations. A miss just rebuilds it, which is still cheaper
-    # than every worker migrating for itself.
-    #
-    # On a miss each shard rebuilds independently rather than a prerequisite
-    # job building once: the shards rebuild in parallel, so a miss costs about
-    # 70s of wall clock, whereas a prerequisite job would serialize its own
-    # checkout and dependency install ahead of every run, hit or miss.
     - name: Cache test database dump
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
       with:
         path: ~/testdb-cache
+        # Keyed on the runner, Postgres version, and all migration files.
         key: ${{ runner.os }}-testdb-pg${{ steps.pgver.outputs.major }}-${{ hashFiles('esp/**/migrations/*.py') }}
     - name: Prepare for Test
       env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,6 +81,10 @@ jobs:
       id: apt-action
       run: |
         PKGS=$(cat esp/packages_base.txt | grep -v '^memcached' | grep -v '^postgres' | grep -v '^libpq-dev' | grep -v '^.*pip' | tr '\n' ' ')
+        # pg_dump/pg_restore/createdb for the test-database seeding step. The
+        # postgresql server package stays filtered out; this job uses a service
+        # container for that.
+        PKGS="$PKGS postgresql-client"
         echo "packages=$PKGS" >> $GITHUB_OUTPUT
     - name: Cache apt packages
       uses: Eeems-Org/apt-cache-action@v1
@@ -95,11 +99,26 @@ jobs:
         CI_JOB: test
         PYTHON_VERSION: ${{ matrix.python-version }}
       run: deploy/ci/install
+    # Exact key only, deliberately: with restore-keys an older dump would be
+    # restored and then saved back under the new key, so it would never catch
+    # up with the migrations. A miss just rebuilds it, which is still cheaper
+    # than every worker migrating for itself.
+    - name: Cache test database dump
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      with:
+        path: ~/testdb-cache
+        key: ${{ runner.os }}-testdb-${{ hashFiles('esp/**/migrations/*.py') }}
     - name: Prepare for Test
       env:
         CI_JOB: test
         PYTHON_VERSION: ${{ matrix.python-version }}
       run: deploy/ci/before_script
+    - name: Seed Test Databases
+      env:
+        DATABASE_USER: testuser
+        DATABASE_PASSWORD: testpassword
+        DATABASE_NAME: test_django
+      run: deploy/ci/setup_test_db
     - name: Run Tests
       env:
         CI_JOB: test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,15 +99,31 @@ jobs:
         CI_JOB: test
         PYTHON_VERSION: ${{ matrix.python-version }}
       run: deploy/ci/install
+    - name: Get PostgreSQL major version
+      id: pgver
+      # Keys the dump cache below, so upgrading the postgres service image
+      # cannot restore a dump taken against a different major version. Read
+      # from the running service rather than the image tag, so there is no
+      # second place to keep in sync. A failed probe yields 'unknown', which
+      # still forms a valid key and only costs a rebuild.
+      run: |
+        major=$(PGPASSWORD=testpassword psql -h localhost -U testuser -d test_django \
+                -tAc "SELECT current_setting('server_version_num')::int / 10000" 2>/dev/null || echo unknown)
+        echo "major=${major:-unknown}" >> $GITHUB_OUTPUT
     # Exact key only, deliberately: with restore-keys an older dump would be
     # restored and then saved back under the new key, so it would never catch
     # up with the migrations. A miss just rebuilds it, which is still cheaper
     # than every worker migrating for itself.
+    #
+    # On a miss each shard rebuilds independently rather than a prerequisite
+    # job building once: the shards rebuild in parallel, so a miss costs about
+    # 70s of wall clock, whereas a prerequisite job would serialize its own
+    # checkout and dependency install ahead of every run, hit or miss.
     - name: Cache test database dump
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
       with:
         path: ~/testdb-cache
-        key: ${{ runner.os }}-testdb-${{ hashFiles('esp/**/migrations/*.py') }}
+        key: ${{ runner.os }}-testdb-pg${{ steps.pgver.outputs.major }}-${{ hashFiles('esp/**/migrations/*.py') }}
     - name: Prepare for Test
       env:
         CI_JOB: test

--- a/deploy/ci/setup_test_db
+++ b/deploy/ci/setup_test_db
@@ -1,22 +1,13 @@
 #!/bin/bash
 set -euf -o pipefail
 
-# Seed the per-worker test databases from a schema dump.
-#
-# Left alone, each xdist worker creates its own test database and runs every
-# migration into it, which costs about 70s per worker. Restoring a dump into
-# them instead costs about 1s each, and pytest's --reuse-db (set in
-# pytest.ini) then makes Django reuse them rather than rebuilding.
-#
-# That reuse still runs migrate in keepdb mode, which takes about 3s and
-# applies anything the dump predates. A dump that has fallen behind the
-# migrations therefore costs a little time, never correctness.
+# Seed the per-worker test databases from a schema dump to save time.
+# Any new migrations are applied separately by each worker.
 
 CACHE_DIR="${TEST_DB_CACHE_DIR:-$HOME/testdb-cache}"
 DUMP="$CACHE_DIR/testdb.dump"
 
-# Seeding is an optimisation, so a missing client is not worth failing over:
-# without it Django builds the test databases itself, slower but identical.
+# If a tool is missing, have Django build the test databases itself.
 for tool in pg_dump pg_restore createdb dropdb; do
     if ! command -v "$tool" > /dev/null 2>&1; then
         echo ">>> $tool not found; skipping the seed step."
@@ -36,8 +27,7 @@ BASE_DB="test_${DATABASE_NAME:-test_django}"
 mkdir -p "$CACHE_DIR"
 
 if [ ! -f "$DUMP" ]; then
-    # Cache miss. Run the migrations once here rather than once per worker;
-    # even this path beats letting every worker migrate for itself.
+    # Cache miss. Run the migrations once here.
     echo ">>> No cached dump. Building one (runs all migrations once)..."
     BUILD_DB="${BASE_DB}_dumpsrc"
     dropdb --if-exists "$BUILD_DB"
@@ -50,8 +40,7 @@ else
     echo ">>> Reusing cached dump ($(du -h "$DUMP" | cut -f1))."
 fi
 
-# pytest runs under -n auto, so xdist makes one database per core, suffixed
-# _gw0 .. _gwN-1. The unsuffixed name is seeded too, for a non-xdist run.
+# makes one database per core, suffixed _gw0 .. _gwN-1.
 WORKERS="$(nproc)"
 for db in "$BASE_DB" $(seq -f "${BASE_DB}_gw%g" 0 $((WORKERS - 1))); do
     dropdb --if-exists "$db"

--- a/deploy/ci/setup_test_db
+++ b/deploy/ci/setup_test_db
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -euf -o pipefail
+
+# Seed the per-worker test databases from a schema dump.
+#
+# Left alone, each xdist worker creates its own test database and runs every
+# migration into it, which costs about 70s per worker. Restoring a dump into
+# them instead costs about 1s each, and pytest's --reuse-db (set in
+# pytest.ini) then makes Django reuse them rather than rebuilding.
+#
+# That reuse still runs migrate in keepdb mode, which takes about 3s and
+# applies anything the dump predates. A dump that has fallen behind the
+# migrations therefore costs a little time, never correctness.
+
+CACHE_DIR="${TEST_DB_CACHE_DIR:-$HOME/testdb-cache}"
+DUMP="$CACHE_DIR/testdb.dump"
+
+# Seeding is an optimisation, so a missing client is not worth failing over:
+# without it Django builds the test databases itself, slower but identical.
+for tool in pg_dump pg_restore createdb dropdb; do
+    if ! command -v "$tool" > /dev/null 2>&1; then
+        echo ">>> $tool not found; skipping the seed step."
+        echo ">>> Django will create the test databases itself instead."
+        exit 0
+    fi
+done
+
+export PGHOST="${DATABASE_HOST:-localhost}"
+export PGPORT="${DATABASE_PORT:-5432}"
+export PGUSER="${DATABASE_USER:-testuser}"
+export PGPASSWORD="${DATABASE_PASSWORD:-testpassword}"
+
+# Django prefixes the configured database name with test_ for the test run.
+BASE_DB="test_${DATABASE_NAME:-test_django}"
+
+mkdir -p "$CACHE_DIR"
+
+if [ ! -f "$DUMP" ]; then
+    # Cache miss. Run the migrations once here rather than once per worker;
+    # even this path beats letting every worker migrate for itself.
+    echo ">>> No cached dump. Building one (runs all migrations once)..."
+    BUILD_DB="${BASE_DB}_dumpsrc"
+    dropdb --if-exists "$BUILD_DB"
+    createdb "$BUILD_DB"
+    (cd esp && DATABASE_NAME="$BUILD_DB" ./manage.py migrate --noinput > /dev/null)
+    pg_dump -Fc -f "$DUMP" "$BUILD_DB"
+    dropdb "$BUILD_DB"
+    echo ">>> Built dump ($(du -h "$DUMP" | cut -f1))."
+else
+    echo ">>> Reusing cached dump ($(du -h "$DUMP" | cut -f1))."
+fi
+
+# pytest runs under -n auto, so xdist makes one database per core, suffixed
+# _gw0 .. _gwN-1. The unsuffixed name is seeded too, for a non-xdist run.
+WORKERS="$(nproc)"
+for db in "$BASE_DB" $(seq -f "${BASE_DB}_gw%g" 0 $((WORKERS - 1))); do
+    dropdb --if-exists "$db"
+    createdb "$db"
+    pg_restore -d "$db" "$DUMP"
+done
+
+echo ">>> Seeded $((WORKERS + 1)) test databases."


### PR DESCRIPTION
This caches a small test database to be used in the CI tests. The cached database is then populated into each pytest worker. This saves ~2-3 min per CI run.

Drafted by Claude Code.