### PR TITLE
Fix: Use passwd_recover for admin password reset (#5998)

### DIFF
--- a/esp/templates/admin/login.html
+++ b/esp/templates/admin/login.html
@@ -49,7 +49,7 @@
     {{ form.password.label_tag }} {{ form.password }}
     <input type="hidden" name="next" value="{{ next }}">
   </div>
-  {% url 'admin_password_reset' as password_reset_url %}
+  {% url 'passwd_recover' as password_reset_url %}
   {% if password_reset_url %}
   <div class="password-reset-link">
     <a href="{{ password_reset_url }}">{% translate 'Forgotten your password or username?' %}</a>


### PR DESCRIPTION
This change ensures that the "Forgotten your password or username?" link is rendered properly and routes locked-out admins to the existing password recovery page (/myesp/passwdrecover), consistent with the user-facing login form.


<img width="1100" height="620" alt="02-after-link-renders" src="https://github.com/user-attachments/assets/86f8a5d3-7fdc-47fc-ae9e-a41de44ee749" />
Fixes #5998