### PR TITLE
Fix: Handle use_student_apps option in lottery assignment (#5996)

### DIFF
--- a/esp/esp/program/controllers/lottery.py
+++ b/esp/esp/program/controllers/lottery.py
@@ -55,6 +55,7 @@ from django.db import transaction
 from django.db.models import Min
 import os
 import operator
+import itertools
 import zlib
 import base64
 from io import BytesIO
@@ -301,9 +302,9 @@ class LotteryAssignmentController(object):
         if self.options['use_student_apps']:
             for i in range(1, self.effective_priority_limit+1):
                 for (student_id, section_id) in priority_regs[i]:
-                    self.ranks[self.student_indices[student_id], self.section_indices[section_id]] = ESPUser.getRankInClass(student_id, self.parent_classes[self.section_indices[section_id]])
-            for (student_id, section_id) in interest_regs_sr + interest_regs_ssi:
-                self.ranks[self.student_indices[student_id], self.section_indices[section_id]] = ESPUser.getRankInClass(student_id, self.parent_classes[self.section_indices[section_id]])
+                    self.ranks[self.student_indices[student_id], self.section_indices[section_id]] = ESPUser.getRankInClass(student_id, int(self.parent_classes[self.section_indices[section_id]]))
+            for (student_id, section_id) in itertools.chain(interest_regs_sr, interest_regs_ssi):
+                self.ranks[self.student_indices[student_id], self.section_indices[section_id]] = ESPUser.getRankInClass(student_id, int(self.parent_classes[self.section_indices[section_id]]))
 
 
         #   Populate section schedule

--- a/esp/esp/program/controllers/test_lottery_controller.py
+++ b/esp/esp/program/controllers/test_lottery_controller.py
@@ -20,6 +20,12 @@ from esp.program.models import (
     StudentRegistration,
     StudentSubjectInterest,
 )
+from esp.program.models.app_ import (
+    StudentAppQuestion,
+    StudentAppResponse,
+    StudentAppReview,
+    StudentApplication,
+)
 from esp.program.tests import ProgramFrameworkTest
 from esp.users.models import ESPUser, StudentInfo
 
@@ -332,3 +338,64 @@ class LotterySaveTest(LotteryTestBase):
             relationship__name='Enrolled',
         ).count()
         self.assertEqual(total_before, total_after)
+
+
+# ---------------------------------------------------------------------------
+# LotteryStudentAppsTest
+# ---------------------------------------------------------------------------
+
+class LotteryStudentAppsTest(LotteryTestBase):
+    """Tests for the use_student_apps option, which ranks students by their
+    application reviews instead of treating every signup as rank 10."""
+
+    def _make_app_controller(self):
+        return LotteryAssignmentController(self.program, use_student_apps=True)
+
+    def test_use_student_apps_initializes(self):
+        """The controller initializes with use_student_apps enabled."""
+        for student in self.students:
+            for cls in self.program.classes():
+                StudentSubjectInterest.objects.get_or_create(
+                    user=student, subject=cls
+                )
+        ctrl = self._make_app_controller()
+        self.assertEqual(ctrl.ranks.shape, (ctrl.num_students, ctrl.num_sections))
+
+    def test_use_student_apps_reads_review_score(self):
+        """A reviewed application sets that student/section entry in ranks."""
+        sr = StudentRegistration.objects.filter(
+            relationship=self.priority_rt,
+            section__parent_class__parent_program=self.program,
+        ).order_by('id').first()
+        self.assertIsNotNone(sr)
+        student, section = sr.user, sr.section
+        subject = section.parent_class
+        teacher = subject.get_teachers()[0]
+
+        question = StudentAppQuestion.objects.create(
+            program=self.program, subject=subject, question='Why this class?'
+        )
+        response = StudentAppResponse.objects.create(
+            question=question, response='Because it is interesting.', complete=True
+        )
+        review = StudentAppReview.objects.create(
+            reviewer=teacher, score=5, comments='Solid application.'
+        )
+        app = StudentApplication.objects.create(program=self.program, user=student)
+        app.questions.add(question)
+        app.responses.add(response)
+        app.reviews.add(review)
+
+        ctrl = self._make_app_controller()
+        si = ctrl.student_indices[student.id]
+        sj = ctrl.section_indices[section.id]
+        self.assertGreaterEqual(sj, 0)
+        self.assertEqual(ctrl.ranks[si, sj], 5)
+
+    def test_use_student_apps_compute_assignments_completes(self):
+        """compute_assignments() runs to completion with use_student_apps on."""
+        ctrl = self._make_app_controller()
+        ctrl.compute_assignments()
+        self.assertEqual(
+            ctrl.student_sections.shape, (ctrl.num_students, ctrl.num_sections)
+        )

--- a/esp/esp/users/models/__init__.py
+++ b/esp/esp/users/models/__init__.py
@@ -1344,7 +1344,7 @@ class BaseESPUser(object):
         for sar in StudentAppResponse.objects.filter(question__subject=subject, studentapplication__user=student):
             if not len(sar.response.strip()):
                 return 1
-        rank = max(list(StudentAppReview.objects.filter(studentapplication__user=student, studentapplication__program__classsubject=subject, reviewer__in=subject.teachers()).values_list('score', flat=True)) + [-1])
+        rank = max(list(StudentAppReview.objects.filter(studentapplication__user=student, studentapplication__program__classsubject=subject, reviewer__in=subject.get_teachers()).values_list('score', flat=True)) + [-1])
         if rank == -1:
             rank = default
         return rank


### PR DESCRIPTION
The Problem: 

When administrators enabled the "use student application ranks" option for the class lottery, the lottery would immediately crash and return a 500 Server Error instead of generating student schedules. This was caused by three separate bugs in the code:

It tried to add two database querysets together using a + sign (which isn't allowed in Django).
It passed a numpy integer instead of a standard Python integer when looking up a class, causing the lookup to fail.
It incorrectly tried to call .teachers() as a function when checking for application reviewers.

The Fix:

Replaced the + sign with itertools.chain() to safely combine the database queries.
Wrapped the numpy value in int() so the class lookup succeeds.
Changed .teachers() to the correct .get_teachers() method.
Added new automated tests to ensure this specific lottery feature doesn't break again in the future.


Fixes #5996

