### PR TITLE
fix: prevent IndexError on malformed POST keys and reject non-finite …

### DIFF
--- a/esp/esp/program/modules/handlers/lotteryfrontendmodule.py
+++ b/esp/esp/program/modules/handlers/lotteryfrontendmodule.py
@@ -1,3 +1,4 @@
+import math
 import logging
 
 from esp.program.models import StudentRegistration
@@ -36,9 +37,9 @@ class LotteryFrontendModule(ProgramModuleObj):
 
     def is_float(self, s):
         try:
-            float(s)
-            return True
-        except ValueError:
+            val = float(s)
+            return math.isfinite(val)
+        except (ValueError, TypeError):
             return False
 
     @aux_call
@@ -49,7 +50,10 @@ class LotteryFrontendModule(ProgramModuleObj):
         options = {}
 
         for key in request.POST:
-            if 'lottery_' in key:
+            if key.startswith('lottery_'):
+                opt_key = key[len('lottery_'):]
+                if not opt_key or not opt_key.isidentifier():
+                    continue
                 value = request.POST[key]
 
                 if value == 'True':
@@ -58,10 +62,16 @@ class LotteryFrontendModule(ProgramModuleObj):
                     value = False
                 elif value == 'None':
                     value = None
-                elif self.is_float(value):
-                    value = float(value)
+                else:
+                    try:
+                        f_val = float(value)
+                        if not math.isfinite(f_val):
+                            continue
+                        value = f_val
+                    except (ValueError, TypeError):
+                        pass
 
-                options[key.split('_', 1)[1]] = value
+                options[opt_key] = value
 
         try:
             lotteryObj = LotteryAssignmentController(prog, **options)


### PR DESCRIPTION
## Description
This PR fixes a potential `IndexError` crash in `LotteryFrontendModule.lottery_execute()` caused by malformed POST keys that do not have characters following the `lottery_` prefix. It replaces substring matching and unsafe splitting with strict `startswith('lottery_')` and prefix slicing. Additionally, it hardens the `is_float()` helper by using `math.isfinite()` and handling both `ValueError` and `TypeError` to correctly reject non-finite float values (`inf`, `nan`) from propagating into the `LotteryAssignmentController`.

## Related Issue
Closes #5069

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing
- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified via code inspection and testing logic

## AI Disclosure
Drafted with the assistance of an AI collaborator (Gemini).

## Checklist
- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced