### PR TITLE
Fix delivery failure notification recipients in cronmail.send_email_requests (#6016)

### DIFF
--- a/esp/esp/dbmail/cronmail.py
+++ b/esp/esp/dbmail/cronmail.py
@@ -32,6 +32,7 @@ Learning Unlimited, Inc.
   Phone: 617-379-0178
   Email: web-team@learningu.org
 """
+from collections import defaultdict
 import logging
 logger = logging.getLogger(__name__)
 
@@ -141,16 +142,22 @@ def send_email_requests():
 
     #   Report any errors
     if errors:
-        recipients = [mailtxt.send_from]
+        errors_by_sender = defaultdict(list)
+        for err in errors:
+            errors_by_sender[err['email'].send_from].append(err)
 
-        if 'bounces' in settings.DEFAULT_EMAIL_ADDRESSES:
-            recipients.append(settings.DEFAULT_EMAIL_ADDRESSES['bounces'])
+        for send_from, sender_errors in errors_by_sender.items():
+            recipients = [send_from] if send_from else []
 
-        mail_context = {'errors': errors}
-        delivery_failed_string = render_to_string('email/delivery_failed', mail_context)
-        logger.warning('Mail delivery failure: %s', delivery_failed_string)
-        # TODO(benkraft): this is probably redundant with the logging now?  (or
-        # rather, it will be if we log at the right level?)
-        send_mail('Mail delivery failure', delivery_failed_string, settings.SERVER_EMAIL, recipients)
+            if 'bounces' in settings.DEFAULT_EMAIL_ADDRESSES:
+                recipients.append(settings.DEFAULT_EMAIL_ADDRESSES['bounces'])
+
+            if recipients:
+                mail_context = {'errors': sender_errors}
+                delivery_failed_string = render_to_string('email/delivery_failed', mail_context)
+                logger.warning('Mail delivery failure: %s', delivery_failed_string)
+                # TODO(benkraft): this is probably redundant with the logging now?  (or
+                # rather, it will be if we log at the right level?)
+                send_mail('Mail delivery failure', delivery_failed_string, settings.SERVER_EMAIL, recipients)
     elif num_sent > 0:
         logger.info('No mail delivery failures')

--- a/esp/esp/dbmail/test_dbmail_cronmail.py
+++ b/esp/esp/dbmail/test_dbmail_cronmail.py
@@ -1,0 +1,220 @@
+from __future__ import absolute_import
+
+from unittest.mock import MagicMock, patch
+
+from django.conf import settings
+from django.test import TestCase, override_settings
+
+from esp.dbmail.cronmail import send_email_requests
+
+
+class MockQuerySet(object):
+    """Mock QuerySet supporting count(), slicing, and iterator() for batch testing."""
+
+    def __init__(self, items):
+        self.items = items
+
+    def count(self):
+        return len(self.items)
+
+    def __getitem__(self, val):
+        if isinstance(val, slice):
+            return MockQuerySet(self.items[val])
+        return self.items[val]
+
+    def iterator(self):
+        return iter(self.items)
+
+
+class MockTextOfEmail(object):
+    """Mock TextOfEmail object with configurable send() behavior."""
+
+    def __init__(self, email_id, send_from, send_to, subject, exception=None):
+        self.id = email_id
+        self.send_from = send_from
+        self.send_to = send_to
+        self.subject = subject
+        self.exception = exception
+
+    def send(self):
+        return self.exception
+
+
+class CronmailSendEmailRequestsTest(TestCase):
+    """Tests for send_email_requests() in esp.dbmail.cronmail."""
+
+    @patch('esp.dbmail.cronmail.send_mail')
+    @patch('esp.dbmail.cronmail.TextOfEmail.objects.filter')
+    def test_delivery_failure_sent_to_failed_email_sender(self, mock_filter, mock_send_mail):
+        """
+        Verify that when an email from sender1 fails and a subsequent email from
+        sender2 succeeds, the delivery failure notification is sent to sender1,
+        NOT to sender2 (fixing loop variable leakage).
+        """
+        mail1 = MockTextOfEmail(
+            email_id=1,
+            send_from='sender1@example.com',
+            send_to='recipient1@example.com',
+            subject='Failed Message',
+            exception=RuntimeError('SMTP connection refused'),
+        )
+        mail2 = MockTextOfEmail(
+            email_id=2,
+            send_from='sender2@example.com',
+            send_to='recipient2@example.com',
+            subject='Successful Message',
+            exception=None,
+        )
+        mock_filter.return_value = MockQuerySet([mail1, mail2])
+
+        send_email_requests()
+
+        # send_mail should have been called for mail delivery failure
+        failure_calls = [
+            call for call in mock_send_mail.call_args_list
+            if call[0][0] == 'Mail delivery failure'
+        ]
+        self.assertEqual(len(failure_calls), 1)
+
+        args, _ = failure_calls[0]
+        subject, body, from_email, recipients = args
+
+        # The failure notification must be sent to sender1, NOT sender2
+        self.assertIn('sender1@example.com', recipients)
+        self.assertNotIn('sender2@example.com', recipients)
+        self.assertIn('Failed Message', body)
+        self.assertNotIn('Successful Message', body)
+
+    @patch('esp.dbmail.cronmail.send_mail')
+    @patch('esp.dbmail.cronmail.TextOfEmail.objects.filter')
+    def test_multiple_senders_receive_separate_failure_notices(self, mock_filter, mock_send_mail):
+        """
+        Verify that when failures occur across multiple senders, each sender
+        receives only their respective failure report.
+        """
+        mail1 = MockTextOfEmail(
+            email_id=1,
+            send_from='alice@example.com',
+            send_to='dest1@example.com',
+            subject='Alice Message',
+            exception=RuntimeError('Mailbox full'),
+        )
+        mail2 = MockTextOfEmail(
+            email_id=2,
+            send_from='bob@example.com',
+            send_to='dest2@example.com',
+            subject='Bob Message',
+            exception=RuntimeError('Host unreachable'),
+        )
+        mock_filter.return_value = MockQuerySet([mail1, mail2])
+
+        send_email_requests()
+
+        failure_calls = [
+            call for call in mock_send_mail.call_args_list
+            if call[0][0] == 'Mail delivery failure'
+        ]
+        self.assertEqual(len(failure_calls), 2)
+
+        # Map each recipient to the body content of their notification
+        notifications = {}
+        for call in failure_calls:
+            args, _ = call
+            recipients = args[3]
+            body = args[1]
+            for r in recipients:
+                notifications[r] = body
+
+        self.assertIn('alice@example.com', notifications)
+        self.assertIn('Alice Message', notifications['alice@example.com'])
+        self.assertNotIn('Bob Message', notifications['alice@example.com'])
+
+        self.assertIn('bob@example.com', notifications)
+        self.assertIn('Bob Message', notifications['bob@example.com'])
+        self.assertNotIn('Alice Message', notifications['bob@example.com'])
+
+    @patch('esp.dbmail.cronmail.send_mail')
+    @patch('esp.dbmail.cronmail.TextOfEmail.objects.filter')
+    def test_same_sender_multiple_failures_grouped(self, mock_filter, mock_send_mail):
+        """
+        Verify that multiple failures from the same sender are grouped into
+        a single delivery failure notification.
+        """
+        mail1 = MockTextOfEmail(
+            email_id=1,
+            send_from='teacher@example.com',
+            send_to='student1@example.com',
+            subject='Class Update 1',
+            exception=RuntimeError('Bounce'),
+        )
+        mail2 = MockTextOfEmail(
+            email_id=2,
+            send_from='teacher@example.com',
+            send_to='student2@example.com',
+            subject='Class Update 2',
+            exception=RuntimeError('Bounce'),
+        )
+        mock_filter.return_value = MockQuerySet([mail1, mail2])
+
+        send_email_requests()
+
+        failure_calls = [
+            call for call in mock_send_mail.call_args_list
+            if call[0][0] == 'Mail delivery failure'
+        ]
+        self.assertEqual(len(failure_calls), 1)
+
+        args, _ = failure_calls[0]
+        body = args[1]
+        recipients = args[3]
+
+        self.assertEqual(recipients[0], 'teacher@example.com')
+        self.assertIn('Class Update 1', body)
+        self.assertIn('Class Update 2', body)
+
+    @override_settings(DEFAULT_EMAIL_ADDRESSES={'bounces': 'bounces@example.com'})
+    @patch('esp.dbmail.cronmail.send_mail')
+    @patch('esp.dbmail.cronmail.TextOfEmail.objects.filter')
+    def test_bounces_address_included_when_configured(self, mock_filter, mock_send_mail):
+        """
+        Verify that the default bounce address is included in recipients
+        when configured in settings.DEFAULT_EMAIL_ADDRESSES.
+        """
+        mail = MockTextOfEmail(
+            email_id=10,
+            send_from='organizer@example.com',
+            send_to='student@example.com',
+            subject='Program Notice',
+            exception=RuntimeError('SMTP error'),
+        )
+        mock_filter.return_value = MockQuerySet([mail])
+
+        send_email_requests()
+
+        failure_calls = [
+            call for call in mock_send_mail.call_args_list
+            if call[0][0] == 'Mail delivery failure'
+        ]
+        self.assertEqual(len(failure_calls), 1)
+
+        recipients = failure_calls[0][0][3]
+        self.assertIn('organizer@example.com', recipients)
+        self.assertIn('bounces@example.com', recipients)
+
+    @patch('esp.dbmail.cronmail.send_mail')
+    @patch('esp.dbmail.cronmail.TextOfEmail.objects.filter')
+    def test_all_successful_sends_no_failure_notifications(self, mock_filter, mock_send_mail):
+        """
+        Verify that no failure notification is dispatched when all emails send successfully.
+        """
+        mail1 = MockTextOfEmail(1, 's1@example.com', 'd1@example.com', 'Sub 1', None)
+        mail2 = MockTextOfEmail(2, 's2@example.com', 'd2@example.com', 'Sub 2', None)
+        mock_filter.return_value = MockQuerySet([mail1, mail2])
+
+        send_email_requests()
+
+        failure_calls = [
+            call for call in mock_send_mail.call_args_list
+            if call[0][0] == 'Mail delivery failure'
+        ]
+        self.assertEqual(len(failure_calls), 0)


### PR DESCRIPTION
### Summary

Fixes #6016.

In `esp/esp/dbmail/cronmail.py`, `send_email_requests()` processes unsent email requests in batches. If any delivery errors occur, lines 143–154 previously sent the delivery failure notification to `recipients = [mailtxt.send_from]`.

Because `mailtxt` is the loop variable from `for mailtxt in mailtxts[:batch_size].iterator():`, it leaked into the function scope and held the value of the **last processed email in the batch** (which is usually a successful email). This caused:
1. Senders whose emails actually failed to never receive delivery failure notifications.
2. The sender of the last evaluated (successful) email to receive a false delivery failure alert.
3. Errors from different senders to be bundled together and sent to the wrong person.

---

### Changes Made

1. **`esp/esp/dbmail/cronmail.py`**:
   - Grouped `errors` by sender address (`err['email'].send_from`) using `defaultdict(list)`.
   - Iterated over each sender to send delivery failure notices containing only their own failed emails.
   - Preserved inclusion of `settings.DEFAULT_EMAIL_ADDRESSES['bounces']` when configured.
   - Guarded `send_mail` with `if recipients:` to ensure emails are only sent when valid recipients exist.

2. **`esp/esp/dbmail/test_dbmail_cronmail.py`**:
   - Added unit test suite covering:
     - Delivery failure notification sent to the failed email sender rather than subsequent successful senders.
     - Separate notifications sent to different failed senders.
     - Grouping of multiple errors from the same sender into a single notification.
     - Inclusion of the global `bounces` address when configured.
     - No failure emails dispatched when all sends succeed.

---

### Testing

- Added 5 new regression unit tests in `esp/esp/dbmail/test_dbmail_cronmail.py`.
- Verified syntax with `python3 -m py_compile`.
- Verified style compliance with `.flake8` rules (4-space indents, no tabs, no trailing whitespace).