### PR TITLE
Convert jQuery-UI popups to Bootstrap modals

### DIFF
--- a/esp/public/media/scripts/ajaxschedulingmodule/ESP/SectionCommentDialog.js
+++ b/esp/public/media/scripts/ajaxschedulingmodule/ESP/SectionCommentDialog.js
@@ -6,24 +6,14 @@
  */
 function SectionCommentDialog(el, sections) {
     this.el = el;
-    this.dialog = el.dialog({
-        autoOpen: false,
-        height: 200,
-        width: 450,
-        modal: true,
-        buttons: {
-            "Set Comment": function() {
-                this.doSetComment();
-                this.dialog.dialog("close");
-            }.bind(this),
-            Cancel: function() {
-                this.dialog.dialog("close");
-            }.bind(this),
-        },
-        close: function() {
-            this.el.find('form')[0].reset();
-        }.bind(this),
-    });
+    this.modal = bootstrap.Modal.getOrCreateInstance(el[0]);
+    el.find('#commentDialog-save').on("click", function() {
+        this.doSetComment();
+        this.modal.hide();
+    }.bind(this));
+    el[0].addEventListener('hidden.bs.modal', function() {
+        this.el.find('form')[0].reset();
+    }.bind(this));
     this.sections = sections;
 
     /**
@@ -35,7 +25,7 @@ function SectionCommentDialog(el, sections) {
         if(section.schedulingLocked) {
             this.el.find('#commentDialog-lock').prop("checked", true);
         }
-        this.dialog.dialog("open");
+        this.modal.show();
     }.bind(this);
 
     this.doSetComment = function() {

--- a/esp/public/media/scripts/csrf_check.js
+++ b/esp/public/media/scripts/csrf_check.js
@@ -1,27 +1,18 @@
-var csrfAlert;
-function makeCsrfAlert()
+var CSRF_ALERT_MESSAGE = 'It appears your session has become disconnected. Please make sure cookies are enabled and try again.';
+
+//  Show the "session disconnected" warning.  Most pages inherit the modal from
+//  elements/html, but a few (the onsite webapps and the Django admin) are built
+//  on their own skeletons without Bootstrap, so fall back to a plain alert there.
+function showCsrfAlert()
 {
-    if(!$j.ui)
+    var el = document.getElementById('csrf-alert-modal');
+    if (el && window.bootstrap)
     {
-	// Load the appropriate javascript and css
-	$j.getScriptWithCaching('/media/scripts/jquery-ui.js', makeCsrfAlert);
-	if (document.createStylesheet)
-	{
-	    document.createStylesheet('/media/styles/jquery-ui/jquery-ui.css');
-	}
-	else
-	{
-	    $j("head").append($j("<link rel='stylesheet' href='/media/styles/jquery-ui/jquery-ui.css' type='text/css' >"));
-	}
+        bootstrap.Modal.getOrCreateInstance(el).show();
     }
     else
     {
-	csrfAlert = $j('<div></div>')
-	    .html('It appears your session has become disconnected. Please make sure cookies are enabled and try again.')
-            .dialog({
-		autoOpen: false,
-		title: 'Oops!'
-            });
+        alert(CSRF_ALERT_MESSAGE);
     }
 }
 
@@ -33,7 +24,6 @@ function strip_tags(str)
 var check_csrf_cookie = function(form)
 {
     //console.log("CSRF check!");
-    //csrfAlert.dialog('open');
     //If the form is null, return false
     if (!form) return false;
 
@@ -63,11 +53,7 @@ var check_csrf_cookie = function(form)
     csrf_cookie = $j.cookie("esp_csrftoken");
     if (csrf_cookie == null)
     {
-	if(!csrfAlert)
-	{
-	    makeCsrfAlert();
-	}
-        csrfAlert.dialog('open');
+        showCsrfAlert();
         return false;
     }
 

--- a/esp/public/media/scripts/lottery_student_reg/class_popups.js
+++ b/esp/public/media/scripts/lottery_student_reg/class_popups.js
@@ -1,33 +1,16 @@
 
-// The class description popup is a global variable, because we only want
-// one object, and we don't want to recreate it each time
-var class_desc_popup;
-// Function to initially create the class description popup (using jQuery UI dialogs)
-create_class_info_dialog = function(){
-    class_desc_popup = $j('<div></div>').dialog({
-	    autoOpen: false,
-	    minWidth: 400,
-	    minHeight: 300,
-	    modal: true,
-	    buttons: {
-		Ok: function() {
-		    $j(this).dialog("close");
-		}
-	    },
-	    title: ''
-	});
-};
+// The class description popup lives in the page as #class-desc-modal
+function class_desc_modal(){
+    return bootstrap.Modal.getOrCreateInstance(document.getElementById('class-desc-modal'));
+}
 
 // Dictionary to keep track of classes' extra info as and when we load them
 var class_info = {};
 // Initial popup that tells the user we're loading the class data
 loading_class_desc = function(){
-    class_desc_popup.dialog('option', 'title', 'Loading');
-    class_desc_popup.dialog('option', 'width', 400);
-    class_desc_popup.dialog('option', 'height', 200);
-    class_desc_popup.dialog('option', 'position', 'center');
-    class_desc_popup.html('Loading class info...');
-    class_desc_popup.dialog('open');
+    $j('#class-desc-modal-title').text('Loading');
+    $j('#class-desc-modal .modal-body').html('Loading class info...');
+    class_desc_modal().show();
 };
 
 
@@ -35,14 +18,11 @@ loading_class_desc = function(){
 fill_class_desc = function(class_id){
     var parent_class_id = sections[class_id].parent_class;
     extra_info = class_info[parent_class_id];
-    class_desc_popup.dialog('option', 'title', sections[class_id].emailcode + ": " + extra_info.title);
-    class_desc_popup.dialog('option', 'width', 600);
-    class_desc_popup.dialog('option', 'height', 400);
-    class_desc_popup.dialog('option', 'position', 'center');
-    class_desc_popup.html('');
-    class_desc_popup.append("<p><b>Category:</b> " + extra_info.category + "</p>");
-    //class_desc_popup.append("<p>Difficulty: " + extra_info.difficulty + "</p>");
-    class_desc_popup.append("<p><b>Description:</b> " + extra_info.class_info + "</p>");
+    $j('#class-desc-modal-title').text(sections[class_id].emailcode + ": " + extra_info.title);
+    var $body = $j('#class-desc-modal .modal-body').empty();
+    $body.append("<p><b>Category:</b> " + extra_info.category + "</p>");
+    //$body.append("<p>Difficulty: " + extra_info.difficulty + "</p>");
+    $body.append("<p><b>Description:</b> " + extra_info.class_info + "</p>");
 };
 
 

--- a/esp/public/media/scripts/lottery_student_reg/splash_timeslot.js
+++ b/esp/public/media/scripts/lottery_student_reg/splash_timeslot.js
@@ -65,9 +65,6 @@ var Timeslot = function(data){
 
     this.add_classes_to_timeslot = function(sections){
 
-	// Create the dialog used to show class info
-	create_class_info_dialog();
-
 	carryover_id_list = timeslot_data['sections'];
 	class_id_list = timeslot_data['starting_sections'];
 

--- a/esp/public/media/scripts/onsite/ajax_status.js
+++ b/esp/public/media/scripts/onsite/ajax_status.js
@@ -249,21 +249,6 @@ function setup_search()
 
 /*  Event handlers  */
 
-function show_loading_box()
-{
-    var loading_box = $j("<div/>").attr("id", "loading_box");
-    loading_box.html("Loading...");
-    loading_box.dialog({
-        autoOpen: true,
-        modal: false
-    });
-}
-
-function hide_loading_box()
-{
-    $j("#loading_box").dialog("close");
-}
-
 function print_schedule()
 {
     printer_name = $j("#printer_selector").attr("value");
@@ -639,11 +624,11 @@ function register_student(student_id, dialog)
                 if(data.status) {
                     fetch_all();
                     set_current_student(parseInt(student_id));
-                    dialog.dialog("close");
+                    bootstrap.Modal.getOrCreateInstance(dialog[0]).hide();
                 } else {
                     $j('#not-registered-msg').hide();
                     $j('#noinfo-msg').show();
-                    $j("#dialog-confirm-button-register").button("disable");
+                    $j("#dialog-confirm-button-register").prop("disabled", true);
                 }
             },
 
@@ -734,9 +719,9 @@ function autocomplete_select_item(event, ui)
             var dialog = $j("#dialog-confirm");
             $j("#not-registered-msg").show();
             $j("#noinfo-msg").hide();
-            $j("#dialog-confirm-button-register").button("enable");
+            $j("#dialog-confirm-button-register").prop("disabled", false);
             dialog.data('student_id', student_id);
-            dialog.dialog('open');
+            bootstrap.Modal.getOrCreateInstance(dialog[0]).show();
         }
         else 
         {
@@ -997,7 +982,7 @@ function render_table(display_mode, student_id)
             }
             
             //  Create a tooltip with more information about the class
-            new_td.addClass("tooltip");
+            new_td.addClass("onsite-tooltip");
             var tooltip_div = $j("<span/>").addClass("tooltip_hover");
             var short_data = section.title + " - Grades " + class_data.grade_min.toString() + "--" + class_data.grade_max.toString();
             if(class_data.hardness_rating) short_data = class_data.hardness_rating + " " + short_data;
@@ -1460,28 +1445,11 @@ $j(document).ready(function () {
     //  Once they have all completed, the results will be parsed and the
     //  class changes grid will be displayed.
 
-    var dialog = $j("#dialog-confirm").dialog({
-        resizable: true,
-        width: 450,
-        height:250,
-        modal: true,
-        buttons: [{
-            id: "dialog-confirm-button-register",
-            text: "Register Account",
-            click: function() {
-                register_student($j(this).data('student_id'),$j(this));
-            }
-        },
-        {
-            id: "dialog-confirm-button-cancel",
-            text: "Cancel",
-            click: function() {
-                $j(this).dialog( "close" );
-            }
-        }]
+    var dialog = $j("#dialog-confirm");
+    //  The Cancel button dismisses the modal via data-bs-dismiss.
+    $j("#dialog-confirm-button-register").on("click", function() {
+        register_student(dialog.data('student_id'), dialog);
     });
-
-    dialog.dialog("close");
 
     $j("#messages").html("Loading class and student data...");
     

--- a/esp/public/media/scripts/program/modules/adminclass.js
+++ b/esp/public/media/scripts/program/modules/adminclass.js
@@ -16,11 +16,7 @@ var handleSubmit = function () { this.submit(); }
 var handleCancel = function () { this.cancel(); }
 
 function show_saving_popup() {
-  saving_popup
-    .dialog('option', 'title', 'Saving')
-    .html('Saving the class status...')
-    .dialog('option', 'buttons', [])
-    .dialog('open');
+  bootstrap.Modal.getOrCreateInstance(document.getElementById('saving_popup')).show();
 }
 
 //returns details (status string, action, and CSS classes) for a given status code
@@ -256,7 +252,7 @@ function update_class(clsid, statusId) {
       el.find("strong").text('[' + status_details['text'] + ']');
       
       // Close the dialog box
-      saving_popup.dialog("close");
+      bootstrap.Modal.getOrCreateInstance(document.getElementById('saving_popup')).hide();
     }
   });
 }

--- a/esp/public/media/scripts/program/modules/admissionsdashboard.js
+++ b/esp/public/media/scripts/program/modules/admissionsdashboard.js
@@ -37,6 +37,17 @@ $j(function () {
             return 'You have unsaved changes; if you leave this page, they will be lost.';
         }
     });
