### PR TITLE
Add independent footer styling for Droplets theme

### DIFF
--- a/esp/esp/themes/tests.py
+++ b/esp/esp/themes/tests.py
@@ -457,6 +457,126 @@ class ScssPipelineTest(TestCase):
         self.assertIn('no SCSS sources', str(ctx.exception))
 
 
+class DropletsFooterStylingTest(TestCase):
+    """Footer background/text/link colors must be independently customizable
+    from the navbar's, defaulting to the previous (shared) appearance so
+    existing sites see no visual change. See issue #5028: the footer's <nav>
+    reuses the navbar's .bg-dark class, so without a footer-specific rule any
+    navbarInverseBackground change also (unintentionally) recolors the footer."""
+
+    def setUp(self):
+        self._css_file = themes_settings.COMPILED_CSS_FILE
+        themes_settings.COMPILED_CSS_FILE = 'theme_compiled_test.css'
+        self.tc = ThemeController()
+        self.css_filename = os.path.join(settings.MEDIA_ROOT, 'styles', themes_settings.COMPILED_CSS_FILE)
+        if not self.tc.has_scss('droplets'):
+            self.skipTest('droplets theme has no SCSS sources')
+
+    def tearDown(self):
+        themes_settings.COMPILED_CSS_FILE = self._css_file
+        if os.path.exists(self.css_filename):
+            os.remove(self.css_filename)
+
+    def test_footer_background_defaults_to_stock_navbar_inverse_background(self):
+        """Leaving both navbarInverseBackground and footerBackground untouched
+        must render the footer identically to the navbar (both at their
+        shared #111111 stock default) -- backward compatible with pre-#5028
+        behavior for a fresh, unmodified droplets site."""
+        self.tc.compile_css('droplets', {}, self.css_filename)
+        with open(self.css_filename) as f:
+            css = f.read()
+        self.assertIn('.navbar.bg-dark {\n  background-color: #111111 !important;\n}', css)
+        self.assertIn('.footer-container .navbar.bg-dark {\n  background-color: #111111 !important;\n}', css)
+
+    def test_footer_background_can_be_customized_independently(self):
+        """Setting footerBackground must recolor only the footer, leaving the
+        navbar's own background-color rule at its own (different) value."""
+        self.tc.compile_css(
+            'droplets',
+            {'navbarInverseBackground': '#00ff00', 'footerBackground': '#ff00ff'},
+            self.css_filename,
+        )
+        with open(self.css_filename) as f:
+            css = f.read()
+        self.assertIn('.footer-container .navbar.bg-dark {\n  background-color: #ff00ff !important;\n}', css)
+        self.assertIn('.navbar.bg-dark {\n  background-color: #00ff00 !important;\n}', css)
+
+    def test_footer_background_bootswatch_default_has_no_override_rule(self):
+        """Under an active Bootswatch theme, an untouched footerBackground must
+        not emit a footer-specific rule at all -- the footer should flow
+        through as pure Bootswatch, same as the navbar."""
+        bw_themes = self.tc.get_bootswatch_themes()
+        if not bw_themes:
+            self.skipTest('Bootswatch 5 npm package not installed')
+        self.tc.compile_css('droplets', {}, self.css_filename, bootswatch_theme=bw_themes[0])
+        with open(self.css_filename) as f:
+            css = f.read()
+        self.assertNotIn('.footer-container .navbar.bg-dark', css)
+
+    def test_footer_background_bootswatch_explicit_override(self):
+        """Under an active Bootswatch theme, explicitly setting footerBackground
+        must still emit a footer-only override rule."""
+        bw_themes = self.tc.get_bootswatch_themes()
+        if not bw_themes:
+            self.skipTest('Bootswatch 5 npm package not installed')
+        self.tc.compile_css(
+            'droplets', {'footerBackground': '#ff00ff'}, self.css_filename, bootswatch_theme=bw_themes[0],
+        )
+        with open(self.css_filename) as f:
+            css = f.read()
+        self.assertIn('.footer-container .navbar.bg-dark {\n  background: #ff00ff !important;\n}', css)
+
+    def test_footer_text_and_link_colors_are_customizable(self):
+        """footerText/footerLinkColor must be substitutable independently of
+        the navbar's own text/link color variables, and must land on the
+        footer-scoped selectors specifically (not merely appear anywhere in
+        the compiled CSS)."""
+        self.tc.compile_css(
+            'droplets',
+            {'footerText': '#123456', 'footerLinkColor': '#654321'},
+            self.css_filename,
+        )
+        with open(self.css_filename) as f:
+            css = f.read()
+        self.assertIn('#footer .qsd_header {\n  color: #123456;', css)
+        self.assertIn('#footer .navbar-nav a {\n  color: #654321;', css)
+        self.assertIn('#footer .qsd_view_visible {\n  border: none;\n  color: #654321;', css)
+
+    def test_footer_background_bootswatch_navbar_only_override_still_tracks(self):
+        """Under an active Bootswatch theme, overriding navbarInverseBackground
+        alone (footerBackground left untouched) must still recolor the footer:
+        with no footer-specific rule emitted, the footer's <nav> falls through
+        to the same .navbar.bg-dark rule the navbar override adds."""
+        bw_themes = self.tc.get_bootswatch_themes()
+        if not bw_themes:
+            self.skipTest('Bootswatch 5 npm package not installed')
+        self.tc.compile_css(
+            'droplets', {'navbarInverseBackground': '#123456'}, self.css_filename, bootswatch_theme=bw_themes[0],
+        )
+        with open(self.css_filename) as f:
+            css = f.read()
+        self.assertNotIn('.footer-container .navbar.bg-dark', css)
+        self.assertIn('.navbar.bg-dark {\n  background: #123456 !important;\n}', css)
+
+    def test_footer_variables_are_literal_hex_for_editor_type_detection(self):
+        """Regression guard for the editor's type-sniffing heuristic
+        (views.py editor(), which classifies each 'advanced' variable's
+        <input> as color/length/text): it infers 'color' input type ONLY
+        from a raw SCSS value starting with '#' -- a variable reference
+        (e.g. '$navbarInverseBackground') or an rgba() default silently
+        falls through to a plain text field showing the raw SCSS source
+        text as the value, instead of a color picker.
+        footerBackground/footerText/footerLinkColor must therefore stay
+        declared as literal hex in variables.scss."""
+        variables = self.tc.find_theme_variables('droplets', theme_only=True, flat=True)
+        for varname in ('footerBackground', 'footerText', 'footerLinkColor'):
+            self.assertTrue(
+                variables[varname].startswith('#'),
+                f'{varname} = {variables[varname]!r} does not start with "#" -- '
+                'the theme editor will render it as a plain text field, not a color picker',
+            )
+
+
 class RecompileThemeCommandTest(TestCase):
     """recompile_theme management command must resolve names before retry."""
 

