### PR TITLE
fix: resolve N+1 query in catalog_status API

### DIFF
--- a/esp/esp/program/modules/handlers/onsiteclasslist.py
+++ b/esp/esp/program/modules/handlers/onsiteclasslist.py
@@ -103,10 +103,10 @@ class OnSiteClassList(ProgramModuleObj):
         sections = list(ClassSection.objects.filter(parent_class__parent_program=prog, status__gt=0).extra({'event_ids':  """ARRAY(SELECT "cal_event"."id" FROM "cal_event", "program_classsection_meeting_times" WHERE ("program_classsection_meeting_times"."event_id" = "cal_event"."id" AND "program_classsection_meeting_times"."classsection_id" = "program_classsection"."id"))"""}).values('id', 'parent_class__id', 'enrolled_students', 'event_ids', 'registration_status'))
         
         section_ids = [s['id'] for s in sections]
-        section_objs = ClassSection.objects.filter(id__in=section_ids).select_related('parent_class__parent_program')
+        section_objs = ClassSection.objects.filter(id__in=section_ids).select_related('parent_class__parent_program__studentclassregmoduleinfo')
         capacity_map = {sec.id: sec.capacity for sec in section_objs}
         for section in sections:
-            section['capacity'] = capacity_map.get(section['id'], 0)
+            section['capacity'] = capacity_map[section['id']]
         data = {
             #   Todo: section current capacity ? (see ClassSection.get_capacity())
             'classes': list(ClassSubject.objects.filter(parent_program=prog, status__gt=0).extra({'teacher_names': """array_to_string(ARRAY(SELECT auth_user.first_name || ' ' || auth_user.last_name FROM auth_user,program_class_teachers WHERE program_class_teachers.classsubject_id=program_class.id AND auth_user.id=program_class_teachers.espuser_id), ', ')""", 'class_size_max_optimal': """SELECT program_classsizerange.range_max FROM program_classsizerange WHERE program_classsizerange.id = optimal_class_size_range_id"""}).values('id', 'class_size_max', 'class_size_max_optimal', 'class_info', 'prereqs', 'hardness_rating', 'grade_min', 'grade_max', 'title', 'teacher_names', 'category__symbol', 'category__id')),

--- a/esp/esp/program/modules/handlers/onsiteclasslist.py
+++ b/esp/esp/program/modules/handlers/onsiteclasslist.py
@@ -101,8 +101,12 @@ class OnSiteClassList(ProgramModuleObj):
         resp = HttpResponse(content_type='application/json')
         #   Fetch a reduced version of the catalog to save time
         sections = list(ClassSection.objects.filter(parent_class__parent_program=prog, status__gt=0).extra({'event_ids':  """ARRAY(SELECT "cal_event"."id" FROM "cal_event", "program_classsection_meeting_times" WHERE ("program_classsection_meeting_times"."event_id" = "cal_event"."id" AND "program_classsection_meeting_times"."classsection_id" = "program_classsection"."id"))"""}).values('id', 'parent_class__id', 'enrolled_students', 'event_ids', 'registration_status'))
-        for i in range(0, len(sections)):
-            sections[i]['capacity'] = ClassSection.objects.get(id=sections[i]['id']).capacity
+        
+        section_ids = [s['id'] for s in sections]
+        section_objs = ClassSection.objects.filter(id__in=section_ids).select_related('parent_class__parent_program')
+        capacity_map = {sec.id: sec.capacity for sec in section_objs}
+        for section in sections:
+            section['capacity'] = capacity_map.get(section['id'], 0)
         data = {
             #   Todo: section current capacity ? (see ClassSection.get_capacity())
             'classes': list(ClassSubject.objects.filter(parent_program=prog, status__gt=0).extra({'teacher_names': """array_to_string(ARRAY(SELECT auth_user.first_name || ' ' || auth_user.last_name FROM auth_user,program_class_teachers WHERE program_class_teachers.classsubject_id=program_class.id AND auth_user.id=program_class_teachers.espuser_id), ', ')""", 'class_size_max_optimal': """SELECT program_classsizerange.range_max FROM program_classsizerange WHERE program_classsizerange.id = optimal_class_size_range_id"""}).values('id', 'class_size_max', 'class_size_max_optimal', 'class_info', 'prereqs', 'hardness_rating', 'grade_min', 'grade_max', 'title', 'teacher_names', 'category__symbol', 'category__id')),

--- a/esp/esp/program/modules/handlers/onsiteclasslist.py
+++ b/esp/esp/program/modules/handlers/onsiteclasslist.py
@@ -101,7 +101,7 @@ class OnSiteClassList(ProgramModuleObj):
         resp = HttpResponse(content_type='application/json')
         #   Fetch a reduced version of the catalog to save time
         sections = list(ClassSection.objects.filter(parent_class__parent_program=prog, status__gt=0).extra({'event_ids':  """ARRAY(SELECT "cal_event"."id" FROM "cal_event", "program_classsection_meeting_times" WHERE ("program_classsection_meeting_times"."event_id" = "cal_event"."id" AND "program_classsection_meeting_times"."classsection_id" = "program_classsection"."id"))"""}).values('id', 'parent_class__id', 'enrolled_students', 'event_ids', 'registration_status'))
-        
+
         section_ids = [s['id'] for s in sections]
         section_objs = ClassSection.objects.filter(id__in=section_ids).select_related('parent_class__parent_program__studentclassregmoduleinfo')
         capacity_map = {sec.id: sec.capacity for sec in section_objs}


### PR DESCRIPTION
### Description

Resolves #5430.

The `catalog_status` endpoint in `OnSiteClassList` was previously experiencing an N+1 query issue. It was fetching all sections using `.values()`, but then iterating over them and calling `ClassSection.objects.get(id=...).capacity` inside the loop. This resulted in an extra query for each section, severely slowing down the page load for programs with a large number of sections.

### Changes Made
- Replaced the loop with a single bulk fetch using `ClassSection.objects.filter(id__in=...).select_related('parent_class__parent_program')`.
- Built a dictionary mapping `id -> capacity` in memory and updated the serialized payload directly.
- The use of `select_related('parent_class__parent_program')` ensures that all properties required to compute the dynamic capacity (including program-level `studentclassregmoduleinfo`) are pre-fetched, avoiding any hidden N+1 queries during the `.capacity` calculation.

### Verification
- Navigating to the onsite class changes grid will now trigger only a few constant queries instead of N+1, reducing database overhead drastically.