+    //  Bound once here rather than per row, since every comments cell shares
+    //  the one modal; it saves whichever cell was opened last.
+    $j('#comments-modal .comments-save').on("click", function () {
+        var text = $j('#comments-modal .comments-textarea').val();
+        var change = {};
+        change[active_comments_field] = text;
+        active_comments_cell.set_comment(text);
+        update(active_comments_app_id, change);
+        bootstrap.Modal.getOrCreateInstance(
+            document.getElementById('comments-modal')).hide();
+    });
 });
 
 function load_class(class_id, prev) {
@@ -148,19 +159,39 @@ function make_teacher_ranking_cell(app, num_apps, readonly) {
     return $teacher_ranking;
 }
 
+//  Which comments cell currently has the shared modal open.
+var active_comments_cell = null;
+var active_comments_app_id = null;
+var active_comments_field = null;
+
+//  Point the shared comments modal at one cell and open it.
+function open_comments_modal($cell, app_id, field, instructions, readonly) {
+    active_comments_cell = $cell;
+    active_comments_app_id = app_id;
+    active_comments_field = field;
+
+    var $modal = $j('#comments-modal');
+    $modal.find('.comments-instructions').text(instructions);
+    $modal.find('.comments-textarea')
+        .val($cell.data('comment'))
+        .prop('readonly', !!readonly);
+    //  Readonly cells get a lone Close button; editable ones get Save/Cancel.
+    $modal.find('.comments-save').toggle(!readonly);
+    $modal.find('.comments-dismiss').text(readonly ? 'Close' : 'Cancel');
+    $modal.one('shown.bs.modal', function () {
+        $modal.find('.comments-textarea').trigger('focus');
+    });
+    bootstrap.Modal.getOrCreateInstance($modal[0]).show();
+}
+
 function make_teacher_comments_cell(app, readonly) {
-    var $textarea = $j('<textarea rows="5" cols="50" />');
-    var $teacher_comments_dialog = $j('<div title="Comments"></div>').append(
-        readonly ? '<p>View teacher comment below.</p>'
-            : '<p>Type your comment below.</p>',
-        $textarea
-    );
     var $teacher_comments = $j('<div></div>')
         .addClass('teacher_comments')
         .on("click", function () {
-            var text = $teacher_comments.data('comment');
-            $teacher_comments_dialog.dialog('open');
-            $textarea.val(text).focus();
+            open_comments_modal($teacher_comments, app.id, 'teacher_comment',
+                                readonly ? 'View teacher comment below.'
+                                         : 'Type your comment below.',
+                                readonly);
         });
     $teacher_comments.set_comment = function (comment) {
         if (readonly) {
@@ -174,26 +205,6 @@ function make_teacher_comments_cell(app, readonly) {
         }
     }
     $teacher_comments.set_comment(app.teacher_comment)
-    $teacher_comments_dialog.dialog({
-        autoOpen: false,
-        modal: true,
-        width: 'auto',
-        buttons: readonly ? {
-            'Close': function () {
-                $j(this).dialog('close');
-            }
-        } : {
-            'Save': function () {
-                var text = $textarea.val();
-                $teacher_comments.set_comment(text);
-                update(app.id, {'teacher_comment': text});
-                $(this).dialog('close');
-            },
-            'Cancel': function () {
-                $j(this).dialog('close');
-            }
-        }
-    });
     return $teacher_comments;
 }
 
@@ -212,39 +223,18 @@ function make_admin_status_cell(app) {
 }
 
 function make_admin_comments_cell(app) {
-    var $textarea = $j('<textarea rows="5" cols="50" />');
-    var $admin_comments_dialog = $j('<div title="Comments"></div>').append(
-        '<p>Type your comment below.</p>',
-        $textarea
-    );
     var $admin_comments = $j('<div></div>')
         .addClass('admin_comments')
-        .data('comment', app.admin_comment || '')
-        .text(app.admin_comment || '(click to add comment)')
-        .css('color', app.admin_comment ? '' : '#aaa')
         .on("click", function () {
-            var text = $admin_comments.data('comment');
-            $admin_comments_dialog.dialog('open');
-            $textarea.val(text).focus();
+            open_comments_modal($admin_comments, app.id, 'admin_comment',
+                                'Type your comment below.', false);
         });
-    $admin_comments_dialog.dialog({
-        autoOpen: false,
-        modal: true,
-        width: 'auto',
-        buttons: {
-            'Save': function () {
-                var text = $textarea.val();
-                $admin_comments.data('comment', text)
-                    .text(text || '(click to add comment)')
-                    .css('color', text ? '' : '#aaa');
-                update(app.id, {'admin_comment': text});
-                $j(this).dialog('close');
-            },
-            'Cancel': function () {
-                $j(this).dialog('close');
-            }
-        }
-    });
+    $admin_comments.set_comment = function (comment) {
+        this.data('comment', comment)
+            .text(comment || '(click to add comment)')
+            .css('color', comment ? '' : '#aaa');
+    };
+    $admin_comments.set_comment(app.admin_comment || '');
     return $admin_comments;
 }
 

--- a/esp/public/media/scripts/program/modules/student_schedule.js
+++ b/esp/public/media/scripts/program/modules/student_schedule.js
@@ -6,21 +6,13 @@
 //  Attach the removal confirmation dialogs to the remove links currently in the
 //  document.  The dialogs live inside the schedule fragment, so this has to be
 //  re-run every time the fragment is replaced.
+//  Keep this in sync with the equivalent inline script in
+//  templates/users/student_schedule.html, which does the same thing for the
+//  server-rendered copy of this schedule.
 function setup_remove_confirmation()
 {
-    //  Create two dialog boxes with two different warning messages,
-    //  one that appears when you try to remove an enrolled class,
-    //  and another that appears when you try removing a non-enrolled class.
-    //  autoOpen: false makes it so that the dialog boxes don't appear on page load.
-    $j("div.remove-confirm").dialog({
-        resizable: false,
-        modal: true,
-        autoOpen: false,
-        closeOnEscape: false
-    });
-
     //  When clicking any remove link, handle the event here rather than immediately removing the class.
-    //  Display a warning dialog box, and give the user an option to confirm the removal or cancel it.
+    //  Display a warning modal, and give the user an option to confirm the removal or cancel it.
     $j("a.remove").click(function(eventObject) {
         //  The hyperlink click is always cancelled at first.
         //  If the user confirms the removal,
@@ -30,15 +22,13 @@ function setup_remove_confirmation()
         var cls_code = $j(this).attr("data-sec-code");
         //  "enrolled" for enrolled classes, "applied" for non-enrolled classes
         var remove_type = $j(this).attr("data-remove-type");
-        $j("#" + remove_type + "-remove-confirm").dialog("option", "title", "Remove class " + cls_code + "?").dialog("option", "buttons", {
-            "Remove class": function() {
-                $j(this).dialog("close");
-                window.location.replace($a_remove_tag.attr("href"));
-            },
-            "Cancel": function() {
-                $j(this).dialog("close");
-            }
-        }).dialog("open");
+        var $modal = $j("#" + remove_type + "-remove-confirm");
+        $modal.find(".modal-title").text("Remove class " + cls_code + "?");
+        $modal.find(".remove-confirm-action").off("click").on("click", function() {
+            bootstrap.Modal.getOrCreateInstance($modal[0]).hide();
+            window.location.replace($a_remove_tag.attr("href"));
+        });
+        bootstrap.Modal.getOrCreateInstance($modal[0]).show();
     });
 }
 

--- a/esp/public/media/styles/onsite_ajax_status.css
+++ b/esp/public/media/styles/onsite_ajax_status.css
@@ -238,17 +238,17 @@ span {
     width: 150px;
 }
 
-.tooltip {
+.onsite-tooltip {
     position: relative; /*this is the key*/
     color: #000000 !important;
     text-decoration: none !important;
 }
 
-.tooltip span.tooltip_hover {
+.onsite-tooltip span.tooltip_hover {
     display: none;
 }
 
-.tooltip:hover span.tooltip_hover { /*the span will display just on :hover state*/
+.onsite-tooltip:hover span.tooltip_hover { /*the span will display just on :hover state*/
     display: block;
     position: absolute;
     z-index: 25;

--- a/esp/templates/SpecRunner.html
+++ b/esp/templates/SpecRunner.html
@@ -16,6 +16,7 @@
 <!-- 3rd party -->
 <script type="text/javascript" src="/media/scripts/ajaxschedulingmodule/jquery.js"></script>
 <script type="text/javascript" src="/media/scripts/jquery-ui.js"></script>
+<script src="/media/theme_editor/node_modules/bootstrap/dist/js/bootstrap.bundle.min.js?v=5.3.3"></script>
 <script type="text/javascript" src="/media/scripts/ajaxschedulingmodule/lib/fixed_table_rc.js"></script>
 
 

--- a/esp/templates/elements/html
+++ b/esp/templates/elements/html
@@ -205,6 +205,24 @@
 
     {% autoescape off %}{{ settings.ADDITIONAL_TEMPLATE_SCRIPTS }}{% endautoescape %}
     {% endblock %}
+{# Shown by csrf_check.js when the session's CSRF cookie is missing #}
+<div class="modal fade" id="csrf-alert-modal" tabindex="-1"
+     aria-labelledby="csrf-alert-modal-title" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="csrf-alert-modal-title">Oops!</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        It appears your session has become disconnected. Please make sure cookies are enabled and try again.
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary" data-bs-dismiss="modal">OK</button>
+      </div>
+    </div>
+  </div>
+</div>
   </body>
 </html>
 

--- a/esp/templates/inclusion/program/class_teacher_list_row.html
+++ b/esp/templates/inclusion/program/class_teacher_list_row.html
@@ -113,7 +113,7 @@
   </td>
   <td class="clsmiddle">
     {% if can_req_cancel %}
-        <button class="btn btn-info" onclick="requestCancel({{cls.id}})">Request Cancellation</button>
+        <button type="button" class="btn btn-info" data-bs-toggle="modal" data-bs-target="#request_{{ cls.id }}">Request Cancellation</button>
     {% endif %}
   </td>
 </tr>

--- a/esp/templates/program/modules/adminclass/listclasses.html
+++ b/esp/templates/program/modules/adminclass/listclasses.html
@@ -31,7 +31,9 @@ json_data = {};
 <hr />
 
 {# Shown by adminclass.js while a class status change is saving #}
-<div class="modal fade" id="saving_popup" tabindex="-1" data-bs-backdrop="static"
+{# No .fade: the AJAX often finishes before a fade-in would, and Bootstrap #}
+{# ignores hide() while a transition is still running, leaving this stuck open. #}
+<div class="modal" id="saving_popup" tabindex="-1" data-bs-backdrop="static"
      aria-labelledby="saving_popup_title" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">

--- a/esp/templates/program/modules/adminclass/listclasses.html
+++ b/esp/templates/program/modules/adminclass/listclasses.html
@@ -13,15 +13,6 @@ json_data = {};
 /* <![CDATA[ */
   var has_moderator_module = "{{ program|hasModule:"TeacherModeratorModule" }}";
   var moderator_title = "{{ program.getModeratorTitle }}";
-  
-  // Create the class description popup for the Status button
-  saving_popup = $j('<div></div>').attr('id', "saving_popup")
-    .dialog({
-      autoOpen: false,
-      minWidth: 250,
-      minHeight: 100,
-      modal: true
-    });
 
   // Set up sorting control
   $j(document).ready(setup_sort_control);
@@ -38,6 +29,20 @@ json_data = {};
 <link rel="stylesheet" href="/media/styles/forms.css" type="text/css" />
 
 <hr />
+
+{# Shown by adminclass.js while a class status change is saving #}
+<div class="modal fade" id="saving_popup" tabindex="-1" data-bs-backdrop="static"
+     aria-labelledby="saving_popup_title" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="saving_popup_title">Saving</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">Saving the class status...</div>
+    </div>
+  </div>
+</div>
 
 <div class="module_group" id="listclasses">
   <div class="module_group_header">

--- a/esp/templates/program/modules/admissionsdashboard/admissions.html
+++ b/esp/templates/program/modules/admissionsdashboard/admissions.html
@@ -66,7 +66,7 @@
     <p>Click on a student's name to the left to view their app here.</p>
   </div>
   {# Shared by every comments cell; admissionsdashboard.js fills it in on click #}
-  <div class="modal fade" id="comments-modal" tabindex="-1"
+  <div class="modal fade" id="comments-modal" tabindex="-1" data-bs-backdrop="static"
        aria-labelledby="comments-modal-title" aria-hidden="true">
     <div class="modal-dialog">
       <div class="modal-content">

--- a/esp/templates/program/modules/admissionsdashboard/admissions.html
+++ b/esp/templates/program/modules/admissionsdashboard/admissions.html
@@ -5,9 +5,12 @@
 <title>Admissions Dashboard</title>
 
 <link href="https://ajax.aspnetcdn.com/ajax/jquery.ui/{{ settings.JQUERY_UI_VERSION }}/themes/base/jquery-ui.css" rel="stylesheet" type="text/css"/>
+<link rel="stylesheet" type="text/css" href="/media/styles/theme_compiled.css?v={{ current_theme_version }}"/>
+<link rel="stylesheet" type="text/css" href="/media/styles/bs5-compat.css" />
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/{{ settings.JQUERY_VERSION }}/jquery.min.js" integrity="{{ settings.JQUERY_HASH }}" crossorigin="anonymous"></script>
 <script src="https://code.jquery.com/jquery-migrate-3.3.2.{% if not settings.DEBUG %}min.{% endif %}js"></script>
 <script type="text/javascript" src="https://ajax.aspnetcdn.com/ajax/jquery.ui/{{ settings.JQUERY_UI_VERSION }}/jquery-ui.js"></script>
+<script src="/media/theme_editor/node_modules/bootstrap/dist/js/bootstrap.bundle.min.js?v=5.3.3"></script>
 <script type="text/javascript" src="/media/scripts/jquery.cookie.js"></script>
 <script type='text/javascript' src='/media/scripts/common.js'></script>
 
@@ -61,6 +64,26 @@
   </div>
   <div id="student-detail">
     <p>Click on a student's name to the left to view their app here.</p>
+  </div>
+  {# Shared by every comments cell; admissionsdashboard.js fills it in on click #}
+  <div class="modal fade" id="comments-modal" tabindex="-1"
+       aria-labelledby="comments-modal-title" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="comments-modal-title">Comments</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <p class="comments-instructions"></p>
+          <textarea rows="5" class="form-control comments-textarea"></textarea>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary comments-dismiss" data-bs-dismiss="modal">Cancel</button>
+          <button type="button" class="btn btn-primary comments-save">Save</button>
+        </div>
+      </div>
+    </div>
   </div>
 </body>
 

--- a/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
+++ b/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
@@ -304,7 +304,7 @@
   </tr>
 </table>
 
-<div class="modal fade" id="commentDialog" tabindex="-1"
+<div class="modal fade" id="commentDialog" tabindex="-1" data-bs-backdrop="static"
      aria-labelledby="commentDialog-title" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">

--- a/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
+++ b/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
@@ -17,12 +17,15 @@
 <link id='sch_css' href='/media/styles/scheduling.css' type='text/css' rel='stylesheet' />
 <link id='tooltip_css' href='/media/styles/tooltips.css' type='text/css' rel='stylesheet' />
 <link href="https://ajax.aspnetcdn.com/ajax/jquery.ui/{{ settings.JQUERY_UI_VERSION }}/themes/base/jquery-ui.css" rel="stylesheet" type="text/css"/>
+<link rel="stylesheet" type="text/css" href="/media/styles/theme_compiled.css?v={{ current_theme_version }}"/>
+<link rel="stylesheet" type="text/css" href="/media/styles/bs5-compat.css" />
 <link rel="stylesheet" type="text/css" href="/media/scripts/ajaxschedulingmodule/lib/fixed_table_rc.css" />
 
 <!-- 3rd party -->
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/{{ settings.JQUERY_VERSION }}/jquery.min.js" integrity="{{ settings.JQUERY_HASH }}" crossorigin="anonymous"></script>
 <script src="https://code.jquery.com/jquery-migrate-3.3.2.{% if not settings.DEBUG %}min.{% endif %}js"></script>
 <script type="text/javascript" src="https://ajax.aspnetcdn.com/ajax/jquery.ui/{{ settings.JQUERY_UI_VERSION }}/jquery-ui.js"></script>
+<script src="/media/theme_editor/node_modules/bootstrap/dist/js/bootstrap.bundle.min.js?v=5.3.3"></script>
 <script type="text/javascript" src="/media/scripts/jquery.cookie.js"></script>
 <script type='text/javascript' src='/media/scripts/common.js'></script>
 <script type="text/javascript" src="/media/scripts/csrf_init.js"></script>
@@ -301,15 +304,30 @@
   </tr>
 </table>
 
-<div id="commentDialog">
-  <form>
-    <fieldset>
-      <label for="commentDialog-comment">Comment</label>
-      <input type="text" id="commentDialog-comment" class="ui-widget-content ui-corner-all" />
-      <input type="checkbox" id="commentDialog-lock" class="ui-widget-content ui-corner-all" />
-      <label for="commentDialog-lock">Lock</label>
-    </fieldset>
-  </form>
+<div class="modal fade" id="commentDialog" tabindex="-1"
+     aria-labelledby="commentDialog-title" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form>
+        <div class="modal-header">
+          <h5 class="modal-title" id="commentDialog-title">Set Comment</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <label for="commentDialog-comment" class="form-label">Comment</label>
+          <input type="text" id="commentDialog-comment" class="form-control" />
+          <div class="form-check mt-3">
+            <input type="checkbox" id="commentDialog-lock" class="form-check-input" />
+            <label for="commentDialog-lock" class="form-check-label">Lock</label>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="button" class="btn btn-primary" id="commentDialog-save">Set Comment</button>
+        </div>
+      </form>
+    </div>
+  </div>
 </div>
 
 <div id="legend">

--- a/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
+++ b/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
@@ -14,11 +14,11 @@
 
 <!-- LIBS -->
 <!-- STYLE -->
+<link rel="stylesheet" type="text/css" href="/media/styles/theme_compiled.css?v={{ current_theme_version }}"/>
+<link rel="stylesheet" type="text/css" href="/media/styles/bs5-compat.css" />
 <link id='sch_css' href='/media/styles/scheduling.css' type='text/css' rel='stylesheet' />
 <link id='tooltip_css' href='/media/styles/tooltips.css' type='text/css' rel='stylesheet' />
 <link href="https://ajax.aspnetcdn.com/ajax/jquery.ui/{{ settings.JQUERY_UI_VERSION }}/themes/base/jquery-ui.css" rel="stylesheet" type="text/css"/>
-<link rel="stylesheet" type="text/css" href="/media/styles/theme_compiled.css?v={{ current_theme_version }}"/>
-<link rel="stylesheet" type="text/css" href="/media/styles/bs5-compat.css" />
 <link rel="stylesheet" type="text/css" href="/media/scripts/ajaxschedulingmodule/lib/fixed_table_rc.css" />
 
 <!-- 3rd party -->

--- a/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
+++ b/esp/templates/program/modules/ajaxschedulingmodule/ajax_scheduling.html
@@ -413,5 +413,23 @@ $j(function() {
 });
 </script>
 
+{# Shown by csrf_check.js when the session's CSRF cookie is missing #}
+<div class="modal fade" id="csrf-alert-modal" tabindex="-1"
+     aria-labelledby="csrf-alert-modal-title" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="csrf-alert-modal-title">Oops!</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        It appears your session has become disconnected. Please make sure cookies are enabled and try again.
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary" data-bs-dismiss="modal">OK</button>
+      </div>
+    </div>
+  </div>
+</div>
 </body>
 </html>

--- a/esp/templates/program/modules/lotterystudentregmodule/student_reg_splash.html
+++ b/esp/templates/program/modules/lotterystudentregmodule/student_reg_splash.html
@@ -50,4 +50,21 @@ var open_class_registration = {{ open_class_registration }};
 	<div id="preferences"></div>
     </div>
 
+    {# Class description popup, filled in by class_popups.js #}
+    <div class="modal fade" id="class-desc-modal" tabindex="-1"
+         aria-labelledby="class-desc-modal-title" aria-hidden="true">
+      <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="class-desc-modal-title"></h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body"></div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Ok</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
 {% endblock %}

--- a/esp/templates/program/modules/lotterystudentregmodule/student_reg_splash.html
+++ b/esp/templates/program/modules/lotterystudentregmodule/student_reg_splash.html
@@ -51,7 +51,7 @@ var open_class_registration = {{ open_class_registration }};
     </div>
 
     {# Class description popup, filled in by class_popups.js #}
-    <div class="modal fade" id="class-desc-modal" tabindex="-1"
+    <div class="modal fade" id="class-desc-modal" tabindex="-1" data-bs-backdrop="static"
          aria-labelledby="class-desc-modal-title" aria-hidden="true">
       <div class="modal-dialog modal-lg">
         <div class="modal-content">

--- a/esp/templates/program/modules/onsiteclasslist/ajax_status.html
+++ b/esp/templates/program/modules/onsiteclasslist/ajax_status.html
@@ -6,6 +6,7 @@
 <script src="https://code.jquery.com/jquery-migrate-3.3.2.{% if not settings.DEBUG %}min.{% endif %}js"></script>
 <script type="text/javascript" src="/media/scripts/jquery.cookie.js"></script>
 <script type="text/javascript" src="https://ajax.aspnetcdn.com/ajax/jquery.ui/{{ settings.JQUERY_UI_VERSION }}/jquery-ui.js"></script>
+<script src="/media/theme_editor/node_modules/bootstrap/dist/js/bootstrap.bundle.min.js?v=5.3.3"></script>
 <script type="text/javascript" src="/media/scripts/common.js"></script>
 <script type="text/javascript">
     $j(document).ready(function() {
@@ -28,6 +29,8 @@
     }
 </style>
 <link href="https://ajax.aspnetcdn.com/ajax/jquery.ui/{{ settings.JQUERY_UI_VERSION }}/themes/base/jquery-ui.css" rel="stylesheet" type="text/css"/>
+<link rel="stylesheet" type="text/css" href="/media/styles/theme_compiled.css?v={{ current_theme_version }}"/>
+<link rel="stylesheet" type="text/css" href="/media/styles/bs5-compat.css" />
 <link rel="stylesheet" type="text/css" href="/media/styles/forms.css" />
 <link rel="stylesheet" type="text/css" href="/media/styles/onsite_ajax_status.css" />
 
@@ -128,18 +131,33 @@
 <div id="space_at_bottom" style="height: 400px;">&nbsp;</div>
 
 <a name="settings" />
-<div id="dialog-confirm" title="Register Account?" class="d-none">
-  <div id="not-registered-msg">
-  <p>
-    This student is not registered with {{ program.name }}. 
-    </p>
-    <p>
-        Please verify that the student is wearing their {{ program.name }}-issued nametag or has otherwise completed all steps (including any forms and/or payment) necessary to participate in the program.
-    </p>
-  </div>
-  <div id="noinfo-msg" style="display:none;">
-  Sorry, but this student needs to supply more information. Please register this student
-  using the New Student Registration form.
+<div class="modal fade" id="dialog-confirm" tabindex="-1" data-bs-backdrop="static"
+     aria-labelledby="dialog-confirm-title" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="dialog-confirm-title">Register Account?</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div id="not-registered-msg">
+        <p>
+          This student is not registered with {{ program.name }}.
+          </p>
+          <p>
+              Please verify that the student is wearing their {{ program.name }}-issued nametag or has otherwise completed all steps (including any forms and/or payment) necessary to participate in the program.
+          </p>
+        </div>
+        <div id="noinfo-msg" style="display:none;">
+        Sorry, but this student needs to supply more information. Please register this student
+        using the New Student Registration form.
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" id="dialog-confirm-button-cancel" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-primary" id="dialog-confirm-button-register">Register Account</button>
+      </div>
+    </div>
   </div>
 </div>
 </body>

--- a/esp/templates/program/modules/onsiteclasslist/ajax_status.html
+++ b/esp/templates/program/modules/onsiteclasslist/ajax_status.html
@@ -160,5 +160,23 @@
     </div>
   </div>
 </div>
+{# Shown by csrf_check.js when the session's CSRF cookie is missing #}
+<div class="modal fade" id="csrf-alert-modal" tabindex="-1"
+     aria-labelledby="csrf-alert-modal-title" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="csrf-alert-modal-title">Oops!</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        It appears your session has become disconnected. Please make sure cookies are enabled and try again.
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary" data-bs-dismiss="modal">OK</button>
+      </div>
+    </div>
+  </div>
+</div>
 </body>
 </html>

--- a/esp/templates/program/modules/teacherclassregmodule/listclasses.html
+++ b/esp/templates/program/modules/teacherclassregmodule/listclasses.html
@@ -1,47 +1,10 @@
-<style>
-.ui-dialog-titlebar-close {
-    padding:0 !important;
-}
-
-.ui-dialog-titlebar-close:after {
-    content: '';
-    width: 18px;
-    height: 20px;
-    display: inline-block;
-    background-image: url(/media/styles/jquery-ui/images/ui-icons_444444_256x240.png);
-    background-position: -96px -128px;
-    background-repeat: no-repeat;
-}
-</style>
-
 {% block xtrajs %}
 <script type="text/javascript">
 $j(function() {
     $j(".cancel_confirm").on("change", function() {
-        $j(this).nextAll("input").prop("disabled", !$j(this).prop("checked"));
+        $j(this).closest("form").find("[type=submit]").prop("disabled", !$j(this).prop("checked"));
     });
 });
-
-function requestCancel(cls) {
-    $j('#request_' + cls).dialog({
-        height: "auto",
-        width: 500,
-        resizable: false,
-        modal: true,
-        autoOpen: true,
-        closeText: "Close",
-        closeOnEscape: true,
-        title: "Class Cancellation Request",
-        // Allows user to escape popup by clicking outside of it
-        open: function(event, ui) { 
-            $j('.ui-widget-overlay').bind('click', function()
-            { 
-                $j(this).siblings('.ui-dialog').find('.ui-dialog-content').dialog('close');
-            });
-        },
-    });
-}
-
 </script>
 {% endblock %}
 
@@ -73,18 +36,31 @@ If you have any questions regarding the program, <br /> please email the
 <div id="battlescreen">
 
 {% for cls in clslist %}
-<!--
-Popup div for class cancellation request
--->
-<div hidden id="request_{{ cls.id }}">
-  <form method="post" action="/teach/{{program.getUrlBase}}/cancelrequest/">
-    <h3>Cancellation Request for {{ cls|truncatewords:6 }}</h3>
-    <input type="hidden" name="cls" value="{{ cls.id }}">
-    <label for="reason_{{ cls.id }}" class="ui-hidden-accessible">Reason for Cancellation:</label>
-    <textarea rows="4" style="width: 450px;" id="reason_{{ cls.id }}" name="reason" placeholder="Enter text here..." required></textarea><br>
-    <input type="checkbox" class="cancel_confirm" name="confirm" id="confirm_{{ cls.id }}" required> <label for="confirm_{{ cls.id }}">I confirm I would like this class to be cancelled.</label><br>
-    <input type="submit" value="Submit" disabled>
-  </form>
+{# Cancellation request modal, opened by the button in class_teacher_list_row.html #}
+<div class="modal fade" id="request_{{ cls.id }}" tabindex="-1" aria-labelledby="request_title_{{ cls.id }}" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form method="post" action="/teach/{{program.getUrlBase}}/cancelrequest/">
+        <div class="modal-header">
+          <h5 class="modal-title" id="request_title_{{ cls.id }}">Cancellation Request for {{ cls|truncatewords:6 }}</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <input type="hidden" name="cls" value="{{ cls.id }}">
+          <label for="reason_{{ cls.id }}" class="form-label">Reason for Cancellation:</label>
+          <textarea rows="4" class="form-control" id="reason_{{ cls.id }}" name="reason" placeholder="Enter text here..." required></textarea>
+          <div class="form-check mt-3">
+            <input type="checkbox" class="form-check-input cancel_confirm" name="confirm" id="confirm_{{ cls.id }}" required>
+            <label class="form-check-label" for="confirm_{{ cls.id }}">I confirm I would like this class to be cancelled.</label>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+          <button type="submit" class="btn btn-danger" disabled>Submit</button>
+        </div>
+      </form>
+    </div>
+  </div>
 </div>
 {% endfor %}
 

--- a/esp/templates/program/modules/volunteersignup/signup.html
+++ b/esp/templates/program/modules/volunteersignup/signup.html
@@ -34,21 +34,13 @@
 <script type="text/javascript">
   function confirm_cancellation() {
       $j("input[name=clear_requests]").val("True");
-      $j("#confirm_cancellation_dialog").dialog("close");
+      bootstrap.Modal.getOrCreateInstance(document.getElementById("confirm_cancellation_dialog")).hide();
       $j("#volunteer_shift_form").trigger("submit");
-  }
-
-  function decline_cancellation() {
-      $j("#confirm_cancellation_dialog").dialog("close");
   }
 
   $j(document).ready(function () {
       Availability.init({{ isAdmin|yesno:"true,false" }});
 
-      $j("#confirm_cancellation_dialog").dialog({
-          autoOpen: false,
-          buttons: [ { text: "Confirm", click: confirm_cancellation }, {text: "Cancel", click: decline_cancellation} ]
-      });
       $j("#volunteer_form_submit").click(function (event) {
           //  Check if the user has previous requests and is asking to clear all of them
           var checkboxes_checked = $j("input[name=requests]:checked");
@@ -58,7 +50,7 @@
               event.preventDefault();
 
               //  Show the confirmation dialog
-              $j("#confirm_cancellation_dialog").dialog("open");
+              bootstrap.Modal.getOrCreateInstance(document.getElementById("confirm_cancellation_dialog")).show();
           }
           else {
               //  They are not cancelling all shifts; submit the form normally
@@ -188,10 +180,25 @@ The directors have been notified that you are no longer able to volunteer at {{ 
     </center>
   </form>
 </div>
-<div id="confirm_cancellation_dialog" title="Confirm Cancellation">
-  You have unchecked all volunteer shifts. If you must cancel your volunteer
-  commitments, please click "Confirm" to notify the directors. Otherwise, click
-  "Cancel".
+<div class="modal fade" id="confirm_cancellation_dialog" tabindex="-1"
+     aria-labelledby="confirm_cancellation_title" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="confirm_cancellation_title">Confirm Cancellation</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        You have unchecked all volunteer shifts. If you must cancel your volunteer
+        commitments, please click "Confirm" to notify the directors. Otherwise, click
+        "Cancel".
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-danger" onclick="confirm_cancellation()">Confirm</button>
+      </div>
+    </div>
+  </div>
 </div>
 
 <div class="summary_div" hidden>

--- a/esp/templates/users/student_schedule.html
+++ b/esp/templates/users/student_schedule.html
@@ -14,20 +14,12 @@
 </style>
 {% if not request.user.onsite_local %}
 <script type="text/javascript">
+//  Keep this in sync with setup_remove_confirmation() in
+//  /media/scripts/program/modules/student_schedule.js, which does the same
+//  thing for the AJAX-rendered copy of this schedule.
 $j(function() {
-    // Create two dialog boxes with two different warning messages,
-    // one that appears when you try to remove an enrolled class,
-    // and another that appears when you try removing a non-enrolled class.
-    // autoOpen: false makes it so that the dialog boxes don't appear on page load.
-    $j( "div.remove-confirm" ).dialog({
-        resizable: false,
-        modal: true,
-        autoOpen: false,
-        closeOnEscape: false
-    });
-
     // When clicking any remove link, handle the event here rather than immediately removing the class.
-    // Display a warning dialog box, and give the user an option to confirm the removal or cancel it.
+    // Display a warning modal, and give the user an option to confirm the removal or cancel it.
     $j("a.remove").click( function(eventObject) {
 
         // The hyperlink click is always cancelled at first.
@@ -37,30 +29,54 @@ $j(function() {
         var $a_remove_tag = $j(this);
         var cls_code = $j(this).attr("data-sec-code");
         var remove_type = $j(this).attr("data-remove-type");    // "enrolled" for enrolled classes, "applied" for non-enrolled classes
-        $j( "#"+remove_type+"-remove-confirm" ).dialog( "option", "title", "Remove class "+cls_code+"?" ).dialog( "option", "buttons", {
-            "Remove class": function() {
-                $j( this ).dialog( "close" );
-                window.location.replace($a_remove_tag.attr("href"));
-            },
-            "Cancel": function() {
-                $j( this ).dialog( "close" );
-            }
-        }).dialog( "open" );
+        var $modal = $j( "#"+remove_type+"-remove-confirm" );
+        $modal.find(".modal-title").text("Remove class "+cls_code+"?");
+        $modal.find(".remove-confirm-action").off("click").on("click", function() {
+            bootstrap.Modal.getOrCreateInstance($modal[0]).hide();
+            window.location.replace($a_remove_tag.attr("href"));
+        });
+        bootstrap.Modal.getOrCreateInstance($modal[0]).show();
     });
 });
 </script>
 {% endif %}
-<div id="enrolled-remove-confirm" class="remove-confirm" style="display:none;">
-    <p><span class="ui-icon ui-icon-alert" style="float: left; margin-right: 7px;"></span>
+<div class="modal fade remove-confirm" id="enrolled-remove-confirm" tabindex="-1"
+     data-bs-backdrop="static" data-bs-keyboard="false" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title"></h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
         This class will be permanently deleted from your schedule.
         If the class fills with new students, you will be unable to add it back to your schedule.
         Are you sure?
-    </p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-danger remove-confirm-action">Remove class</button>
+      </div>
+    </div>
+  </div>
 </div>
-<div id="applied-remove-confirm" class="remove-confirm" style="display:none;">
-    <p><span class="ui-icon ui-icon-alert" style="float: left; margin-right: 7px;"></span>
+<div class="modal fade remove-confirm" id="applied-remove-confirm" tabindex="-1"
+     data-bs-backdrop="static" data-bs-keyboard="false" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title"></h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
         Are you sure you want to remove this class?
-    </p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-danger remove-confirm-action">Remove class</button>
+      </div>
+    </div>
+  </div>
 </div>
 
 <p>

--- a/esp/templates/users/student_schedule.html
+++ b/esp/templates/users/student_schedule.html
@@ -41,11 +41,12 @@ $j(function() {
 </script>
 {% endif %}
 <div class="modal fade remove-confirm" id="enrolled-remove-confirm" tabindex="-1"
-     data-bs-backdrop="static" data-bs-keyboard="false" aria-hidden="true">
+     data-bs-backdrop="static" data-bs-keyboard="false"
+     aria-labelledby="enrolled-remove-confirm-title" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title"></h5>
+        <h5 class="modal-title" id="enrolled-remove-confirm-title"></h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
@@ -61,11 +62,12 @@ $j(function() {
   </div>
 </div>
 <div class="modal fade remove-confirm" id="applied-remove-confirm" tabindex="-1"
-     data-bs-backdrop="static" data-bs-keyboard="false" aria-hidden="true">
+     data-bs-backdrop="static" data-bs-keyboard="false"
+     aria-labelledby="applied-remove-confirm-title" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title"></h5>
+        <h5 class="modal-title" id="applied-remove-confirm-title"></h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">

--- a/esp/templates/users/student_schedule_inline.html
+++ b/esp/templates/users/student_schedule_inline.html
@@ -2,11 +2,12 @@
 <link rel='stylesheet' type='text/css' href='/media/styles/forms.css' />
 
 <div class="modal fade remove-confirm" id="enrolled-remove-confirm" tabindex="-1"
-     data-bs-backdrop="static" data-bs-keyboard="false" aria-hidden="true">
+     data-bs-backdrop="static" data-bs-keyboard="false"
+     aria-labelledby="enrolled-remove-confirm-title" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title"></h5>
+        <h5 class="modal-title" id="enrolled-remove-confirm-title"></h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
@@ -22,11 +23,12 @@
   </div>
 </div>
 <div class="modal fade remove-confirm" id="applied-remove-confirm" tabindex="-1"
-     data-bs-backdrop="static" data-bs-keyboard="false" aria-hidden="true">
+     data-bs-backdrop="static" data-bs-keyboard="false"
+     aria-labelledby="applied-remove-confirm-title" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title"></h5>
+        <h5 class="modal-title" id="applied-remove-confirm-title"></h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">

--- a/esp/templates/users/student_schedule_inline.html
+++ b/esp/templates/users/student_schedule_inline.html
@@ -1,17 +1,43 @@
 {% spaceless %}
 <link rel='stylesheet' type='text/css' href='/media/styles/forms.css' />
 
-<div id="enrolled-remove-confirm" class="remove-confirm" style="display:none;">
-    <p><span class="ui-icon ui-icon-alert" style="float: left; margin-right: 7px;"></span>
+<div class="modal fade remove-confirm" id="enrolled-remove-confirm" tabindex="-1"
+     data-bs-backdrop="static" data-bs-keyboard="false" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title"></h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
         This class will be permanently deleted from your schedule.
         If the class fills with new students, you will be unable to add it back to you
         Are you sure?
-    </p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-danger remove-confirm-action">Remove class</button>
+      </div>
+    </div>
+  </div>
 </div>
-<div id="applied-remove-confirm" class="remove-confirm" style="display:none;">
-    <p><span class="ui-icon ui-icon-alert" style="float: left; margin-right: 7px;"></span>
+<div class="modal fade remove-confirm" id="applied-remove-confirm" tabindex="-1"
+     data-bs-backdrop="static" data-bs-keyboard="false" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title"></h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
         Are you sure you want to remove this class?
-    </p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-danger remove-confirm-action">Remove class</button>
+      </div>
+    </div>
+  </div>
 </div>
 <div id='program_form' class='program_form_small'>
 <table cellpadding='3' style='width: 500px; margin: auto' border=1>


### PR DESCRIPTION
## Description

Converts every remaining jQuery-UI `.dialog()` popup to a Bootstrap 5 modal. The site's theme is built around Bootstrap, so these dialogs rendered with jQuery-UI's own grey title bar and chrome - and in several cases were visibly broken (the teacher cancellation dialog rendered as a bare title bar with its form invisible, and the scheduling comment dialog had no title at all).

Nine popup sites are converted, each as its own commit as requested

1. Teacher class-cancellation popup 
2. Admin class status "Saving" indicator
3. Volunteer signup cancellation dialog
4. Scheduling section comment dialog
5. Student schedule removal confirmations - both enrolled/applied, across the server-rendered and AJAX-rendered copies
6. Lottery class description popup
7. Onsite check-in registration dialog
8. Sitewide CSRF session alert
9. Admissions dashboard comment popups

There are **zero `.dialog()` calls left** in the codebase. jQuery-UI itself stays loaded - it's still used for datepicker, accordion, tabs, sortable, autocomplete and the `.button()` widget elsewhere.

A few things worth calling out

- **Three standalone pages had no Bootstrap at all** (`ajax_scheduling.html`, `onsiteclasslist/ajax_status.html`, `admissionsdashboard/admissions.html`) - they don't extend `elements/html`. Bootstrap CSS/JS had to be added to each; without it the scheduler's JS threw in `SectionCommentDialog` and took the whole matrix down.
- **`.tooltip` class collision on the onsite page** - that page applies its own legacy `.tooltip` class to every class cell, and Bootstrap's `.tooltip` (`opacity: 0; position: absolute`) hid the entire status matrix. Renamed to `.onsite-tooltip`: one line in `onsite/ajax_status.js` plus three rules in `onsite_ajax_status.css`, which only that page loads.
- **`csrf_check.js` keeps a plain `alert()` fallback.** It's loaded sitewide via `csrf_init.js`, including Django admin and the two onsite webapps, which have no Bootstrap. The modal is used where it exists; the alert covers the rest rather than throwing.
- **Backdrop/Esc behaviour was matched per dialog** rather than defaulted - e.g. the student schedule confirmations keep their original `closeOnEscape: false`, and dialogs that were `modal: true` (which jQuery-UI does *not* dismiss on overlay click) use `data-bs-backdrop="static"`.
- **Deploy note:** `render_class_teacher_list_row` is a `@cache_inclusion_tag` whose cache depends on model rows, not template contents. The argcache should be flushed on deploy, otherwise cached rows keep the old `onclick="requestCancel(...)"` for a handler this PR removes.

## Related Issue

Closes #6010

## Type of Change

- [x] Refactor / cleanup

## Testing

- [x] Existing tests pass
- [x] Manually verified

**Automated tests** - ran every suite touching the changed modules locally via Docker, all 123 pass

```
docker compose exec web python esp/manage.py test esp.program.modules.tests.teacherclassregmodule esp.program.modules.tests.test_volunteersignup esp.program.modules.handlers.tests.test_onsiteclasslist esp.program.modules.tests.adminclass esp.program.modules.tests.ajaxschedulingmodule esp.program.modules.tests.test_lotterystudentregmodule esp.web.tests_csrf_view esp.application
```

<img width="431" height="60" alt="Screenshot 2026-09-12 at 11 37 02 AM" src="https://github.com/user-attachments/assets/8d1ea764-da78-4a8b-a481-85f72efec349" />


<hr>

**Manual verification** — reproduced each popup in the docker-compose dev environment, before and after the change.

### 1. Teacher class-cancellation popup

*Before:* jQuery-UI dialog renders as a bare title bar - the reason field, checkbox and submit button are invisible

<img width="1280" height="760" alt="teacher-before" src="https://github.com/user-attachments/assets/d05f6696-4e92-4663-ab9f-216340e03b80" />

*After:* Bootstrap modal with the reason field, confirmation checkbox and working submit

<img width="1280" height="761" alt="teacher-after" src="https://github.com/user-attachments/assets/f498c0e4-fd83-42d4-a6b6-c3e13cf12a86" />

### 2. Admin class status "Saving" popup

*Before:* grey jQuery-UI title bar and unstyled body

<img width="1280" height="761" alt="admin-before" src="https://github.com/user-attachments/assets/5441039d-b785-408f-9b66-02689d2aa8a5" />

*After:* themed Bootstrap modal

<img width="1280" height="760" alt="admin-after" src="https://github.com/user-attachments/assets/f1d33489-bea4-44e2-9fd9-38d288bf9518" />

### 3. Volunteer signup cancellation dialog

*Before:* jQuery-UI chrome with plain browser buttons, clashing with the themed page behind it

<img width="1280" height="760" alt="volunteer-before" src="https://github.com/user-attachments/assets/4e09b4a4-af6a-4908-87e9-295508e2b6b5" />

*After:* Bootstrap modal with themed Cancel / Confirm buttons

<img width="1280" height="760" alt="volunteer-after" src="https://github.com/user-attachments/assets/ab8b06ca-255e-45be-a1fe-442b5ee2b407" />

### 4. Scheduling section comment dialog

*Before:* completely blank title bar, cramped form fields on one line

<img width="1279" height="760" alt="ajax-before" src="https://github.com/user-attachments/assets/edf2fe0b-2692-4b63-887f-d07d3b4d415e" />

*After:* proper "Set Comment" title, labelled comment field and Lock checkbox

<img width="1278" height="760" alt="ajax-after" src="https://github.com/user-attachments/assets/c31fbe45-8b88-4b21-9c1d-eb4d2a77b530" />

### 5. Student schedule removal confirmation

*Before:* jQuery-UI dialog with dynamic title, plain buttons

<img width="1279" height="759" alt="class-before" src="https://github.com/user-attachments/assets/032d0472-fec2-469e-93f9-224366560bb3" />

*After:* Bootstrap modal, same dynamic title, themed Cancel / Remove class buttons

<img width="1280" height="759" alt="class-after" src="https://github.com/user-attachments/assets/fb0c732e-b852-4ab6-84ed-15261ebcd254" />

### 6. Lottery class description popup

*Before:* jQuery-UI dialog with a large empty gap from its fixed height

<img width="1280" height="759" alt="lottery-before" src="https://github.com/user-attachments/assets/03e7b159-e9bc-4ceb-9807-436bb493dea5" />

*After:* Bootstrap modal sized to its content

<img width="1280" height="760" alt="lottery-after" src="https://github.com/user-attachments/assets/c37a6b7f-bb96-4da8-b3f9-23738f7bedb6" />

### 7. Onsite check-in registration dialog

*Before:* jQuery-UI "Register Account?" dialog

<img width="1280" height="760" alt="onsite-before" src="https://github.com/user-attachments/assets/e2485fcd-1660-48a9-bc93-ee91395a77fd" />

After: Bootstrap modal. Adding Bootstrap to this page also slightly restyles the sidebar (tighter checkbox spacing, "Find a class" input now inline) — cosmetic only, the status matrix and all controls are unaffected.

<img width="1280" height="760" alt="onsite-after" src="https://github.com/user-attachments/assets/e3cc88ed-33ca-48ba-89b1-d88a3ca8555f" />

### 8. Sitewide CSRF session alert

*Before:* jQuery-UI "Oops!" dialog

<img width="1280" height="760" alt="csrf-before" src="https://github.com/user-attachments/assets/92f89596-ad09-42d9-85a1-66ec67e11581" />

*After:* Bootstrap modal with an OK button

<img width="1280" height="759" alt="csrf-after" src="https://github.com/user-attachments/assets/6d69ed79-c794-40c6-8f9d-7ca41d02809f" />

### 9. Admissions dashboard comment popups

*Before:* one jQuery-UI dialog built per table row (6 dialog widgets in the DOM for 3 applications)

<img width="1280" height="760" alt="admission-before" src="https://github.com/user-attachments/assets/57a1cc80-063e-414a-82f4-2a97eeeb791f" />

*After:* a single shared Bootstrap modal reused by every row

<img width="1280" height="760" alt="admission-after" src="https://github.com/user-attachments/assets/1140b7bd-a197-4111-9de3-013136bb4e4a" />


<hr>

Beyond the visuals, the following were verified functionally:

- Checkbox still enables the cancellation submit button; form still posts to `cancelrequest`
- Volunteer "Confirm" still clears all shift requests (verified in the DB)
- Scheduling dialog still saves comment and lock state, and resets the form on close
- Student schedule removal navigates to the correct `clearslot` URL, with no handler stacking across repeated AJAX fragment reloads
- Lottery popup shows its loading state, fills from AJAX, and swaps cleanly between classes
- Onsite register button disables during the request and re-enables on reopen
- CSRF alert falls back to `alert()` where Bootstrap isn't present
- Admissions dashboard: comments save to the correct application when rows are edited out of order (the per-row dialogs are now one shared modal), and readonly mode doesn't leak into editable rows

## AI Disclosure

AI assisted

## Checklist

- [x] Self-reviewed the code
- [x] No new warnings or errors introduced