--- a/esp/esp/themes/theme_data/droplets/scss/main.scss
+++ b/esp/esp/themes/theme_data/droplets/scss/main.scss
@@ -312,19 +312,19 @@ div.navbar-collapse {
 }
 
 #footer .navbar-nav a {
-    color: rgba(255, 255, 255, 0.85);
+    color: $footerLinkColor;
     padding: 0.25rem 0.75rem;
 }
 
 #footer .qsd_header {
-    color: rgba(255, 255, 255, 0.7);
+    color: $footerText;
     border-color: rgba(255, 255, 255, 0.35);
     margin-bottom: 0.25rem;
 }
 
 #footer .qsd_view_visible {
     border: none;
-    color: rgba(255, 255, 255, 0.85);
+    color: $footerLinkColor;
 }
 
 // Bootstrap 5 gives .dropdown-menu 0.5rem of vertical padding.  The navbar
@@ -394,9 +394,23 @@ div.navbar-collapse {
         .navbar-dark .navbar-nav .nav-item:hover,
         .navbar-dark .navbar-nav .nav-item:focus-within { background-color: $navbarInverseBackgroundHighlight !important; }
     }
+    //  Footer defaults to the same $primary background as the navbar (no rule
+    //  needed for that — .footer-container .navbar.bg-dark already matches the
+    //  unconditional .navbar.bg-dark rule above).  Only force $footerBackground
+    //  when the admin actually changed it, same rationale as navbarInverseBackground.
+    @if index($esp-overridden, 'footerBackground') {
+        .footer-container .navbar.bg-dark { background: $footerBackground !important; }
+    }
 } @else {
     .navbar.bg-dark {
         background-color: $navbarInverseBackground !important;
+    }
+
+    //  Footer background defaults to $navbarInverseBackground (same as the
+    //  navbar) but can be customized independently — see issue #5028.  Higher
+    //  specificity than .navbar.bg-dark above so it wins for the footer only.
+    .footer-container .navbar.bg-dark {
+        background-color: $footerBackground !important;
     }
 
     .navbar-dark .navbar-nav .nav-link,

--- a/esp/esp/themes/theme_data/droplets/scss/variables.scss
+++ b/esp/esp/themes/theme_data/droplets/scss/variables.scss
@@ -1,3 +1,16 @@
 $navbarBrandFontSize: 24px;
 $navbarFontSize: 20px;
 $navbarCollapseWidth: 979px;
+
+// Footer colors default to the navbar-inverse background's own stock value
+// and the footer's previous hardcoded rendering, so leaving them untouched
+// renders identically to before this PR (see main.scss for how they're
+// used).  Literal hex, not a $navbarInverseBackground reference or rgba():
+// the theme editor's "advanced variables" section infers the input type
+// (color/length/text) from the raw declared value (see
+// esp/esp/themes/views.py's editor() view), and only a leading '#' is
+// recognized as a color -- a variable reference or rgba() falls through to
+// a plain text field with the raw source text shown as the value.
+$footerBackground: #111111;
+$footerText: #b8b8b8;
+$footerLinkColor: #dbdbdb;


### PR DESCRIPTION
## Description

The footer's `<nav>` in the Droplets theme reuses the exact same `navbar navbar-dark bg-dark` classes as the header navbar, so there was no way to give the footer its own background/text/link colors without also recoloring the header.

The fix adds `footerBackground`, `footerText`, and `footerLinkColor` as new theme-editor variables, scoped to `.footer-container` so they only affect the footer. Defaults match the current rendering exactly, so existing sites see no visual change unless an admin explicitly customizes the new fields.

This supersedes #5029, which was written against the LESS pipeline and was closed after the SCSS migration (#5936) made it a no-op - this PR reimplements the same feature against the current SCSS pipeline.

## Related Issue

Closes #5028

## Type of Change

- [x] Bug fix

## Testing

- [x] Existing tests pass
- [x] New tests added (if applicable)
- [x] Manually verified

**Manual verification** - reproduced the bug and the fix in a live dev server:

_Before:_ header and footer forced to the same color (`navbarInverseBackground` set, footer has no independent color yet)

<img width="1280" height="762" alt="Screenshot 2026-09-08 at 6 49 14 PM" src="https://github.com/user-attachments/assets/01a9a604-b703-44a8-8210-706469e5772a" />


_After:_ header unchanged, footer independently recolored via the new `footerBackground` field - confirmed the new fields also render as working color pickers in the Theme Editor UI, with correct persisted values

<img width="1280" height="761" alt="Screenshot 2026-09-08 at 6 51 26 PM" src="https://github.com/user-attachments/assets/40ae58a2-2657-450e-a88f-5d2cb4336cbd" />

<hr>

**Automated tests** - added a `DropletsFooterStylingTest` class (7 tests) covering default backward compatibility, independent override, both Bootswatch code paths, and a regression guard for the editor's color-picker input-type detection. Ran the full `esp/themes` suite locally via Docker - all 46 tests pass, including the 7 new ones.

```
docker compose exec -w /app/esp web pytest esp/themes -v
```

<img width="1026" height="571" alt="Screenshot 2026-09-08 at 7 02 32 PM" src="https://github.com/user-attachments/assets/88a956c2-1fc9-4ebc-86b5-ed1267c3ee98" />


## AI Disclosure

AI assisted

## Checklist

- [x] Self-reviewed the code
- [x] No new warnings or errors introduced