### PR TITLE
fix: prevent paid_list() crash on non-integer filter values (#5731)

### DIFF
--- a/esp/esp/program/modules/handlers/programprintables.py
+++ b/esp/esp/program/modules/handlers/programprintables.py
@@ -151,7 +151,7 @@ class ProgramPrintables(ProgramModuleObj):
                 single_select = False
 
             if ids is None:
-                transfers = pac.all_transfers().exclude(line_item__text__in=exclude_line_items).order_by('line_item', 'user').select_related()
+                lineitems = pac.all_transfers().exclude(line_item__text__in=exclude_line_items).order_by('line_item', 'user').select_related()
             else:
                 lineitems = pac.all_transfers().filter(line_item__id__in=ids).order_by('line_item', 'user').select_related()
         else:


### PR DESCRIPTION
## Description
Fixed a bug in `ProgramPrintables.paid_list()` where passing a non-integer query parameter (`?filter=abc`) caused a `ValueError`, setting `ids = None`. In this fallback branch, the queryset was incorrectly assigned to `transfers` instead of `lineitems`, resulting in an undefined variable crash during iteration. Updated the fallback to assign the queryset to `lineitems`.

## Related Issue
Closes #5731

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing
- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified via code inspection

## Checklist
- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced