### PR TITLE
Fix #6014: Remove underlines and fix padding in bigpicture sidebar

### DIFF
--- a/esp/esp/themes/theme_data/barebones/templates/main.html
+++ b/esp/esp/themes/theme_data/barebones/templates/main.html
@@ -52,7 +52,7 @@ Example stylesheet inclusion tag:
 <div class="container">
   <div class="row">
     {% block sidebar %}
-    <div class="hidden" id="sidebar">
+    <div class="col-md-3 hidden" id="sidebar">
       <ul class="nav flex-column sidebar">
         {% include "sidebar/me.html" %}
         {% include "sidebar/programs.html" %}
@@ -62,7 +62,7 @@ Example stylesheet inclusion tag:
     </div>
     {% endblock %}
 
-    <main id="main" class="col-md-12 resizable" tabindex="-1">
+    <main id="main" class="col-md-9 resizable" tabindex="-1">
       {% if request.COOKIES.esp_testing_role %}
       <div style="background: #fcf8e3; border: 1px solid #c09853; color: #c09853; padding: 8px 15px; margin-bottom: 15px; border-radius: 4px; text-align: center;">
         <strong>Testing Mode ({{ request.COOKIES.esp_testing_role }})</strong> &mdash;

--- a/esp/esp/themes/theme_data/bigpicture/templates/sidebar/nav.html
+++ b/esp/esp/themes/theme_data/bigpicture/templates/sidebar/nav.html
@@ -4,7 +4,7 @@
     <li class="dropdown-header">
         {# links on headers are optional #}
         {% if section.header_link %}
-        <a href="{{section.header_link}}">
+        <a class="text-decoration-none d-block p-3" href="{{section.header_link}}">
         {% endif %}
             {{section.header}}
         {% if section.header_link %}
@@ -16,7 +16,7 @@
     {% for item in section.links %}
     {# TODO(benkraft): allow adding classes to items so we can do logged-in only #}
     <li>
-        <a href="{{item.link}}">
+        <a  class="text-decoration-none d-block p-3" href="{{item.link}}">
             {% if item.icon %}
             <i class="bi bi-{{item.icon}}"></i>
             {% endif %}
@@ -41,7 +41,7 @@
             <li class="dropdown-header">
                 {# links on headers are optional #}
                 {% if section.header_link %}
-                <a href="{{section.header_link}}">
+                <a class="text-decoration-none d-block p-3" href="{{section.header_link}}">
                 {% endif %}
                     {{section.header}}
                 {% if section.header_link %}
@@ -53,7 +53,7 @@
             {% for item in section.links %}
             {# TODO(benkraft): allow adding classes to items so we can do logged-in only #}
             <li>
-                <a href="{{item.link}}">
+                <a  class="text-decoration-none d-block p-3" href="{{item.link}}">
                     {% if item.icon %}
                     <i class="bi bi-{{item.icon}}"></i>
                     {% endif %}


### PR DESCRIPTION
## Description

Updated the Bootstrap utility classes in the bigpicture sidebar templates (`nav.html` and `admin.html`) by adding `text-decoration-none d-block p-3` to remove link underlines and ensure the hover highlight stretches fully across the container. Also updated the column grid layout in `main.html` to allocate correct spacing for the sidebar (`col-md-3`) and main content (`col-md-9`).

## Related Issue

Closes #6014

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

## AI Disclosure

Used AI to learn how to navigate the repository, locate the correct Django HTML templates, and identify the necessary Bootstrap utility classes for the fix. 

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced