### PR TITLE
Don't assume `classreg` exists in `students()`

### DIFF
--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -686,10 +686,8 @@ class Program(models.Model, CustomFormsLinkModel):
     def _classreg_students(self):
         """Students registered for at least one class.
 
-        The 'classreg' key is contributed by StudentClassRegModule, so it is
-        absent for a program that does not use that module. Such a program has
-        no class registrations to count, so treat it as none rather than
-        raising KeyError out of the program cap checks below.
+        StudentClassRegModule contributes the 'classreg' key, so a program
+        without that module has none to count.
         """
         return self.students().get('classreg', ESPUser.objects.none())
 

--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -684,11 +684,7 @@ class Program(models.Model, CustomFormsLinkModel):
     # and for the grade-based version every registration profile for the
     # program, so they're probably not worth caching.
     def _classreg_students(self):
-        """Students registered for at least one class.
-
-        StudentClassRegModule contributes the 'classreg' key, so a program
-        without that module has none to count.
-        """
+        """Students registered for at least one class."""
         return self.students().get('classreg', ESPUser.objects.none())
 
     def _students_in_program_in_grades(self, grades):

--- a/esp/esp/program/models/__init__.py
+++ b/esp/esp/program/models/__init__.py
@@ -683,6 +683,16 @@ class Program(models.Model, CustomFormsLinkModel):
     # everything in sight, including every student registration for the program
     # and for the grade-based version every registration profile for the
     # program, so they're probably not worth caching.
+    def _classreg_students(self):
+        """Students registered for at least one class.
+
+        The 'classreg' key is contributed by StudentClassRegModule, so it is
+        absent for a program that does not use that module. Such a program has
+        no class registrations to count, so treat it as none rather than
+        raising KeyError out of the program cap checks below.
+        """
+        return self.students().get('classreg', ESPUser.objects.none())
+
     def _students_in_program_in_grades(self, grades):
         """The number of students in the program in a set of grades
 
@@ -691,7 +701,7 @@ class Program(models.Model, CustomFormsLinkModel):
         # Due to how RegistrationProfiles work, this is ~impossible to do
         # efficiently.  getGrade is cached, though, and probably most of those
         # caches will be warm, so it'll probably be okay.  Maybe.  Hopefully.
-        return len([student for student in self.students()['classreg']
+        return len([student for student in self._classreg_students()
                     if student.getGrade(self, assume_student=True) in grades])
 
     def _students_in_program(self):
@@ -699,13 +709,12 @@ class Program(models.Model, CustomFormsLinkModel):
 
         Used by the program cap logic.
         """
-        return self.students()['classreg'].count()
+        return self._classreg_students().count()
 
     @cache_function
     def _student_is_in_program(self, user):
         """Return whether the student is in the program."""
-        students = self.students()['classreg']
-        return students.filter(id=user.id).exists()
+        return self._classreg_students().filter(id=user.id).exists()
     _student_is_in_program.depend_on_row('program.ClassSubject', lambda cls: {'self': cls.parent_program})
     _student_is_in_program.depend_on_row('program.ClassSection', lambda cls: {'self': cls.parent_class.parent_program})
     _student_is_in_program.depend_on_row('program.StudentRegistration', lambda sr: {'user': sr.user})

--- a/esp/esp/program/tests.py
+++ b/esp/esp/program/tests.py
@@ -930,6 +930,24 @@ class ProgramCapTest(ProgramFrameworkTest):
             # Assert that everyone can join the program.
             self.assertTrue(self.program.user_can_join(user))
 
+    def test_cap_without_classreg_module(self):
+        # The 'classreg' key comes from StudentClassRegModule, so a program
+        # without that module has no class registrations to count. The cap
+        # checks used to index it unconditionally and raise KeyError, which
+        # surfaced as a 500 on the student registration page.
+        self.program.program_modules.remove(
+            ProgramModule.objects.get(handler='StudentClassRegModule'))
+        self.program.program_size_max = 3
+        self.program.save()
+
+        self.assertNotIn('classreg', self.program.students())
+        self.assertEqual(self.program._students_in_program(), 0)
+        self.assertEqual(self.program._students_in_program_in_grades([10]), 0)
+        self.assertFalse(self.program._student_is_in_program(self.students[0]))
+        for user in self.students:
+            # Nothing to count means nothing to cap against.
+            self.assertTrue(self.program.user_can_join(user))
+
     def test_simple_cap(self):
         enrolled, _ = RegistrationType.objects.get_or_create(
             name='Enrolled', category='student')

--- a/esp/esp/program/tests.py
+++ b/esp/esp/program/tests.py
@@ -931,10 +931,8 @@ class ProgramCapTest(ProgramFrameworkTest):
             self.assertTrue(self.program.user_can_join(user))
 
     def test_cap_without_classreg_module(self):
-        # The 'classreg' key comes from StudentClassRegModule, so a program
-        # without that module has no class registrations to count. The cap
-        # checks used to index it unconditionally and raise KeyError, which
-        # surfaced as a 500 on the student registration page.
+        # Without StudentClassRegModule there is no 'classreg' key, which the
+        # cap checks used to index unconditionally and 500 the reg page.
         classreg_modules = list(self.program.program_modules.filter(handler='StudentClassRegModule'))
         self.assertTrue(classreg_modules)
         self.program.program_modules.remove(*classreg_modules)
@@ -945,7 +943,6 @@ class ProgramCapTest(ProgramFrameworkTest):
         self.assertEqual(self.program._students_in_program_in_grades([10]), 0)
         self.assertFalse(self.program._student_is_in_program(self.students[0]))
         for user in self.students:
-            # Nothing to count means nothing to cap against.
             self.assertTrue(self.program.user_can_join(user))
 
     def test_simple_cap(self):

--- a/esp/esp/program/tests.py
+++ b/esp/esp/program/tests.py
@@ -935,9 +935,9 @@ class ProgramCapTest(ProgramFrameworkTest):
         # without that module has no class registrations to count. The cap
         # checks used to index it unconditionally and raise KeyError, which
         # surfaced as a 500 on the student registration page.
-        self.program.program_modules.remove(
-            ProgramModule.objects.get(handler='StudentClassRegModule'))
-        self.program.program_size_max = 3
+        classreg_modules = list(self.program.program_modules.filter(handler='StudentClassRegModule'))
+        self.assertTrue(classreg_modules)
+        self.program.program_modules.remove(*classreg_modules)
         self.program.save()
 
         self.assertNotIn('classreg', self.program.students())


### PR DESCRIPTION
CI tests in #5988 revealed that depending on the state of the database, this dictionary pull could error. This adds a small check to prevent it (and some associated regression tests).

Done by Claude Code.