### PR TITLE
Fix mutable default context={} and unvalidated id lookup in survey views

### DIFF
--- a/esp/esp/survey/tests.py
+++ b/esp/esp/survey/tests.py
@@ -10,6 +10,8 @@ import datetime
 from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
+from django.http import HttpResponse
+from django.test import RequestFactory
 from unittest.mock import MagicMock, patch
 
 from esp.program.models import Program
@@ -23,6 +25,7 @@ from esp.survey.models import (
     Survey,
     SurveyResponse,
 )
+from esp.survey.views import survey_review
 from esp.tests.util import CacheFlushTestCase as TestCase
 
 
@@ -658,3 +661,99 @@ class TeacherSurveyMultiSectionTest(ProgramFrameworkTest):
                          "Class should appear exactly once in summary table")
         # Should show total 2 responses in the summary table
         self.assertIn('>2<', summary_section)
+
+
+# ===== View Tests (regressions for #5991) =====
+
+class SurveyReviewSingleErrorHandlingTest(ProgramFrameworkTest):
+    """
+    Regression tests for #5991: `survey_review_single` used to pass an
+    unvalidated query-string key straight into `SurveyResponse.objects.filter
+    (id=...)`, raising an unhandled ValueError (-> 500 with no friendly
+    message) for a non-numeric key instead of falling through to the
+    existing "pick an individual response" ESPError message.
+    """
+
+    def setUp(self, *args, **kwargs):
+        kwargs.update({
+            'num_timeslots': 1, 'timeslot_length': 50, 'timeslot_gap': 10,
+            'num_teachers': 1, 'classes_per_teacher': 1, 'sections_per_class': 1,
+            'num_rooms': 1,
+        })
+        super().setUp(*args, **kwargs)
+
+        self.survey, _ = Survey.objects.get_or_create(
+            name='Review Single Survey', program=self.program, category='learn')
+        self.response = SurveyResponse.objects.create(survey=self.survey)
+
+        self.admin = self.admins[0]
+        self.review_single_url = '/manage/%s/surveys/review_single' % self.program.getUrlBase()
+
+    def test_non_numeric_key_shows_friendly_error(self):
+        """A non-numeric query-string key no longer raises an unhandled ValueError."""
+        self.client.login(username=self.admin.username, password='password')
+        response = self.client.get('%s?not-a-number=' % self.review_single_url)
+        self.assertEqual(response.status_code, 500)
+        content = str(response.content, encoding='UTF-8')
+        self.assertIn('reviewing the whole survey', content)
+
+    def test_valid_response_id_still_works(self):
+        """A valid numeric response id still resolves to that response's page."""
+        self.client.login(username=self.admin.username, password='password')
+        response = self.client.get('%s?%d=' % (self.review_single_url, self.response.id))
+        self.assertEqual(response.status_code, 200)
+
+    def test_missing_response_id_shows_friendly_error(self):
+        """No query string at all still hits the pre-existing friendly error path."""
+        self.client.login(username=self.admin.username, password='password')
+        response = self.client.get(self.review_single_url)
+        self.assertEqual(response.status_code, 500)
+        content = str(response.content, encoding='UTF-8')
+        self.assertIn('reviewing the whole survey', content)
+
+
+class SurveyViewsContextIsolationTest(ProgramFrameworkTest):
+    """
+    Regression tests for #5991: `context = {}` as a default argument is a
+    single dict created once at function-definition time, so every call
+    that doesn't pass its own `context` used to mutate and reuse the exact
+    same shared dict across requests. This class asserts each call now gets
+    its own fresh dict.
+    """
+
+    def setUp(self, *args, **kwargs):
+        kwargs.update({
+            'num_timeslots': 1, 'timeslot_length': 50, 'timeslot_gap': 10,
+            'num_teachers': 1, 'classes_per_teacher': 1, 'sections_per_class': 1,
+            'num_rooms': 1,
+        })
+        super().setUp(*args, **kwargs)
+
+        Survey.objects.get_or_create(
+            name='Context Isolation Survey', program=self.program, category='learn')
+
+        self.admin = self.admins[0]
+        self.factory = RequestFactory()
+
+    def _manage_request(self):
+        request = self.factory.get('/')
+        request.user = self.admin
+        request.session = {}
+        return request
+
+    @patch('esp.survey.views.render_to_response')
+    def test_context_dict_not_shared_across_calls(self, mock_render):
+        """Two calls to survey_review get two distinct context dict objects."""
+        mock_render.return_value = HttpResponse('')
+
+        survey_review(self._manage_request(), 'manage', self.program.program_type, self.program.program_instance)
+        first_context = mock_render.call_args[0][2]
+
+        # Simulate data one request left behind in its context dict.
+        first_context['leaked_from_first_request'] = True
+
+        survey_review(self._manage_request(), 'manage', self.program.program_type, self.program.program_instance)
+        second_context = mock_render.call_args[0][2]
+
+        self.assertIsNot(first_context, second_context)
+        self.assertNotIn('leaked_from_first_request', second_context)

--- a/esp/esp/survey/views.py
+++ b/esp/esp/survey/views.py
@@ -56,7 +56,9 @@ from wsgiref.util import FileWrapper
 from django.contrib.auth.decorators import login_required
 
 @login_required
-def survey_view(request, tl, program, instance, template = 'survey/survey.html', context = {}):
+def survey_view(request, tl, program, instance, template = 'survey/survey.html', context = None):
+    if context is None:
+        context = {}
     try:
         prog = Program.by_prog_inst(program, instance)
     except Program.DoesNotExist:
@@ -241,8 +243,10 @@ def get_survey_info(request, tl, program, instance):
 
     return (user, prog, surveys)
 
-def display_survey(user, prog, surveys, request, tl, format, template = 'survey/review.html', context = {}):
+def display_survey(user, prog, surveys, request, tl, format, template = 'survey/review.html', context = None):
     """ Wrapper doing the necessary work for the survey output. """
+    if context is None:
+        context = {}
     from esp.program.models import ClassSubject, ClassSection
 
     def getByIdOrNone(model, key):
@@ -614,22 +618,28 @@ def teacher_survey_all(request):
     return render_to_response('survey/teacher_all_reviews.html', request, context)
 
 @login_required
-def survey_review(request, tl, program, instance, template = 'survey/review.html', context = {}):
+def survey_review(request, tl, program, instance, template = 'survey/review.html', context = None):
     """ A view of all the survey results pertaining to a particular user in the given program. """
+    if context is None:
+        context = {}
 
     (user, prog, surveys) = get_survey_info(request, tl, program, instance)
     return display_survey(user, prog, surveys, request, tl, 'html', template, context)
 
 @login_required
-def survey_graphical(request, tl, program, instance, template = 'survey/review.tex', context = {}):
+def survey_graphical(request, tl, program, instance, template = 'survey/review.tex', context = None):
     """ A PDF view of the survey results with histograms. """
+    if context is None:
+        context = {}
 
     (user, prog, surveys) = get_survey_info(request, tl, program, instance)
     return display_survey(user, prog, surveys, request, tl, 'tex', template, context)
 
 @login_required
-def survey_review_single(request, tl, program, instance, template = 'survey/review_single.html', context = {}):
+def survey_review_single(request, tl, program, instance, template = 'survey/review_single.html', context = None):
     """ View a single survey response. """
+    if context is None:
+        context = {}
     try:
         prog = Program.by_prog_inst(program, instance)
     except Program.DoesNotExist:
@@ -641,7 +651,10 @@ def survey_review_single(request, tl, program, instance, template = 'survey/revi
     survey_response = None
     ints = list(request.GET.items())
     if len(ints) == 1:
-        srs = SurveyResponse.objects.filter(id=ints[0][0])
+        try:
+            srs = SurveyResponse.objects.filter(id=ints[0][0])
+        except (ValueError, TypeError):
+            srs = []
         if len(srs) == 1:
             survey_response = srs[0]
     if survey_response is None:


### PR DESCRIPTION
## Description

Fixes two related bugs in `esp/esp/survey/views.py`:

1. Five view functions (`survey_view`, `display_survey`, `survey_review`, `survey_graphical`, `survey_review_single`) declared `context = {}` as a default argument. Default argument objects are created once at function-definition time, and none of this file's callers ever pass their own `context`, so every request mutated and reused the exact same shared dict across requests - a cross-request state pollution bug.

2. `survey_review_single` passed an unvalidated query-string key straight into `SurveyResponse.objects.filter(id=ints[0][0])`, so a non-numeric key raised an unhandled `ValueError` (raw 500) instead of falling through to the existing friendly "pick an individual response" `ESPError` message.

The fix changes all five `context = {}` defaults to `context = None` with `if context is None: context = {}` inside the function body, and wraps the id lookup in `try/except (ValueError, TypeError)` so a bad key falls through to the pre-existing friendly error path instead of crashing.

## Related Issue

Closes #5991

## Type of Change

- [x] Bug fix

## Testing

- [x] Existing tests pass
- [x] New tests added (if applicable)
- [x] Manually verified

Added two new test classes to `esp/esp/survey/tests.py`:
- `SurveyReviewSingleErrorHandlingTest` - non-numeric query key, missing query string, and a valid numeric id, confirming the friendly error page renders instead of crashing.
- `SurveyViewsContextIsolationTest` - directly asserts two calls to `survey_review` get two distinct `context` dict objects, and that data injected into the first call's context doesn't leak into the second.

Ran the full `esp.survey.tests` module locally via Docker - all 46 tests pass, including the 4 new ones:

```
docker compose exec web python esp/manage.py test esp.survey.tests
```

<img width="440" height="72" alt="Screenshot 2026-09-07 at 11 46 51 PM" src="https://github.com/user-attachments/assets/ff4e72e0-262a-48b3-9872-104b0d89be47" />


**Manual verification** - reproduced the original crash, applied the fix, confirmed clean resolution:

*Before:* raw `ValueError: Field 'id' expected a number but got 'not-a-number'.` crash page at `/manage/Test/2026/surveys/review_single?not-a-number=`

<img width="1523" height="784" alt="before-fix-1" src="https://github.com/user-attachments/assets/d87bcf6a-a475-424b-95cf-23bd65844b8e" />
<img width="1280" height="659" alt="before-fix-2" src="https://github.com/user-attachments/assets/0080377d-86a9-4923-8c23-9dc7b95503ac" />


*After:* clean "We couldn't complete that request" friendly error page, same URL

<img width="1280" height="659" alt="after-fix" src="https://github.com/user-attachments/assets/5a66a0b4-b86e-417b-b93e-d4be07e7679a" />


## AI Disclosure

AI assisted

## Checklist

- [x] Self-reviewed the code
- [x] No new warnings or errors introduced