### PR TITLE
Fix unhandled ValueError and KeyError on query parameters across ProgramPrintables (#6017)

### DIFF
--- a/esp/esp/program/modules/handlers/programprintables.py
+++ b/esp/esp/program/modules/handlers/programprintables.py
@@ -201,30 +201,39 @@ class ProgramPrintables(ProgramModuleObj):
         category_options = prog.class_categories.all().values_list('category', flat=True)
         categories = category_options
 
-        if request.GET.get('first_sort', ''):
-            sort_list.append( cmp_fn[request.GET['first_sort']] )
-            sort_name_list.append( request.GET['first_sort'] )
+        first_sort = request.GET.get('first_sort', '')
+        if first_sort in cmp_fn:
+            sort_list.append( cmp_fn[first_sort] )
+            sort_name_list.append( first_sort )
         else:
             sort_list.append( cmp_fn["category"] )
 
-        if request.GET.get('second_sort', ''):
-            sort_list.append( cmp_fn[request.GET['second_sort']] )
-            sort_name_list.append( request.GET['second_sort'] )
+        second_sort = request.GET.get('second_sort', '')
+        if second_sort in cmp_fn:
+            sort_list.append( cmp_fn[second_sort] )
+            sort_name_list.append( second_sort )
         else:
             sort_list.append( cmp_fn["timeblock"] )
 
-        if request.GET.get('third_sort', ''):
-            sort_list.append( cmp_fn[request.GET['third_sort']] )
-            sort_name_list.append( request.GET['third_sort'] )
+        third_sort = request.GET.get('third_sort', '')
+        if third_sort in cmp_fn:
+            sort_list.append( cmp_fn[third_sort] )
+            sort_name_list.append( third_sort )
         else:
             sort_list.append( cmp_fn["title"] )
 
         if 'categories' in request.GET:
             categories = request.GET.getlist('categories')
         if 'grade_min' in request.GET:
-            grade_min = int(request.GET['grade_min'])
+            try:
+                grade_min = int(request.GET['grade_min'])
+            except ValueError:
+                pass
         if 'grade_max' in request.GET:
-            grade_max = int(request.GET['grade_max'])
+            try:
+                grade_max = int(request.GET['grade_max'])
+            except ValueError:
+                pass
 
         classes = ClassSubject.objects.filter(parent_program = self.program, status__gt=0)
         classes = classes.filter(grade_min__lte=grade_max)
@@ -299,12 +308,18 @@ class ProgramPrintables(ProgramModuleObj):
         classes = ClassSubject.objects.filter(parent_program = self.program)
 
         if 'mingrade' in request.GET:
-            mingrade=int(request.GET['mingrade'])
-            classes = classes.filter(grade_max__gte=mingrade)
+            try:
+                mingrade = int(request.GET['mingrade'])
+                classes = classes.filter(grade_max__gte=mingrade)
+            except ValueError:
+                pass
 
         if 'maxgrade' in request.GET:
-            maxgrade=int(request.GET['maxgrade'])
-            classes = classes.filter(grade_min__lte=maxgrade)
+            try:
+                maxgrade = int(request.GET['maxgrade'])
+                classes = classes.filter(grade_min__lte=maxgrade)
+            except ValueError:
+                pass
 
         if 'open' in request.GET:
             classes = [cls for cls in classes if not cls.isFull()]
@@ -410,8 +425,11 @@ class ProgramPrintables(ProgramModuleObj):
         comments = 'comments' in request.GET
         classes = ClassSubject.objects.filter(parent_program = prog)
         if 'clsids' in request.GET:
-            clsids = [int(clsid) for clsid in request.GET['clsids'].split(",")]
-            classes = [cls for cls in classes if cls.id in clsids]
+            try:
+                clsids = [int(clsid.strip()) for clsid in request.GET['clsids'].split(",") if clsid.strip()]
+                classes = [cls for cls in classes if cls.id in clsids]
+            except ValueError:
+                pass
         if 'accepted' in request.GET:
             classes = [cls for cls in classes if cls.status > 0]
         elif 'cancelled' in request.GET:
@@ -453,14 +471,23 @@ class ProgramPrintables(ProgramModuleObj):
         classes = ClassSubject.objects.filter(parent_program = self.program)
 
         if 'clsids' in request.GET:
-            clsids = [int(clsid) for clsid in request.GET['clsids'].split(",")]
-            classes = [cls for cls in classes if cls.id in clsids]
+            try:
+                clsids = [int(clsid.strip()) for clsid in request.GET['clsids'].split(",") if clsid.strip()]
+                classes = [cls for cls in classes if cls.id in clsids]
+            except ValueError:
+                pass
 
         if 'grade_min' in request.GET:
-            classes = [cls for cls in classes if cls.grade_max >= int(request.GET['grade_min'])]
+            try:
+                classes = [cls for cls in classes if cls.grade_max >= int(request.GET['grade_min'])]
+            except ValueError:
+                pass
 
         if 'grade_max' in request.GET:
-            classes = [cls for cls in classes if cls.grade_min <= int(request.GET['grade_max'])]
+            try:
+                classes = [cls for cls in classes if cls.grade_min <= int(request.GET['grade_max'])]
+            except ValueError:
+                pass
 
         if 'accepted' in request.GET:
             classes = [cls for cls in classes if cls.status > 0]
@@ -501,18 +528,30 @@ class ProgramPrintables(ProgramModuleObj):
         sections = self.program.sections()
 
         if 'secids' in request.GET:
-            secids = [int(secid) for secid in request.GET['secids'].split(",")]
-            sections = [sec for sec in sections if sec.id in secids]
+            try:
+                secids = [int(secid.strip()) for secid in request.GET['secids'].split(",") if secid.strip()]
+                sections = [sec for sec in sections if sec.id in secids]
+            except ValueError:
+                pass
 
         if 'clsids' in request.GET:
-            clsids = [int(clsid) for clsid in request.GET['clsids'].split(",")]
-            sections = [sec for sec in sections if sec.parent_class.id in clsids]
+            try:
+                clsids = [int(clsid.strip()) for clsid in request.GET['clsids'].split(",") if clsid.strip()]
+                sections = [sec for sec in sections if sec.parent_class.id in clsids]
+            except ValueError:
+                pass
 
         if 'grade_min' in request.GET:
-            sections = [sec for sec in sections if sec.parent_class.grade_max >= int(request.GET['grade_min'])]
+            try:
+                sections = [sec for sec in sections if sec.parent_class.grade_max >= int(request.GET['grade_min'])]
+            except ValueError:
+                pass
 
         if 'grade_max' in request.GET:
-            sections = [sec for sec in sections if sec.parent_class.grade_min <= int(request.GET['grade_max'])]
+            try:
+                sections = [sec for sec in sections if sec.parent_class.grade_min <= int(request.GET['grade_max'])]
+            except ValueError:
+                pass
 
         if 'accepted' in request.GET:
             sections = [sec for sec in sections if sec.status > 0]

--- a/esp/esp/program/modules/handlers/programprintables.py
+++ b/esp/esp/program/modules/handlers/programprintables.py
@@ -202,21 +202,21 @@ class ProgramPrintables(ProgramModuleObj):
         categories = category_options
 
         first_sort = request.GET.get('first_sort', '')
-        if first_sort in cmp_fn:
+        if first_sort and first_sort in cmp_fn:
             sort_list.append( cmp_fn[first_sort] )
             sort_name_list.append( first_sort )
         else:
             sort_list.append( cmp_fn["category"] )
 
         second_sort = request.GET.get('second_sort', '')
-        if second_sort in cmp_fn:
+        if second_sort and second_sort in cmp_fn:
             sort_list.append( cmp_fn[second_sort] )
             sort_name_list.append( second_sort )
         else:
             sort_list.append( cmp_fn["timeblock"] )
 
         third_sort = request.GET.get('third_sort', '')
-        if third_sort in cmp_fn:
+        if third_sort and third_sort in cmp_fn:
             sort_list.append( cmp_fn[third_sort] )
             sort_name_list.append( third_sort )
         else:

--- a/esp/esp/program/modules/tests/programprintables.py
+++ b/esp/esp/program/modules/tests/programprintables.py
@@ -276,3 +276,99 @@ class TestAllClassesFieldConverter(ProgramFrameworkTest):
 
         for t in class_subject.prettyrooms():
             self.assertIn(t, formatted_rooms)
+
+    def test_catalog_invalid_sort_and_grades_do_not_crash(self):
+        """
+        Verify that catalog() falls back gracefully when provided with
+        unrecognized sort keys or non-integer grade bounds (#6017).
+        """
+        self._login_admin()
+        req = self.factory.get(
+            f'/manage/{self.program.getUrlBase()}/catalog',
+            {
+                'first_sort': 'invalid_sort_key',
+                'second_sort': 'non_existent_key',
+                'third_sort': 'bad_key',
+                'grade_min': 'invalid',
+                'grade_max': 'xyz',
+            }
+        )
+        req.user = self.admins[0]
+        req.session = self.client.session
+        response = self.moduleobj.catalog(req, None, None, None, self.moduleobj, None, self.program)
+        self.assertEqual(response.status_code, 200)
+
+    def test_coursecatalog_invalid_grades_do_not_crash(self):
+        """
+        Verify that coursecatalog() ignores non-integer mingrade and maxgrade
+        parameters without raising ValueError (#6017).
+        """
+        self._login_admin()
+        req = self.factory.get(
+            f'/learn/{self.program.getUrlBase()}/catalog/tex',
+            {
+                'mingrade': 'not_an_int',
+                'maxgrade': 'bad_grade',
+                'sort_name_list': 'timeblock',
+            }
+        )
+        req.user = self.admins[0]
+        req.session = self.client.session
+        response = self.moduleobj.coursecatalog(req, None, None, None, self.moduleobj, 'tex', self.program)
+        self.assertEqual(response.status_code, 200)
+
+    def test_classesbyfoo_trailing_commas_and_invalid_grades(self):
+        """
+        Verify that classesbyFOO() handles trailing commas in clsids and
+        non-integer grade bounds gracefully without crashing (#6017).
+        """
+        self._login_admin()
+        req = self.factory.get(
+            f'/manage/{self.program.getUrlBase()}/classesbyFOO',
+            {
+                'clsids': '1,2,',
+                'grade_min': 'invalid',
+                'grade_max': 'xyz',
+            }
+        )
+        req.user = self.admins[0]
+        req.session = self.client.session
+        response = self.moduleobj.classesbyFOO(req, None, None, None, self.moduleobj, None, self.program)
+        self.assertEqual(response.status_code, 200)
+
+    def test_sectionsbyfoo_trailing_commas_and_invalid_grades(self):
+        """
+        Verify that sectionsbyFOO() handles trailing commas in secids/clsids
+        and non-integer grade bounds gracefully without crashing (#6017).
+        """
+        self._login_admin()
+        req = self.factory.get(
+            f'/manage/{self.program.getUrlBase()}/sectionsbyFOO',
+            {
+                'secids': '1,2,',
+                'clsids': '3,4,',
+                'grade_min': 'invalid',
+                'grade_max': 'xyz',
+            }
+        )
+        req.user = self.admins[0]
+        req.session = self.client.session
+        response = self.moduleobj.sectionsbyFOO(req, None, None, None, self.moduleobj, None, self.program)
+        self.assertEqual(response.status_code, 200)
+
+    def test_classflagdetails_trailing_commas_in_clsids(self):
+        """
+        Verify that classflagdetails() handles trailing commas in clsids
+        gracefully without raising ValueError (#6017).
+        """
+        self._login_admin()
+        req = self.factory.get(
+            f'/manage/{self.program.getUrlBase()}/classflagdetails',
+            {
+                'clsids': '1,2,',
+            }
+        )
+        req.user = self.admins[0]
+        req.session = self.client.session
+        response = self.moduleobj.classflagdetails(req, None, None, None, self.moduleobj, None, self.program)
+        self.assertEqual(response.status_code, 200)

--- a/esp/esp/program/modules/tests/programprintables.py
+++ b/esp/esp/program/modules/tests/programprintables.py
@@ -229,54 +229,6 @@ class TestAllClassesSelectionForm(ProgramFrameworkTest):
         form = AllClassesSelectionForm(self.program, params)
         self.assertTrue(form.is_valid())
 
-
-class TestAllClassesFieldConverter(ProgramFrameworkTest):
-
-    def setUp(self, *args, **kwargs):
-        super().setUp(*args, **kwargs)
-        self.class_subjects = ClassSubject.objects.all()
-        self.class_subject_fieldnames = [field.name for field in ClassSubject._meta.fields]
-        self.converter = AllClassesFieldConverter(self.program)
-
-    def test_fieldvalue_fakefield(self):
-        """
-        An invalid field should raise a ValueError
-        """
-        class_subject = self.class_subjects[0]
-        self.assertRaises(ValueError, self.converter.fieldvalue, *[class_subject, 'fake_field'])
-
-    def test_class_subject_fields_accepted(self):
-        """
-        Verifies that the fields on a class subject instance are formatted
-        by the converter.
-        """
-        class_subject = self.class_subjects[0]
-        for fieldname in self.class_subject_fieldnames:
-            self.assertEqual(self.converter.fieldvalue(class_subject, fieldname), \
-                             getattr(class_subject, fieldname))
-
-    def test_class_subject_teachers_format(self):
-        class_subject = self.class_subjects[0]
-
-        teacher_names = [t.name() for t in class_subject.get_teachers()]
-        formatted_teachers = [t.strip() for t in self.converter. \
-                              fieldvalue(class_subject, 'teachers').split(',')]
-        self.assertEqual(set(formatted_teachers), set(teacher_names))
-
-    def test_class_times_format(self):
-        class_subject = self.class_subjects[0]
-        formatted_times = self.converter.fieldvalue(class_subject, 'times')
-
-        for t in class_subject.friendly_times():
-            self.assertIn(t, formatted_times)
-
-    def test_class_rooms_format(self):
-        class_subject = self.class_subjects[0]
-        formatted_rooms = self.converter.fieldvalue(class_subject, 'rooms')
-
-        for t in class_subject.prettyrooms():
-            self.assertIn(t, formatted_rooms)
-
     def test_catalog_invalid_sort_and_grades_do_not_crash(self):
         """
         Verify that catalog() falls back gracefully when provided with
@@ -372,3 +324,51 @@ class TestAllClassesFieldConverter(ProgramFrameworkTest):
         req.session = self.client.session
         response = self.moduleobj.classflagdetails(req, None, None, None, self.moduleobj, None, self.program)
         self.assertEqual(response.status_code, 200)
+
+
+class TestAllClassesFieldConverter(ProgramFrameworkTest):
+
+    def setUp(self, *args, **kwargs):
+        super().setUp(*args, **kwargs)
+        self.class_subjects = ClassSubject.objects.all()
+        self.class_subject_fieldnames = [field.name for field in ClassSubject._meta.fields]
+        self.converter = AllClassesFieldConverter(self.program)
+
+    def test_fieldvalue_fakefield(self):
+        """
+        An invalid field should raise a ValueError
+        """
+        class_subject = self.class_subjects[0]
+        self.assertRaises(ValueError, self.converter.fieldvalue, *[class_subject, 'fake_field'])
+
+    def test_class_subject_fields_accepted(self):
+        """
+        Verifies that the fields on a class subject instance are formatted
+        by the converter.
+        """
+        class_subject = self.class_subjects[0]
+        for fieldname in self.class_subject_fieldnames:
+            self.assertEqual(self.converter.fieldvalue(class_subject, fieldname), \
+                             getattr(class_subject, fieldname))
+
+    def test_class_subject_teachers_format(self):
+        class_subject = self.class_subjects[0]
+
+        teacher_names = [t.name() for t in class_subject.get_teachers()]
+        formatted_teachers = [t.strip() for t in self.converter. \
+                              fieldvalue(class_subject, 'teachers').split(',')]
+        self.assertEqual(set(formatted_teachers), set(teacher_names))
+
+    def test_class_times_format(self):
+        class_subject = self.class_subjects[0]
+        formatted_times = self.converter.fieldvalue(class_subject, 'times')
+
+        for t in class_subject.friendly_times():
+            self.assertIn(t, formatted_times)
+
+    def test_class_rooms_format(self):
+        class_subject = self.class_subjects[0]
+        formatted_rooms = self.converter.fieldvalue(class_subject, 'rooms')
+
+        for t in class_subject.prettyrooms():
+            self.assertIn(t, formatted_rooms)


### PR DESCRIPTION
### Summary

Fixes #6017.

Following up on #6000 (which fixed unhandled `ValueError` in `paid_list`), multiple sibling printable views in `esp/esp/program/modules/handlers/programprintables.py` still parsed `request.GET` parameters without exception handling, leading to HTTP 500 crashes:

1. **`catalog()`**: `cmp_fn[request.GET['first_sort']]` raised `KeyError` on unrecognized sort keys; `grade_min` and `grade_max` raised `ValueError` on non-numeric input.
2. **`coursecatalog()`**: `mingrade` and `maxgrade` raised unhandled `ValueError` on non-numeric input.
3. **`classflagdetails()`**: `clsids` raised `ValueError` on trailing commas (e.g. `?clsids=1,2,`) or non-integer tokens.
4. **`classesbyFOO()`**: `clsids`, `grade_min`, and `grade_max` raised unhandled `ValueError`.
5. **`sectionsbyFOO()`**: `secids`, `clsids`, `grade_min`, and `grade_max` raised unhandled `ValueError`.

---

### Changes Made

- **`esp/esp/program/modules/handlers/programprintables.py`**:
  - Validated sort keys (`first_sort`, `second_sort`, `third_sort`) against `cmp_fn` keys before lookup, falling back to default sort orders instead of raising `KeyError`.
  - Wrapped `grade_min`, `grade_max`, `mingrade`, and `maxgrade` integer conversions in `try...except ValueError` blocks to fallback to defaults or ignore invalid filter inputs.
  - Stripped tokens and wrapped comma-separated ID lists (`clsids`, `secids`) in `try...except ValueError` blocks to safely handle trailing commas and invalid tokens.

- **`esp/esp/program/modules/tests/programprintables.py`**:
  - Added 5 regression tests covering invalid sort keys, non-numeric grades, and trailing commas across `catalog`, `coursecatalog`, `classflagdetails`, `classesbyFOO`, and `sectionsbyFOO`.

---

### Testing

- Added 5 regression tests in `esp/esp/program/modules/tests/programprintables.py`.
- Verified syntax with `python3 -m py_compile`.
- Verified style compliance with `.flake8` rules (4-space indents, no tabs, no trailing whitespace).