### PR TITLE
Guard PersistentQueryFilter lookup by filterid against stale/invalid ids

### DIFF
--- a/esp/esp/program/modules/handlers/batchclassregmodule.py
+++ b/esp/esp/program/modules/handlers/batchclassregmodule.py
@@ -119,7 +119,10 @@ class BatchClassRegModule(ProgramModuleObj):
         except (ClassSection.DoesNotExist, ValueError):
             raise ESPError()('Invalid class section selected')
 
-        filterObj = PersistentQueryFilter.objects.get(id=request.GET['filterid'])
+        try:
+            filterObj = PersistentQueryFilter.objects.get(id=request.GET['filterid'])
+        except (PersistentQueryFilter.DoesNotExist, ValueError):
+            raise ESPError()('The specified filter no longer exists or is invalid. Please restart the batch class registration process.')
         override_full = 'override_full' in request.POST
 
         result = self.batch_register(filterObj, section, override_full)

--- a/esp/esp/program/modules/handlers/listgenmodule.py
+++ b/esp/esp/program/modules/handlers/listgenmodule.py
@@ -326,7 +326,10 @@ class ListGenModule(ProgramModuleObj):
 
         if filterObj is None:
             if 'filterid' in request.GET:
-                filterObj = PersistentQueryFilter.objects.get(id=request.GET['filterid'])
+                try:
+                    filterObj = PersistentQueryFilter.objects.get(id=request.GET['filterid'])
+                except (PersistentQueryFilter.DoesNotExist, ValueError):
+                    raise ESPError('The specified filter no longer exists or is invalid. Please restart the process.', log=False)
             else:
                 raise ESPError('Could not determine the query filter ID.', log=False)
 


### PR DESCRIPTION
## Description

Several handler modules guard `PersistentQueryFilter.objects.get(id=request.GET['filterid'])` with a try/except that catches `DoesNotExist`/`ValueError` and returns a friendly `ESPError` (see `usergroupmodule.py`, `admincore.py`, `userrecordsmodule.py`, `deactivationmodule.py`). Two modules performed the same lookup unguarded:

- `batchclassregmodule.py:122` (`batchclassregfinal`)
- `listgenmodule.py:329` (`generateList`)

A stale, tampered, or expired `filterid` query param (bookmarked link, two admins working concurrently, filter object deleted/expired) raised `PersistentQueryFilter.DoesNotExist`, surfacing as an unhandled 500 instead of a controlled error  the same failure mode already fixed in ResourceModule (#5744).

`batchclassregmodule.py` now wraps the lookup in try/except, matching the style of the existing `ClassSection` guard a few lines above it. `listgenmodule.py` wraps the lookup using `raise ESPError(..., log=False)` to match this file's existing error-raising convention (rather than the `raise ESPError()(...)` style used in the other three files).

## Related Issue

Closes #6026

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually verified

Ran:

    docker compose exec web python manage.py test esp.program.modules.tests.batchclassregmodule esp.program.modules.tests.listgenmodule

All 15 tests pass.

## AI Disclosure

I used an AI assistant as a research aid while investigating this issue. All changes were written, reviewed, tested, and verified by me in a local dev environment, and I understand and stand behind the fix.

## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced